### PR TITLE
fix for incorrect formatting

### DIFF
--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -73,7 +73,7 @@ async fn upload_with_progress(
         let os_version = nao
             .get_os_version()
             .await
-            .wrap_err("failed to get OS version of {nao_address}")?;
+            .wrap_err_with(|| format!("failed to get OS version of {nao_address}"))?;
         if os_version != OS_VERSION {
             bail!("mismatched OS versions: Expected {OS_VERSION}, found {os_version}");
         }


### PR DESCRIPTION
## Introduced Changes
Fix incorrect formatting of nao_address

Fixes #

Before the OS error message printed "failed to get OS version of {nao_address}", now the actual address is inserted.
