### PR TITLE
Create Profile with LTO, use it for pregame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ walkdir = "2.3.2"
 webots = { version = "0.6.0" }
 vision = { path = "crates/vision" }
 
+[profile.release-lto]
+inherits = "release"
+lto = true
+
 [profile.incremental]
 inherits = "release"
 incremental = true

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -16,7 +16,7 @@ use crate::{
 
 #[derive(Args)]
 pub struct Arguments {
-    #[arg(long, default_value = "release")]
+    #[arg(long, default_value = "release-lto")]
     pub profile: String,
     /// Do not update nor install SDK
     #[arg(long)]


### PR DESCRIPTION
## Introduced Changes

This PR creates an additional build profile `release-lto`.
This profile enables Link-Time-Optimization (LTO).

I did not do detailed benchmarks, but at least the binary size reduces drastically:

| profile       | size |
|---------------|----:|
| `incremental` |     15M  |
| `release`     | 13M  |
| `release-lto` | 9.3M |

Pepsi uses this profile by default for pregame scenarios.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

compile and upload (with or without `--profile release-lto`)