### PR TITLE
HuLA DBus interface for efficiently querying battery status and IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,6 +2157,7 @@ dependencies = [
  "alsa",
  "chrono",
  "color-eyre",
+ "constants",
  "ctrlc",
  "cyclers",
  "fern",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,7 @@ name = "hula-types"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ color-eyre = "0.6.2"
 colored = "2.0.0"
 communication = { path = "crates/communication" }
 compiled-nn = "0.12.0"
+constants = { path = "crates/constants" }
 context_attribute = { path = "crates/context_attribute" }
 control = { path = "crates/control" }
 convert_case = "0.6.0"

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -1,1 +1,5 @@
+pub const HULA_DBUS_INTERFACE: &str = "org.hulks.hula";
+pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
+pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
+pub const OS_RELEASE_PATH: &str = "/etc/os-release";

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -11,6 +11,7 @@ nao = ["alsa", "nao_camera", "v4l"]
 [dependencies]
 alsa = { optional = true, workspace = true }
 color-eyre = { workspace = true }
+constants = { workspace = true }
 chrono = { workspace = true }
 ctrlc = { workspace = true }
 cyclers = { workspace = true }

--- a/crates/hulk/src/nao/hula_wrapper.rs
+++ b/crates/hulk/src/nao/hula_wrapper.rs
@@ -8,6 +8,7 @@ use color_eyre::{eyre::WrapErr, Result};
 use types::{hardware::Ids, Joints, Leds, SensorData};
 
 use super::hula::{read_from_hula, write_to_hula, ControlStorage};
+use constants::HULA_SOCKET_PATH;
 
 pub struct HulaWrapper {
     now: SystemTime,
@@ -17,7 +18,8 @@ pub struct HulaWrapper {
 
 impl HulaWrapper {
     pub fn new() -> Result<Self> {
-        let mut stream = UnixStream::connect("/tmp/hula").wrap_err("failed to open HULA socket")?;
+        let mut stream =
+            UnixStream::connect(HULA_SOCKET_PATH).wrap_err("failed to open HULA socket")?;
         let state_storage = read_from_hula(&mut stream).wrap_err("failed to read from HULA")?;
         let ids = Ids {
             body_id: from_utf8(&state_storage.robot_configuration.body_id)

--- a/tools/aliveness/Cargo.lock
+++ b/tools/aliveness/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aliveness-service"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aliveness",
  "color-eyre",

--- a/tools/aliveness/Cargo.lock
+++ b/tools/aliveness/Cargo.lock
@@ -645,6 +645,7 @@ name = "hula-types"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "zbus",
 ]
 
 [[package]]

--- a/tools/aliveness/Cargo.toml
+++ b/tools/aliveness/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["full"] }
 tokio-util = "0.7.4"
-zbus = { version = "3.7.0", features = ["tokio"] }
+zbus = { version = "3.7.0" }

--- a/tools/aliveness/Cargo.toml
+++ b/tools/aliveness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aliveness-service"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"

--- a/tools/aliveness/Cargo.toml
+++ b/tools/aliveness/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["full"] }
 tokio-util = "0.7.4"
-zbus = { version = "3.7.0" }
+zbus = { version = "3.7.0", features = ["tokio"] }

--- a/tools/aliveness/src/main.rs
+++ b/tools/aliveness/src/main.rs
@@ -161,7 +161,7 @@ async fn join_multicast(
     dbus_connection: Connection,
     interface_name: String,
 ) -> Result<AlivenessService> {
-    let mut robot_info = RobotInfo::initialize().await?;
+    let mut robot_info = RobotInfo::initialize(&dbus_connection).await?;
 
     let socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, BEACON_PORT))
         .await
@@ -206,15 +206,6 @@ async fn join_multicast(
     Ok(AlivenessService { token, handle })
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<()> {
-    env_logger::init();
-
-    let interface_name = args().nth(1).unwrap_or_else(|| "enp4s0".to_owned());
-
-    listen_for_network_change(interface_name).await
-}
-
 async fn handle_beacon(
     socket: &UdpSocket,
     dbus_connection: &Connection,
@@ -243,4 +234,13 @@ async fn handle_beacon(
         .await
         .wrap_err_with(|| format!("failed to send beacon response to peer at {peer}"))?;
     Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    env_logger::init();
+
+    let interface_name = args().nth(1).unwrap_or_else(|| "enp4s0".to_owned());
+
+    listen_for_network_change(interface_name).await
 }

--- a/tools/aliveness/src/robot_info.rs
+++ b/tools/aliveness/src/robot_info.rs
@@ -23,11 +23,10 @@ pub struct RobotInfo {
     pub body_id: Option<String>,
     pub head_id: Option<String>,
     proxy: RobotInfoProxy<'static>,
-    _connection: Connection,
 }
 
 impl RobotInfo {
-    pub async fn initialize() -> Result<Self> {
+    pub async fn initialize(connection: &Connection) -> Result<Self> {
         let hulks_os_version = get_hulks_os_version()
             .await
             .wrap_err("failed to load HULKs-OS version")?;
@@ -36,8 +35,7 @@ impl RobotInfo {
             .into_string()
             .map_err(|hostname| eyre!("invalid utf8 in hostname: {hostname:?}"))?;
 
-        let _connection = Connection::session().await?;
-        let proxy = RobotInfoProxy::new(&_connection)
+        let proxy = RobotInfoProxy::new(connection)
             .await
             .wrap_err("failed to connect to dbus proxy")?;
 
@@ -47,7 +45,6 @@ impl RobotInfo {
             body_id: None,
             head_id: None,
             proxy,
-            _connection,
         })
     }
 

--- a/tools/aliveness/src/robot_info.rs
+++ b/tools/aliveness/src/robot_info.rs
@@ -1,0 +1,86 @@
+use color_eyre::eyre::{eyre, Context, Result};
+use configparser::ini::Ini;
+use constants::OS_RELEASE_PATH;
+use hula_types::Battery;
+
+use zbus::{dbus_proxy, zvariant::Optional, Connection};
+
+// It is unfortunately not possible to deduplicate those values since they are literals
+#[dbus_proxy(
+    default_service = "org.hulks.hula",
+    interface = "org.hulks.hula",
+    default_path = "/org/hulks/HuLA"
+)]
+trait RobotInfo {
+    fn body_id(&self) -> zbus::Result<Optional<String>>;
+    fn head_id(&self) -> zbus::Result<Optional<String>>;
+    fn battery(&self) -> zbus::Result<Optional<Battery>>;
+}
+
+pub struct RobotInfo {
+    pub hulks_os_version: String,
+    pub hostname: String,
+    pub body_id: Option<String>,
+    pub head_id: Option<String>,
+    proxy: RobotInfoProxy<'static>,
+    _connection: Connection,
+}
+
+impl RobotInfo {
+    pub async fn initialize() -> Result<Self> {
+        let hulks_os_version = get_hulks_os_version()
+            .await
+            .wrap_err("failed to load HULKs-OS version")?;
+        let hostname = hostname::get()
+            .wrap_err("failed to query hostname")?
+            .into_string()
+            .map_err(|hostname| eyre!("invalid utf8 in hostname: {hostname:?}"))?;
+
+        let _connection = Connection::session().await?;
+        let proxy = RobotInfoProxy::new(&_connection)
+            .await
+            .wrap_err("failed to connect to dbus proxy")?;
+
+        Ok(Self {
+            hulks_os_version,
+            hostname,
+            body_id: None,
+            head_id: None,
+            proxy,
+            _connection,
+        })
+    }
+
+    pub async fn battery(&self) -> Option<Battery> {
+        match self.proxy.battery().await {
+            Ok(battery) => Option::from(battery),
+            Err(_) => None,
+        }
+    }
+
+    pub async fn body_id(&mut self) -> Option<String> {
+        if self.head_id.is_none() {
+            if let Ok(head_id) = self.proxy.body_id().await {
+                self.head_id = Option::from(head_id)
+            }
+        }
+        self.head_id.clone()
+    }
+
+    pub async fn head_id(&mut self) -> Option<String> {
+        if self.body_id.is_none() {
+            if let Ok(body_id) = self.proxy.body_id().await {
+                self.body_id = Option::from(body_id)
+            }
+        }
+        self.body_id.clone()
+    }
+}
+
+async fn get_hulks_os_version() -> Result<String> {
+    let mut os_release = Ini::new();
+    os_release.load_async(OS_RELEASE_PATH).await.unwrap();
+    os_release
+        .get("default", "VERSION_ID")
+        .ok_or_else(|| eyre!("no VERSION_ID in {OS_RELEASE_PATH}"))
+}

--- a/tools/aliveness/src/robot_info.rs
+++ b/tools/aliveness/src/robot_info.rs
@@ -49,26 +49,19 @@ impl RobotInfo {
     }
 
     pub async fn battery(&self) -> Option<Battery> {
-        match self.proxy.battery().await {
-            Ok(battery) => Option::from(battery),
-            Err(_) => None,
-        }
+        self.proxy.battery().await.ok().and_then(Option::from)
     }
 
     pub async fn body_id(&mut self) -> Option<String> {
         if self.head_id.is_none() {
-            if let Ok(head_id) = self.proxy.body_id().await {
-                self.head_id = Option::from(head_id)
-            }
+            self.head_id = self.proxy.head_id().await.ok().and_then(Option::from)
         }
         self.head_id.clone()
     }
 
     pub async fn head_id(&mut self) -> Option<String> {
         if self.body_id.is_none() {
-            if let Ok(body_id) = self.proxy.body_id().await {
-                self.body_id = Option::from(body_id)
-            }
+            self.body_id = self.proxy.body_id().await.ok().and_then(Option::from)
         }
         self.body_id.clone()
     }

--- a/tools/aliveness/src/robot_info.rs
+++ b/tools/aliveness/src/robot_info.rs
@@ -5,7 +5,6 @@ use hula_types::Battery;
 
 use zbus::{dbus_proxy, zvariant::Optional, Connection};
 
-// It is unfortunately not possible to deduplicate those values since they are literals
 #[dbus_proxy(
     default_service = "org.hulks.hula",
     interface = "org.hulks.hula",

--- a/tools/hula/Cargo.lock
+++ b/tools/hula/Cargo.lock
@@ -36,6 +36,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b19760fa2b7301cf235360ffd6d3558b1ed4249edd16d6cca8d690cee265b95"
+dependencies = [
+ "event-listener",
+ "futures-core",
+ "parking_lot",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
+name = "async-trait"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +144,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "build-env"
@@ -182,6 +274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "constants"
 version = "0.1.0"
 
@@ -190,6 +291,34 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cstr-argument"
@@ -246,6 +375,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +494,15 @@ checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -327,10 +533,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "futures-core"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+
+[[package]]
+name = "futures-task"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-util"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -348,6 +634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hula"
 version = "0.3.1"
 dependencies = [
@@ -361,6 +653,7 @@ dependencies = [
  "log",
  "rmp-serde",
  "systemd",
+ "zbus",
 ]
 
 [[package]]
@@ -368,6 +661,7 @@ name = "hula-types"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -405,6 +699,25 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -476,6 +789,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,12 +814,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -534,6 +889,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "ordered-stream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360a24bdacdb7801a1a6af8500392864791c130ebe8bd9a063158cab00040c90"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +909,35 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "paste"
@@ -558,10 +952,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "polling"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "windows-sys",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -606,6 +1036,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +1101,15 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rmp"
@@ -665,6 +1154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +1186,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +1215,37 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -732,12 +1280,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -756,8 +1338,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -768,7 +1367,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -803,6 +1414,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uds_windows"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+dependencies = [
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,10 +1460,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -891,6 +1530,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "winapi"
@@ -979,3 +1627,91 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "zbus"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f1a9e02a5659c712de386c2af5156c51a530fac0668d3ff85fa26a2bc006ba"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "byteorder",
+ "derivative",
+ "dirs",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cd9f07964695e00bfef8e589d1752ea0480b8a619f2064cbaccb8a6c2ed59"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34f314916bd89bdb9934154627fab152f4f28acdda03e7c4c68181b214fe7e3"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576cc41e65c7f283e5460f5818073e68fb1f1631502b969ef228c2e03c862efb"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd4aafc0dee96ae7242a24249ce9babf21e1562822f03df650d4e68c20e41ed"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/tools/hula/Cargo.lock
+++ b/tools/hula/Cargo.lock
@@ -641,7 +641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hula"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/tools/hula/Cargo.toml
+++ b/tools/hula/Cargo.toml
@@ -5,4 +5,15 @@ members = [
 ]
 
 [workspace.dependencies]
+chrono = "0.4.23"
+clap = { version = "4.0.29", features = ["derive"] }
+color-eyre = "0.6.2"
+constants = { path = "../../crates/constants" }
+env_logger = "0.10.0"
+epoll = "4.3.1"
+hula-types = { path = "types/" }
+log = "0.4.17"
+rmp-serde = "1.1.1"
+serde = { version = "1.0.149", features = ["derive"] }
+systemd = "0.10.0"
 zbus = "3.7.0"

--- a/tools/hula/Cargo.toml
+++ b/tools/hula/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
-
 members = [
   "types",
   "proxy",
 ]
+
+[workspace.dependencies]
+zbus = "3.7.0"

--- a/tools/hula/proxy/Cargo.toml
+++ b/tools/hula/proxy/Cargo.toml
@@ -6,14 +6,14 @@ license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
-chrono = "0.4.23"
-clap = { version = "4.0.29", features = ["derive"] }
-color-eyre = "0.6.2"
-constants = { path = "../../../crates/constants" }
-env_logger = "0.10.0"
-epoll = "4.3.1"
-hula-types = { path = "../types/" }
-log = "0.4.17"
-rmp-serde = "1.1.1"
-systemd = "0.10.0"
+chrono = { workspace = true }
+clap = { workspace = true }
+color-eyre = { workspace = true }
+constants = { workspace = true }
+env_logger = { workspace = true }
+epoll = { workspace = true }
+hula-types = { workspace = true }
+log = { workspace = true }
+rmp-serde = { workspace = true }
+systemd = { workspace = true }
 zbus = { workspace = true }

--- a/tools/hula/proxy/Cargo.toml
+++ b/tools/hula/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hula"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"

--- a/tools/hula/proxy/Cargo.toml
+++ b/tools/hula/proxy/Cargo.toml
@@ -16,3 +16,4 @@ hula-types = { path = "../types/" }
 log = "0.4.17"
 rmp-serde = "1.1.1"
 systemd = "0.10.0"
+zbus = { workspace = true }

--- a/tools/hula/proxy/src/dbus.rs
+++ b/tools/hula/proxy/src/dbus.rs
@@ -43,7 +43,7 @@ impl RobotInfo {
 
 pub fn serve_dbus(shared_state: Arc<Mutex<SharedState>>) -> Result<Connection, Error> {
     let robot_info = RobotInfo { shared_state };
-    ConnectionBuilder::session()?
+    ConnectionBuilder::system()?
         .name(HULA_DBUS_SERVICE)?
         .serve_at(HULA_DBUS_PATH, robot_info)?
         .build()

--- a/tools/hula/proxy/src/dbus.rs
+++ b/tools/hula/proxy/src/dbus.rs
@@ -17,23 +17,19 @@ struct RobotInfo {
 #[dbus_interface(name = "org.hulks.hula")]
 impl RobotInfo {
     fn head_id(&self) -> Optional<String> {
-        match self.shared_state.lock().unwrap().configuration {
-            Some(configuration) => {
-                let head_id = configuration.head_id.to_vec();
-                Optional::from(Some(String::from_utf8(head_id).unwrap()))
-            }
-            None => Optional::from(None),
-        }
+        let configuration = self.shared_state.lock().unwrap().configuration;
+        Optional::from(configuration.and_then(|configuration| {
+            let head_id = configuration.head_id.to_vec();
+            String::from_utf8(head_id).ok()
+        }))
     }
 
     fn body_id(&self) -> Optional<String> {
-        match self.shared_state.lock().unwrap().configuration {
-            Some(configuration) => {
-                let body_id = configuration.body_id.to_vec();
-                Optional::from(Some(String::from_utf8(body_id).unwrap()))
-            }
-            None => Optional::from(None),
-        }
+        let configuration = self.shared_state.lock().unwrap().configuration;
+        Optional::from(configuration.and_then(|configuration| {
+            let body_id = configuration.body_id.to_vec();
+            String::from_utf8(body_id).ok()
+        }))
     }
 
     fn battery(&self) -> Optional<Battery> {

--- a/tools/hula/proxy/src/dbus.rs
+++ b/tools/hula/proxy/src/dbus.rs
@@ -1,0 +1,49 @@
+use hula_types::Battery;
+use std::sync::{Arc, Mutex};
+use zbus::{
+    blocking::{Connection, ConnectionBuilder},
+    dbus_interface,
+    zvariant::Optional,
+    Error,
+};
+
+use crate::SharedState;
+
+struct RobotInfo {
+    shared_state: Arc<Mutex<SharedState>>,
+}
+
+#[dbus_interface(name = "org.hulks.hula")]
+impl RobotInfo {
+    fn head_id(&self) -> Optional<String> {
+        match self.shared_state.lock().unwrap().configuration {
+            Some(configuration) => {
+                let head_id = configuration.head_id.to_vec();
+                Optional::from(Some(String::from_utf8(head_id).unwrap()))
+            }
+            None => Optional::from(None),
+        }
+    }
+
+    fn body_id(&self) -> Optional<String> {
+        match self.shared_state.lock().unwrap().configuration {
+            Some(configuration) => {
+                let body_id = configuration.body_id.to_vec();
+                Optional::from(Some(String::from_utf8(body_id).unwrap()))
+            }
+            None => Optional::from(None),
+        }
+    }
+
+    fn battery(&self) -> Optional<Battery> {
+        Optional::from(self.shared_state.lock().unwrap().battery)
+    }
+}
+
+pub fn serve_dbus(shared_state: Arc<Mutex<SharedState>>) -> Result<Connection, Error> {
+    let robot_info = RobotInfo { shared_state };
+    ConnectionBuilder::session()?
+        .name("org.hulks.hula")?
+        .serve_at("/org/hulks/HuLA", robot_info)?
+        .build()
+}

--- a/tools/hula/proxy/src/dbus.rs
+++ b/tools/hula/proxy/src/dbus.rs
@@ -8,6 +8,7 @@ use zbus::{
 };
 
 use crate::SharedState;
+use constants::{HULA_DBUS_PATH, HULA_DBUS_SERVICE};
 
 struct RobotInfo {
     shared_state: Arc<Mutex<SharedState>>,
@@ -43,7 +44,7 @@ impl RobotInfo {
 pub fn serve_dbus(shared_state: Arc<Mutex<SharedState>>) -> Result<Connection, Error> {
     let robot_info = RobotInfo { shared_state };
     ConnectionBuilder::session()?
-        .name("org.hulks.hula")?
-        .serve_at("/org/hulks/HuLA", robot_info)?
+        .name(HULA_DBUS_SERVICE)?
+        .serve_at(HULA_DBUS_PATH, robot_info)?
         .build()
 }

--- a/tools/hula/proxy/src/idle.rs
+++ b/tools/hula/proxy/src/idle.rs
@@ -2,15 +2,12 @@ use std::{
     f32::consts::PI,
     io::{BufWriter, Write},
     os::unix::net::UnixStream,
-    sync::{Arc, Mutex},
     time::UNIX_EPOCH,
 };
 
 use color_eyre::eyre::{Result, WrapErr};
 use hula_types::{Battery, LolaControlFrame};
 use rmp_serde::encode::write_named;
-
-use crate::SharedState;
 
 pub fn knight_rider_eyes() -> ([f32; 24], [f32; 24]) {
     let since_epoch = UNIX_EPOCH.elapsed().expect("time ran backwards");
@@ -113,13 +110,10 @@ pub fn charging_skull(battery: &Battery) -> [f32; 12] {
     skull
 }
 
-pub fn send_idle(
-    writer: &mut BufWriter<UnixStream>,
-    shared_state: &Arc<Mutex<SharedState>>,
-) -> Result<()> {
+pub fn send_idle(writer: &mut BufWriter<UnixStream>, battery: Option<Battery>) -> Result<()> {
     let mut control_frame = LolaControlFrame::default();
     (control_frame.left_eye, control_frame.right_eye) = knight_rider_eyes();
-    if let Some(battery) = &shared_state.lock().unwrap().battery {
+    if let Some(battery) = &battery {
         control_frame.skull = charging_skull(battery);
     }
     write_named(writer, &control_frame).wrap_err("failed to serialize control message")?;

--- a/tools/hula/proxy/src/idle.rs
+++ b/tools/hula/proxy/src/idle.rs
@@ -2,12 +2,15 @@ use std::{
     f32::consts::PI,
     io::{BufWriter, Write},
     os::unix::net::UnixStream,
+    sync::{Arc, Mutex},
     time::UNIX_EPOCH,
 };
 
 use color_eyre::eyre::{Result, WrapErr};
 use hula_types::{Battery, LolaControlFrame};
 use rmp_serde::encode::write_named;
+
+use crate::SharedState;
 
 pub fn knight_rider_eyes() -> ([f32; 24], [f32; 24]) {
     let since_epoch = UNIX_EPOCH.elapsed().expect("time ran backwards");
@@ -110,10 +113,13 @@ pub fn charging_skull(battery: &Battery) -> [f32; 12] {
     skull
 }
 
-pub fn send_idle(writer: &mut BufWriter<UnixStream>, battery: &Option<Battery>) -> Result<()> {
+pub fn send_idle(
+    writer: &mut BufWriter<UnixStream>,
+    shared_state: &Arc<Mutex<SharedState>>,
+) -> Result<()> {
     let mut control_frame = LolaControlFrame::default();
     (control_frame.left_eye, control_frame.right_eye) = knight_rider_eyes();
-    if let Some(battery) = battery {
+    if let Some(battery) = &shared_state.lock().unwrap().battery {
         control_frame.skull = charging_skull(battery);
     }
     write_named(writer, &control_frame).wrap_err("failed to serialize control message")?;

--- a/tools/hula/proxy/src/main.rs
+++ b/tools/hula/proxy/src/main.rs
@@ -6,8 +6,9 @@ use hula_types::{Battery, RobotConfiguration};
 use log::{debug, LevelFilter};
 use systemd::daemon::{notify, STATE_READY};
 
-use crate::proxy::Proxy;
+use crate::{dbus::serve_dbus, proxy::Proxy};
 
+mod dbus;
 mod idle;
 mod proxy;
 
@@ -42,6 +43,7 @@ fn main() -> Result<()> {
         .init();
 
     let shared_state = Arc::new(Mutex::new(SharedState::default()));
+    let _handle = serve_dbus(shared_state.clone());
 
     let proxy = Proxy::initialize(shared_state).wrap_err("failed to initialize proxy")?;
     notify(false, [(STATE_READY, "1")].iter())

--- a/tools/hula/proxy/src/main.rs
+++ b/tools/hula/proxy/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
         .init();
 
     let shared_state = Arc::new(Mutex::new(SharedState::default()));
-    let _handle = serve_dbus(shared_state.clone());
+    let _connection = serve_dbus(shared_state.clone()).wrap_err("failed to initialize DBus")?;
 
     let proxy = Proxy::initialize(shared_state).wrap_err("failed to initialize proxy")?;
     notify(false, [(STATE_READY, "1")].iter())

--- a/tools/hula/proxy/src/proxy.rs
+++ b/tools/hula/proxy/src/proxy.rs
@@ -111,7 +111,8 @@ impl Proxy {
                 .values()
                 .any(|connection| connection.is_sending_control_frames)
             {
-                send_idle(&mut writer, &self.shared_state).wrap_err(
+                let battery = self.shared_state.lock().unwrap().battery;
+                send_idle(&mut writer, battery).wrap_err(
                     "a shadowy flight into the dangerous world of a man who does not exist",
                 )?;
             }

--- a/tools/hula/types/Cargo.toml
+++ b/tools/hula/types/Cargo.toml
@@ -6,5 +6,5 @@ license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
-serde = { version = "1.0.149", features = ["derive"] }
+serde = { workspace = true }
 zbus = { workspace = true }

--- a/tools/hula/types/Cargo.toml
+++ b/tools/hula/types/Cargo.toml
@@ -7,3 +7,4 @@ homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 serde = { version = "1.0.149", features = ["derive"] }
+zbus = { workspace = true }

--- a/tools/hula/types/src/robot_state.rs
+++ b/tools/hula/types/src/robot_state.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize};
+use zbus::zvariant::Type;
 
 #[derive(Debug, Default, Deserialize)]
 #[repr(C)]
@@ -66,7 +67,7 @@ where
         .ok_or_else(|| serde::de::Error::custom("version is not a number"))
 }
 
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, Type)]
 #[repr(C)]
 pub struct Battery {
     pub charge: f32,

--- a/tools/hula/types/src/robot_state.rs
+++ b/tools/hula/types/src/robot_state.rs
@@ -67,7 +67,7 @@ where
         .ok_or_else(|| serde::de::Error::custom("version is not a number"))
 }
 
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, Type)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, Type)]
 #[repr(C)]
 pub struct Battery {
     pub charge: f32,


### PR DESCRIPTION
## Introduced Changes

This PR adds a DBus interface to HuLA for efficiently querying the battery status and body/head IDs.

This reduces the load of the aliveness service on HuLA since it only interacts with HuLA when actual requests are received.

## ToDo / Known Issues

- [x] Replace session with system DBus (the session bus one will only work after the first user login and restarting aliveness)

## Ideas for Next Iterations (Not This PR)

None yet.

## How to Test

Build a new image using the branch of HULKs/meta-hulks#11 and flash it to a NAO (currently, the NAOs `27`-`32` are already flashed with this image).

Use `./pepsi aliveness` to check that everything works as expected.
