### PR TITLE
Remove hint for nao password in documentation

### DIFF
--- a/docs/operating_system/partitioning.md
+++ b/docs/operating_system/partitioning.md
@@ -30,7 +30,6 @@ To inspect the EFI files mount this partition:
 
 ```sh
 sudo su
-# enter the password for the nao user
 mount /dev/mmcblk1p2 /mnt/
 # inspect files at /mnt/
 ```


### PR DESCRIPTION
## Introduced Changes

The nao user has no password anymore, the documentation is no longer referencing this password.

## How to Test

Build the documentation, inspect the changes.