### PR TITLE
Additional output for positions difference

### DIFF
--- a/crates/control/src/motion/joint_command_sender.rs
+++ b/crates/control/src/motion/joint_command_sender.rs
@@ -14,6 +14,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     pub positions: AdditionalOutput<Joints, "positions">,
+    pub positions_difference: AdditionalOutput<Joints, "positions_difference">,
     pub stiffnesses: AdditionalOutput<Joints, "stiffnesses">,
 
     pub center_head_position: Parameter<HeadJoints, "center_head_position">,
@@ -89,6 +90,9 @@ impl JointCommandSender {
             .wrap_err("failed to write to actuators")?;
 
         context.positions.fill_if_subscribed(|| positions);
+        context
+            .positions_difference
+            .fill_if_subscribed(|| positions - current_positions);
         context.stiffnesses.fill_if_subscribed(|| stiffnesses);
 
         Ok(MainOutputs {})

--- a/crates/types/src/joints.rs
+++ b/crates/types/src/joints.rs
@@ -1,6 +1,6 @@
 use std::{
     iter::Sum,
-    ops::{Add, Mul},
+    ops::{Add, Mul, Sub},
 };
 
 use approx::{AbsDiffEq, RelativeEq};
@@ -56,6 +56,17 @@ impl Add for HeadJoints {
         Self::Output {
             yaw: self.yaw + right.yaw,
             pitch: self.pitch + right.pitch,
+        }
+    }
+}
+
+impl Sub for HeadJoints {
+    type Output = HeadJoints;
+
+    fn sub(self, right: Self) -> Self::Output {
+        Self::Output {
+            yaw: self.yaw - right.yaw,
+            pitch: self.pitch - right.pitch,
         }
     }
 }
@@ -124,6 +135,21 @@ impl Add for ArmJoints {
     }
 }
 
+impl Sub for ArmJoints {
+    type Output = ArmJoints;
+
+    fn sub(self, right: Self) -> Self::Output {
+        Self::Output {
+            shoulder_pitch: self.shoulder_pitch - right.shoulder_pitch,
+            shoulder_roll: self.shoulder_roll - right.shoulder_roll,
+            elbow_yaw: self.elbow_yaw - right.elbow_yaw,
+            elbow_roll: self.elbow_roll - right.elbow_roll,
+            wrist_yaw: self.wrist_yaw - right.wrist_yaw,
+            hand: self.hand - right.hand,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize, SerializeHierarchy)]
 pub struct LegJoints {
     pub hip_yaw_pitch: f32,
@@ -184,6 +210,21 @@ impl Add for LegJoints {
             knee_pitch: self.knee_pitch + right.knee_pitch,
             ankle_pitch: self.ankle_pitch + right.ankle_pitch,
             ankle_roll: self.ankle_roll + right.ankle_roll,
+        }
+    }
+}
+
+impl Sub for LegJoints {
+    type Output = LegJoints;
+
+    fn sub(self, right: Self) -> Self::Output {
+        Self::Output {
+            hip_yaw_pitch: self.hip_yaw_pitch - right.hip_yaw_pitch,
+            hip_roll: self.hip_roll - right.hip_roll,
+            hip_pitch: self.hip_pitch - right.hip_pitch,
+            knee_pitch: self.knee_pitch - right.knee_pitch,
+            ankle_pitch: self.ankle_pitch - right.ankle_pitch,
+            ankle_roll: self.ankle_roll - right.ankle_roll,
         }
     }
 }
@@ -396,6 +437,20 @@ impl Add for Joints {
             right_arm: self.right_arm + right.right_arm,
             left_leg: self.left_leg + right.left_leg,
             right_leg: self.right_leg + right.right_leg,
+        }
+    }
+}
+
+impl Sub for Joints {
+    type Output = Joints;
+
+    fn sub(self, right: Self) -> Self::Output {
+        Self::Output {
+            head: self.head - right.head,
+            left_arm: self.left_arm - right.left_arm,
+            right_arm: self.right_arm - right.right_arm,
+            left_leg: self.left_leg - right.left_leg,
+            right_leg: self.right_leg - right.right_leg,
         }
     }
 }

--- a/crates/types/src/joints.rs
+++ b/crates/types/src/joints.rs
@@ -52,10 +52,10 @@ impl Mul<f32> for HeadJoints {
 impl Add for HeadJoints {
     type Output = HeadJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            yaw: self.yaw + rhs.yaw,
-            pitch: self.pitch + rhs.pitch,
+            yaw: self.yaw + right.yaw,
+            pitch: self.pitch + right.pitch,
         }
     }
 }
@@ -112,14 +112,14 @@ impl Mul<f32> for ArmJoints {
 impl Add for ArmJoints {
     type Output = ArmJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            shoulder_pitch: self.shoulder_pitch + rhs.shoulder_pitch,
-            shoulder_roll: self.shoulder_roll + rhs.shoulder_roll,
-            elbow_yaw: self.elbow_yaw + rhs.elbow_yaw,
-            elbow_roll: self.elbow_roll + rhs.elbow_roll,
-            wrist_yaw: self.wrist_yaw + rhs.wrist_yaw,
-            hand: self.hand + rhs.hand,
+            shoulder_pitch: self.shoulder_pitch + right.shoulder_pitch,
+            shoulder_roll: self.shoulder_roll + right.shoulder_roll,
+            elbow_yaw: self.elbow_yaw + right.elbow_yaw,
+            elbow_roll: self.elbow_roll + right.elbow_roll,
+            wrist_yaw: self.wrist_yaw + right.wrist_yaw,
+            hand: self.hand + right.hand,
         }
     }
 }
@@ -176,17 +176,18 @@ impl Mul<f32> for LegJoints {
 impl Add for LegJoints {
     type Output = LegJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            hip_yaw_pitch: self.hip_yaw_pitch + rhs.hip_yaw_pitch,
-            hip_roll: self.hip_roll + rhs.hip_roll,
-            hip_pitch: self.hip_pitch + rhs.hip_pitch,
-            knee_pitch: self.knee_pitch + rhs.knee_pitch,
-            ankle_pitch: self.ankle_pitch + rhs.ankle_pitch,
-            ankle_roll: self.ankle_roll + rhs.ankle_roll,
+            hip_yaw_pitch: self.hip_yaw_pitch + right.hip_yaw_pitch,
+            hip_roll: self.hip_roll + right.hip_roll,
+            hip_pitch: self.hip_pitch + right.hip_pitch,
+            knee_pitch: self.knee_pitch + right.knee_pitch,
+            ankle_pitch: self.ankle_pitch + right.ankle_pitch,
+            ankle_roll: self.ankle_roll + right.ankle_roll,
         }
     }
 }
+
 impl AbsDiffEq for LegJoints {
     type Epsilon = f32;
 
@@ -278,12 +279,12 @@ impl Mul<f32> for BodyJoints {
 impl Add for BodyJoints {
     type Output = BodyJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            left_arm: self.left_arm + rhs.left_arm,
-            right_arm: self.right_arm + rhs.right_arm,
-            left_leg: self.left_leg + rhs.left_leg,
-            right_leg: self.right_leg + rhs.right_leg,
+            left_arm: self.left_arm + right.left_arm,
+            right_arm: self.right_arm + right.right_arm,
+            left_leg: self.left_leg + right.left_leg,
+            right_leg: self.right_leg + right.right_leg,
         }
     }
 }
@@ -388,13 +389,13 @@ impl Mul<f32> for Joints {
 impl Add for Joints {
     type Output = Joints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            head: self.head + rhs.head,
-            left_arm: self.left_arm + rhs.left_arm,
-            right_arm: self.right_arm + rhs.right_arm,
-            left_leg: self.left_leg + rhs.left_leg,
-            right_leg: self.right_leg + rhs.right_leg,
+            head: self.head + right.head,
+            left_arm: self.left_arm + right.left_arm,
+            right_arm: self.right_arm + right.right_arm,
+            left_leg: self.left_leg + right.left_leg,
+            right_leg: self.right_leg + right.right_leg,
         }
     }
 }

--- a/crates/types/src/line.rs
+++ b/crates/types/src/line.rs
@@ -117,8 +117,8 @@ where
 {
     type Output = Line<DIMENSION>;
 
-    fn mul(self, rhs: Line<DIMENSION>) -> Self::Output {
-        Line(self * rhs.0, self * rhs.1)
+    fn mul(self, right: Line<DIMENSION>) -> Self::Output {
+        Line(self * right.0, self * right.1)
     }
 }
 

--- a/crates/types/src/step_plan.rs
+++ b/crates/types/src/step_plan.rs
@@ -31,11 +31,11 @@ impl Step {
 impl Sub<Step> for Step {
     type Output = Step;
 
-    fn sub(self, rhs: Step) -> Self::Output {
+    fn sub(self, right: Step) -> Self::Output {
         Self {
-            forward: self.forward - rhs.forward,
-            left: self.left - rhs.left,
-            turn: self.turn - rhs.turn,
+            forward: self.forward - right.forward,
+            left: self.left - right.left,
+            turn: self.turn - right.turn,
         }
     }
 }

--- a/tools/camera_matrix_extractor/src/joints.rs
+++ b/tools/camera_matrix_extractor/src/joints.rs
@@ -39,10 +39,10 @@ impl Mul<f32> for HeadJoints {
 impl Add for HeadJoints {
     type Output = HeadJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            yaw: self.yaw + rhs.yaw,
-            pitch: self.pitch + rhs.pitch,
+            yaw: self.yaw + right.yaw,
+            pitch: self.pitch + right.pitch,
         }
     }
 }
@@ -75,14 +75,14 @@ impl Mul<f32> for ArmJoints {
 impl Add for ArmJoints {
     type Output = ArmJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            shoulder_pitch: self.shoulder_pitch + rhs.shoulder_pitch,
-            shoulder_roll: self.shoulder_roll + rhs.shoulder_roll,
-            elbow_yaw: self.elbow_yaw + rhs.elbow_yaw,
-            elbow_roll: self.elbow_roll + rhs.elbow_roll,
-            wrist_yaw: self.wrist_yaw + rhs.wrist_yaw,
-            hand: self.hand + rhs.hand,
+            shoulder_pitch: self.shoulder_pitch + right.shoulder_pitch,
+            shoulder_roll: self.shoulder_roll + right.shoulder_roll,
+            elbow_yaw: self.elbow_yaw + right.elbow_yaw,
+            elbow_roll: self.elbow_roll + right.elbow_roll,
+            wrist_yaw: self.wrist_yaw + right.wrist_yaw,
+            hand: self.hand + right.hand,
         }
     }
 }
@@ -115,14 +115,14 @@ impl Mul<f32> for LegJoints {
 impl Add for LegJoints {
     type Output = LegJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            hip_yaw_pitch: self.hip_yaw_pitch + rhs.hip_yaw_pitch,
-            hip_roll: self.hip_roll + rhs.hip_roll,
-            hip_pitch: self.hip_pitch + rhs.hip_pitch,
-            knee_pitch: self.knee_pitch + rhs.knee_pitch,
-            ankle_pitch: self.ankle_pitch + rhs.ankle_pitch,
-            ankle_roll: self.ankle_roll + rhs.ankle_roll,
+            hip_yaw_pitch: self.hip_yaw_pitch + right.hip_yaw_pitch,
+            hip_roll: self.hip_roll + right.hip_roll,
+            hip_pitch: self.hip_pitch + right.hip_pitch,
+            knee_pitch: self.knee_pitch + right.knee_pitch,
+            ankle_pitch: self.ankle_pitch + right.ankle_pitch,
+            ankle_roll: self.ankle_roll + right.ankle_roll,
         }
     }
 }
@@ -162,12 +162,12 @@ impl Mul<f32> for BodyJoints {
 impl Add for BodyJoints {
     type Output = BodyJoints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            left_arm: self.left_arm + rhs.left_arm,
-            right_arm: self.right_arm + rhs.right_arm,
-            left_leg: self.left_leg + rhs.left_leg,
-            right_leg: self.right_leg + rhs.right_leg,
+            left_arm: self.left_arm + right.left_arm,
+            right_arm: self.right_arm + right.right_arm,
+            left_leg: self.left_leg + right.left_leg,
+            right_leg: self.right_leg + right.right_leg,
         }
     }
 }
@@ -255,13 +255,13 @@ impl Mul<f32> for Joints {
 impl Add for Joints {
     type Output = Joints;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, right: Self) -> Self::Output {
         Self::Output {
-            head: self.head + rhs.head,
-            left_arm: self.left_arm + rhs.left_arm,
-            right_arm: self.right_arm + rhs.right_arm,
-            left_leg: self.left_leg + rhs.left_leg,
-            right_leg: self.right_leg + rhs.right_leg,
+            head: self.head + right.head,
+            left_arm: self.left_arm + right.left_arm,
+            right_arm: self.right_arm + right.right_arm,
+            left_leg: self.left_leg + right.left_leg,
+            right_leg: self.right_leg + right.right_leg,
         }
     }
 }


### PR DESCRIPTION
## Introduced Changes

This PR adds an additional output describing the difference between the set and measured joint positions. It furthermore renames all occurrences of `rhs` to `right` to avoid abbreviations.

Resolves #118.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

Nothing here.

## How to Test

Flash a NAO and start twix. Plot any of the additional `positions_difference` output values and observe them when the robot is in motion.
