### PR TITLE
implement `SerializeHierarchy` for `VectorN<T>`

### DIFF
--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -284,7 +284,7 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
     fn deserialize_path<S>(
         &mut self,
         path: &str,
-        _data: S::Serialized,
+        data: S::Serialized,
     ) -> Result<(), Error<S::Error>>
     where
         S: Serializer,
@@ -295,7 +295,7 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
             .position(|name| name == &path);
         match index {
             Some(index) => {
-                let deserialized = S::deserialize(_data).map_err(Error::DeserializationFailed)?;
+                let deserialized = S::deserialize(data).map_err(Error::DeserializationFailed)?;
                 self[index] = deserialized;
                 Ok(())
             }
@@ -331,43 +331,13 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar, const N: usize> Serialize
     fn deserialize_path<S>(
         &mut self,
         path: &str,
-        _data: S::Serialized,
+        data: S::Serialized,
     ) -> Result<(), Error<S::Error>>
     where
         S: Serializer,
         S::Error: error::Error,
     {
-        self.coords.deserialize_path::<S>(path, _data)
-    }
-
-    fn exists(path: &str) -> bool {
-        Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::exists(path)
-    }
-
-    fn get_fields() -> BTreeSet<String> {
-        Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::get_fields()
-    }
-}
-
-impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point2<T> {
-    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
-    where
-        S: Serializer,
-        S::Error: error::Error,
-    {
-        self.coords.serialize_path::<S>(path)
-    }
-
-    fn deserialize_path<S>(
-        &mut self,
-        path: &str,
-        _data: S::Serialized,
-    ) -> Result<(), Error<S::Error>>
-    where
-        S: Serializer,
-        S::Error: error::Error,
-    {
-        self.coords.deserialize_path::<S>(path, _data)
+        self.coords.deserialize_path::<S>(path, data)
     }
 
     fn exists(path: &str) -> bool {

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -371,71 +371,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Po
     }
 
     fn exists(path: &str) -> bool {
-        Vector2::<T>::exists(path)
+        Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::exists(path)
     }
 
     fn get_fields() -> BTreeSet<String> {
-        Vector2::<T>::get_fields()
-    }
-}
-
-impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point3<T> {
-    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
-    where
-        S: Serializer,
-        S::Error: error::Error,
-    {
-        self.coords.serialize_path::<S>(path)
-    }
-
-    fn deserialize_path<S>(
-        &mut self,
-        path: &str,
-        _data: S::Serialized,
-    ) -> Result<(), Error<S::Error>>
-    where
-        S: Serializer,
-        S::Error: error::Error,
-    {
-        self.coords.deserialize_path::<S>(path, _data)
-    }
-
-    fn exists(path: &str) -> bool {
-        Vector3::<T>::exists(path)
-    }
-
-    fn get_fields() -> BTreeSet<String> {
-        Vector3::<T>::get_fields()
-    }
-}
-
-impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point4<T> {
-    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
-    where
-        S: Serializer,
-        S::Error: error::Error,
-    {
-        self.coords.serialize_path::<S>(path)
-    }
-
-    fn deserialize_path<S>(
-        &mut self,
-        path: &str,
-        _data: S::Serialized,
-    ) -> Result<(), Error<S::Error>>
-    where
-        S: Serializer,
-        S::Error: error::Error,
-    {
-        self.coords.deserialize_path::<S>(path, _data)
-    }
-
-    fn exists(path: &str) -> bool {
-        Vector4::<T>::exists(path)
-    }
-
-    fn get_fields() -> BTreeSet<String> {
-        Vector4::<T>::get_fields()
+        Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::get_fields()
     }
 }
 

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -349,6 +349,96 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar, const N: usize> Serialize
     }
 }
 
+impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point2<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.serialize_path::<S>(path)
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.deserialize_path::<S>(path, _data)
+    }
+
+    fn exists(path: &str) -> bool {
+        Vector2::<T>::exists(path)
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        Vector2::<T>::get_fields()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point3<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.serialize_path::<S>(path)
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.deserialize_path::<S>(path, _data)
+    }
+
+    fn exists(path: &str) -> bool {
+        Vector3::<T>::exists(path)
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        Vector3::<T>::get_fields()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point4<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.serialize_path::<S>(path)
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.deserialize_path::<S>(path, _data)
+    }
+
+    fn exists(path: &str) -> bool {
+        Vector4::<T>::exists(path)
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        Vector4::<T>::get_fields()
+    }
+}
+
 macro_rules! serialize_hierarchy_primary_impl {
     ($type:ty) => {
         impl SerializeHierarchy for $type {

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -262,6 +262,144 @@ impl<T> SerializeHierarchy for Vec<T> {
     }
 }
 
+impl<T: Serialize + DeserializeOwned> SerializeHierarchy for Vector2<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        let idx = ["x", "y"].into_iter().position(|x| x == path);
+        match idx {
+            Some(i) => S::serialize(&self[i]).map_err(Error::SerializationFailed),
+            _ => Err(Error::UnexpectedPathSegment {
+                segment: String::from(path),
+            }),
+        }
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        let idx = ["x", "y"].into_iter().position(|x| x == path);
+        match idx {
+            Some(i) => {
+                let deserialized = S::deserialize(_data).map_err(Error::DeserializationFailed)?;
+                self[i] = deserialized;
+                Ok(())
+            }
+            None => Err(Error::UnexpectedPathSegment {
+                segment: String::from(path),
+            }),
+        }
+    }
+
+    fn exists(_path: &str) -> bool {
+        matches!(_path, "x" | "y")
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        ["x", "y"].into_iter().map(String::from).collect()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> SerializeHierarchy for Vector3<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        let idx = ["x", "y", "z"].into_iter().position(|x| x == path);
+        match idx {
+            Some(i) => S::serialize(&self[i]).map_err(Error::SerializationFailed),
+            _ => Err(Error::UnexpectedPathSegment {
+                segment: String::from(path),
+            }),
+        }
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        let idx = ["x", "y", "z"].into_iter().position(|x| x == path);
+        match idx {
+            Some(i) => {
+                let deserialized = S::deserialize(_data).map_err(Error::DeserializationFailed)?;
+                self[i] = deserialized;
+                Ok(())
+            }
+            None => Err(Error::UnexpectedPathSegment {
+                segment: String::from(path),
+            }),
+        }
+    }
+
+    fn exists(_path: &str) -> bool {
+        matches!(_path, "x" | "y" | "z")
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        ["x", "y", "z"].into_iter().map(String::from).collect()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> SerializeHierarchy for Vector4<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        let idx = ["x", "y", "z", "w"].into_iter().position(|x| x == path);
+        match idx {
+            Some(i) => S::serialize(&self[i]).map_err(Error::SerializationFailed),
+            _ => Err(Error::UnexpectedPathSegment {
+                segment: String::from(path),
+            }),
+        }
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        let idx = ["x", "y", "z", "w"].into_iter().position(|x| x == path);
+        match idx {
+            Some(i) => {
+                let deserialized = S::deserialize(_data).map_err(Error::DeserializationFailed)?;
+                self[i] = deserialized;
+                Ok(())
+            }
+            None => Err(Error::UnexpectedPathSegment {
+                segment: String::from(path),
+            }),
+        }
+    }
+
+    fn exists(_path: &str) -> bool {
+        matches!(_path, "x" | "y" | "z" | "w")
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        ["x", "y", "z", "w"].into_iter().map(String::from).collect()
+    }
+}
+
 macro_rules! serialize_hierarchy_primary_impl {
     ($type:ty) => {
         impl SerializeHierarchy for $type {
@@ -315,9 +453,6 @@ serialize_hierarchy_primary_impl!(usize);
 serialize_hierarchy_primary_impl!(Point2<f32>);
 serialize_hierarchy_primary_impl!(Point2<u16>);
 serialize_hierarchy_primary_impl!(Point3<f32>);
-serialize_hierarchy_primary_impl!(Vector2<f32>);
-serialize_hierarchy_primary_impl!(Vector3<f32>);
-serialize_hierarchy_primary_impl!(Vector4<f32>);
 serialize_hierarchy_primary_impl!(SMatrix<f32, 3, 3>);
 serialize_hierarchy_primary_impl!(Isometry2<f32>);
 serialize_hierarchy_primary_impl!(Isometry3<f32>);

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -10,8 +10,7 @@ use std::{
 pub use bincode;
 use bincode::{deserialize, serialize};
 use nalgebra::{
-    ArrayStorage, Const, Isometry2, Isometry3, Matrix, Point, SMatrix, Scalar, UnitComplex,
-    Vector2, U1,
+    ArrayStorage, Const, Isometry2, Isometry3, Matrix, Point, SMatrix, Scalar, UnitComplex, U1,
 };
 use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json;
@@ -272,7 +271,7 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
         S::Error: error::Error,
     {
         let index = ["x", "y", "z", "w", "v", "u"][0..N]
-            .into_iter()
+            .iter()
             .position(|name| name == &path);
         match index {
             Some(index) => S::serialize(&self[index]).map_err(Error::SerializationFailed),
@@ -292,7 +291,7 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
         S::Error: error::Error,
     {
         let index = ["x", "y", "z", "w", "v", "u"][0..N]
-            .into_iter()
+            .iter()
             .position(|name| name == &path);
         match index {
             Some(index) => {
@@ -312,7 +311,7 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
 
     fn get_fields() -> BTreeSet<String> {
         ["x", "y", "z", "w", "v", "u"][0..N]
-            .into_iter()
+            .iter()
             .map(|path| String::from(*path))
             .collect()
     }

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -10,7 +10,8 @@ use std::{
 pub use bincode;
 use bincode::{deserialize, serialize};
 use nalgebra::{
-    Isometry2, Isometry3, Point2, Point3, SMatrix, Scalar, UnitComplex, Vector2, Vector3, Vector4,
+    Isometry2, Isometry3, Point2, Point3, Point4, SMatrix, Scalar, UnitComplex, Vector2, Vector3,
+    Vector4,
 };
 use serde::{de::DeserializeOwned, Serialize};
 pub use serde_json;
@@ -457,6 +458,36 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Po
 
     fn get_fields() -> BTreeSet<String> {
         Vector3::<T>::get_fields()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Point4<T> {
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.serialize_path::<S>(path)
+    }
+
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        self.coords.deserialize_path::<S>(path, _data)
+    }
+
+    fn exists(path: &str) -> bool {
+        Vector4::<T>::exists(path)
+    }
+
+    fn get_fields() -> BTreeSet<String> {
+        Vector4::<T>::get_fields()
     }
 }
 

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -406,13 +406,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Po
         S: Serializer,
         S::Error: error::Error,
     {
-        let index = ["x", "y"].into_iter().position(|name| name == path);
-        match index {
-            Some(index) => S::serialize(&self[index]).map_err(Error::SerializationFailed),
-            _ => Err(Error::UnexpectedPathSegment {
-                segment: String::from(path),
-            }),
-        }
+        self.coords.serialize_path::<S>(path)
     }
 
     fn deserialize_path<S>(
@@ -424,25 +418,15 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Po
         S: Serializer,
         S::Error: error::Error,
     {
-        let index = ["x", "y"].into_iter().position(|name| name == path);
-        match index {
-            Some(index) => {
-                let deserialized = S::deserialize(_data).map_err(Error::DeserializationFailed)?;
-                self[index] = deserialized;
-                Ok(())
-            }
-            None => Err(Error::UnexpectedPathSegment {
-                segment: String::from(path),
-            }),
-        }
+        self.coords.deserialize_path::<S>(path, _data)
     }
 
     fn exists(path: &str) -> bool {
-        matches!(path, "x" | "y")
+        Vector2::<T>::exists(path)
     }
 
     fn get_fields() -> BTreeSet<String> {
-        ["x", "y"].into_iter().map(String::from).collect()
+        Vector2::<T>::get_fields()
     }
 }
 
@@ -452,13 +436,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Po
         S: Serializer,
         S::Error: error::Error,
     {
-        let index = ["x", "y", "z"].into_iter().position(|name| name == path);
-        match index {
-            Some(index) => S::serialize(&self[index]).map_err(Error::SerializationFailed),
-            _ => Err(Error::UnexpectedPathSegment {
-                segment: String::from(path),
-            }),
-        }
+        self.coords.serialize_path::<S>(path)
     }
 
     fn deserialize_path<S>(
@@ -470,25 +448,15 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar> SerializeHierarchy for Po
         S: Serializer,
         S::Error: error::Error,
     {
-        let index = ["x", "y", "z"].into_iter().position(|name| name == path);
-        match index {
-            Some(index) => {
-                let deserialized = S::deserialize(_data).map_err(Error::DeserializationFailed)?;
-                self[index] = deserialized;
-                Ok(())
-            }
-            None => Err(Error::UnexpectedPathSegment {
-                segment: String::from(path),
-            }),
-        }
+        self.coords.deserialize_path::<S>(path, _data)
     }
 
     fn exists(path: &str) -> bool {
-        matches!(path, "x" | "y" | "z")
+        Vector3::<T>::exists(path)
     }
 
     fn get_fields() -> BTreeSet<String> {
-        ["x", "y", "z"].into_iter().map(String::from).collect()
+        Vector3::<T>::get_fields()
     }
 }
 


### PR DESCRIPTION
Co-authored-by: okiwi6 <45100017+okiwi6@users.noreply.github.com>

## Introduced Changes

Implement `SerializeHierarchy` for `Vector2<T>`, `Vector3<T>`, `Vector4<T>` in order to serialze vectors into more specific paths (xy/xyz/xyzw).

## Fixes 

This enables for example plotting vector components in twix


## Further ideas

Also manually implement `SerializeHierarchy` for `Point`


