### PR TITLE
GUI for manual calibration

### DIFF
--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -148,7 +148,7 @@ impl Display for SelectablePanel {
             SelectablePanel::ImageSegments(_) => ImageSegmentsPanel::NAME,
             SelectablePanel::Map(_) => MapPanel::NAME,
             SelectablePanel::Parameter(_) => ParameterPanel::NAME,
-            SelectablePanel::ManualCalibration(_) => ParameterPanel::NAME,
+            SelectablePanel::ManualCalibration(_) => ManualCalibrationPanel::NAME,
         };
         f.write_str(panel_name)
     }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -23,8 +23,8 @@ use fern::{colors::ColoredLevelConfig, Dispatch, InitError};
 use nao::Nao;
 use panel::Panel;
 use panels::{
-    BehaviorSimulatorPanel, ImagePanel, ImageSegmentsPanel, MapPanel, ParameterPanel, PlotPanel,
-    TextPanel,
+    BehaviorSimulatorPanel, ImagePanel, ImageSegmentsPanel, ManualCalibrationPanel, MapPanel,
+    ParameterPanel, PlotPanel, TextPanel,
 };
 use serde_json::{from_str, to_string, Value};
 use tokio::sync::mpsc;
@@ -74,6 +74,7 @@ enum SelectablePanel {
     ImageSegments(ImageSegmentsPanel),
     Map(MapPanel),
     Parameter(ParameterPanel),
+    ManualCalibration(ManualCalibrationPanel),
 }
 
 impl SelectablePanel {
@@ -98,6 +99,9 @@ impl SelectablePanel {
             "image segments" => SelectablePanel::ImageSegments(ImageSegmentsPanel::new(nao, value)),
             "map" => SelectablePanel::Map(MapPanel::new(nao, value)),
             "parameter" => SelectablePanel::Parameter(ParameterPanel::new(nao, value)),
+            "manual calibration" => {
+                SelectablePanel::ManualCalibration(ManualCalibrationPanel::new(nao, value))
+            }
             name => bail!("unexpected panel name: {name}"),
         })
     }
@@ -111,6 +115,7 @@ impl SelectablePanel {
             SelectablePanel::ImageSegments(panel) => panel.save(),
             SelectablePanel::Map(panel) => panel.save(),
             SelectablePanel::Parameter(panel) => panel.save(),
+            SelectablePanel::ManualCalibration(panel) => panel.save(),
         };
         value["_panel_type"] = Value::String(self.to_string());
 
@@ -128,6 +133,7 @@ impl Widget for &mut SelectablePanel {
             SelectablePanel::ImageSegments(panel) => panel.ui(ui),
             SelectablePanel::Map(panel) => panel.ui(ui),
             SelectablePanel::Parameter(panel) => panel.ui(ui),
+            SelectablePanel::ManualCalibration(panel) => panel.ui(ui),
         }
     }
 }
@@ -142,6 +148,7 @@ impl Display for SelectablePanel {
             SelectablePanel::ImageSegments(_) => ImageSegmentsPanel::NAME,
             SelectablePanel::Map(_) => MapPanel::NAME,
             SelectablePanel::Parameter(_) => ParameterPanel::NAME,
+            SelectablePanel::ManualCalibration(_) => ParameterPanel::NAME,
         };
         f.write_str(panel_name)
     }
@@ -267,6 +274,7 @@ impl App for TwixApp {
                         "Image Segments".to_string(),
                         "Map".to_string(),
                         "Parameter".to_string(),
+                        "Manual Calibration".to_string(),
                     ],
                 )
                 .ui(ui);

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -95,18 +95,7 @@ fn add_extrinsic_calibration_ui_components(
         ui.label(format!("{label:#} Camera"));
 
         let settable = camera_parameter_option.is_some();
-        ui.add_enabled_ui(settable, |ui| {
-            if ui.button("Set").clicked() {
-                if let Some(camera_parameter_value) = camera_parameter_option {
-                    match serde_json::value::to_value(camera_parameter_value) {
-                        Ok(value) => {
-                            nao.update_parameter_value(camera_matrix_subscription_path, value);
-                        }
-                        Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
-                    }
-                }
-            }
-        });
+
         add_save_button(
             ui,
             camera_matrix_subscription_path,
@@ -120,7 +109,6 @@ fn add_extrinsic_calibration_ui_components(
         );
     });
 
-    ui.label(""); // TODO Identify a better way to do vertical spaces.
     let mut changed = false;
     ui.collapsing(
         format!("Intrinsic Parameters {label:#}"),
@@ -156,7 +144,6 @@ fn add_extrinsic_calibration_ui_components(
                         changed = true
                     };
                 }
-                ui.label(""); // TODO Identify a better way to do vertical spaces.
             }
             _ => {
                 ui.label("Intrinsic parameters not recieved.");
@@ -213,7 +200,6 @@ impl Widget for &mut ManualCalibrationPanel {
                     extrinsic_rotation_subscription,
                 );
 
-                ui.label("");
                 ui.separator();
             }
         })

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -1,0 +1,182 @@
+use std::{str::FromStr, sync::Arc};
+
+use color_eyre::{
+    eyre::{bail, eyre},
+    Result,
+};
+use communication::client::CyclerOutput;
+use eframe::egui::{InnerResponse, Label, Response, ScrollArea, TextEdit, Ui, Widget};
+use log::error;
+use regex::Regex;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::{runtime::Runtime, sync::mpsc, task::block_in_place};
+
+use crate::{nao::Nao, panel::Panel, value_buffer::ValueBuffer};
+use repository::{get_repository_root, HardwareIds, Repository};
+
+// TODO move this elsewhere
+fn get_last_octet_from_connection_url(connection_address: &str) -> Option<String> {
+    // //  lazy_static! {
+    //     static ref RE: Regex = Regex::new("...").unwrap();
+    // }
+    // RE.is_match(text)
+
+    // Extract the ip address from a url like "ws://{ip_address}:1337"
+    // pass: ws://10.12.34.13 OR ws://10.12.34.13:1234
+    // fail: 10.12.34.13... ws://localhost OR ws://localhost:1234
+    let re = Regex::new(
+        r"(?m)^ws://(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    .(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    .(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    .(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
+    (?::[\d]*)?$",
+    )
+    .unwrap();
+
+    let captures = re.captures(connection_address);
+    captures.and_then(|capture| capture.get(1).and_then(|v| Some(v.as_str().to_string())))
+}
+
+struct RepoConfigurationHandler {
+    repository: Repository,
+    file_io_runtime: Runtime, // to call async functions.
+}
+
+impl RepoConfigurationHandler {
+    fn new() -> Self {
+        let runtime = Runtime::new().unwrap();
+        let repo_root = runtime.block_on(get_repository_root()).unwrap();
+
+        Self {
+            repository: Repository::new(repo_root),
+            file_io_runtime: runtime,
+        }
+    }
+
+    fn get_hardware_ids_from_url(&self, connection_url: &str) -> Result<HardwareIds> {
+        let nao_id_from_last_octet = get_last_octet_from_connection_url(connection_url)
+            .and_then(|nao_id_str| nao_id_str.parse::<u8>().ok());
+
+        match nao_id_from_last_octet {
+            Some(nao_id) => {
+                let ids = self
+                    .file_io_runtime
+                    .block_on(self.repository.get_hardware_ids())
+                    .unwrap();
+
+                ids.get(&nao_id).map_or(
+                    Err(eyre!("Nao ID not found in hardware ID list.")),
+                    |hardware_ids| -> Result<HardwareIds> { Ok(hardware_ids.clone()) },
+                )
+            }
+            None => Err(eyre!("Nao ID couldn't be extracted from connection url")),
+        }
+    }
+}
+
+pub struct ManualCalibrationPanel {
+    nao: Arc<Nao>,
+    paths: [String; 2],
+    camera_value_buffers: [ValueBuffer; 2],
+    camera_rotation: [String; 2],
+    update_notify_sender: mpsc::Sender<()>,
+    update_notify_receiver: mpsc::Receiver<()>,
+}
+
+const CAMERA_KEY_BASE: &'static str = "camera_matrix_parameters.vision_";
+const ROTATIONS: &'static str = ".extrinsic_rotations";
+
+impl Panel for ManualCalibrationPanel {
+    const NAME: &'static str = "Parameter";
+
+    fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
+        let paths = ["top", "bottom"].map(|name| (CAMERA_KEY_BASE.to_owned() + name + ROTATIONS));
+        let value_buffers = paths.clone().map(|path| nao.subscribe_parameter(&path));
+
+        let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+
+        let connection_url = nao.get_address();
+        println!("Address {:?}", connection_url);
+
+        if let Some(url) = connection_url {
+            let config_handler = RepoConfigurationHandler::new();
+            let nao_hardware_ids = config_handler.get_hardware_ids_from_url(&url);
+
+            if let Ok(hwardware_ids) = nao_hardware_ids {
+                println!(
+                    "Nao ID {:?} {:?}",
+                    hwardware_ids.head_id, hwardware_ids.body_id
+                );
+            }
+        }
+
+        Self {
+            nao,
+            paths,
+            camera_value_buffers: value_buffers,
+            camera_rotation: [String::new(), String::new()],
+            update_notify_sender,
+            update_notify_receiver,
+        }
+    }
+    // fn save(&self) -> Value {
+    //     json!({
+    //         "subscribe_key": self.path.clone()
+    //     })
+    // }
+}
+
+fn add_edit_components_for_one_camera(
+    ui: &mut Ui,
+    camera_index: usize,
+    panel: &mut ManualCalibrationPanel,
+) -> InnerResponse<Response> {
+    let value_buffer = &panel.camera_value_buffers[camera_index];
+    let rotation_value = &mut panel.camera_rotation[camera_index];
+    let path = &panel.paths[camera_index];
+
+    ui.horizontal(|ui| {
+        let settable = !rotation_value.is_empty();
+        ui.add_enabled_ui(settable, |ui| {
+            if ui.button(format!("Set {}", camera_index)).clicked() {
+                match serde_json::value::to_value(&rotation_value) {
+                    Ok(value) => {
+                        panel.nao.update_parameter_value(&path, value);
+                    }
+                    Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
+                }
+            }
+        });
+        match value_buffer.get_latest() {
+            Ok(value) => {
+                if panel.update_notify_receiver.try_recv().is_ok() {
+                    *rotation_value = serde_json::to_string_pretty(&value).unwrap();
+                }
+                // ScrollArea::vertical().show(ui, |ui: &mut Ui| {
+                ui.add(Label::new(path));
+                ui.add(Label::new("Rotations"));
+                ui.add(
+                    TextEdit::multiline(&mut rotation_value.clone())
+                        .code_editor()
+                        .desired_width(f32::INFINITY),
+                )
+                // });
+            }
+            Err(error) => ui.label(format!("{error:#?}")),
+        }
+    })
+}
+
+impl Widget for &mut ManualCalibrationPanel {
+    fn ui(self, ui: &mut Ui) -> Response {
+        ui.vertical(|ui| {
+            // ui.horizontal(|ui| {
+            //     ui.label(format!("NAO Number: {}, head id {}, body id {}"));
+            // });
+            add_edit_components_for_one_camera(ui, 0, self);
+            add_edit_components_for_one_camera(ui, 1, self);
+        })
+        .response
+    }
+}

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -105,7 +105,6 @@ fn add_extrinsic_calibration_ui_components(
             },
             nao.clone(),
             repository_parameters,
-            settable,
         );
     });
 

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -28,7 +28,7 @@ const CAMERA_KEY_BASE: &str = "camera_matrix_parameters.vision_";
 const ROTATIONS: &str = ".extrinsic_rotations";
 
 impl Panel for ManualCalibrationPanel {
-    const NAME: &'static str = "Parameter";
+    const NAME: &'static str = "Manual Calibration";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         let extrinsic_rotation_subscriptions = ["top", "bottom"].map(|name| {
@@ -64,6 +64,7 @@ fn add_calibration_ui_components_for_one_camera(
     camera_index: usize,
     panel: &mut ManualCalibrationPanel,
 ) -> InnerResponse<()> {
+    let nao = Arc::clone(&panel.nao);
     let extrinsic_rotation_subscriptions =
         &mut panel.extrinsic_rotation_subscriptions[camera_index];
     let rotations_parameter_buffer = &extrinsic_rotation_subscriptions.value_buffer;
@@ -71,9 +72,6 @@ fn add_calibration_ui_components_for_one_camera(
     let rotations_path = &extrinsic_rotation_subscriptions.path;
     let rotations_update_notify_receiver =
         &mut extrinsic_rotation_subscriptions.update_notify_receiver;
-
-    let nao = panel.nao;
-    let current_url = &panel.current_url;
     let repository_configuration_handler = &panel.repository_configuration_handler;
 
     ui.horizontal(|ui| {
@@ -92,7 +90,6 @@ fn add_calibration_ui_components_for_one_camera(
 
         add_save_button(
             ui,
-            current_url,
             rotations_path,
             rotation_value,
             nao,

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -1,169 +1,123 @@
-use std::{str::FromStr, sync::Arc};
-
-use color_eyre::{
-    eyre::{bail, eyre},
-    Result,
-};
-use communication::client::CyclerOutput;
-use eframe::egui::{InnerResponse, Label, Response, ScrollArea, TextEdit, Ui, Widget};
-use log::error;
-use regex::Regex;
-use serde::Serialize;
+use eframe::egui::{InnerResponse, Response, ScrollArea, TextEdit, Ui, Widget};
+use log::{error, info};
 use serde_json::Value;
-use tokio::{runtime::Runtime, sync::mpsc, task::block_in_place};
+use std::sync::Arc;
+use tokio::sync::mpsc;
 
-use crate::{nao::Nao, panel::Panel, value_buffer::ValueBuffer};
-use repository::{get_repository_root, HardwareIds, Repository};
+use crate::{
+    nao::Nao, panel::Panel, repository_configuration_handler::RepositoryConfigurationHandler,
+    value_buffer::ValueBuffer,
+};
 
-// TODO move this elsewhere
-fn get_last_octet_from_connection_url(connection_address: &str) -> Option<String> {
-    // //  lazy_static! {
-    //     static ref RE: Regex = Regex::new("...").unwrap();
-    // }
-    // RE.is_match(text)
+use super::parameter::{add_save_button, subscribe};
 
-    // Extract the ip address from a url like "ws://{ip_address}:1337"
-    // pass: ws://10.12.34.13 OR ws://10.12.34.13:1234
-    // fail: 10.12.34.13... ws://localhost OR ws://localhost:1234
-    let re = Regex::new(
-        r"(?m)^ws://(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-    .(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-    .(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-    .(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
-    (?::[\d]*)?$",
-    )
-    .unwrap();
-
-    let captures = re.captures(connection_address);
-    captures.and_then(|capture| capture.get(1).and_then(|v| Some(v.as_str().to_string())))
-}
-
-struct RepoConfigurationHandler {
-    repository: Repository,
-    file_io_runtime: Runtime, // to call async functions.
-}
-
-impl RepoConfigurationHandler {
-    fn new() -> Self {
-        let runtime = Runtime::new().unwrap();
-        let repo_root = runtime.block_on(get_repository_root()).unwrap();
-
-        Self {
-            repository: Repository::new(repo_root),
-            file_io_runtime: runtime,
-        }
-    }
-
-    fn get_hardware_ids_from_url(&self, connection_url: &str) -> Result<HardwareIds> {
-        let nao_id_from_last_octet = get_last_octet_from_connection_url(connection_url)
-            .and_then(|nao_id_str| nao_id_str.parse::<u8>().ok());
-
-        match nao_id_from_last_octet {
-            Some(nao_id) => {
-                let ids = self
-                    .file_io_runtime
-                    .block_on(self.repository.get_hardware_ids())
-                    .unwrap();
-
-                ids.get(&nao_id).map_or(
-                    Err(eyre!("Nao ID not found in hardware ID list.")),
-                    |hardware_ids| -> Result<HardwareIds> { Ok(hardware_ids.clone()) },
-                )
-            }
-            None => Err(eyre!("Nao ID couldn't be extracted from connection url")),
-        }
-    }
+struct CameraParameterSubscriptions {
+    path: String,
+    value_buffer: ValueBuffer,
+    value: String,
+    update_notify_receiver: mpsc::Receiver<()>,
 }
 
 pub struct ManualCalibrationPanel {
     nao: Arc<Nao>,
-    paths: [String; 2],
-    camera_value_buffers: [ValueBuffer; 2],
-    camera_rotation: [String; 2],
-    update_notify_sender: mpsc::Sender<()>,
-    update_notify_receiver: mpsc::Receiver<()>,
+    repository_configuration_handler: RepositoryConfigurationHandler,
+    extrinsic_rotation_subscriptions: [CameraParameterSubscriptions; 2],
 }
 
-const CAMERA_KEY_BASE: &'static str = "camera_matrix_parameters.vision_";
-const ROTATIONS: &'static str = ".extrinsic_rotations";
+const CAMERA_KEY_BASE: &str = "camera_matrix_parameters.vision_";
+const ROTATIONS: &str = ".extrinsic_rotations";
 
 impl Panel for ManualCalibrationPanel {
     const NAME: &'static str = "Parameter";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
-        let paths = ["top", "bottom"].map(|name| (CAMERA_KEY_BASE.to_owned() + name + ROTATIONS));
-        let value_buffers = paths.clone().map(|path| nao.subscribe_parameter(&path));
+        let extrinsic_rotation_subscriptions = ["top", "bottom"].map(|name| {
+            let path = CAMERA_KEY_BASE.to_owned() + name + ROTATIONS;
 
-        let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+            let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender.clone());
+
+            info!("Subscribing to path {}", path);
+
+            CameraParameterSubscriptions {
+                path,
+                value_buffer: value_buffer.unwrap(),
+                value: String::new(),
+                update_notify_receiver,
+            }
+        });
 
         let connection_url = nao.get_address();
-        println!("Address {:?}", connection_url);
-
-        if let Some(url) = connection_url {
-            let config_handler = RepoConfigurationHandler::new();
-            let nao_hardware_ids = config_handler.get_hardware_ids_from_url(&url);
-
-            if let Ok(hwardware_ids) = nao_hardware_ids {
-                println!(
-                    "Nao ID {:?} {:?}",
-                    hwardware_ids.head_id, hwardware_ids.body_id
-                );
-            }
-        }
+        let repository_configuration_handler = RepositoryConfigurationHandler::new();
+        repository_configuration_handler.print_nao_ids(connection_url.clone());
 
         Self {
             nao,
-            paths,
-            camera_value_buffers: value_buffers,
-            camera_rotation: [String::new(), String::new()],
-            update_notify_sender,
-            update_notify_receiver,
+            repository_configuration_handler,
+            extrinsic_rotation_subscriptions,
         }
     }
-    // fn save(&self) -> Value {
-    //     json!({
-    //         "subscribe_key": self.path.clone()
-    //     })
-    // }
 }
 
-fn add_edit_components_for_one_camera(
+fn add_calibration_ui_components_for_one_camera(
     ui: &mut Ui,
     camera_index: usize,
     panel: &mut ManualCalibrationPanel,
-) -> InnerResponse<Response> {
-    let value_buffer = &panel.camera_value_buffers[camera_index];
-    let rotation_value = &mut panel.camera_rotation[camera_index];
-    let path = &panel.paths[camera_index];
+) -> InnerResponse<()> {
+    let extrinsic_rotation_subscriptions =
+        &mut panel.extrinsic_rotation_subscriptions[camera_index];
+    let rotations_parameter_buffer = &extrinsic_rotation_subscriptions.value_buffer;
+    let rotation_value = &mut extrinsic_rotation_subscriptions.value;
+    let rotations_path = &extrinsic_rotation_subscriptions.path;
+    let rotations_update_notify_receiver =
+        &mut extrinsic_rotation_subscriptions.update_notify_receiver;
+
+    let nao = panel.nao;
+    let current_url = &panel.current_url;
+    let repository_configuration_handler = &panel.repository_configuration_handler;
 
     ui.horizontal(|ui| {
+        ui.label(rotations_path);
         let settable = !rotation_value.is_empty();
         ui.add_enabled_ui(settable, |ui| {
             if ui.button(format!("Set {}", camera_index)).clicked() {
                 match serde_json::value::to_value(&rotation_value) {
                     Ok(value) => {
-                        panel.nao.update_parameter_value(&path, value);
+                        panel.nao.update_parameter_value(rotations_path, value);
                     }
                     Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
                 }
             }
         });
-        match value_buffer.get_latest() {
+
+        add_save_button(
+            ui,
+            current_url,
+            rotations_path,
+            rotation_value,
+            nao,
+            repository_configuration_handler,
+            settable,
+        );
+
+        match rotations_parameter_buffer.get_latest() {
             Ok(value) => {
-                if panel.update_notify_receiver.try_recv().is_ok() {
+                if rotations_update_notify_receiver.try_recv().is_ok() {
                     *rotation_value = serde_json::to_string_pretty(&value).unwrap();
                 }
-                // ScrollArea::vertical().show(ui, |ui: &mut Ui| {
-                ui.add(Label::new(path));
-                ui.add(Label::new("Rotations"));
-                ui.add(
-                    TextEdit::multiline(&mut rotation_value.clone())
-                        .code_editor()
-                        .desired_width(f32::INFINITY),
-                )
-                // });
+                ScrollArea::vertical()
+                    .id_source(rotations_path)
+                    .show(ui, |ui: &mut Ui| {
+                        ui.add(
+                            TextEdit::multiline(rotation_value)
+                                .code_editor()
+                                .desired_width(f32::INFINITY),
+                        )
+                    });
             }
-            Err(error) => ui.label(format!("{error:#?}")),
+            Err(error) => {
+                ui.label(format!("{error:#?}"));
+            }
         }
     })
 }
@@ -171,11 +125,8 @@ fn add_edit_components_for_one_camera(
 impl Widget for &mut ManualCalibrationPanel {
     fn ui(self, ui: &mut Ui) -> Response {
         ui.vertical(|ui| {
-            // ui.horizontal(|ui| {
-            //     ui.label(format!("NAO Number: {}, head id {}, body id {}"));
-            // });
-            add_edit_components_for_one_camera(ui, 0, self);
-            add_edit_components_for_one_camera(ui, 1, self);
+            add_calibration_ui_components_for_one_camera(ui, 0, self);
+            add_calibration_ui_components_for_one_camera(ui, 1, self);
         })
         .response
     }

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -1,7 +1,8 @@
-use eframe::egui::{InnerResponse, Response, ScrollArea, TextEdit, Ui, Widget};
+use eframe::egui::{Response, Slider, Ui, Widget};
 use log::{error, info};
+use nalgebra::Vector3;
 use serde_json::Value;
-use std::sync::Arc;
+use std::{ops::RangeInclusive, sync::Arc};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -11,17 +12,18 @@ use crate::{
 
 use super::parameter::{add_save_button, subscribe};
 
-struct CameraParameterSubscriptions {
+struct CameraParameterSubscriptions<DeserializedValueType> {
+    human_friendly_label: String,
     path: String,
     value_buffer: ValueBuffer,
-    value: String,
+    value: DeserializedValueType,
     update_notify_receiver: mpsc::Receiver<()>,
 }
 
 pub struct ManualCalibrationPanel {
     nao: Arc<Nao>,
     repository_configuration_handler: RepositoryConfigurationHandler,
-    extrinsic_rotation_subscriptions: [CameraParameterSubscriptions; 2],
+    extrinsic_rotation_subscriptions: [CameraParameterSubscriptions<Vector3<f32>>; 2],
 }
 
 const CAMERA_KEY_BASE: &str = "camera_matrix_parameters.vision_";
@@ -31,25 +33,26 @@ impl Panel for ManualCalibrationPanel {
     const NAME: &'static str = "Manual Calibration";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
-        let extrinsic_rotation_subscriptions = ["top", "bottom"].map(|name| {
-            let path = CAMERA_KEY_BASE.to_owned() + name + ROTATIONS;
+        let extrinsic_rotation_subscriptions = ["Top", "Bottom"].map(|name| {
+            let path = CAMERA_KEY_BASE.to_owned() + name.to_lowercase().as_str() + ROTATIONS;
 
             let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
-            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender.clone());
+            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender);
 
             info!("Subscribing to path {}", path);
 
             CameraParameterSubscriptions {
+                human_friendly_label: name.to_string() + " Extrinsic Rotations",
                 path,
                 value_buffer: value_buffer.unwrap(),
-                value: String::new(),
+                value: Vector3::zeros(),
                 update_notify_receiver,
             }
         });
 
         let connection_url = nao.get_address();
         let repository_configuration_handler = RepositoryConfigurationHandler::new();
-        repository_configuration_handler.print_nao_ids(connection_url.clone());
+        repository_configuration_handler.print_nao_ids(connection_url);
 
         Self {
             nao,
@@ -59,71 +62,82 @@ impl Panel for ManualCalibrationPanel {
     }
 }
 
-fn add_calibration_ui_components_for_one_camera(
+fn add_extrinsic_calibration_ui_components(
     ui: &mut Ui,
-    camera_index: usize,
-    panel: &mut ManualCalibrationPanel,
-) -> InnerResponse<()> {
-    let nao = Arc::clone(&panel.nao);
-    let extrinsic_rotation_subscriptions =
-        &mut panel.extrinsic_rotation_subscriptions[camera_index];
+    nao: Arc<Nao>,
+    repository_configuration_handler: &RepositoryConfigurationHandler,
+    extrinsic_rotation_subscriptions: &mut CameraParameterSubscriptions<Vector3<f32>>,
+) {
     let rotations_parameter_buffer = &extrinsic_rotation_subscriptions.value_buffer;
     let rotation_value = &mut extrinsic_rotation_subscriptions.value;
+    let label = &extrinsic_rotation_subscriptions.human_friendly_label;
     let rotations_path = &extrinsic_rotation_subscriptions.path;
     let rotations_update_notify_receiver =
         &mut extrinsic_rotation_subscriptions.update_notify_receiver;
-    let repository_configuration_handler = &panel.repository_configuration_handler;
 
     ui.horizontal(|ui| {
-        ui.label(rotations_path);
+        ui.label(label);
         let settable = !rotation_value.is_empty();
         ui.add_enabled_ui(settable, |ui| {
-            if ui.button(format!("Set {}", camera_index)).clicked() {
+            if ui.button("Set").clicked() {
                 match serde_json::value::to_value(&rotation_value) {
                     Ok(value) => {
-                        panel.nao.update_parameter_value(rotations_path, value);
+                        nao.update_parameter_value(rotations_path, value);
                     }
                     Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
                 }
             }
         });
 
-        add_save_button(
-            ui,
-            rotations_path,
-            rotation_value,
-            nao,
-            repository_configuration_handler,
-            settable,
-        );
-
-        match rotations_parameter_buffer.get_latest() {
+        // TODO Fix this as it looks utterly ridiculous.
+        match serde_json::value::to_value(&rotation_value) {
             Ok(value) => {
-                if rotations_update_notify_receiver.try_recv().is_ok() {
-                    *rotation_value = serde_json::to_string_pretty(&value).unwrap();
-                }
-                ScrollArea::vertical()
-                    .id_source(rotations_path)
-                    .show(ui, |ui: &mut Ui| {
-                        ui.add(
-                            TextEdit::multiline(rotation_value)
-                                .code_editor()
-                                .desired_width(f32::INFINITY),
-                        )
-                    });
+                add_save_button(
+                    ui,
+                    rotations_path,
+                    serde_json::to_string::<Value>(&value).unwrap().as_str(),
+                    nao,
+                    repository_configuration_handler,
+                    settable,
+                );
             }
-            Err(error) => {
-                ui.label(format!("{error:#?}"));
-            }
+            Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
         }
-    })
+    });
+    match rotations_parameter_buffer.get_latest() {
+        Ok(value) => {
+            if rotations_update_notify_receiver.try_recv().is_ok() {
+                *rotation_value = serde_json::from_value::<Vector3<f32>>(value).unwrap();
+            }
+            ui.vertical(|ui| {
+                for (axis_value, axis_name) in
+                    rotation_value.iter_mut().zip(["Roll", "Pitch", "Yaw"])
+                {
+                    ui.add(
+                        Slider::new(axis_value, RangeInclusive::new(-40.0, 40.0))
+                            .text(axis_name)
+                            .step_by(0.1),
+                    );
+                }
+            });
+        }
+        Err(error) => {
+            ui.label(format!("{error:#?}"));
+        }
+    }
 }
 
 impl Widget for &mut ManualCalibrationPanel {
     fn ui(self, ui: &mut Ui) -> Response {
         ui.vertical(|ui| {
-            add_calibration_ui_components_for_one_camera(ui, 0, self);
-            add_calibration_ui_components_for_one_camera(ui, 1, self);
+            for extrinsic_rotation_subscription in &mut self.extrinsic_rotation_subscriptions {
+                add_extrinsic_calibration_ui_components(
+                    ui,
+                    self.nao.clone(),
+                    &self.repository_configuration_handler,
+                    extrinsic_rotation_subscription,
+                );
+            }
         })
         .response
     }

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -94,8 +94,6 @@ fn add_extrinsic_calibration_ui_components(
 
         ui.label(format!("{label:#} Camera"));
 
-        let settable = camera_parameter_option.is_some();
-
         add_save_button(
             ui,
             camera_matrix_subscription_path,
@@ -108,6 +106,7 @@ fn add_extrinsic_calibration_ui_components(
         );
     });
 
+    ui.style_mut().spacing.slider_width = ui.available_size().x - 100.0;
     let mut changed = false;
     ui.collapsing(
         format!("Intrinsic Parameters {label:#}"),

--- a/tools/twix/src/panels/mod.rs
+++ b/tools/twix/src/panels/mod.rs
@@ -1,6 +1,7 @@
 mod behavior_simulator;
 mod image;
 mod image_segments;
+mod manual_camera_calibration;
 mod map;
 mod parameter;
 mod plot;
@@ -9,6 +10,7 @@ mod text;
 pub use self::behavior_simulator::BehaviorSimulatorPanel;
 pub use self::image::ImagePanel;
 pub use image_segments::ImageSegmentsPanel;
+pub use manual_camera_calibration::ManualCalibrationPanel;
 pub use map::MapPanel;
 pub use parameter::ParameterPanel;
 pub use plot::PlotPanel;

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -65,6 +65,15 @@ impl Panel for ParameterPanel {
 
 impl Widget for &mut ParameterPanel {
     fn ui(self, ui: &mut Ui) -> Response {
+        {
+            let current_address = self.nao.get_address();
+            if self.current_url != current_address {
+                self.current_url = current_address;
+                self.repository_configuration_handler
+                    .print_nao_ids(self.current_url.clone());
+            }
+        }
+
         ui.vertical(|ui| {
             ui.horizontal(|ui| {
                 let path_edit =

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -134,7 +134,7 @@ pub fn add_save_button<SerdesJsonValueProvider>(
     repository_parameters: &Option<RepositoryParameters>,
     settable: bool,
 ) where
-    SerdesJsonValueProvider: Fn() -> Result<serde_json::Value>,
+    SerdesJsonValueProvider: FnOnce() -> Result<serde_json::Value>,
 {
     ui.add_enabled_ui(settable, |ui| {
         if ui.button("Save to disk").clicked() {

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -128,7 +128,7 @@ impl Widget for &mut ParameterPanel {
 
 pub fn add_save_button<SerdesJsonValueProvider>(
     ui: &mut Ui,
-    parameter_path: &String,
+    parameter_path: &str,
     parameter_value_provider_fn: SerdesJsonValueProvider,
     nao: Arc<Nao>,
     repository_parameters: &Option<RepositoryParameters>,
@@ -141,7 +141,7 @@ pub fn add_save_button<SerdesJsonValueProvider>(
             if let Some(address) = nao.get_address() {
                 match (parameter_value_provider_fn(), repository_parameters) {
                     (Ok(value), Some(repository_parameters)) => {
-                        repository_parameters.write(&address, parameter_path.clone(), value);
+                        repository_parameters.write(&address, parameter_path.to_owned(), value);
                     }
                     (Err(error), _) => {
                         error!("Failed to serialize parameter value: {error:#?}")

--- a/tools/twix/src/panels/parameter.rs
+++ b/tools/twix/src/panels/parameter.rs
@@ -98,7 +98,6 @@ impl Widget for &mut ParameterPanel {
                     },
                     self.nao.clone(),
                     &self.repository_parameters,
-                    settable,
                 );
             });
 
@@ -132,11 +131,10 @@ pub fn add_save_button<SerdesJsonValueProvider>(
     parameter_value_provider_fn: SerdesJsonValueProvider,
     nao: Arc<Nao>,
     repository_parameters: &Option<RepositoryParameters>,
-    settable: bool,
 ) where
     SerdesJsonValueProvider: FnOnce() -> Result<serde_json::Value>,
 {
-    ui.add_enabled_ui(settable, |ui| {
+    ui.add_enabled_ui(repository_parameters.is_some(), |ui| {
         if ui.button("Save to disk").clicked() {
             if let Some(address) = nao.get_address() {
                 match (parameter_value_provider_fn(), repository_parameters) {


### PR DESCRIPTION
## Introduced Changes

**REQUIRES** #184

Provides a GUI for manual calibration. In addition, this incorporates the save-to-disk facility from the parameters panel. For detailed ideas and the implementation plans, please take a look at #117 .

### Actual files changes
Due to dependency on above mentioned #184 , a large diff is shown. Below are the files actually added/ changed in this PR.
```bash
$ gd 121_locate_configuration_files_twix 117_gui_for_manual_calibration --name-only
tools/twix/src/main.rs
tools/twix/src/panels/manual_camera_calibration.rs
tools/twix/src/panels/mod.rs
tools/twix/src/panels/parameter.rs
```

Fixes #

#117 

## ToDo / Known Issues

- [x] UI stuff probably is ultra* hacky and bad, fix them.
    - While not the best, esp in UX aspects, this is now in a useable state. Tested on Nao and Webots.
- [x] Add sliders instead of editors
- [x] Single save button for all? or one per parameter (or one for top, one for bottom)?
    - Split per camera.
- [x] slider limit calculation
    - Decided on +- 15 deg for extrinsic. This is a good value based on past experience.

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

![image](https://user-images.githubusercontent.com/6742239/233802147-1efddf0d-fed7-4041-bc84-3978816d9455.png)

Open twix, load the panel "Manual Calibration", there the UI should present calibration ability for intrinsic & extrinsic values.
The UI should be intuitive enough to figure out the rest, use the sliders to adjust parameters. Use save to disk to save on the PC with the correct head/ body ID mapping (Uses feature implemented in #184 )
