### PR TITLE
Use unfiltered FSR in walking

### DIFF
--- a/crates/control/src/motion/walking_engine.rs
+++ b/crates/control/src/motion/walking_engine.rs
@@ -197,15 +197,11 @@ impl WalkingEngine {
             WalkState::Kicking(..) => self.kick_cycle(last_cycle_duration),
         }
 
+        let left_foot_pressure = context.sensor_data.force_sensitive_resistors.left.sum();
+        let right_foot_pressure = context.sensor_data.force_sensitive_resistors.right.sum();
         let has_support_changed = match self.swing_side {
-            Side::Left => {
-                context.sensor_data.force_sensitive_resistors.left.sum()
-                    > context.sensor_data.force_sensitive_resistors.right.sum()
-            }
-            Side::Right => {
-                context.sensor_data.force_sensitive_resistors.right.sum()
-                    > context.sensor_data.force_sensitive_resistors.left.sum()
-            }
+            Side::Left => left_foot_pressure > right_foot_pressure,
+            Side::Right => right_foot_pressure > left_foot_pressure,
         };
         if has_support_changed && self.t > context.config.minimal_step_duration {
             let deviation_from_plan = self

--- a/crates/control/src/motion/walking_engine.rs
+++ b/crates/control/src/motion/walking_engine.rs
@@ -167,21 +167,18 @@ impl WalkingEngine {
 
         let is_step_started_this_cycle = self.t.is_zero();
         if is_step_started_this_cycle {
-            match context.has_ground_contact {
-                true => {
-                    self.initialize_step_states_from_request(
-                        *context.walk_command,
-                        self.swing_side,
-                        context.config,
-                        context.kick_steps,
-                    );
-                }
-                false => {
-                    self.current_step = Step::zero();
-                    self.step_duration = Duration::ZERO;
-                    self.swing_side = Side::Left;
-                    self.max_swing_foot_lift = 0.0;
-                }
+            if *context.has_ground_contact {
+                self.initialize_step_states_from_request(
+                    *context.walk_command,
+                    self.swing_side,
+                    context.config,
+                    context.kick_steps,
+                );
+            } else {
+                self.current_step = Step::zero();
+                self.step_duration = Duration::ZERO;
+                self.swing_side = Side::Left;
+                self.max_swing_foot_lift = 0.0;
             }
         }
 

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -290,8 +290,8 @@
   "walking_engine": {
     "arm_stiffness": 0.8,
     "backward_foot_support_offset": -0.025,
-    "base_foot_lift": 0.019,
-    "base_step_duration": { "nanos": 260000000, "secs": 0 },
+    "base_foot_lift": 0.015,
+    "base_step_duration": { "nanos": 280000000, "secs": 0 },
     "emergency_foot_lift": 0.03,
     "emergency_step": { "forward": 0.0, "left": 0.1, "turn": 0.0 },
     "emergency_step_duration": { "nanos": 280000000, "secs": 0 },


### PR DESCRIPTION
## Introduced Changes

- Use unfiltered FSR in walking-engine
- Move ground check outside the function
- Adjusted walking parameters

As suggested by @philipniklas-r

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

Check benefits for using weights for the FSRs

## How to Test

Check nao while walking for stability and speed
Lift up nao in order to check if ground contact recognition is working 
