### PR TITLE
Announce node names via ittapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1031,7 @@ dependencies = [
  "communication",
  "control",
  "framework",
+ "ittapi",
  "quote",
  "serde",
  "serialize_hierarchy",
@@ -2102,6 +2109,26 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "ittapi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e648c437172ce7d3ac35ca11a068755072054826fa455a916b43524fa4a62a7"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b32a4d23f72548178dde54f3c12c6b6a08598e25575c0d0fa5bd861e0dc1a5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "jni"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ home = "0.5.4"
 i2cdev = "0.5.1"
 image = "0.24.4"
 itertools = "0.10.5"
+ittapi = "0.3.3"
 kinematics = { path = "crates/kinematics" }
 libc = "0.2.137"
 log = "0.4.17"

--- a/crates/code_generation/src/cycler.rs
+++ b/crates/code_generation/src/cycler.rs
@@ -524,6 +524,8 @@ impl Cycler<'_> {
             pub fn cycle(&mut self) -> color_eyre::Result<()> {
                 use color_eyre::eyre::WrapErr;
                 {
+                    let instance_name = format!("{:?}", self.instance);
+                    let itt_domain = ittapi::Domain::new(&instance_name);
                     #before_first_node
                     #first_node
                     #after_first_node

--- a/crates/code_generation/src/node.rs
+++ b/crates/code_generation/src/node.rs
@@ -421,13 +421,17 @@ impl Node<'_> {
             self.get_main_output_setters_from_cycle_result();
         let main_output_setters_from_default = self.get_main_output_setters_from_default();
         let error_message = format!("failed to execute cycle of node `{}`", self.node_name);
+        let node_name = self.node_name;
         let node_execution = quote! {
-            let main_outputs = self.#node_name_identifier_snake_case.cycle(
-                #cycler_module_name_identifier::#(#path_segments::)*CycleContext {
-                    #(#field_initializers,)*
-                },
-            )
-            .wrap_err(#error_message)?;
+            let main_outputs = {
+                let _task = ittapi::Task::begin(&itt_domain, #node_name);
+                self.#node_name_identifier_snake_case.cycle(
+                    #cycler_module_name_identifier::#(#path_segments::)*CycleContext {
+                        #(#field_initializers,)*
+                    },
+                )
+                .wrap_err(#error_message)?
+            };
             #(#main_output_setters_from_cycle_result)*
         };
 

--- a/crates/cyclers/Cargo.toml
+++ b/crates/cyclers/Cargo.toml
@@ -10,6 +10,7 @@ color-eyre = { workspace = true }
 control = { workspace = true }
 communication = { workspace = true }
 framework = { workspace = true }
+ittapi = { workspace = true }
 spl_network = { workspace = true }
 serde = { workspace = true }
 serialize_hierarchy = { workspace = true }


### PR DESCRIPTION
## Introduced Changes

uses `ittapi` to announce tasks for later use in intel vtune profiling.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

everyting should compile.
You can test this via vtune (proper how-to is planned)
