### PR TITLE
Twix Remote Control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "gilrs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0342acdc7b591d171212e17c9350ca02383b86d5f9af33c6e3598e03a6c57e"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4e9fae0d270709ce2c8aacb34f2b7293d4828ce748360ec364ccb7c1585e53"
+dependencies = [
+ "core-foundation",
+ "io-kit-sys",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.25.1",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.43.0",
+]
+
+[[package]]
 name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2580,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7789f7f3c9686f96164f5109d69152de759e76e284f736bd57661c6df5091919"
+dependencies = [
+ "core-foundation-sys",
+ "mach",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2763,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,6 +2819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4660,6 +4722,7 @@ dependencies = [
  "egui_extras",
  "fern",
  "fuzzy-matcher",
+ "gilrs",
  "image",
  "itertools",
  "log",
@@ -5135,6 +5198,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ filtering = { path = "crates/filtering" }
 framework = { path = "crates/framework" }
 futures-util = "0.3.24"
 fuzzy-matcher = "0.3.7"
+gilrs = "0.10.1"
 glob = "0.3.0"
 hardware = { path = "crates/hardware" }
 home = "0.5.4"

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -15,6 +15,7 @@ egui_dock = { workspace = true }
 egui_extras = { workspace = true }
 fern = { workspace = true }
 fuzzy-matcher = { workspace = true }
+gilrs = { workspace = true }
 image = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -27,7 +27,7 @@ use nao::Nao;
 use panel::Panel;
 use panels::{
     BehaviorSimulatorPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel, ManualCalibrationPanel,
-    MapPanel, ParameterPanel, PlotPanel, SegmenterCalibrationPanel, RemotePanel, TextPanel,
+    MapPanel, ParameterPanel, PlotPanel, RemotePanel, SegmenterCalibrationPanel, TextPanel,
 };
 use serde_json::{from_str, to_string, Value};
 use tokio::sync::mpsc;

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -27,7 +27,7 @@ use nao::Nao;
 use panel::Panel;
 use panels::{
     BehaviorSimulatorPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel, ManualCalibrationPanel,
-    MapPanel, ParameterPanel, PlotPanel, SegmenterCalibrationPanel, TextPanel,
+    MapPanel, ParameterPanel, PlotPanel, SegmenterCalibrationPanel, RemotePanel, TextPanel,
 };
 use serde_json::{from_str, to_string, Value};
 use tokio::sync::mpsc;
@@ -82,6 +82,7 @@ enum SelectablePanel {
     ManualCalibration(ManualCalibrationPanel),
     LookAt(LookAtPanel),
     SegmenterCalibration(SegmenterCalibrationPanel),
+    Remote(RemotePanel),
 }
 
 impl SelectablePanel {
@@ -113,7 +114,7 @@ impl SelectablePanel {
             "segmenter calibration" => {
                 SelectablePanel::SegmenterCalibration(SegmenterCalibrationPanel::new(nao, value))
             }
-
+            "remote" => SelectablePanel::Remote(RemotePanel::new(nao, value)),
             name => bail!("unexpected panel name: {name}"),
         })
     }
@@ -130,6 +131,7 @@ impl SelectablePanel {
             SelectablePanel::ManualCalibration(panel) => panel.save(),
             SelectablePanel::LookAt(panel) => panel.save(),
             SelectablePanel::SegmenterCalibration(panel) => panel.save(),
+            SelectablePanel::Remote(panel) => panel.save(),
         };
         value["_panel_type"] = Value::String(self.to_string());
 
@@ -150,6 +152,7 @@ impl Widget for &mut SelectablePanel {
             SelectablePanel::ManualCalibration(panel) => panel.ui(ui),
             SelectablePanel::LookAt(panel) => panel.ui(ui),
             SelectablePanel::SegmenterCalibration(panel) => panel.ui(ui),
+            SelectablePanel::Remote(panel) => panel.ui(ui),
         }
     }
 }
@@ -167,6 +170,7 @@ impl Display for SelectablePanel {
             SelectablePanel::ManualCalibration(_) => ManualCalibrationPanel::NAME,
             SelectablePanel::LookAt(_) => LookAtPanel::NAME,
             SelectablePanel::SegmenterCalibration(_) => SegmenterCalibrationPanel::NAME,
+            SelectablePanel::Remote(_) => RemotePanel::NAME,
         };
         f.write_str(panel_name)
     }
@@ -307,6 +311,7 @@ impl App for TwixApp {
                             "Manual Calibration".to_string(),
                             "Look At".to_string(),
                             "Segmenter Calibration".to_string(),
+                            "Remote".to_string(),
                         ],
                         "Panel",
                     )

--- a/tools/twix/src/panels/mod.rs
+++ b/tools/twix/src/panels/mod.rs
@@ -6,6 +6,7 @@ mod manual_camera_calibration;
 mod map;
 mod parameter;
 mod plot;
+mod remote;
 mod segmenter_calibration;
 mod text;
 
@@ -17,5 +18,6 @@ pub use manual_camera_calibration::ManualCalibrationPanel;
 pub use map::MapPanel;
 pub use parameter::ParameterPanel;
 pub use plot::PlotPanel;
+pub use remote::RemotePanel;
 pub use segmenter_calibration::SegmenterCalibrationPanel;
 pub use text::TextPanel;

--- a/tools/twix/src/panels/remote.rs
+++ b/tools/twix/src/panels/remote.rs
@@ -42,7 +42,7 @@ fn get_axis_value(gamepad: Gamepad, axis: Axis) -> Option<f32> {
 impl RemotePanel {
     fn update_step(&self, step: Value) {
         self.nao
-            .update_parameter_value("control.step_planner.injected_step", step);
+            .update_parameter_value("step_planner.injected_step", step);
     }
 }
 

--- a/tools/twix/src/panels/remote.rs
+++ b/tools/twix/src/panels/remote.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use eframe::egui::Widget;
+use gilrs::{Axis, Event, GamepadId, Gilrs};
+use serde_json::{json, Value};
+use types::Step;
+
+use crate::{nao::Nao, panel::Panel};
+
+pub struct RemotePanel {
+    nao: Arc<Nao>,
+    gilrs: Gilrs,
+    active_gamepad: Option<GamepadId>,
+}
+
+impl Panel for RemotePanel {
+    const NAME: &'static str = "Remote";
+
+    fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
+        let gilrs = Gilrs::new().unwrap();
+        let active_gamepad = None;
+
+        Self {
+            nao,
+            gilrs,
+            active_gamepad,
+        }
+    }
+
+    fn save(&self) -> Value {
+        json!({})
+    }
+}
+
+impl Widget for &mut RemotePanel {
+    fn ui(self, ui: &mut eframe::egui::Ui) -> eframe::egui::Response {
+        while let Some(Event { id, .. }) = self.gilrs.next_event() {
+            self.active_gamepad = Some(id);
+        }
+
+        if let Some(gamepad) = self.active_gamepad.map(|id| self.gilrs.gamepad(id)) {
+            let left = match gamepad.axis_data(Axis::LeftStickX) {
+                Some(data) => -data.value(), // inverted because left is negative on the joystick
+                _ => 0.0,
+            };
+            let forward = match gamepad.axis_data(Axis::LeftStickY) {
+                Some(data) => data.value(),
+                _ => 0.0,
+            };
+            let turn = match gamepad.axis_data(Axis::RightStickX) {
+                Some(data) => data.value(),
+                _ => 0.0,
+            };
+
+            let step = Step {
+                forward,
+                left,
+                turn,
+            };
+
+            self.nao.update_parameter_value(
+                "control.step_planner.injected_step",
+                serde_json::to_value(step).unwrap(),
+            );
+            ui.label(&format!("{:#?}", step))
+        } else {
+            ui.label("No controller found")
+        }
+    }
+}

--- a/tools/twix/src/panels/remote.rs
+++ b/tools/twix/src/panels/remote.rs
@@ -32,6 +32,10 @@ impl Panel for RemotePanel {
     }
 }
 
+fn get_axis_value(gamepad: Gamepad, axis: Axis) -> Option<f32> {
+    Some(gamepad.axis_data(axis)?.value())
+}
+
 impl Widget for &mut RemotePanel {
     fn ui(self, ui: &mut eframe::egui::Ui) -> eframe::egui::Response {
         while let Some(Event { id, .. }) = self.gilrs.next_event() {
@@ -39,18 +43,9 @@ impl Widget for &mut RemotePanel {
         }
 
         if let Some(gamepad) = self.active_gamepad.map(|id| self.gilrs.gamepad(id)) {
-            let left = match gamepad.axis_data(Axis::LeftStickX) {
-                Some(data) => -data.value(), // inverted because left is negative on the joystick
-                _ => 0.0,
-            };
-            let forward = match gamepad.axis_data(Axis::LeftStickY) {
-                Some(data) => data.value(),
-                _ => 0.0,
-            };
-            let turn = match gamepad.axis_data(Axis::RightStickX) {
-                Some(data) => data.value(),
-                _ => 0.0,
-            };
+            let left = get_axis_value(gamepad, Axis::LeftStickX).unwrap_or(0.0);
+            let forward = get_axis_value(gamepad, Axis::LeftStickY).unwrap_or(0.0);
+            let turn = get_axis_value(gamepad, Axis::RightStickX).unwrap_or(0.0);
 
             let step = Step {
                 forward,

--- a/tools/twix/src/panels/remote.rs
+++ b/tools/twix/src/panels/remote.rs
@@ -43,9 +43,12 @@ impl Widget for &mut RemotePanel {
         }
 
         if let Some(gamepad) = self.active_gamepad.map(|id| self.gilrs.gamepad(id)) {
-            let left = get_axis_value(gamepad, Axis::LeftStickX).unwrap_or(0.0);
+            let right = get_axis_value(gamepad, Axis::LeftStickX).unwrap_or(0.0);
             let forward = get_axis_value(gamepad, Axis::LeftStickY).unwrap_or(0.0);
-            let turn = get_axis_value(gamepad, Axis::RightStickX).unwrap_or(0.0);
+            let turn_right = get_axis_value(gamepad, Axis::RightStickX).unwrap_or(0.0);
+
+            let left = -right;
+            let turn = -turn_right;
 
             let step = Step {
                 forward,

--- a/tools/twix/src/panels/remote.rs
+++ b/tools/twix/src/panels/remote.rs
@@ -18,7 +18,7 @@ impl Panel for RemotePanel {
     const NAME: &'static str = "Remote";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
-        let gilrs = Gilrs::new().unwrap();
+        let gilrs = Gilrs::new().expect("could not initialize gamepad library");
         let active_gamepad = None;
         let enabled = false;
 


### PR DESCRIPTION
## Introduced Changes

Allows twix to act as a remote control for the robot. Currently only supports walking, no kicks.
Tested with my steamdeck but should™ work with any controller.

Based on: #22 

## ToDo / Known Issues

- [x] [Install libudev in CI runners](https://github.com/HULKs/hulk/actions/runs/3615021255/jobs/6091848765)

## Ideas for Next Iterations (Not This PR)

- Add kick support
- Visualization of next step in twix
- Only update parameter when axis value changes
- Add support for controlling with keyboard (WASD, arrowkeys, etc.)

## How to Test

- Connect gamepad to computer
- Start twix and open "Remote" panel
- Connect to nao
- Press the start button on the controller or check the "enabled" checkbox
- Move left/right stick to make the robot walk/turn in that direction.