### PR TITLE
Handle missing HuLA socket file gracefully at startup

### DIFF
--- a/tools/hula/proxy/Cargo.toml
+++ b/tools/hula/proxy/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "GPL-3.0-only"
 name = "hula"
-version = "0.3.0"
+version = "0.3.1"
 homepage = "https://github.com/hulks/hulk"
 
 [dependencies]


### PR DESCRIPTION
## Introduced Changes

what it says

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

`. ~/.naosdk/5.2.0/envi[...]`
`cd tools/hula/`
`cargo build`
`scp` and `./hula`
