### PR TITLE
Add required features to bin targets

### DIFF
--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -31,3 +31,11 @@ tokio-util = { workspace = true }
 types = { workspace = true }
 v4l = { optional = true, workspace = true }
 webots = { optional = true, workspace = true }
+
+[[bin]]
+name = "nao"
+required-features = ["nao"]
+
+[[bin]]
+name = "webots"
+required-features = ["webots"]


### PR DESCRIPTION
## Introduced Changes

What it says.
This has two benefits:
- Hints to rust-analyzer how to lint those bin modules even without the `features = all` setting.
- Compilation fails earlier if for whatever reason the user forgot to enable one of features.

## How to Test

Shouldn't change anything functionally but if you run rust-analyzer without enabling all features, there should be no error messages now. Previously there was one in each of `crates/hulk/src/bin/{nao,webots}.rs`