### PR TITLE
Add Pepsi error message when battery state is not available

### DIFF
--- a/tools/pepsi/src/aliveness.rs
+++ b/tools/pepsi/src/aliveness.rs
@@ -65,6 +65,7 @@ fn print_summary(states: &AlivenessList) {
     const DISCHARGING_ICON: &str = "󰁽";
     const OS_ICON: &str = "󱑞";
     const ALL_OK_ICON: &str = "✔";
+    const UNKNOWN_CHARGE: &str = "?";
 
     for (ip, state) in states.iter() {
         let id = match ip {
@@ -82,10 +83,14 @@ fn print_summary(states: &AlivenessList) {
                 } else {
                     DISCHARGING_ICON
                 };
-
                 output.push_str(&format!("{icon} {charge}%{:SPACING$}", ""))
             }
-        }
+        } else {
+            output.push_str(&format!(
+                "{DISCHARGING_ICON}{UNKNOWN_CHARGE}{:SPACING$}",
+                ""
+            ))
+        };
 
         let version = &state.hulks_os_version;
         if version != OS_VERSION {

--- a/tools/pepsi/src/aliveness.rs
+++ b/tools/pepsi/src/aliveness.rs
@@ -65,7 +65,7 @@ fn print_summary(states: &AlivenessList) {
     const DISCHARGING_ICON: &str = "󰁽";
     const OS_ICON: &str = "󱑞";
     const ALL_OK_ICON: &str = "✔";
-    const UNKNOWN_CHARGE: &str = "?";
+    const UNKNOWN_CHARGE_ICON: &str = "󰁽?";
 
     for (ip, state) in states.iter() {
         let id = match ip {
@@ -86,11 +86,8 @@ fn print_summary(states: &AlivenessList) {
                 output.push_str(&format!("{icon} {charge}%{:SPACING$}", ""))
             }
         } else {
-            output.push_str(&format!(
-                "{DISCHARGING_ICON}{UNKNOWN_CHARGE}{:SPACING$}",
-                ""
-            ))
-        };
+            output.push_str(&format!("{UNKNOWN_CHARGE_ICON}{:SPACING$}", ""))
+        }
 
         let version = &state.hulks_os_version;
         if version != OS_VERSION {


### PR DESCRIPTION
## Introduced Changes

Add Pepsi error message when battery state is not available

Fixes #105

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Run pepsi aliveness with a robot, which has over 95% charge or without running Hula.
