### PR TITLE
Fix (sonar) obstacles on twix map panel

### DIFF
--- a/tools/twix/src/panels/map/layers/obstacles.rs
+++ b/tools/twix/src/panels/map/layers/obstacles.rs
@@ -30,7 +30,7 @@ impl Layer for Obstacles {
     }
 
     fn paint(&self, painter: &TwixPainter, _field_dimensions: &FieldDimensions) -> Result<()> {
-        let robot_to_field: Isometry2<f32> = self.robot_to_field.require_latest()?;
+        let robot_to_field: Isometry2<f32> = self.robot_to_field.parse_latest().unwrap_or_default();
         let obstacles: Vec<Obstacle> = self.obstacles.require_latest()?;
 
         let hip_height_stroke = Stroke {


### PR DESCRIPTION
## Introduced Changes
Uses the default position if it is none.
This is wanted, because otherwise no obstacles are displayed.

## How to Test
Open twix and check the map panels with obstacles enabled and see if you can see obstacles when holding your hand in front of the sonar sensors.
