### PR TITLE
Fixed webots collision rotations

### DIFF
--- a/webots/protos/NAO.proto
+++ b/webots/protos/NAO.proto
@@ -410,7 +410,7 @@ PROTO NAO [
                       children [
                         Transform {
                           translation 0.000000 0.000000 0.000000
-                          rotation 1.000000 0.000000 0.000000 1.570796
+                          rotation 1.000000 0.000000 0.000000 0.000000
                           children [
                             Cylinder {
                               radius 0.035
@@ -1111,7 +1111,7 @@ PROTO NAO [
                                 name "LElbowRollBothCollision_shape"
                                 boundingObject Transform {
                                   translation 0.000000 0.000000 0.000000
-                                  rotation 1.000000 0.000000 0.000000 1.570796
+                                  rotation 1.000000 0.000000 0.000000 0.000000
                                   children [
                                     Cylinder {
                                       radius 0.028
@@ -3081,7 +3081,7 @@ PROTO NAO [
                                 name "RElbowRollBothCollision_shape"
                                 boundingObject Transform {
                                   translation 0.000000 0.000000 0.000000
-                                  rotation 1.000000 0.000000 0.000000 1.570796
+                                  rotation 1.000000 0.000000 0.000000 0.000000
                                   children [
                                     Cylinder {
                                       radius 0.028

--- a/webots/protos/NAO.proto
+++ b/webots/protos/NAO.proto
@@ -1114,8 +1114,8 @@ PROTO NAO [
                                   rotation 1.000000 0.000000 0.000000 0.000000
                                   children [
                                     Cylinder {
-                                      radius 0.028
-                                      height 0.150
+                                      radius 0.025
+                                      height 0.133
                                     }
                                   ]
                                 }
@@ -1615,13 +1615,33 @@ PROTO NAO [
                                           Solid {
                                             translation -0.030000 -0.002500 0.082500
                                             rotation 0.000001 -0.707108 -0.707105 3.141591
-                                            name "LAnkleRollBothCollision_shape"
+                                            name "LAnkleRollBothCollision_shape_front"
                                             boundingObject Transform {
-                                              translation -0.003000 -0.060000 -0.005000
-                                              rotation 0.000000 1.000000 0.000000 0.000000
+                                              translation -0.003000 -0.0212500 -0.005000
+                                              rotation 0.000000 1.000000 0.000000 1.572728
                                               children [
-                                                Box {
-                                                   size 0.030000 0.155000 0.090000
+                                                Cylinder {
+                                                  radius 0.03875
+                                                  height 0.03
+                                                }
+                                              ]
+                                            }
+                                            physics Physics {
+                                              density -1
+                                              mass 0.001
+                                            }
+                                          }
+                                          Solid {
+                                            translation -0.030000 -0.002500 0.082500
+                                            rotation 0.000001 -0.707108 -0.707105 3.141591
+                                            name "LAnkleRollBothCollision_shape_rear"
+                                            boundingObject Transform {
+                                              translation -0.003000 -0.100000 -0.005000
+                                              rotation 0.000000 1.000000 0.000000 1.572728
+                                              children [
+                                                Cylinder {
+                                                  radius 0.03875
+                                                  height 0.03
                                                 }
                                               ]
                                             }
@@ -2276,19 +2296,35 @@ PROTO NAO [
                                           Solid {
                                             translation -0.030000 0.002500 0.082500
                                             rotation 0.000001 -0.707108 -0.707105 3.141591
-                                            name "RAnkleRollBothCollision_shape"
+                                            name "RAnkleRollBothCollision_shape_front"
                                             boundingObject Transform {
-                                              translation -0.003000 -0.060000 0.005000
-                                              rotation 0.000000 1.000000 0.000000 0.000000
+                                              translation -0.003000 -0.0212500 0.005000
+                                              rotation 0.000000 1.000000 0.000000 1.572728
                                               children [
-                                                Box {
-                                                   size 0.030000 0.155000 0.090000
+                                                Cylinder {
+                                                  radius 0.03875
+                                                  height 0.03
                                                 }
                                               ]
                                             }
                                             physics Physics {
                                               density -1
                                               mass 0.001
+                                            }
+                                          }
+                                          Solid {
+                                            translation -0.030000 0.002500 0.082500
+                                            rotation 0.000001 -0.707108 -0.707105 3.141591
+                                            name "RAnkleRollBothCollision_shape_rear"
+                                            boundingObject Transform {
+                                              translation -0.003000 -0.100000 0.005000
+                                              rotation 0.000000 1.000000 0.000000 1.572728
+                                              children [
+                                                Cylinder {
+                                                  radius 0.03875
+                                                  height 0.03
+                                                }
+                                              ]
                                             }
                                           }
                                           Solid {
@@ -3084,8 +3120,8 @@ PROTO NAO [
                                   rotation 1.000000 0.000000 0.000000 0.000000
                                   children [
                                     Cylinder {
-                                      radius 0.028
-                                      height 0.150
+                                      radius 0.025
+                                      height 0.133
                                     }
                                   ]
                                 }


### PR DESCRIPTION
## Introduced Changes

Fixed rotation of arm and head collision cylinders. Changed foot collision mesh to dual cylinders to improve standup front/back.


## Ideas for Next Iterations (Not This PR)

Further improvements on collision meshes to come.
