### PR TITLE
Pepsi subcommand for flashing HULKs-OS images to NAOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "clap_complete",
  "color-eyre",
  "colored 2.0.0",
+ "constants",
  "futures",
  "nao",
  "regex",
@@ -3343,6 +3344,7 @@ name = "repository"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "constants",
  "futures",
  "glob",
  "home",

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -3,5 +3,5 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "5.7.0";
+pub const OS_VERSION: &str = "5.7.1";
 pub const SDK_VERSION: &str = "5.7.0";

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -3,3 +3,5 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
+pub const OS_VERSION: &str = "5.7.0";
+pub const SDK_VERSION: &str = "5.7.0";

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -37,15 +37,17 @@ impl Nao {
         command
     }
 
-    fn rsync_with_nao(&self) -> Command {
+    fn rsync_with_nao(&self, mkpath: bool) -> Command {
         let mut command = Command::new("rsync");
         let ssh_flags = self.get_ssh_flags().join(" ");
         command
             .arg("--compress")
-            .arg("--mkpath")
             .arg("--recursive")
             .arg("--times")
             .arg(format!("--rsh=ssh {ssh_flags}"));
+        if mkpath {
+            command.arg("--mkpath");
+        }
         command
     }
 
@@ -121,7 +123,7 @@ impl Nao {
         }
 
         let status = self
-            .rsync_with_nao()
+            .rsync_with_nao(true)
             .arg(format!("{}:hulk/logs/", self.host))
             .arg(local_directory.as_ref().to_str().unwrap())
             .status()
@@ -172,7 +174,7 @@ impl Nao {
         local_directory: impl AsRef<Path>,
         delete_remaining: bool,
     ) -> Result<()> {
-        let mut command = self.rsync_with_nao();
+        let mut command = self.rsync_with_nao(true);
         command
             .arg("--keep-dirlinks")
             .arg("--copy-links")
@@ -278,7 +280,7 @@ impl Nao {
 
     pub async fn flash_image(&self, image_path: impl AsRef<Path>) -> Result<()> {
         let status = self
-            .rsync_with_nao()
+            .rsync_with_nao(false)
             .arg(image_path.as_ref().to_str().unwrap())
             .arg(format!("{}:/data/.image/", self.host))
             .status()

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -275,6 +275,22 @@ impl Nao {
 
         Ok(())
     }
+
+    pub async fn flash_image(&self, image_path: impl AsRef<Path>) -> Result<()> {
+        let status = self
+            .rsync_with_nao()
+            .arg(image_path.as_ref().to_str().unwrap())
+            .arg(format!("{}:/data/.image/", self.host))
+            .status()
+            .await
+            .wrap_err("failed to execute rsync command")?;
+
+        if !status.success() {
+            bail!("failed to upload image")
+        }
+
+        self.reboot().await
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/repository/Cargo.toml
+++ b/crates/repository/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 color-eyre = { workspace = true }
+constants = { workspace = true }
 glob = { workspace = true }
 futures = { workspace = true }
 home = { workspace = true }

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -13,6 +13,7 @@ use color_eyre::{
     eyre::{bail, eyre, Context},
     Result,
 };
+use constants::SDK_VERSION;
 use futures::future::join_all;
 use glob::glob;
 use home::home_dir;
@@ -29,8 +30,6 @@ use tokio::{
 };
 
 use spl_network_messages::PlayerNumber;
-
-pub const SDK_VERSION: &str = "5.7.0";
 
 pub struct Repository {
     root: PathBuf,

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -421,12 +421,13 @@ impl Repository {
 
 async fn download_with_fallback(
     output_path: impl AsRef<OsStr>,
-    urls: Vec<String>,
+    urls: impl IntoIterator<Item = impl AsRef<OsStr>>,
     connect_timeout: Duration,
 ) -> Result<()> {
-    for (i, url) in urls.iter().enumerate() {
+    for (i, url) in urls.into_iter().enumerate() {
+        let url = url.as_ref();
         if i > 0 {
-            println!("Falling back to downloading from {url}");
+            println!("Falling back to downloading from {url:?}");
         }
 
         let status = Command::new("curl")
@@ -461,7 +462,7 @@ async fn download_image(
             .context("Failed to create download directory")?;
     }
     let image_path = downloads_directory.as_ref().join(image_name);
-    let urls = vec![
+    let urls = [
         format!("http://bighulk.hulks.dev/image/{image_name}"),
         format!("https://github.com/HULKs/meta-hulks/releases/download/{version}/{image_name}"),
     ];
@@ -494,7 +495,7 @@ async fn download_sdk(
             .context("Failed to create download directory")?;
     }
     let installer_path = downloads_directory.as_ref().join(installer_name);
-    let urls = vec![
+    let urls = [
         format!("http://bighulk.hulks.dev/sdk/{installer_name}"),
         format!("https://github.com/HULKs/meta-hulks/releases/download/{version}/{installer_name}"),
     ];

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -432,6 +432,7 @@ async fn download_with_fallback(
         let status = Command::new("curl")
             .arg("--connect-timeout")
             .arg(connect_timeout.as_secs_f32().to_string())
+            .arg("--fail")
             .arg("--location")
             .arg("--progress-bar")
             .arg("--output")
@@ -446,7 +447,7 @@ async fn download_with_fallback(
         }
     }
 
-    bail!("curl exited with status")
+    bail!("curl exited with error")
 }
 
 async fn download_image(

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -31,6 +31,8 @@ use tokio::{
 
 use spl_network_messages::PlayerNumber;
 
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub struct Repository {
     root: PathBuf,
 }
@@ -464,7 +466,7 @@ async fn download_image(
     ];
 
     println!("Downloading image from {}", urls[0]);
-    download_with_fallback(&image_path, urls, Duration::from_secs(5)).await
+    download_with_fallback(&image_path, urls, CONNECT_TIMEOUT).await
 }
 
 pub async fn get_image_path(version: &str) -> Result<PathBuf> {
@@ -497,7 +499,7 @@ async fn download_sdk(
     ];
 
     println!("Downloading SDK from {}", urls[0]);
-    download_with_fallback(&installer_path, urls, Duration::from_secs(5)).await?;
+    download_with_fallback(&installer_path, urls, CONNECT_TIMEOUT).await?;
 
     set_permissions(&installer_path, Permissions::from_mode(0o755))
         .await

--- a/docs/setup/nao_image_and_sdk.md
+++ b/docs/setup/nao_image_and_sdk.md
@@ -17,8 +17,7 @@ Within the HULKs repository, use the following command to e.g. upload to NAO 42:
 ./pepsi upload 42
 ```
 
-Pepsi will automatically download the SDK from the BigHULK or GitHub and ask you to install it during the compilation process.
-Just choose the defaults if unsure.
+Pepsi will automatically download the SDK from the BigHULK (internal server only accessible in the HULKs lab network) or GitHub and ask you to install it during the compilation process.
 
 ## Image & SDK Creation
 
@@ -161,17 +160,9 @@ Thus small changes afterwards might only take a few minutes.
 
 As soon as the build has successfully finished, the image can be deployed.
 After BitBake ran all tasks up to nao-image, a new `.opn` file is generated in `build/tmp/deploy/images/nao-v6/nao-image-HULKs-OS-[...].ext3.gz.opn`.
-The image can now be flashed to a USB flash drive:
+The image can now be flashed to a NAO as described in the [NAO setup section](./nao_setup.md#flashing-the-firmware).
 
-```sh
-dd if=nao-image-HULKs-OS-[...].ext3.gz.opn.opn of=/dev/sdb status=progress
-sync
-```
-
-A RoboCupper image needs to be flashed first because the Yocto `.opn` does not flash the chestboard (which needs up-to-date software).
-Now flash the NAO with the Yocto image.
-The flashing process may take 1-3 minutes.
-It is finished if the HULA process displays a red LED animation in the eyes.
+Make sure a RoboCupper image has been flashed before flashing the first Yocto image, since the latter does not flash the chestboard (which needs up-to-date software). This step is not required for flashing subsequent Yocto images.
 
 ### Building the SDK
 
@@ -199,17 +190,18 @@ The HULKs use semantic versioning for the Yocto images and SDKs.
 This means that versions are increased depending on the severity of changes.
 The following policy exists for the HULKs:
 
--   Images have major, minor, and patch version numbers (e.g. 4.2.3), SDKs have only have major and minor (e.g. 4.2)
--   Same version numbers of images and SDKs are compatible to each other
+-   Both images and SDKs have major, minor, and patch version numbers (e.g. 4.2.3)
+-   Images and SDKs with the same major and minor version number are compatible with each other
 -   Major changes, refactorings, implementations result in the increase of the major version number
 -   Minor changes, additions and iterations result in the increase of the minor version number
 -   Changes in the image that do not require SDK recreation, result in the increase of the patch version number (which only requires to create a new image)
 
 Before building new images, the version number needs to be set in `meta-hulks/conf/distro/HULKsOS.conf`.
 Only change the `DISTRO_VERSION`, the `SDK_VERSION` is automatically derived from the `DISTRO_VERSION`.
-Once new SDKs are deployed at the BigHULKs for HULKs members or in the local downloads directory `sdk/downloads` in the HULKs repository for non HULKs members, the Pepsi tool needs to learn to use the new SDK.
-Therefore update the version in `crates/repository/src/lib.rs` in the variable `SDK_VERSION`.
-Successive builds with Pepsi will use the new version.
+
+Once a new image and/or SDK is released, pepsi needs to know the new version numbers.
+Therefore update the variables `OS_VERSION` and/or `SDK_VERSION` in `crates/constants/src/lib.rs`.
+Successive builds with pepsi will use the new version.
 
 ### Advanced: Upgrade Rust Version
 

--- a/docs/setup/nao_image_and_sdk.md
+++ b/docs/setup/nao_image_and_sdk.md
@@ -10,32 +10,15 @@ The SDK contains a full cross-compilation toolchain that is self-contained and c
 
 ## Use an Existing Yocto SDK with the HULKs Code
 
-=== "HULKs Members"
+You can just use [pepsi](../tooling/pepsi.md) to compile and upload to a booted NAO.
+Within the HULKs repository, use the following command to e.g. upload to NAO 42:
 
-    HULKs members can just use the Pepsi tool (TODO: link to Pepsi) to compile and upload to a booted NAO.
-    This needs to be done in the lab or with VPN access to the BigHULK.
-    Within the HULKs repository, use the following command to e.g. upload to NAO 42:
+```sh
+./pepsi upload 42
+```
 
-    ```sh
-    ./pepsi upload 42
-    ```
-
-    You will be asked to install the SDK during the compilation process.
-    Just choose the defaults if unsure or ask your fellow HULK.
-
-=== "Non HULKs Members"
-
-    Non HULKs members need to copy the Yocto SDK to the local downloads folder to prevent the Pepsi tool (TODO: link to Pepsi) from downloading it during compilation.
-    For instructions on how to build the image and SDK refer to the section [Image & SDK Creation](#image-sdk-creation).
-
-    ```sh
-    mkdir -p sdk/downloads/
-    cp .../HULKs-OS-toolchain-[...].sh sdk/downloads/
-    ./pepsi upload 42
-    ```
-
-    You will be asked to install the SDK during the compilation process.
-    Just choose the defaults if unsure.
+Pepsi will automatically download the SDK from the BigHULK or GitHub and ask you to install it during the compilation process.
+Just choose the defaults if unsure.
 
 ## Image & SDK Creation
 

--- a/docs/setup/nao_setup.md
+++ b/docs/setup/nao_setup.md
@@ -38,6 +38,10 @@ See [Nao Image and SDK](./nao_image_and_sdk.md) to learn how to acquire or build
 
 ## Flashing the Firmware
 
+You can flash the firmware both using [pepsi](../tooling/pepsi.md) or manually using an USB stick.
+
+Flashing with pepsi is done using the `gammaray` subcommand and is the preferred option. The following steps are only necessary for manual flashing with an USB stick.
+
 ### Preparing a Flash-Stick
 
 First, the firmware image has to be flashed to a USB stick.

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -48,6 +48,8 @@ Many subcommands can act on multiple robots concurrently.
 
 `logs` or and `postgame` can be used after a (test-)game to download logs, the latter also shuts down the HULKs binary and disables wifi.
 
+`gammaray` is used for flashing a HULKs-OS image to one or more robots.
+
 ## Build Options
 
 For subcommands that build a binary, you can specify a target and a build profile.

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -12,6 +12,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 color-eyre = { workspace = true }
 colored = { workspace = true }
+constants = { workspace = true }
 futures = { workspace = true }
 nao = { workspace = true }
 regex = { workspace = true }

--- a/tools/pepsi/src/aliveness.rs
+++ b/tools/pepsi/src/aliveness.rs
@@ -9,7 +9,7 @@ use aliveness::{
     service_manager::{ServiceState, SystemServices},
     AlivenessError, AlivenessState,
 };
-use repository::SDK_VERSION;
+use constants::OS_VERSION;
 
 #[derive(Args)]
 pub struct Arguments {
@@ -88,7 +88,7 @@ fn print_summary(states: &AlivenessList) {
         }
 
         let version = &state.hulks_os_version;
-        if version != SDK_VERSION {
+        if version != OS_VERSION {
             output.push_str(&format!("{OS_ICON} {version}{:SPACING$}", ""))
         }
 

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -72,8 +72,9 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const COMPLETION_SUBCOMMANDS: [(&str, &str); 12] = [
+            const COMPLETION_SUBCOMMANDS: [(&str, &str); 13] = [
                 ("aliveness", ""),
+                ("gammaray", ""),
                 ("hulk", ""),
                 ("logs", "delete"),
                 ("logs", "downloads"),

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -1,4 +1,4 @@
-use std::{iter::repeat, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::Args;
 use color_eyre::{eyre::Context, Result};
@@ -28,14 +28,14 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
         Some(image_path) => image_path,
         None => get_image_path(version).await?,
     };
+    let image_path = image_path.as_path();
 
     let results: Vec<_> = arguments
         .naos
         .into_iter()
-        .zip(repeat(image_path))
-        .map(|(nao_address, image_path)| async move {
+        .map(|nao_address| async move {
             let nao = Nao::new(nao_address.ip);
-            // nao.flash_image(image_path.clone())
+            println!("Starting image upload to {nao_address}");
             nao.flash_image(image_path)
                 .await
                 .wrap_err_with(|| format!("failed to flash image to {nao_address}"))

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -1,0 +1,48 @@
+use std::{iter::repeat, path::PathBuf};
+
+use clap::Args;
+use color_eyre::{eyre::Context, Result};
+use constants::OS_VERSION;
+use futures::{stream::FuturesUnordered, StreamExt};
+use nao::Nao;
+use repository::get_image_path;
+
+use crate::{parsers::NaoAddress, results::gather_results};
+
+#[derive(Args)]
+pub struct Arguments {
+    /// Alternative path to an image
+    #[arg(long)]
+    image_path: Option<PathBuf>,
+    /// Alternative HULKs-OS version e.g. 3.3
+    #[arg(long)]
+    os_version: Option<String>,
+    /// The NAOs to flash the image to, e.g. 20w or 10.1.24.22
+    #[arg(required = true)]
+    naos: Vec<NaoAddress>,
+}
+
+pub async fn gammaray(arguments: Arguments) -> Result<()> {
+    let version = arguments.os_version.as_deref().unwrap_or(OS_VERSION);
+    let image_path = match arguments.image_path {
+        Some(image_path) => image_path,
+        None => get_image_path(version).await?,
+    };
+
+    let results: Vec<_> = arguments
+        .naos
+        .into_iter()
+        .zip(repeat(image_path))
+        .map(|(nao_address, image_path)| async move {
+            let nao = Nao::new(nao_address.ip);
+            // nao.flash_image(image_path.clone())
+            nao.flash_image(image_path)
+                .await
+                .wrap_err_with(|| format!("failed to flash image to {nao_address}"))
+        })
+        .collect::<FuturesUnordered<_>>()
+        .collect()
+        .await;
+
+    gather_results(results, "failed to execute some image flashing tasks")
+}

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -12,6 +12,7 @@ use analyze::{analyze, Arguments as AnalyzeArguments};
 use cargo::{cargo, Arguments as CargoArguments, Command as CargoCommand};
 use communication::{communication, Arguments as CommunicationArguments};
 use completions::{completions, Arguments as CompletionArguments};
+use gammaray::{gammaray, Arguments as GammarayArguments};
 use hulk::{hulk, Arguments as HulkArguments};
 use location::{location, Arguments as LocationArguments};
 use logs::{logs, Arguments as LogsArguments};
@@ -31,6 +32,7 @@ mod analyze;
 mod cargo;
 mod communication;
 mod completions;
+mod gammaray;
 mod hulk;
 mod location;
 mod logs;
@@ -79,6 +81,9 @@ async fn main() -> Result<()> {
         Command::Completions(arguments) => completions(arguments, Arguments::command())
             .await
             .wrap_err("failed to execute completion command")?,
+        Command::Gammaray(arguments) => gammaray(arguments)
+            .await
+            .wrap_err("failed to execute gammaray command")?,
         Command::Hulk(arguments) => hulk(arguments)
             .await
             .wrap_err("failed to execute hulk command")?,
@@ -151,6 +156,8 @@ enum Command {
     Communication(CommunicationArguments),
     /// Generates shell completion files
     Completions(CompletionArguments),
+    /// Flash a HULKs-OS image to NAOs
+    Gammaray(GammarayArguments),
     /// Control the HULK service
     Hulk(HulkArguments),
     /// Control the configured location


### PR DESCRIPTION
## Introduced Changes

This PR adds a new pepsi subcommand (`gammaray`) for flashing a HULKs-OS image via the network.

It automatically downloads the latest image from the BigHULK and falls back to downloading from Github releases. This fallback mechanism has also been added for the SDK download.
Images are saved under `$HOME/.naosdk/images` and only downloaded once.

Optionally, the user may specify a custom version or local file by providing the `--os-version` or `--image-path` flag with corresponding values.

## ToDo / Known Issues

- [x] Make images accessible under `http://bighulk.hulks.dev/image/{image_name}`
- [x] Testing in the lab

## Ideas for Next Iterations (Not This PR)

Nothing here.

## How to Test

```
./pepsi gammaray 25
./pepsi gammaray --image-path=/path/to/image 25
./pepsi gammaray --os-version=5.4.0 25
```
