### PR TITLE
Pepsi 2.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,7 +2287,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "clap 4.0.22",

--- a/src/framework/communication/configuration_directory.rs
+++ b/src/framework/communication/configuration_directory.rs
@@ -15,7 +15,7 @@ pub fn deserialize<P: AsRef<Path>>(root_path: P, ids: HardwareIds) -> anyhow::Re
     let location_directory = if webots_id_found {
         "webots_location"
     } else if behavior_simulator_id_found {
-        "behavior_simulator"
+        "behavior_simulator_location"
     } else {
         "nao_location"
     };

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "GPL-3.0-only"
 name = "pepsi"
-version = "2.4.0"
+version = "2.4.1"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/tools/pepsi/src/location.rs
+++ b/tools/pepsi/src/location.rs
@@ -46,7 +46,7 @@ pub async fn location(arguments: Arguments, repository: &Repository) -> anyhow::
                 .context("Failed to get configured locations")?
             {
                 println!(
-                    "- {target:20}{}",
+                    "- {target:30}{}",
                     location.unwrap_or_else(|| "<NOT_CONFIGURED>".to_string())
                 );
             }

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -57,7 +57,7 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> anyhow::
         .collect();
 
     repository
-        .set_location("nao_location", &arguments.location)
+        .set_location("nao", &arguments.location)
         .await
         .with_context(|| anyhow!("Failed setting location for nao to {}", arguments.location))?;
 


### PR DESCRIPTION
## Introduced Changes

- Fix location subcommand failing to remove symlink if not previously configured
- All location symlinks now adhere to the TARGET_location naming
- Increment pepsi version to make numbers grow

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Use the location subcommand to set etc. locations.