### PR TITLE
Supertwix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "communication",
+ "convert_case",
  "eframe",
  "egui_dock",
  "egui_extras",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "egui_dock"
 version = "0.2.1"
-source = "git+https://github.com/Avarel/egui_dock/?branch=tab_add#d8302974bbbcfc52a061eb91120005b9ce9ab52e"
+source = "git+https://github.com/Avarel/egui_dock/?branch=tab_add#996fa6ab698c1ac0c71499ce69416e08e335594b"
 dependencies = [
  "egui",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,9 +947,10 @@ dependencies = [
 [[package]]
 name = "egui_dock"
 version = "0.2.1"
-source = "git+https://github.com/knoellle/egui_dock/#aa66bc27ee08eb237127a53d256c299c472e0834"
+source = "git+https://github.com/knoellle/egui_dock/#f7d1a20df6fb767f4e20b4536cc6289f6ce51442"
 dependencies = [
  "egui",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "egui_dock"
 version = "0.2.1"
-source = "git+https://github.com/knoellle/egui_dock/#6f65b115bc4aac2b9dfd3f2292c938353936d75c"
+source = "git+https://github.com/knoellle/egui_dock/#aa66bc27ee08eb237127a53d256c299c472e0834"
 dependencies = [
  "egui",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_dock"
+version = "0.2.1"
+source = "git+https://github.com/Avarel/egui_dock/?branch=tab_add#d8302974bbbcfc52a061eb91120005b9ce9ab52e"
+dependencies = [
+ "egui",
+]
+
+[[package]]
 name = "egui_extras"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,6 +3210,7 @@ dependencies = [
  "anyhow",
  "communication",
  "eframe",
+ "egui_dock",
  "egui_extras",
  "fern",
  "fuzzy-matcher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "egui_dock"
 version = "0.2.1"
-source = "git+https://github.com/Avarel/egui_dock/?branch=tab_add#996fa6ab698c1ac0c71499ce69416e08e335594b"
+source = "git+https://github.com/knoellle/egui_dock/#6f65b115bc4aac2b9dfd3f2292c938353936d75c"
 dependencies = [
  "egui",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ convert_case = "0.6.0"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dbus = "0.9.6"
 eframe = { version = "0.19.0", features = ["persistence"] }
-egui_dock = { version = "0.2.1", git = "https://github.com/knoellle/egui_dock/" }
+egui_dock = { version = "0.2.1", git = "https://github.com/knoellle/egui_dock/", features = [
+  "serde",
+] }
 egui_extras = { version = "0.19.0", features = ["image"] }
 epoll = "4.3.1"
 fern = { version = "0.6.1", features = ["colored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ convert_case = "0.6.0"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dbus = "0.9.6"
 eframe = { version = "0.19.0", features = ["persistence"] }
-egui_dock = { version = "0.2.1", git = "https://github.com/Avarel/egui_dock/", branch = "tab_add" }
+egui_dock = { version = "0.2.1", git = "https://github.com/knoellle/egui_dock/" }
 egui_extras = { version = "0.19.0", features = ["image"] }
 epoll = "4.3.1"
 fern = { version = "0.6.1", features = ["colored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ convert_case = "0.6.0"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dbus = "0.9.6"
 eframe = { version = "0.19.0", features = ["persistence"] }
+egui_dock = { version = "0.2.1", git = "https://github.com/Avarel/egui_dock/", branch = "tab_add" }
 egui_extras = { version = "0.19.0", features = ["image"] }
 epoll = "4.3.1"
 fern = { version = "0.6.1", features = ["colored"] }

--- a/crates/communication/src/communication.rs
+++ b/crates/communication/src/communication.rs
@@ -6,7 +6,7 @@ use tokio::{
 use uuid::Uuid;
 
 use crate::{
-    connector::{self, connector},
+    connector::{self, connector, ConnectionStatus},
     parameter_subscription_manager::{self, parameter_subscription_manager},
     HierarchyType, OutputHierarchy, SubscriberMessage,
 };
@@ -78,6 +78,15 @@ impl Communication {
             .send(connector::Message::SetAddress(address))
             .await
             .unwrap();
+    }
+
+    pub async fn subscribe_connection_updates(&self) -> mpsc::Receiver<ConnectionStatus> {
+        let (subscriber_sender, subscriber_receiver) = mpsc::channel(10);
+        self.connector
+            .send(connector::Message::SubscribeToUpdates(subscriber_sender))
+            .await
+            .unwrap();
+        subscriber_receiver
     }
 
     pub async fn subscribe_output(

--- a/crates/communication/src/lib.rs
+++ b/crates/communication/src/lib.rs
@@ -9,4 +9,5 @@ mod responder;
 mod types;
 
 pub use crate::communication::Communication;
+pub use connector::ConnectionStatus;
 pub use types::{Cycler, CyclerOutput, HierarchyType, Output, OutputHierarchy, SubscriberMessage};

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 communication = { workspace = true }
 eframe = { workspace = true }
 egui_extras = { workspace = true }
+egui_dock = { workspace = true }
 fern = { workspace = true }
 fuzzy-matcher = { workspace = true }
 image = { workspace = true }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-only"
 anyhow = { workspace = true }
 communication = { workspace = true }
 eframe = { workspace = true }
+convert_case = { workspace = true }
 egui_extras = { workspace = true }
 egui_dock = { workspace = true }
 fern = { workspace = true }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -227,6 +227,11 @@ impl App for TwixApp {
             })
         });
         CentralPanel::default().show(context, |ui| {
+            if ui.input_mut().consume_key(Modifiers::CTRL, Key::T) {
+                let tab = SelectablePanel::Text(TextPanel::new(self.nao.clone(), None));
+                self.tree.push_to_focused_leaf(tab);
+            }
+
             let mut style = egui_dock::Style::from_egui(ui.style().as_ref());
             style.show_add_buttons = true;
             style.add_tab_align = TabAddAlign::Left;

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -16,8 +16,7 @@ use fern::{colors::ColoredLevelConfig, Dispatch, InitError};
 use nao::Nao;
 use panel::Panel;
 use panels::{ImagePanel, ImageSegmentsPanel, MapPanel, ParameterPanel, PlotPanel, TextPanel};
-use serde::Serialize;
-use serde_json::{from_str, json, to_string, to_string_pretty, Value};
+use serde_json::{from_str, to_string, to_string_pretty, Value};
 
 mod completion_edit;
 mod image_buffer;
@@ -43,28 +42,7 @@ fn setup_logger() -> Result<(), InitError> {
     Ok(())
 }
 
-#[derive(Serialize)]
-struct X {
-    hello: String,
-    test: f32,
-}
-
-fn convert_tree(tree: Tree<Value>) -> Tree<X> {
-    tree.map_tabs(|value| X {
-        hello: value["hello"].as_str().unwrap().to_string(),
-        test: 13.37,
-    })
-}
-
 fn main() {
-    // let tree = Tree::<Value>::from_str("");
-    let tab1 = json!({"hello": "world"});
-    let tab2 = json!({"hello": "Konrad"});
-    let mut tree = Tree::new(vec![tab1]);
-    tree.split_below(NodeIndex::root(), 0.50, vec![tab2]);
-    // println!("{}", to_string_pretty(&tree).unwrap());
-    // println!("{}", to_string_pretty(&convert_tree(tree)).unwrap());
-    // return;
     setup_logger().unwrap();
     let options = NativeOptions::default();
     run_native(
@@ -110,7 +88,6 @@ impl SelectablePanel {
             SelectablePanel::ImageSegments(panel) => panel.save(),
             SelectablePanel::Map(panel) => panel.save(),
             SelectablePanel::Parameter(panel) => panel.save(),
-            _ => json!({}),
         };
         value["_panel_type"] = Value::String(self.to_string());
 

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -7,9 +7,10 @@ use anyhow::Result;
 
 use completion_edit::CompletionEdit;
 use eframe::{
-    egui::{CentralPanel, Context, Key, Modifiers, TopBottomPanel, Visuals, Widget},
+    egui::{CentralPanel, Context, Key, Modifiers, TopBottomPanel, Ui, Visuals, Widget},
     run_native, App, CreationContext, Frame, NativeOptions, Storage,
 };
+use egui_dock::{DockArea, NodeIndex, Tree};
 use fern::{colors::ColoredLevelConfig, Dispatch, InitError};
 
 use log::warn;
@@ -74,6 +75,19 @@ impl SelectablePanel {
     }
 }
 
+impl Widget for &mut SelectablePanel {
+    fn ui(self, ui: &mut Ui) -> eframe::egui::Response {
+        match self {
+            SelectablePanel::Text(panel) => panel.ui(ui),
+            SelectablePanel::Plot(panel) => panel.ui(ui),
+            SelectablePanel::Image(panel) => panel.ui(ui),
+            SelectablePanel::ImageSegments(panel) => panel.ui(ui),
+            SelectablePanel::Map(panel) => panel.ui(ui),
+            SelectablePanel::Parameter(panel) => panel.ui(ui),
+        }
+    }
+}
+
 impl Display for SelectablePanel {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let panel_name = match self {
@@ -94,6 +108,7 @@ struct TwixApp {
     ip_address: String,
     panel_selection: String,
     active_panel: SelectablePanel,
+    tree: Tree<SelectablePanel>,
 }
 
 impl TwixApp {
@@ -157,6 +172,12 @@ impl TwixApp {
             ),
         };
 
+        let tab1 = SelectablePanel::Map(MapPanel::new(nao.clone(), creation_context.storage));
+        let tab2 = SelectablePanel::Image(ImagePanel::new(nao.clone(), creation_context.storage));
+
+        let mut tree = Tree::new(vec![tab1]);
+        tree.split_below(NodeIndex::root(), 0.50, vec![tab2]);
+
         let mut style = (*creation_context.egui_ctx.style()).clone();
         style.visuals = Visuals::dark();
         creation_context.egui_ctx.set_style(style);
@@ -166,6 +187,7 @@ impl TwixApp {
             ip_address: ip_address.unwrap_or_default(),
             panel_selection,
             active_panel,
+            tree,
         }
     }
 }
@@ -251,13 +273,19 @@ impl App for TwixApp {
                 }
             })
         });
-        CentralPanel::default().show(context, |ui| match &mut self.active_panel {
-            SelectablePanel::Text(panel) => panel.ui(ui),
-            SelectablePanel::Plot(panel) => panel.ui(ui),
-            SelectablePanel::Image(panel) => panel.ui(ui),
-            SelectablePanel::ImageSegments(panel) => panel.ui(ui),
-            SelectablePanel::Map(panel) => panel.ui(ui),
-            SelectablePanel::Parameter(panel) => panel.ui(ui),
+        CentralPanel::default().show(context, |ui| {
+            let mut style = egui_dock::Style::from_egui(ui.style().as_ref());
+            style.show_add_buttons = true;
+            // Uncomment once TabAddAlign is accessible from outside the egui_dock crate.
+            // style.add_tab_align = egui_dock::TabAddAlign::Left;
+            let mut tab_viewer = TabViewer::default();
+            DockArea::new(&mut self.tree)
+                .style(style)
+                .show_inside(ui, &mut tab_viewer);
+            for node_id in tab_viewer.nodes_to_add_tabs_to {
+                let tab = SelectablePanel::Text(TextPanel::new(self.nao.clone(), None));
+                self.tree[node_id].insert_tab(0.into(), tab);
+            }
         });
     }
 
@@ -274,5 +302,26 @@ impl App for TwixApp {
         );
         storage.set_string("selected_panel", self.active_panel.to_string());
         self.active_panel.save(storage);
+    }
+}
+
+#[derive(Default)]
+struct TabViewer {
+    nodes_to_add_tabs_to: Vec<NodeIndex>,
+}
+
+impl egui_dock::TabViewer for TabViewer {
+    type Tab = SelectablePanel;
+
+    fn ui(&mut self, ui: &mut Ui, tab: &mut Self::Tab) {
+        tab.ui(ui);
+    }
+
+    fn title(&mut self, tab: &mut Self::Tab) -> eframe::egui::WidgetText {
+        format!("{tab}").into()
+    }
+
+    fn on_add(&mut self, node: NodeIndex) {
+        self.nodes_to_add_tabs_to.push(node);
     }
 }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -284,7 +284,8 @@ impl App for TwixApp {
                 .show_inside(ui, &mut tab_viewer);
             for node_id in tab_viewer.nodes_to_add_tabs_to {
                 let tab = SelectablePanel::Text(TextPanel::new(self.nao.clone(), None));
-                self.tree[node_id].insert_tab(0.into(), tab);
+                let index = self.tree[node_id].tabs_count();
+                self.tree[node_id].insert_tab(index.into(), tab);
             }
         });
     }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -148,19 +148,6 @@ impl TwixApp {
             connection_intent,
         ));
 
-        let (panel_selection, active_panel) = match creation_context
-            .storage
-            .and_then(|storage| storage.get_string("selected_panel"))
-            .and_then(|panel_name| {
-                SelectablePanel::try_from_name(&panel_name, nao.clone(), creation_context.storage)
-            }) {
-            Some(panel) => (format!("{panel}"), panel),
-            None => (
-                "Text".to_string(),
-                SelectablePanel::Text(TextPanel::new(nao.clone(), creation_context.storage)),
-            ),
-        };
-
         let tab1 = SelectablePanel::Map(MapPanel::new(nao.clone(), creation_context.storage));
         let tab2 = SelectablePanel::Image(ImagePanel::new(nao.clone(), creation_context.storage));
 

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -16,7 +16,7 @@ use fern::{colors::ColoredLevelConfig, Dispatch, InitError};
 use nao::Nao;
 use panel::Panel;
 use panels::{ImagePanel, ImageSegmentsPanel, MapPanel, ParameterPanel, PlotPanel, TextPanel};
-use serde_json::{from_str, to_string, to_string_pretty, Value};
+use serde_json::{from_str, to_string, Value};
 
 mod completion_edit;
 mod image_buffer;
@@ -254,7 +254,6 @@ impl App for TwixApp {
 
     fn save(&mut self, storage: &mut dyn Storage) {
         let tree = self.tree.map_tabs(|panel| panel.save());
-        println!("{}", to_string_pretty(&tree).unwrap());
 
         storage.set_string("tree", to_string(&tree).unwrap());
         storage.set_string("ip_address", self.ip_address.clone());

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -13,7 +13,6 @@ use eframe::{
 use egui_dock::{DockArea, NodeIndex, Tree};
 use fern::{colors::ColoredLevelConfig, Dispatch, InitError};
 
-use log::warn;
 use nao::Nao;
 use panel::Panel;
 use panels::{ImagePanel, ImageSegmentsPanel, MapPanel, ParameterPanel, PlotPanel, TextPanel};
@@ -236,8 +235,7 @@ impl App for TwixApp {
         CentralPanel::default().show(context, |ui| {
             let mut style = egui_dock::Style::from_egui(ui.style().as_ref());
             style.show_add_buttons = true;
-            // Uncomment once TabAddAlign is accessible from outside the egui_dock crate.
-            // style.add_tab_align = egui_dock::TabAddAlign::Left;
+            style.add_tab_align = egui_dock::TabAddAlign::Left;
             let mut tab_viewer = TabViewer::default();
             DockArea::new(&mut self.tree)
                 .style(style)

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -159,12 +159,20 @@ impl TwixApp {
             connection_intent,
         ));
 
-        let tree: Tree<Value> = creation_context
+        let tree: Option<Tree<Value>> = creation_context
             .storage
             .and_then(|storage| storage.get_string("tree"))
-            .and_then(|string| from_str(&string).ok())
-            .unwrap_or_else(|| Tree::new(Vec::new()));
-        let tree = tree.map_tabs(|value| SelectablePanel::new(nao.clone(), Some(value)).unwrap());
+            .and_then(|string| from_str(&string).ok());
+
+        let tree = match tree {
+            Some(tree) => {
+                tree.map_tabs(|value| SelectablePanel::new(nao.clone(), Some(value)).unwrap())
+            }
+            None => Tree::new(vec![SelectablePanel::Text(TextPanel::new(
+                nao.clone(),
+                None,
+            ))]),
+        };
 
         let connection_status = ConnectionStatus::Disconnected {
             address: None,

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -239,7 +239,7 @@ impl App for TwixApp {
                 }
 
                 if self.active_tab_index() != Some(self.last_focused_tab) {
-                    self.last_focused_tab = self.active_tab_index().unwrap();
+                    self.last_focused_tab = self.active_tab_index().unwrap_or((0.into(), 0.into()));
                     if let Some(name) = self.active_panel().map(|panel| format!("{panel}")) {
                         self.panel_selection = name
                     }
@@ -266,7 +266,9 @@ impl App for TwixApp {
                         self.nao.clone(),
                         None,
                     ) {
-                        *self.active_panel().unwrap() = panel;
+                        if let Some(active_panel) = self.active_panel() {
+                            *active_panel = panel;
+                        }
                     }
                 }
             })

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -124,6 +124,7 @@ struct TwixApp {
     connection_intent: bool,
     ip_address: String,
     panel_selection: String,
+    last_focused_tab: Option<NodeIndex>,
     tree: Tree<SelectablePanel>,
 }
 
@@ -164,6 +165,7 @@ impl TwixApp {
             ip_address: ip_address.unwrap_or_default(),
             panel_selection,
             tree,
+            last_focused_tab: None,
         }
     }
 }
@@ -190,6 +192,12 @@ impl App for TwixApp {
                     .changed()
                 {
                     self.nao.set_connect(self.connection_intent);
+                }
+                if self.tree.focused_leaf() != self.last_focused_tab {
+                    self.last_focused_tab = self.tree.focused_leaf();
+                    if let Some(name) = self.active_panel().map(|panel| format!("{panel}")) {
+                        self.panel_selection = name
+                    }
                 }
                 let panel_input = CompletionEdit::new(
                     &mut self.panel_selection,

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -16,7 +16,7 @@ use fern::{colors::ColoredLevelConfig, Dispatch, InitError};
 use nao::Nao;
 use panel::Panel;
 use panels::{ImagePanel, ImageSegmentsPanel, MapPanel, ParameterPanel, PlotPanel, TextPanel};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::{from_str, json, to_string, to_string_pretty, Value};
 
 mod completion_edit;
@@ -202,7 +202,7 @@ fn ip_to_socket_address(ip_address: &str) -> String {
 }
 
 impl App for TwixApp {
-    fn update(&mut self, context: &Context, frame: &mut Frame) {
+    fn update(&mut self, context: &Context, _frame: &mut Frame) {
         context.request_repaint();
         TopBottomPanel::top("top_bar").show(context, |ui| {
             ui.horizontal(|ui| {

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -194,8 +194,8 @@ impl App for TwixApp {
                     self.nao.set_connect(self.connection_intent);
                 }
 
-                if self.active_tab() != Some(self.last_focused_tab) {
-                    self.last_focused_tab = self.active_tab().unwrap();
+                if self.active_tab_index() != Some(self.last_focused_tab) {
+                    self.last_focused_tab = self.active_tab_index().unwrap();
                     if let Some(name) = self.active_panel().map(|panel| format!("{panel}")) {
                         self.panel_selection = name
                     }
@@ -272,7 +272,7 @@ impl TwixApp {
         Some(tab)
     }
 
-    fn active_tab(&self) -> Option<(NodeIndex, TabIndex)> {
+    fn active_tab_index(&self) -> Option<(NodeIndex, TabIndex)> {
         let node = self.tree.focused_leaf()?;
         if let egui_dock::Node::Leaf { active, .. } = &self.tree[node] {
             Some((node, *active))

--- a/tools/twix/src/nao.rs
+++ b/tools/twix/src/nao.rs
@@ -1,4 +1,6 @@
-use communication::{Communication, Cycler, CyclerOutput, HierarchyType, OutputHierarchy};
+use communication::{
+    Communication, ConnectionStatus, Cycler, CyclerOutput, HierarchyType, OutputHierarchy,
+};
 
 use serde_json::Value;
 use tokio::runtime::{Builder, Runtime};
@@ -44,6 +46,12 @@ impl Nao {
     pub fn subscribe_parameter(&self, path: &str) -> ValueBuffer {
         let _guard = self.runtime.enter();
         ValueBuffer::parameter(self.communication.clone(), path.to_string())
+    }
+
+    pub fn subscribe_status_updates(&self) -> tokio::sync::mpsc::Receiver<ConnectionStatus> {
+        let _guard = self.runtime.enter();
+        self.runtime
+            .block_on(self.communication.subscribe_connection_updates())
     }
 
     pub fn get_output_hierarchy(&self) -> Option<OutputHierarchy> {

--- a/tools/twix/src/panel.rs
+++ b/tools/twix/src/panel.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use eframe::Storage;
+use serde_json::{json, Value};
 
 use crate::nao::Nao;
 
 pub trait Panel {
     const NAME: &'static str;
-    fn new(nao: Arc<Nao>, storage: Option<&dyn Storage>) -> Self;
-    fn save(&mut self, _storage: &mut dyn Storage) {}
+    fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self;
+    fn save(&self) -> Value {
+        json!({})
+    }
 }

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -37,7 +37,7 @@ impl Panel for ImagePanel {
 
     fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
         let cycler_name = value
-            .and_then(|value| value.get("image.cycler"))
+            .and_then(|value| value.get("cycler"))
             .and_then(|value| value.as_str())
             .unwrap_or("vision_top");
         let cycler = match cycler_name {
@@ -47,7 +47,11 @@ impl Panel for ImagePanel {
         };
         let image_buffer = nao.subscribe_image(cycler);
         let cycler_selector = VisionCyclerSelector::new(cycler);
-        let overlays = Overlays::new(nao.clone(), todo!(), cycler_selector.selected_cycler());
+        let overlays = Overlays::new(
+            nao.clone(),
+            value.and_then(|value| value.get("overlays")),
+            cycler_selector.selected_cycler(),
+        );
         Self {
             nao,
             image_buffer,
@@ -64,13 +68,14 @@ impl Panel for ImagePanel {
                 error!("Invalid camera cycler: {cycler}");
                 "vision_top"
             }
-        };
+        }
+        .to_string();
 
-        // self.overlays.save(storage)
-        todo!();
+        let overlays = self.overlays.save();
 
         return json!({
-            "cycler": cycler.to_string(),
+            "cycler": cycler,
+            "overlays":overlays,
         });
     }
 }

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -5,7 +5,6 @@ use communication::Cycler;
 use eframe::{
     egui::{Response, Ui, Widget},
     emath::Rect,
-    Storage,
 };
 use egui_extras::RetainedImage;
 use log::error;

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -72,10 +72,10 @@ impl Panel for ImagePanel {
 
         let overlays = self.overlays.save();
 
-        return json!({
+        json!({
             "cycler": cycler,
             "overlays":overlays,
-        });
+        })
     }
 }
 

--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -9,7 +9,7 @@ use eframe::{
 
 use crate::{nao::Nao, twix_painter::TwixPainter};
 
-use super::overlays::LineDetection;
+use super::overlays::{BallDetection, LineDetection};
 
 pub trait Overlay {
     const NAME: &'static str;
@@ -78,16 +78,22 @@ where
 
 pub struct Overlays {
     pub line_detection: EnabledOverlay<LineDetection>,
+    pub ball_detection: EnabledOverlay<BallDetection>,
 }
 
 impl Overlays {
     pub fn new(nao: Arc<Nao>, storage: Option<&dyn Storage>, selected_cycler: Cycler) -> Self {
-        let line_detection = EnabledOverlay::new(nao, storage, true, selected_cycler);
-        Self { line_detection }
+        let line_detection = EnabledOverlay::new(nao.clone(), storage, true, selected_cycler);
+        let ball_detection = EnabledOverlay::new(nao, storage, true, selected_cycler);
+        Self {
+            line_detection,
+            ball_detection,
+        }
     }
 
     pub fn update_cycler(&mut self, selected_cycler: Cycler) {
         self.line_detection.update_cycler(selected_cycler);
+        self.ball_detection.update_cycler(selected_cycler);
     }
 
     pub fn combo_box(&mut self, ui: &mut Ui, selected_cycler: Cycler) {
@@ -95,15 +101,18 @@ impl Overlays {
             .selected_text("Overlays")
             .show_ui(ui, |ui| {
                 self.line_detection.checkbox(ui, selected_cycler);
+                self.ball_detection.checkbox(ui, selected_cycler);
             });
     }
 
     pub fn paint(&self, painter: &TwixPainter) -> Result<()> {
         let _ = self.line_detection.paint(painter);
+        let _ = self.ball_detection.paint(painter);
         Ok(())
     }
 
     pub fn save(&self, storage: &mut dyn Storage) {
         self.line_detection.save(storage);
+        self.ball_detection.save(storage);
     }
 }

--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use communication::Cycler;
-use eframe::egui::{ComboBox, Ui};
+use convert_case::Casing;
+use eframe::egui::Ui;
 use serde_json::{json, Value};
 
 use crate::{nao::Nao, twix_painter::TwixPainter};
@@ -35,7 +36,7 @@ where
         selected_cycler: Cycler,
     ) -> Self {
         let active = value
-            .and_then(|value| value.get(T::NAME))
+            .and_then(|value| value.get(T::NAME.to_case(convert_case::Case::Snake)))
             .and_then(|value| value.get("active"))
             .and_then(|value| value.as_bool())
             .unwrap_or(active);
@@ -110,8 +111,8 @@ impl Overlays {
 
     pub fn save(&self) -> Value {
         json!({
-            "Line Detection": self.line_detection.save(),
-            "Ball Detection": self.ball_detection.save(),
+            "line_detection": self.line_detection.save(),
+            "ball_detection": self.ball_detection.save(),
         })
     }
 }

--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -2,10 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use communication::Cycler;
-use eframe::{
-    egui::{ComboBox, Ui},
-    Storage,
-};
+use eframe::{egui::Ui, Storage};
 
 use crate::{nao::Nao, twix_painter::TwixPainter};
 

--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -97,12 +97,10 @@ impl Overlays {
     }
 
     pub fn combo_box(&mut self, ui: &mut Ui, selected_cycler: Cycler) {
-        ComboBox::from_id_source("Overlays")
-            .selected_text("Overlays")
-            .show_ui(ui, |ui| {
-                self.line_detection.checkbox(ui, selected_cycler);
-                self.ball_detection.checkbox(ui, selected_cycler);
-            });
+        ui.menu_button("Overlays", |ui| {
+            self.line_detection.checkbox(ui, selected_cycler);
+            self.ball_detection.checkbox(ui, selected_cycler);
+        });
     }
 
     pub fn paint(&self, painter: &TwixPainter) -> Result<()> {

--- a/tools/twix/src/panels/image/overlays/ball_detection.rs
+++ b/tools/twix/src/panels/image/overlays/ball_detection.rs
@@ -1,0 +1,80 @@
+use std::str::FromStr;
+
+use communication::CyclerOutput;
+use eframe::epaint::{Color32, Stroke};
+use types::{Ball, CandidateEvaluation, Circle};
+
+use crate::{panels::image::overlay::Overlay, value_buffer::ValueBuffer};
+
+pub struct BallDetection {
+    balls: ValueBuffer,
+    filtered_balls: ValueBuffer,
+    ball_candidates: ValueBuffer,
+}
+
+impl Overlay for BallDetection {
+    const NAME: &'static str = "Ball Detection";
+
+    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: communication::Cycler) -> Self {
+        let camera_position = match selected_cycler {
+            communication::Cycler::VisionTop => "top",
+            communication::Cycler::VisionBottom => "bottom",
+            cycler => panic!("Invalid vision cycler: {cycler}"),
+        };
+        Self {
+            balls: nao.subscribe_output(
+                CyclerOutput::from_str(&format!("{}.main.balls", selected_cycler)).unwrap(),
+            ),
+            filtered_balls: nao.subscribe_output(
+                CyclerOutput::from_str(&format!(
+                    "control.additional.filtered_balls_in_image_{}",
+                    camera_position,
+                ))
+                .unwrap(),
+            ),
+            ball_candidates: nao.subscribe_output(
+                CyclerOutput::from_str(&format!("{}.additional.ball_candidates", selected_cycler))
+                    .unwrap(),
+            ),
+        }
+    }
+
+    fn paint(&self, painter: &crate::twix_painter::TwixPainter) -> anyhow::Result<()> {
+        let filtered_balls: Vec<Circle> = self.filtered_balls.require_latest()?;
+        for circle in filtered_balls.iter() {
+            painter.circle_stroke(circle.center, circle.radius, Stroke::new(3.0, Color32::RED));
+        }
+
+        let ball_candidates: Vec<CandidateEvaluation> = self.ball_candidates.require_latest()?;
+        for candidate in ball_candidates.iter() {
+            let circle = candidate.candidate_circle;
+            painter.circle_stroke(
+                circle.center,
+                circle.radius,
+                Stroke::new(2.0, Color32::BLUE),
+            );
+        }
+
+        let balls: Vec<Ball> = self.balls.require_latest()?;
+        for ball in balls.iter() {
+            let circle = ball.image_location;
+            painter.circle_stroke(
+                circle.center,
+                circle.radius,
+                Stroke::new(2.0, Color32::GREEN),
+            );
+        }
+
+        for candidate in ball_candidates.iter() {
+            if let Some(circle) = candidate.corrected_circle {
+                painter.circle_stroke(
+                    circle.center,
+                    circle.radius,
+                    Stroke::new(1.0, Color32::WHITE),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -5,7 +5,11 @@ use eframe::epaint::{Color32, Stroke};
 use nalgebra::{point, Point2};
 use types::ImageLines;
 
-use crate::{panels::image::overlay::Overlay, value_buffer::ValueBuffer};
+use crate::{
+    panels::image::overlay::Overlay,
+    twix_painter::{to_444, TwixPainter},
+    value_buffer::ValueBuffer,
+};
 
 pub struct LineDetection {
     lines_in_image: ValueBuffer,
@@ -23,7 +27,7 @@ impl Overlay for LineDetection {
         }
     }
 
-    fn paint(&self, painter: &crate::twix_painter::TwixPainter) -> anyhow::Result<()> {
+    fn paint(&self, painter: &TwixPainter) -> anyhow::Result<()> {
         let lines_in_image: ImageLines = self.lines_in_image.require_latest()?;
         for point in lines_in_image.points {
             painter.circle_stroke(to_444(point), 3.0, Stroke::new(1.0, Color32::RED))
@@ -37,8 +41,4 @@ impl Overlay for LineDetection {
         }
         Ok(())
     }
-}
-
-fn to_444(point: Point2<f32>) -> Point2<f32> {
-    point![point.x * 2.0, point.y]
 }

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use communication::{Cycler, CyclerOutput};
 use eframe::epaint::{Color32, Stroke};
-use nalgebra::{point, Point2};
 use types::ImageLines;
 
 use crate::{

--- a/tools/twix/src/panels/image/overlays/mod.rs
+++ b/tools/twix/src/panels/image/overlays/mod.rs
@@ -1,3 +1,5 @@
 mod line_detection;
+mod ball_detection;
 
 pub use line_detection::LineDetection;
+pub use ball_detection::BallDetection;

--- a/tools/twix/src/panels/image/overlays/mod.rs
+++ b/tools/twix/src/panels/image/overlays/mod.rs
@@ -1,5 +1,5 @@
-mod line_detection;
 mod ball_detection;
+mod line_detection;
 
-pub use line_detection::LineDetection;
 pub use ball_detection::BallDetection;
+pub use line_detection::LineDetection;

--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -4,9 +4,9 @@ use communication::CyclerOutput;
 use eframe::{
     egui::{ComboBox, Response, Ui, Widget},
     epaint::{Color32, Stroke},
-    Storage,
 };
 use nalgebra::{point, vector, Similarity2};
+use serde_json::Value;
 use types::{CameraPosition, ImageSegments, Rgb, RgbChannel};
 
 use crate::{nao::Nao, panel::Panel, twix_painter::CoordinateSystem, value_buffer::ValueBuffer};
@@ -39,7 +39,7 @@ pub struct ImageSegmentsPanel {
 impl Panel for ImageSegmentsPanel {
     const NAME: &'static str = "Image Segments";
 
-    fn new(nao: Arc<Nao>, _storage: Option<&dyn Storage>) -> Self {
+    fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
         let value_buffer =
             nao.subscribe_output(CyclerOutput::from_str("vision_top.main.image_segments").unwrap());
         Self {

--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -39,7 +39,7 @@ pub struct ImageSegmentsPanel {
 impl Panel for ImageSegmentsPanel {
     const NAME: &'static str = "Image Segments";
 
-    fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
+    fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         let value_buffer =
             nao.subscribe_output(CyclerOutput::from_str("vision_top.main.image_segments").unwrap());
         Self {

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -71,18 +71,16 @@ impl Panel for MapPanel {
 
 impl Widget for &mut MapPanel {
     fn ui(self, ui: &mut Ui) -> eframe::egui::Response {
-        ComboBox::from_id_source("Layers")
-            .selected_text("Layers")
-            .show_ui(ui, |ui: &mut Ui| {
-                self.field.checkbox(ui);
-                self.image_segments.checkbox(ui);
-                self.robot_pose.checkbox(ui);
-                self.ball_position.checkbox(ui);
-                self.obstacles.checkbox(ui);
-                self.path_obstacles.checkbox(ui);
-                self.path.checkbox(ui);
-                self.kick_decisions.checkbox(ui);
-            });
+        ui.menu_button("Overlays", |ui| {
+            self.field.checkbox(ui);
+            self.image_segments.checkbox(ui);
+            self.robot_pose.checkbox(ui);
+            self.ball_position.checkbox(ui);
+            self.obstacles.checkbox(ui);
+            self.path_obstacles.checkbox(ui);
+            self.path.checkbox(ui);
+            self.kick_decisions.checkbox(ui);
+        });
 
         let field_dimensions: FieldDimensions = match self.field_dimensions.get_latest() {
             Ok(value) => from_value(value).unwrap(),

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -5,7 +5,7 @@ use eframe::{
     Storage,
 };
 use nalgebra::{vector, Similarity2, Translation2};
-use serde_json::from_value;
+use serde_json::{from_value, json, Value};
 use types::{self, FieldDimensions};
 
 use crate::{nao::Nao, panel::Panel, twix_painter::TwixPainter, value_buffer::ValueBuffer};
@@ -31,15 +31,15 @@ pub struct MapPanel {
 impl Panel for MapPanel {
     const NAME: &'static str = "Map";
 
-    fn new(nao: Arc<Nao>, storage: Option<&dyn Storage>) -> Self {
-        let field = EnabledLayer::new(nao.clone(), storage, true);
-        let image_segments = EnabledLayer::new(nao.clone(), storage, false);
-        let robot_pose = EnabledLayer::new(nao.clone(), storage, true);
-        let ball_position = EnabledLayer::new(nao.clone(), storage, false);
-        let obstacles = EnabledLayer::new(nao.clone(), storage, false);
-        let path_obstacles = EnabledLayer::new(nao.clone(), storage, false);
-        let path = EnabledLayer::new(nao.clone(), storage, false);
-        let kick_decisions = EnabledLayer::new(nao.clone(), storage, false);
+    fn new(nao: Arc<Nao>, storage: Option<&Value>) -> Self {
+        let field = EnabledLayer::new(nao.clone(), None, true);
+        let image_segments = EnabledLayer::new(nao.clone(), None, false);
+        let robot_pose = EnabledLayer::new(nao.clone(), None, true);
+        let ball_position = EnabledLayer::new(nao.clone(), None, false);
+        let obstacles = EnabledLayer::new(nao.clone(), None, false);
+        let path_obstacles = EnabledLayer::new(nao.clone(), None, false);
+        let path = EnabledLayer::new(nao.clone(), None, false);
+        let kick_decisions = EnabledLayer::new(nao.clone(), None, false);
 
         let field_dimensions = nao.subscribe_parameter("field_dimensions");
         let transformation = Similarity2::identity();
@@ -57,15 +57,18 @@ impl Panel for MapPanel {
         }
     }
 
-    fn save(&mut self, storage: &mut dyn Storage) {
-        self.field.save(storage);
-        self.image_segments.save(storage);
-        self.robot_pose.save(storage);
-        self.ball_position.save(storage);
-        self.obstacles.save(storage);
-        self.path_obstacles.save(storage);
-        self.path.save(storage);
-        self.kick_decisions.save(storage);
+    fn save(&self) -> Value {
+        todo!();
+        json!({
+            // "field": self.field.save(),
+            // "image_segments": self.image_segments.save(),
+            // "robot_pose": self.robot_pose.save(),
+            // "ball_position": self.ball_position.save(),
+            // "obstacles": self.obstacles.save(),
+            // "path_obstacles": self.path_obstacles.save(),
+            // "path": self.path.save(),
+            // "kick_decisions": self.kick_decisions.save(),
+        })
     }
 }
 

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use eframe::{
-    egui::{ComboBox, Ui, Widget},
+    egui::{Ui, Widget},
     Storage,
 };
 use nalgebra::{vector, Similarity2, Translation2};

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use eframe::{
-    egui::{Ui, Widget},
-    Storage,
-};
+use eframe::egui::{Ui, Widget};
 use nalgebra::{vector, Similarity2, Translation2};
 use serde_json::{from_value, json, Value};
 use types::{self, FieldDimensions};
@@ -31,15 +28,15 @@ pub struct MapPanel {
 impl Panel for MapPanel {
     const NAME: &'static str = "Map";
 
-    fn new(nao: Arc<Nao>, storage: Option<&Value>) -> Self {
-        let field = EnabledLayer::new(nao.clone(), None, true);
-        let image_segments = EnabledLayer::new(nao.clone(), None, false);
-        let robot_pose = EnabledLayer::new(nao.clone(), None, true);
-        let ball_position = EnabledLayer::new(nao.clone(), None, false);
-        let obstacles = EnabledLayer::new(nao.clone(), None, false);
-        let path_obstacles = EnabledLayer::new(nao.clone(), None, false);
-        let path = EnabledLayer::new(nao.clone(), None, false);
-        let kick_decisions = EnabledLayer::new(nao.clone(), None, false);
+    fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
+        let field = EnabledLayer::new(nao.clone(), value, true);
+        let image_segments = EnabledLayer::new(nao.clone(), value, false);
+        let robot_pose = EnabledLayer::new(nao.clone(), value, true);
+        let ball_position = EnabledLayer::new(nao.clone(), value, false);
+        let obstacles = EnabledLayer::new(nao.clone(), value, false);
+        let path_obstacles = EnabledLayer::new(nao.clone(), value, false);
+        let path = EnabledLayer::new(nao.clone(), value, false);
+        let kick_decisions = EnabledLayer::new(nao.clone(), value, false);
 
         let field_dimensions = nao.subscribe_parameter("field_dimensions");
         let transformation = Similarity2::identity();
@@ -58,16 +55,15 @@ impl Panel for MapPanel {
     }
 
     fn save(&self) -> Value {
-        todo!();
         json!({
-            // "field": self.field.save(),
-            // "image_segments": self.image_segments.save(),
-            // "robot_pose": self.robot_pose.save(),
-            // "ball_position": self.ball_position.save(),
-            // "obstacles": self.obstacles.save(),
-            // "path_obstacles": self.path_obstacles.save(),
-            // "path": self.path.save(),
-            // "kick_decisions": self.kick_decisions.save(),
+            "field": self.field.save(),
+            "image_segments": self.image_segments.save(),
+            "robot_pose": self.robot_pose.save(),
+            "ball_position": self.ball_position.save(),
+            "obstacles": self.obstacles.save(),
+            "path_obstacles": self.path_obstacles.save(),
+            "path": self.path.save(),
+            "kick_decisions": self.kick_decisions.save(),
         })
     }
 }

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use eframe::{
-    egui::{Response, ScrollArea, TextEdit, Ui, Widget},
-    Storage,
-};
+use eframe::egui::{Response, ScrollArea, TextEdit, Ui, Widget};
 use log::error;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
@@ -22,22 +19,8 @@ pub struct ParameterPanel {
 impl Panel for ParameterPanel {
     const NAME: &'static str = "Parameter";
 
-    fn new(nao: Arc<Nao>, _storage: Option<&dyn Storage>) -> Self {
-        let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
-        Self {
-            nao,
-            path: String::new(),
-            value_buffer: None,
-            parameter_value: String::new(),
-            update_notify_sender,
-            update_notify_receiver,
-        }
-    }
-}
-
-impl ParameterPanel {
-    pub fn new2(nao: Arc<Nao>, value: &Value) -> Self {
-        let path = match value.get("subscribe_key") {
+    fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
+        let path = match value.and_then(|value| value.get("subscribe_key")) {
             Some(Value::String(string)) => string.clone(),
             _ => String::new(),
         };
@@ -51,7 +34,7 @@ impl ParameterPanel {
             update_notify_receiver,
         }
     }
-    pub fn save2(&self) -> Value {
+    fn save(&self) -> Value {
         json!({
             "subscribe_key": self.path.clone()
         })

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -5,6 +5,7 @@ use eframe::{
     Storage,
 };
 use log::error;
+use serde_json::{json, Value};
 use tokio::sync::mpsc;
 
 use crate::{completion_edit::CompletionEdit, nao::Nao, panel::Panel, value_buffer::ValueBuffer};
@@ -31,6 +32,29 @@ impl Panel for ParameterPanel {
             update_notify_sender,
             update_notify_receiver,
         }
+    }
+}
+
+impl ParameterPanel {
+    pub fn new2(nao: Arc<Nao>, value: &Value) -> Self {
+        let path = match value.get("subscribe_key") {
+            Some(Value::String(string)) => string.clone(),
+            _ => String::new(),
+        };
+        let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+        Self {
+            nao,
+            path,
+            value_buffer: None,
+            parameter_value: String::new(),
+            update_notify_sender,
+            update_notify_receiver,
+        }
+    }
+    pub fn save2(&self) -> Value {
+        json!({
+            "subscribe_key": self.path.clone()
+        })
     }
 }
 

--- a/tools/twix/src/panels/plot.rs
+++ b/tools/twix/src/panels/plot.rs
@@ -8,11 +8,11 @@ use eframe::{
         DragValue, Response, Widget,
     },
     epaint::Color32,
-    Storage,
 };
 use log::{error, info};
 
 use communication::CyclerOutput;
+use serde_json::Value;
 
 use crate::{completion_edit::CompletionEdit, nao::Nao, panel::Panel, value_buffer::ValueBuffer};
 
@@ -41,7 +41,7 @@ pub struct PlotPanel {
 impl Panel for PlotPanel {
     const NAME: &'static str = "Plot";
 
-    fn new(nao: Arc<Nao>, _storage: Option<&dyn Storage>) -> Self {
+    fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         Self {
             nao,
             line_datas: Vec::new(),

--- a/tools/twix/src/panels/text.rs
+++ b/tools/twix/src/panels/text.rs
@@ -1,10 +1,7 @@
 use std::{str::FromStr, sync::Arc};
 
 use communication::CyclerOutput;
-use eframe::{
-    egui::{ScrollArea, Widget},
-    Storage,
-};
+use eframe::egui::{ScrollArea, Widget};
 use log::error;
 use serde_json::{json, Value};
 
@@ -19,37 +16,8 @@ pub struct TextPanel {
 impl Panel for TextPanel {
     const NAME: &'static str = "Text";
 
-    fn new(nao: Arc<Nao>, storage: Option<&dyn Storage>) -> Self {
-        let output = match storage.and_then(|storage| storage.get_string("text_panel_output")) {
-            Some(stored_output) => stored_output,
-            None => String::new(),
-        };
-        let values = if !output.is_empty() {
-            let output = CyclerOutput::from_str(&output);
-            match output {
-                Ok(output) => Some(nao.subscribe_output(output)),
-                Err(error) => {
-                    error!("Failed to subscribe: {error:?}");
-                    None
-                }
-            }
-        } else {
-            None
-        };
-        Self {
-            nao,
-            output,
-            values,
-        }
-    }
-
-    fn save(&mut self, storage: &mut dyn Storage) {
-        storage.set_string("text_panel_output", self.output.clone());
-    }
-}
-impl TextPanel {
-    pub fn new2(nao: Arc<Nao>, value: &Value) -> Self {
-        let output = match value.get("subscribe_key") {
+    fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
+        let output = match value.and_then(|value| value.get("subscribe_key")) {
             Some(Value::String(string)) => string.to_string(),
             _ => String::new(),
         };
@@ -72,7 +40,7 @@ impl TextPanel {
         }
     }
 
-    pub fn save2(&self) -> Value {
+    fn save(&self) -> Value {
         json!({
             "subscribe_key": self.output.clone()
         })

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -455,3 +455,7 @@ fn sort_rect(rect: Rect) -> Rect {
         },
     }
 }
+
+pub fn to_444(point: Point2<f32>) -> Point2<f32> {
+    point![point.x * 2.0, point.y]
+}


### PR DESCRIPTION
Merged version of multiple separate PRs because some of them depend on each other and having to chain rebases is a pain.
Also, no one was going to review five different PRs where some of the code was already deprecated.

## Introduced Changes

- Dockable panels using [egui_dock](https://crates.io/crates/egui_dock)
- Ball detection overlay
- Popups don't close on the first interaction anymore
- Better connection status indication

## ToDo / Known Issues

- [ ] Program crashes when closing the last tab


## Ideas for Next Iterations (Not This PR)

- Add more keybindings for navigating and manipulating the panel tree.

## How to Test

- Docking
  - Spawn new tabs by clicking the little `+` icon or pressing `Ctrl`+`t`.
  - Tabs can be dragged around to rearrange them, convert them into panels and back.
  - Changing panel type (Text, Map, Image, etc.) should (only) change the active tab.
- Ball detection overlay
  - Open an image panel and enable it in the overlays menu.
  - Should work the same as in flora
- Popups don't close on the first interaction anymore
  - pretty self explanatory
  - less annoying now when toggling more than one map layer
  - perhaps more annoying when just toggling one as you need one extra click
- Status indication
  - The label next to the "connection intent" checkbox now changes both text and color depending on the connection state.
  - White: No connection intent
  - Yellow: Connecting
  - Green: Connected
  - Red: Failed to connect