### PR TITLE
Dynamic pepsi completion using aliveness

### DIFF
--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -73,3 +73,12 @@ Example:
 ```
 
 Refer to your shell's completion documentation for details.
+
+The shells completions for fish, zsh and bash include dynamic suggestions for all pepsi subcommands taking a NAO address as an argument (e.g. `pepsi upload`).
+Those suggestions are retrieved using the aliveness service and require a version of pepsi to be installed in the `PATH`, e.g. by using
+
+```
+cargo install --path tools/pepsi
+```
+
+and adding `~/.cargo/bin` to the `PATH`.

--- a/tools/aliveness/Cargo.lock
+++ b/tools/aliveness/Cargo.lock
@@ -1241,7 +1241,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys",
 ]
 
@@ -1583,7 +1582,6 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "lazy_static",
  "nix",
  "once_cell",
  "ordered-stream",
@@ -1592,7 +1590,6 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
- "tokio",
  "tracing",
  "uds_windows",
  "winapi",

--- a/tools/pepsi/src/aliveness.rs
+++ b/tools/pepsi/src/aliveness.rs
@@ -180,3 +180,16 @@ async fn query_aliveness_list(arguments: &Arguments) -> Result<AlivenessList, Al
     let responses = query_aliveness(arguments.timeout, ips).await?;
     Ok(responses.into_iter().collect())
 }
+
+pub async fn completions() -> Result<Vec<u8>, AlivenessError> {
+    const COMPLETIONS_TIMEOUT: Duration = Duration::from_millis(200);
+    let aliveness_states = query_aliveness(COMPLETIONS_TIMEOUT, None).await?;
+    let completions = aliveness_states
+        .iter()
+        .filter_map(|(ip, _)| match ip {
+            IpAddr::V4(ip) => Some(ip.octets()[3]),
+            _ => None,
+        })
+        .collect();
+    Ok(completions)
+}

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -26,7 +26,10 @@ pub async fn completions(arguments: Arguments, mut command: Command) -> Result<(
             _ => ' ',
         };
         let colon = match arguments.complete_assignments {
-            true => ":",
+            true => match arguments.shell {
+                Shell::Zsh => "\\:",
+                _ => ":",
+            },
             false => "",
         };
 

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -20,6 +20,7 @@ pub async fn completions(arguments: Arguments, mut command: Command) -> Result<(
         let separator = match arguments.shell {
             Shell::Bash => ' ',
             Shell::Fish => '\n',
+            Shell::Zsh => '\n',
             _ => ' ',
         };
 
@@ -80,6 +81,17 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                     );
                 }
             }
+        }
+        Shell::Zsh => {
+            let re = Regex::new("(::naos -- .*):").unwrap();
+            let completions = re.replace_all(&static_completions, "$1:_pepsi__complete_naos");
+            println!(
+                "{completions}\n(( $+functions[_pepsi__complete_naos] )) ||\n\
+                _pepsi__complete_naos() {{\n    \
+                    local commands; commands=(\"${{(@f)$({completion_cmd})}}\")\n    \
+                    _describe -t commands 'pepsi complete naos' commands \"$@\"\n\
+                }}"
+            );
         }
         _ => print!("{static_completions}"),
     };

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -1,0 +1,86 @@
+use clap::{Args, Command};
+use clap_complete::{generate, Shell};
+use color_eyre::Result;
+use regex::Regex;
+
+use crate::aliveness::completions as complete_naos;
+
+#[derive(Args)]
+pub struct Arguments {
+    #[arg(long, hide = true)]
+    complete_naos: bool,
+    #[clap(name = "shell")]
+    pub shell: clap_complete::shells::Shell,
+}
+
+pub async fn completions(arguments: Arguments, mut command: Command) -> Result<()> {
+    if arguments.complete_naos {
+        let naos = complete_naos().await?;
+
+        let separator = match arguments.shell {
+            Shell::Bash => ' ',
+            Shell::Fish => '\n',
+            _ => ' ',
+        };
+
+        for nao in naos {
+            print!("{nao}{separator}");
+        }
+        return Ok(());
+    }
+
+    let mut static_completion = Vec::new();
+    generate(
+        arguments.shell,
+        &mut command,
+        "pepsi",
+        &mut static_completion,
+    );
+
+    let static_completions = String::from_utf8(static_completion)?;
+    dynamic_completions(arguments.shell, static_completions);
+    Ok(())
+}
+
+fn dynamic_completions(shell: Shell, static_completions: String) {
+    let completion_cmd = format!("pepsi completions --complete-naos {shell}");
+
+    match shell {
+        Shell::Bash => {
+            let re = Regex::new("(?:<NAOS>|\\[NAOS\\])...").unwrap();
+            let completions = re.replace_all(&static_completions, format!("$({completion_cmd})"));
+            print!("{completions}")
+        }
+        Shell::Fish => {
+            const COMPLETION_SUBCOMMANDS: [(&str, &str); 11] = [
+                ("aliveness", ""),
+                ("hulk", ""),
+                ("logs", "delete"),
+                ("logs", "downloads"),
+                ("postgame", ""),
+                ("poweroff", ""),
+                ("reboot", ""),
+                ("upload", ""),
+                ("wireless", "list"),
+                ("wireless", "set"),
+                ("wireless", "status"),
+            ];
+            print!("{static_completions}");
+            for (first, second) in COMPLETION_SUBCOMMANDS {
+                if second.is_empty() {
+                    println!(
+                        "complete -c pepsi -n \"__fish_seen_subcommand_from {first}\" \
+                             -f -a \"({completion_cmd})\""
+                    );
+                } else {
+                    println!(
+                        "complete -c pepsi -n \"__fish_seen_subcommand_from {first}; \
+                             and __fish_seen_subcommand_from {second}\" \
+                             -f -a \"({completion_cmd})\""
+                    );
+                }
+            }
+        }
+        _ => print!("{static_completions}"),
+    };
+}

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -50,30 +50,30 @@ mod wireless;
 async fn main() -> Result<()> {
     let arguments = Arguments::parse();
     let repository_root = match arguments.repository_root {
-        Some(repository_root) => repository_root,
+        Some(repository_root) => Ok(repository_root),
         None => get_repository_root()
             .await
-            .wrap_err("failed to get repository root")?,
+            .wrap_err("failed to get repository root"),
     };
-    let repository = Repository::new(repository_root);
+    let repository = repository_root.map(Repository::new);
 
     match arguments.command {
-        Command::Analyze(arguments) => analyze(arguments, &repository)
+        Command::Analyze(arguments) => analyze(arguments, &repository?)
             .await
             .wrap_err("failed to execute analyze command")?,
         Command::Aliveness(arguments) => aliveness(arguments)
             .await
             .wrap_err("failed to execute aliveness command")?,
-        Command::Build(arguments) => cargo(arguments, &repository, CargoCommand::Build)
+        Command::Build(arguments) => cargo(arguments, &repository?, CargoCommand::Build)
             .await
             .wrap_err("failed to execute build command")?,
-        Command::Check(arguments) => cargo(arguments, &repository, CargoCommand::Check)
+        Command::Check(arguments) => cargo(arguments, &repository?, CargoCommand::Check)
             .await
             .wrap_err("failed to execute check command")?,
-        Command::Clippy(arguments) => cargo(arguments, &repository, CargoCommand::Clippy)
+        Command::Clippy(arguments) => cargo(arguments, &repository?, CargoCommand::Clippy)
             .await
             .wrap_err("failed to execute clippy command")?,
-        Command::Communication(arguments) => communication(arguments, &repository)
+        Command::Communication(arguments) => communication(arguments, &repository?)
             .await
             .wrap_err("failed to execute communication command")?,
         Command::Completions(arguments) => completions(arguments, Arguments::command())
@@ -82,13 +82,13 @@ async fn main() -> Result<()> {
         Command::Hulk(arguments) => hulk(arguments)
             .await
             .wrap_err("failed to execute hulk command")?,
-        Command::Location(arguments) => location(arguments, &repository)
+        Command::Location(arguments) => location(arguments, &repository?)
             .await
             .wrap_err("failed to execute location command")?,
         Command::Logs(arguments) => logs(arguments)
             .await
             .wrap_err("failed to execute logs command")?,
-        Command::Playernumber(arguments) => player_number(arguments, &repository)
+        Command::Playernumber(arguments) => player_number(arguments, &repository?)
             .await
             .wrap_err("failed to execute player_number command")?,
         Command::Postgame(arguments) => post_game(arguments)
@@ -97,22 +97,22 @@ async fn main() -> Result<()> {
         Command::Poweroff(arguments) => power_off(arguments)
             .await
             .wrap_err("failed to execute power_off command")?,
-        Command::Pregame(arguments) => pre_game(arguments, &repository)
+        Command::Pregame(arguments) => pre_game(arguments, &repository?)
             .await
             .wrap_err("failed to execute pre_game command")?,
         Command::Reboot(arguments) => reboot(arguments)
             .await
             .wrap_err("failed to execute reboot command")?,
-        Command::Run(arguments) => cargo(arguments, &repository, CargoCommand::Run)
+        Command::Run(arguments) => cargo(arguments, &repository?, CargoCommand::Run)
             .await
             .wrap_err("failed to execute run command")?,
-        Command::Sdk(arguments) => sdk(arguments, &repository)
+        Command::Sdk(arguments) => sdk(arguments, &repository?)
             .await
             .wrap_err("failed to execute sdk command")?,
         Command::Shell(arguments) => shell(arguments)
             .await
             .wrap_err("failed to execute shell command")?,
-        Command::Upload(arguments) => upload(arguments, &repository)
+        Command::Upload(arguments) => upload(arguments, &repository?)
             .await
             .wrap_err("failed to execute upload command")?,
         Command::Wireless(arguments) => wireless(arguments)


### PR DESCRIPTION
## Introduced Changes

This PR adds dynamic shell completions for all pepsi subcommands that take NAO addresses as a parameter (e.g. `pepsi upload`).

The NAO addresses to complete with are retrieved using the aliveness service, so only alive NAOs will be suggested. It requires pepsi to be installed to the `PATH`.

The shells fish, zsh and bash are supported.

## ToDo / Known Issues

Nothing here.

## Ideas for Next Iterations (Not This PR)

None here.

## How to Test

Build and install the latest version of pepsi, e.g. with

```
cargo install --path tools/pepsi
```

and by adding `~/.cargo/bin` to the `PATH`.

Now, generate the completions for your favourite shell, e.g. for fish using

```
./pepsi completions fish > ~/.config/fish/completions/pepsi.fish
```

Restart the shell, make sure at least one NAO is alive and observe the behavior of hitting Tab after e.g. `pepsi upload`.
