### PR TITLE
Rename set_play to sub_state to match current game rules

### DIFF
--- a/crates/control/src/game_controller_filter.rs
+++ b/crates/control/src/game_controller_filter.rs
@@ -63,7 +63,7 @@ impl GameControllerFilter {
                 remaining_amount_of_messages: game_controller_state_message
                     .hulks_team
                     .remaining_amount_of_messages,
-                set_play: game_controller_state_message.set_play,
+                sub_state: game_controller_state_message.sub_state,
             });
         }
         Ok(MainOutputs {

--- a/crates/control/src/game_state_filter.rs
+++ b/crates/control/src/game_state_filter.rs
@@ -236,7 +236,7 @@ impl State {
         ball_detected_far_from_kick_off_point: bool,
         config: &GameStateFilterConfiguration,
     ) -> FilteredGameState {
-        let is_in_set_play = matches!(game_controller_state.set_play, Some(_));
+        let is_in_sub_state = matches!(game_controller_state.sub_state, Some(_));
         let opponent_is_kicking_team = matches!(
             game_controller_state.kicking_team,
             Team::Opponent | Team::Uncertain
@@ -259,13 +259,13 @@ impl State {
                 let opponent_kick_off = opponent_is_kicking_team
                     && kick_off_grace_period
                     && !ball_detected_far_from_kick_off_point;
-                let opponent_set_play = opponent_is_kicking_team && is_in_set_play;
+                let opponent_sub_state = opponent_is_kicking_team && is_in_sub_state;
                 FilteredGameState::Playing {
-                    ball_is_free: !opponent_kick_off && !opponent_set_play,
+                    ball_is_free: !opponent_kick_off && !opponent_sub_state,
                 }
             }
             State::Playing => FilteredGameState::Playing {
-                ball_is_free: !(is_in_set_play && opponent_is_kicking_team),
+                ball_is_free: !(is_in_sub_state && opponent_is_kicking_team),
             },
             State::WhistleInPlaying { .. } => FilteredGameState::Ready {
                 kicking_team: Team::Uncertain,

--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -31,7 +31,7 @@ use crate::{
 pub struct GameControllerStateMessage {
     pub game_phase: GamePhase,
     pub game_state: GameState,
-    pub set_play: Option<SetPlay>,
+    pub sub_state: Option<SubState>,
     pub half: Half,
     pub remaining_time_in_half: Duration,
     pub secondary_time: Duration,
@@ -113,7 +113,7 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
         Ok(GameControllerStateMessage {
             game_phase: GamePhase::try_from(message.gamePhase, message.kickingTeam)?,
             game_state: GameState::try_from(message.state)?,
-            set_play: SetPlay::try_from(message.setPlay)?,
+            sub_state: SubState::try_from(message.setPlay)?,
             half: message.firstHalf.try_into()?,
             remaining_time_in_half: Duration::from_secs(message.secsRemaining.max(0).try_into()?),
             secondary_time: Duration::from_secs(message.secondaryTime.max(0).try_into()?),
@@ -208,22 +208,22 @@ impl Team {
     }
 }
 
-impl SetPlay {
-    fn try_from(set_play: u8) -> Result<Option<Self>> {
-        match set_play {
+impl SubState {
+    fn try_from(sub_state: u8) -> Result<Option<Self>> {
+        match sub_state {
             SET_PLAY_NONE => Ok(None),
-            SET_PLAY_GOAL_KICK => Ok(Some(SetPlay::GoalKick)),
-            SET_PLAY_PUSHING_FREE_KICK => Ok(Some(SetPlay::PushingFreeKick)),
-            SET_PLAY_CORNER_KICK => Ok(Some(SetPlay::CornerKick)),
-            SET_PLAY_KICK_IN => Ok(Some(SetPlay::KickIn)),
-            SET_PLAY_PENALTY_KICK => Ok(Some(SetPlay::PenaltyKick)),
-            _ => bail!("unexpected set play"),
+            SET_PLAY_GOAL_KICK => Ok(Some(SubState::GoalKick)),
+            SET_PLAY_PUSHING_FREE_KICK => Ok(Some(SubState::PushingFreeKick)),
+            SET_PLAY_CORNER_KICK => Ok(Some(SubState::CornerKick)),
+            SET_PLAY_KICK_IN => Ok(Some(SubState::KickIn)),
+            SET_PLAY_PENALTY_KICK => Ok(Some(SubState::PenaltyKick)),
+            _ => bail!("unexpected sub state"),
         }
     }
 }
 
 #[derive(Default, Clone, Copy, Debug, Deserialize, Serialize, SerializeHierarchy)]
-pub enum SetPlay {
+pub enum SubState {
     #[default]
     GoalKick,
     PushingFreeKick,

--- a/crates/spl_network_messages/src/lib.rs
+++ b/crates/spl_network_messages/src/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 pub use game_controller_return_message::GameControllerReturnMessage;
 pub use game_controller_state_message::{
-    GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player, SetPlay,
+    GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player, SubState,
     Team, TeamColor, TeamState,
 };
 use serialize_hierarchy::SerializeHierarchy;

--- a/crates/spl_network_messages/src/lib.rs
+++ b/crates/spl_network_messages/src/lib.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 
 pub use game_controller_return_message::GameControllerReturnMessage;
 pub use game_controller_state_message::{
-    GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player, SubState,
-    Team, TeamColor, TeamState,
+    GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player,
+    SubState, Team, TeamColor, TeamState,
 };
 use serialize_hierarchy::SerializeHierarchy;
 pub use spl_message::SplMessage;

--- a/crates/types/src/game_controller_state.rs
+++ b/crates/types/src/game_controller_state.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
-use spl_network_messages::{GamePhase, GameState, Penalty, SetPlay, Team};
+use spl_network_messages::{GamePhase, GameState, Penalty, SubState, Team};
 
 use super::Players;
 
@@ -14,5 +14,5 @@ pub struct GameControllerState {
     pub last_game_state_change: SystemTime,
     pub penalties: Players<Option<Penalty>>,
     pub remaining_amount_of_messages: u16,
-    pub set_play: Option<SetPlay>,
+    pub sub_state: Option<SubState>,
 }

--- a/tests/behavior/demonstration.lua
+++ b/tests/behavior/demonstration.lua
@@ -36,7 +36,7 @@ function on_cycle()
   end
 
   if state.cycle_count == 3000 then
-    state.game_controller_state.set_play = "PushingFreeKick"
+    state.game_controller_state.sub_state = "PushingFreeKick"
     state.game_controller_state.kicking_team = "Opponent"
     state.filtered_game_state.Playing.ball_is_free = false
   end

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -57,7 +57,7 @@ impl State {
                 five: None,
             },
             remaining_amount_of_messages: 1200,
-            set_play: None,
+            sub_state: None,
         };
 
         Self {


### PR DESCRIPTION
## Introduced Changes

Renamed all instances of set_play, and SetPlay to sub_state, respectively Sub_State to match current naming conventions of RoboCup 2023 Rules.


## ToDo / Known Issues

Header files based on SPL Messages have not been updated as they are based on the game controller.

## Ideas for Next Iterations (Not This PR)

## How to Test

No testing should be necessary as pepsi does not complain and only renaming was done.