### PR TITLE
Add penalty_boxes overlay to Twix Image panels

### DIFF
--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 
 use crate::{nao::Nao, twix_painter::TwixPainter};
 
-use super::overlays::{BallDetection, LineDetection};
+use super::overlays::{BallDetection, LineDetection, PenaltyBoxes};
 
 pub trait Overlay {
     const NAME: &'static str;
@@ -79,33 +79,39 @@ where
 pub struct Overlays {
     pub line_detection: EnabledOverlay<LineDetection>,
     pub ball_detection: EnabledOverlay<BallDetection>,
+    pub penalty_boxes: EnabledOverlay<PenaltyBoxes>,
 }
 
 impl Overlays {
     pub fn new(nao: Arc<Nao>, storage: Option<&Value>, selected_cycler: Cycler) -> Self {
         let line_detection = EnabledOverlay::new(nao.clone(), storage, true, selected_cycler);
-        let ball_detection = EnabledOverlay::new(nao, storage, true, selected_cycler);
+        let ball_detection = EnabledOverlay::new(nao.clone(), storage, true, selected_cycler);
+        let penalty_boxes = EnabledOverlay::new(nao, storage, true, selected_cycler);
         Self {
             line_detection,
             ball_detection,
+            penalty_boxes,
         }
     }
 
     pub fn update_cycler(&mut self, selected_cycler: Cycler) {
         self.line_detection.update_cycler(selected_cycler);
         self.ball_detection.update_cycler(selected_cycler);
+        self.penalty_boxes.update_cycler(selected_cycler);
     }
 
     pub fn combo_box(&mut self, ui: &mut Ui, selected_cycler: Cycler) {
         ui.menu_button("Overlays", |ui| {
             self.line_detection.checkbox(ui, selected_cycler);
             self.ball_detection.checkbox(ui, selected_cycler);
+            self.penalty_boxes.checkbox(ui, selected_cycler);
         });
     }
 
     pub fn paint(&self, painter: &TwixPainter) -> Result<()> {
         let _ = self.line_detection.paint(painter);
         let _ = self.ball_detection.paint(painter);
+        let _ = self.penalty_boxes.paint(painter);
         Ok(())
     }
 
@@ -113,6 +119,7 @@ impl Overlays {
         json!({
             "line_detection": self.line_detection.save(),
             "ball_detection": self.ball_detection.save(),
+            "penalty_boxes": self.penalty_boxes.save(),
         })
     }
 }

--- a/tools/twix/src/panels/image/overlays/mod.rs
+++ b/tools/twix/src/panels/image/overlays/mod.rs
@@ -1,5 +1,7 @@
 mod ball_detection;
 mod line_detection;
+mod penalty_boxes;
 
 pub use ball_detection::BallDetection;
 pub use line_detection::LineDetection;
+pub use penalty_boxes::PenaltyBoxes;

--- a/tools/twix/src/panels/image/overlays/penalty_boxes.rs
+++ b/tools/twix/src/panels/image/overlays/penalty_boxes.rs
@@ -1,0 +1,41 @@
+use std::str::FromStr;
+
+use color_eyre::Result;
+use communication::client::{Cycler, CyclerOutput};
+use eframe::epaint::{Color32, Stroke};
+use types::Line2;
+
+use crate::{
+    panels::image::overlay::Overlay, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+};
+
+pub struct PenaltyBoxes {
+    penalty_boxes: ValueBuffer,
+}
+
+impl Overlay for PenaltyBoxes {
+    const NAME: &'static str = "Penalty Boxes";
+
+    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
+        let top_or_bottom = match selected_cycler {
+            Cycler::VisionTop => "top",
+            _ => "bottom",
+        };
+        Self {
+            penalty_boxes: nao.subscribe_output(
+                CyclerOutput::from_str(&format!(
+                    "Control.additional_outputs.projected_field_lines.{top_or_bottom}"
+                ))
+                .unwrap(),
+            ),
+        }
+    }
+
+    fn paint(&self, painter: &TwixPainter) -> Result<()> {
+        let penalty_boxes_lines_in_image: Vec<Line2> = self.penalty_boxes.require_latest()?;
+        for line in penalty_boxes_lines_in_image {
+            painter.line_segment(line.0, line.1, Stroke::new(3.0, Color32::BLACK));
+        }
+        Ok(())
+    }
+}

--- a/tools/twix/src/panels/image/overlays/penalty_boxes.rs
+++ b/tools/twix/src/panels/image/overlays/penalty_boxes.rs
@@ -19,7 +19,8 @@ impl Overlay for PenaltyBoxes {
     fn new(nao: Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
         let top_or_bottom = match selected_cycler {
             Cycler::VisionTop => "top",
-            _ => "bottom",
+            Cycler::VisionBottom => "bottom",
+            cycler => panic!("Invalid vision cycler: {cycler}"),
         };
         Self {
             penalty_boxes: nao.subscribe_output(CyclerOutput {

--- a/tools/twix/src/panels/image/overlays/penalty_boxes.rs
+++ b/tools/twix/src/panels/image/overlays/penalty_boxes.rs
@@ -1,7 +1,7 @@
-use std::str::FromStr;
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput};
+use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::{Color32, Stroke};
 use types::Line2;
 
@@ -16,18 +16,18 @@ pub struct PenaltyBoxes {
 impl Overlay for PenaltyBoxes {
     const NAME: &'static str = "Penalty Boxes";
 
-    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
+    fn new(nao: Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
         let top_or_bottom = match selected_cycler {
             Cycler::VisionTop => "top",
             _ => "bottom",
         };
         Self {
-            penalty_boxes: nao.subscribe_output(
-                CyclerOutput::from_str(&format!(
-                    "Control.additional_outputs.projected_field_lines.{top_or_bottom}"
-                ))
-                .unwrap(),
-            ),
+            penalty_boxes: nao.subscribe_output(CyclerOutput {
+                cycler: Cycler::Control,
+                output: Output::Additional {
+                    path: format!("projected_field_lines.{top_or_bottom}"),
+                },
+            }),
         }
     }
 


### PR DESCRIPTION
## Introduced Changes

Add penalty_boxes overlay to Twix Image panels

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

 - idea from Schmiddy: turn Robot 90 deg and use T-junction instead of penalty-boxes for manual calibration
 - idea from Schmiddy: generating the projected Penalty boxes should happen in vision-cyclers, not in Control
 - add goal box to penalty box to make things easier on SMD-like field-sizes
 - a new panel with sliders for pitch/yaw/roll parameters
 - easier saving

## How to Test

Turn on Penalty Boxes overlay in Twix Image panel and do manual camera calibration
