### PR TITLE
Restrict map zoom

### DIFF
--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -108,19 +108,22 @@ impl Widget for &mut MapPanel {
         let _ = self.kick_decisions.paint(&painter, &field_dimensions);
 
         if let Some(pointer_position) = ui.input().pointer.interact_pos() {
-            let pointer_in_world_before_zoom = painter.transform_pixel_to_world(pointer_position);
-            let zoom_factor = 1.01_f32.powf(ui.input().scroll_delta.y);
-            let zoom_transform = Similarity2::from_scaling(zoom_factor);
-            painter.append_transform(zoom_transform);
-            let pointer_in_pixel_after_zoom =
-                painter.transform_world_to_pixel(pointer_in_world_before_zoom);
-            let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
-            let pixel_drag = vector![response.drag_delta().x, response.drag_delta().y];
-            self.transformation.append_scaling_mut(zoom_factor);
-            self.transformation
-                .append_translation_mut(&Translation2::from(
-                    pixel_drag + vector![shift_from_zoom.x, shift_from_zoom.y],
-                ));
+            if response.rect.contains(pointer_position) {
+                let pointer_in_world_before_zoom =
+                    painter.transform_pixel_to_world(pointer_position);
+                let zoom_factor = 1.01_f32.powf(ui.input().scroll_delta.y);
+                let zoom_transform = Similarity2::from_scaling(zoom_factor);
+                painter.append_transform(zoom_transform);
+                let pointer_in_pixel_after_zoom =
+                    painter.transform_world_to_pixel(pointer_in_world_before_zoom);
+                let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
+                let pixel_drag = vector![response.drag_delta().x, response.drag_delta().y];
+                self.transformation.append_scaling_mut(zoom_factor);
+                self.transformation
+                    .append_translation_mut(&Translation2::from(
+                        pixel_drag + vector![shift_from_zoom.x, shift_from_zoom.y],
+                    ));
+            }
         }
 
         if response.double_clicked() {

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use eframe::egui::{Ui, Widget};
+use eframe::egui::{Response, Ui, Widget};
 use nalgebra::{vector, Similarity2, Translation2};
 use serde_json::{from_value, json, Value};
 use types::{self, FieldDimensions};
@@ -107,29 +107,39 @@ impl Widget for &mut MapPanel {
         let _ = self.ball_position.paint(&painter, &field_dimensions);
         let _ = self.kick_decisions.paint(&painter, &field_dimensions);
 
-        if let Some(pointer_position) = ui.input().pointer.interact_pos() {
-            if response.rect.contains(pointer_position) {
-                let pointer_in_world_before_zoom =
-                    painter.transform_pixel_to_world(pointer_position);
-                let zoom_factor = 1.01_f32.powf(ui.input().scroll_delta.y);
-                let zoom_transform = Similarity2::from_scaling(zoom_factor);
-                painter.append_transform(zoom_transform);
-                let pointer_in_pixel_after_zoom =
-                    painter.transform_world_to_pixel(pointer_in_world_before_zoom);
-                let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
-                let pixel_drag = vector![response.drag_delta().x, response.drag_delta().y];
-                self.transformation.append_scaling_mut(zoom_factor);
-                self.transformation
-                    .append_translation_mut(&Translation2::from(
-                        pixel_drag + vector![shift_from_zoom.x, shift_from_zoom.y],
-                    ));
-            }
-        }
-
+        self.apply_zoom_and_pan(ui, &mut painter, &response);
         if response.double_clicked() {
             self.transformation = Similarity2::identity();
         }
 
         response
+    }
+}
+
+impl MapPanel {
+    fn apply_zoom_and_pan(
+        &mut self,
+        ui: &mut Ui,
+        painter: &mut TwixPainter,
+        response: &Response,
+    ) {
+        let pointer_position = match ui.input().pointer.interact_pos() {
+            Some(position) if response.rect.contains(position) => position,
+            _ => return,
+        };
+
+        let pointer_in_world_before_zoom = painter.transform_pixel_to_world(pointer_position);
+        let zoom_factor = 1.01_f32.powf(ui.input().scroll_delta.y);
+        let zoom_transform = Similarity2::from_scaling(zoom_factor);
+        painter.append_transform(zoom_transform);
+        let pointer_in_pixel_after_zoom =
+            painter.transform_world_to_pixel(pointer_in_world_before_zoom);
+        let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
+        let pixel_drag = vector![response.drag_delta().x, response.drag_delta().y];
+        self.transformation.append_scaling_mut(zoom_factor);
+        self.transformation
+            .append_translation_mut(&Translation2::from(
+                pixel_drag + vector![shift_from_zoom.x, shift_from_zoom.y],
+            ));
     }
 }

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -117,12 +117,7 @@ impl Widget for &mut MapPanel {
 }
 
 impl MapPanel {
-    fn apply_zoom_and_pan(
-        &mut self,
-        ui: &mut Ui,
-        painter: &mut TwixPainter,
-        response: &Response,
-    ) {
+    fn apply_zoom_and_pan(&mut self, ui: &mut Ui, painter: &mut TwixPainter, response: &Response) {
         let pointer_position = match ui.input().pointer.interact_pos() {
             Some(position) if response.rect.contains(position) => position,
             _ => return,


### PR DESCRIPTION
## Introduced Changes

Previously the map panel would always zoom when scrolling anywhere within twix, even when another scroll area is focused.
Now zooming only works when the cursor is over the map panel.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

## How to Test

Open map panel, open another panel next to it and try scrolling.