### PR TITLE
Error propagation in communication

### DIFF
--- a/crates/communication/src/server/parameters/directory.rs
+++ b/crates/communication/src/server/parameters/directory.rs
@@ -11,23 +11,23 @@ use tokio::fs::{read_to_string, write};
 #[derive(Debug, thiserror::Error)]
 pub enum DirectoryError {
     #[error("failed to get default parameters")]
-    DefaultParametersNotGet(SerializationError),
+    DefaultParametersNotGet(#[source] SerializationError),
     #[error("failed to get default parameters of location")]
-    DefaultParametersOfLocationNotGet(SerializationError),
+    DefaultParametersOfLocationNotGet(#[source] SerializationError),
     #[error("failed to get body parameters")]
-    BodyParametersNotGet(SerializationError),
+    BodyParametersNotGet(#[source] SerializationError),
     #[error("failed to get head parameters")]
-    HeadParametersNotGet(SerializationError),
+    HeadParametersNotGet(#[source] SerializationError),
     #[error("failed to get body parameters of location")]
-    BodyParametersOfLocationNotGet(SerializationError),
+    BodyParametersOfLocationNotGet(#[source] SerializationError),
     #[error("failed to get head parameters of location")]
-    HeadParametersOfLocationNotGet(SerializationError),
+    HeadParametersOfLocationNotGet(#[source] SerializationError),
     #[error("failed to convert dynamic JSON object into resulting parameters object")]
-    JsonValueNotConvertedToParameters(error::Error),
+    JsonValueNotConvertedToParameters(#[source] error::Error),
     #[error("failed to convert parameters object into dynamic JSON object")]
-    ParametersNotConvertedToJsonValue(error::Error),
+    ParametersNotConvertedToJsonValue(#[source] error::Error),
     #[error("failed to set head parameters of location")]
-    HeadParametersOfLocationNotSet(SerializationError),
+    HeadParametersOfLocationNotSet(#[source] SerializationError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/communication/src/server/runtime.rs
+++ b/crates/communication/src/server/runtime.rs
@@ -36,15 +36,15 @@ use super::{
 #[derive(Debug, thiserror::Error)]
 pub enum StartError {
     #[error("error while accepting connections")]
-    AcceptError(AcceptError),
-    #[error("one or more tasks encountered an error")]
+    AcceptError(#[source] AcceptError),
+    #[error("one or more tasks encountered an error: {0:?}")]
     TasksErrored(Vec<StartError>),
     #[error("thread not started")]
-    ThreadNotStarted(io::Error),
+    ThreadNotStarted(#[source] io::Error),
     #[error("runtime not started")]
-    RuntimeNotStarted(io::Error),
+    RuntimeNotStarted(#[source] io::Error),
     #[error("initial parameters not parsed")]
-    InitialParametersNotParsed(DirectoryError),
+    InitialParametersNotParsed(#[source] DirectoryError),
 }
 
 pub struct Runtime<Parameters> {


### PR DESCRIPTION
## Introduced Changes

Propagates errors via `thiserror` and `#[source]` annotation.
This displays the entire chain of errors

```
Error:
   0: failed to start communication server
   1: initial parameters not parsed
```

vs (new)

```
Error:
   0: failed to start communication server
   1: initial parameters not parsed
   2: failed to convert dynamic JSON object into resulting parameters object
   3: missing field `enable`
```

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

e.g. remove a key in the `default.json` or trigger any other error in communication
