### PR TITLE
Resubscribe Parameter Panels in Twix

### DIFF
--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -24,11 +24,14 @@ impl Panel for ParameterPanel {
             Some(Value::String(string)) => string.clone(),
             _ => String::new(),
         };
+        let value_buffer = nao.subscribe_parameter(&path);
         let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+        value_buffer.listen_to_updates(update_notify_sender.clone());
+
         Self {
             nao,
             path,
-            value_buffer: None,
+            value_buffer: Some(value_buffer),
             parameter_value: String::new(),
             update_notify_sender,
             update_notify_receiver,

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -24,14 +24,21 @@ impl Panel for ParameterPanel {
             Some(Value::String(string)) => string.clone(),
             _ => String::new(),
         };
-        let value_buffer = nao.subscribe_parameter(&path);
+
         let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
-        value_buffer.listen_to_updates(update_notify_sender.clone());
+        let value_buffer = match path.is_empty() {
+            true => None,
+            false => {
+                let value_buffer = nao.subscribe_parameter(&path);
+                value_buffer.listen_to_updates(update_notify_sender.clone());
+                Some(value_buffer)
+            }
+        };
 
         Self {
             nao,
             path,
-            value_buffer: Some(value_buffer),
+            value_buffer,
             parameter_value: String::new(),
             update_notify_sender,
             update_notify_receiver,

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -82,7 +82,7 @@ impl Widget for &mut ParameterPanel {
                         });
                     }
                     Err(error) => {
-                        ui.label(format!("{error:#?}"));
+                        ui.label(error);
                     }
                 }
             }


### PR DESCRIPTION
## Introduced Changes

Correctly initialize parameter panels at twix startup.
Previously the previous path would be restored, but the the values wouldn't be subscribed requiring manually clicking on the input field and pressing enter for the current parameter values to show up and be editable.
Also some minor refactoring.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

- Open parameter panel and connect to a hulk instance
- Subscribe some path with the parameter panel
- Restart twix, everything should be restored instead of just the path text.