### PR TITLE
Make type casts in spl_network crate platform agnostic

### DIFF
--- a/crates/spl_network/src/game_controller_return_message.rs
+++ b/crates/spl_network/src/game_controller_return_message.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of, slice::from_raw_parts};
+use std::{ffi::c_char, mem::size_of, slice::from_raw_parts};
 
 use nalgebra::Isometry2;
 use serde::{Deserialize, Serialize};
@@ -46,10 +46,10 @@ impl From<GameControllerReturnMessage> for RoboCupGameControlReturnData {
         };
         RoboCupGameControlReturnData {
             header: [
-                GAMECONTROLLER_RETURN_STRUCT_HEADER[0] as i8,
-                GAMECONTROLLER_RETURN_STRUCT_HEADER[1] as i8,
-                GAMECONTROLLER_RETURN_STRUCT_HEADER[2] as i8,
-                GAMECONTROLLER_RETURN_STRUCT_HEADER[3] as i8,
+                GAMECONTROLLER_RETURN_STRUCT_HEADER[0] as c_char,
+                GAMECONTROLLER_RETURN_STRUCT_HEADER[1] as c_char,
+                GAMECONTROLLER_RETURN_STRUCT_HEADER[2] as c_char,
+                GAMECONTROLLER_RETURN_STRUCT_HEADER[3] as c_char,
             ],
             version: GAMECONTROLLER_RETURN_STRUCT_VERSION,
             playerNum: match message.player_number {

--- a/crates/spl_network/src/game_controller_state_message.rs
+++ b/crates/spl_network/src/game_controller_state_message.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::{TryFrom, TryInto},
+    ffi::c_char,
     mem::size_of,
     ptr::read,
     time::Duration,
@@ -54,10 +55,10 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
     type Error = anyhow::Error;
 
     fn try_from(message: RoboCupGameControlData) -> anyhow::Result<Self> {
-        if message.header[0] != GAMECONTROLLER_STRUCT_HEADER[0] as i8
-            && message.header[1] != GAMECONTROLLER_STRUCT_HEADER[1] as i8
-            && message.header[2] != GAMECONTROLLER_STRUCT_HEADER[2] as i8
-            && message.header[3] != GAMECONTROLLER_STRUCT_HEADER[3] as i8
+        if message.header[0] != GAMECONTROLLER_STRUCT_HEADER[0] as c_char
+            && message.header[1] != GAMECONTROLLER_STRUCT_HEADER[1] as c_char
+            && message.header[2] != GAMECONTROLLER_STRUCT_HEADER[2] as c_char
+            && message.header[3] != GAMECONTROLLER_STRUCT_HEADER[3] as c_char
         {
             bail!("Unexpected header");
         }

--- a/crates/spl_network/src/spl_message.rs
+++ b/crates/spl_network/src/spl_message.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::{TryFrom, TryInto},
+    ffi::c_char,
     mem::size_of,
     ptr::read,
     slice::from_raw_parts,
@@ -52,10 +53,10 @@ impl TryFrom<SPLStandardMessage> for SplMessage {
     type Error = anyhow::Error;
 
     fn try_from(message: SPLStandardMessage) -> anyhow::Result<Self> {
-        if message.header[0] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[0] as i8
-            && message.header[1] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[1] as i8
-            && message.header[2] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[2] as i8
-            && message.header[3] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[3] as i8
+        if message.header[0] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[0] as c_char
+            && message.header[1] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[1] as c_char
+            && message.header[2] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[2] as c_char
+            && message.header[3] != SPL_STANDARD_MESSAGE_STRUCT_HEADER[3] as c_char
         {
             bail!("Unexpected header");
         }
@@ -123,10 +124,10 @@ impl From<SplMessage> for SPLStandardMessage {
         };
         Self {
             header: [
-                SPL_STANDARD_MESSAGE_STRUCT_HEADER[0] as i8,
-                SPL_STANDARD_MESSAGE_STRUCT_HEADER[1] as i8,
-                SPL_STANDARD_MESSAGE_STRUCT_HEADER[2] as i8,
-                SPL_STANDARD_MESSAGE_STRUCT_HEADER[3] as i8,
+                SPL_STANDARD_MESSAGE_STRUCT_HEADER[0] as c_char,
+                SPL_STANDARD_MESSAGE_STRUCT_HEADER[1] as c_char,
+                SPL_STANDARD_MESSAGE_STRUCT_HEADER[2] as c_char,
+                SPL_STANDARD_MESSAGE_STRUCT_HEADER[3] as c_char,
             ],
             version: SPL_STANDARD_MESSAGE_STRUCT_VERSION,
             playerNum: match message.player_number {


### PR DESCRIPTION
## Introduced Changes

I had an issue with compiling the spl_network crate on my phone. According to the [documentation](https://doc.rust-lang.org/std/os/raw/type.c_char.html), the `c_char` type can be either a `u8` or an `i8` depending on the platform.

The code generated from the SPL standard message header file by bindgen currently looks like this:
```rs
pub struct SPLStandardMessage {
    pub header: [::std::os::raw::c_char; 4usize],
   ...
}
```
However, we were casting rust `char`s to `i8` directly instead of `c_char` which led to a type error.

## ToDo / Known Issues

- [ ] Decide whether to use `c_char` from `os::raw` or `ffi`. The generated code uses `os::raw`, but `ffi` seems more fitting.

## Ideas for Next Iterations (Not This PR)



## How to Test

See if everything still compiles for x86 locally, for the nao using the toolchain, and on android.