### PR TITLE
Introduce double buffered HULA reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,6 +2209,7 @@ dependencies = [
  "cyclers",
  "fern",
  "i2cdev",
+ "libc",
  "log",
  "nalgebra",
  "nao_camera",

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"
 
 [features]
-nao = ["alsa", "nao_camera", "v4l"]
+nao = ["alsa", "libc", "nao_camera", "v4l"]
 
 [dependencies]
 alsa = { optional = true, workspace = true }
@@ -17,6 +17,7 @@ ctrlc = { workspace = true }
 cyclers = { workspace = true }
 fern = { workspace = true }
 i2cdev = { workspace = true }
+libc = { optional = true, workspace = true }
 log = { workspace = true }
 nalgebra = { workspace = true }
 nao_camera = { optional = true, workspace = true }

--- a/crates/hulk/src/nao/double_buffered_reader.rs
+++ b/crates/hulk/src/nao/double_buffered_reader.rs
@@ -1,76 +1,161 @@
 use std::{
     io::{self, ErrorKind, Read},
-    mem::size_of,
+    mem::{size_of, MaybeUninit},
     os::unix::{io::AsRawFd, prelude::RawFd},
+    ptr::null_mut,
 };
+
+use libc::{fd_set, select, FD_SET, FD_ZERO};
 
 use super::hula::StateStorage;
 
-pub struct DoubleBufferedReader {
-    buffers: [[u8; size_of::<StateStorage>()]; 2],
+const NUMBER_OF_BUFFERS: usize = 2;
+
+pub struct DoubleBufferedReader<Reader, Poller> {
+    reader: Reader,
+    poller: Poller,
+    buffers: [[u8; size_of::<StateStorage>()]; NUMBER_OF_BUFFERS],
     active_buffer_index: usize,
-    incomplete_offset: usize,
+    number_of_read_bytes_in_active_buffer: usize,
 }
 
-impl Default for DoubleBufferedReader {
-    fn default() -> Self {
+impl<Reader, Poller> DoubleBufferedReader<Reader, Poller>
+where
+    Reader: AsRawFd + Read,
+    Poller: Poll,
+{
+    pub fn from_reader_and_poller(reader: Reader, poller: Poller) -> Self {
         Self {
-            buffers: [[0; size_of::<StateStorage>()]; 2],
+            reader,
+            poller,
+            buffers: [[0; size_of::<StateStorage>()]; NUMBER_OF_BUFFERS],
             active_buffer_index: Default::default(),
-            incomplete_offset: Default::default(),
+            number_of_read_bytes_in_active_buffer: Default::default(),
         }
     }
-}
 
-impl DoubleBufferedReader {
-    fn swap_buffers(&mut self) {
-        self.incomplete_offset = 0;
-        self.active_buffer_index = (self.active_buffer_index + 1) % 2;
+    fn previous_active_buffer_index(&self) -> usize {
+        (self.active_buffer_index + NUMBER_OF_BUFFERS - 1) % NUMBER_OF_BUFFERS
     }
 
-    pub fn read(
-        &mut self,
-        reader: &mut (impl AsRawFd + Read),
-        mut poll_reader: impl FnMut(RawFd) -> io::Result<()>,
-    ) -> io::Result<()> {
-        let mut buffers_swapped = false;
+    fn next_active_buffer_index(&self) -> usize {
+        (self.active_buffer_index + 1) % NUMBER_OF_BUFFERS
+    }
+
+    fn activate_next_buffer(&mut self) {
+        self.active_buffer_index = self.next_active_buffer_index();
+        self.number_of_read_bytes_in_active_buffer = 0;
+    }
+
+    pub fn drain(&mut self) -> io::Result<&StateStorage> {
+        let mut is_at_least_one_buffer_complete = false;
         loop {
-            match reader.read(&mut self.buffers[self.active_buffer_index][self.incomplete_offset..])
-            {
+            match self.reader.read(
+                &mut self.buffers[self.active_buffer_index]
+                    [self.number_of_read_bytes_in_active_buffer..],
+            ) {
                 Ok(number_of_read_bytes) => {
-                    self.incomplete_offset += number_of_read_bytes;
-                    assert!(self.incomplete_offset <= self.buffers[self.active_buffer_index].len());
-                    if self.incomplete_offset == self.buffers[self.active_buffer_index].len() {
-                        self.swap_buffers();
-                        buffers_swapped = true;
+                    self.number_of_read_bytes_in_active_buffer += number_of_read_bytes;
+                    assert!(
+                        self.number_of_read_bytes_in_active_buffer
+                            <= self.buffers[self.active_buffer_index].len()
+                    );
+                    let is_active_buffer_complete = self.number_of_read_bytes_in_active_buffer
+                        == self.buffers[self.active_buffer_index].len();
+                    if is_active_buffer_complete {
+                        self.activate_next_buffer();
+                        is_at_least_one_buffer_complete = true;
                     }
                 }
                 Err(ref error) if error.kind() == ErrorKind::WouldBlock => {
-                    if buffers_swapped {
-                        return Ok(());
+                    if is_at_least_one_buffer_complete {
+                        return Ok(unsafe {
+                            &*(self.buffers[self.previous_active_buffer_index()].as_ptr()
+                                as *const StateStorage)
+                        });
                     }
-                    poll_reader(reader.as_raw_fd())?;
+                    self.poller.poll(self.reader.as_raw_fd())?;
                 }
                 Err(error) => return Err(error),
             }
         }
     }
+}
 
-    /// Precondition: `read()` has been called once
-    pub fn get_last(&self) -> &StateStorage {
-        let inactive_buffer_index = (self.active_buffer_index + 1) % 2;
-        unsafe { &*(self.buffers[inactive_buffer_index].as_ptr() as *const StateStorage) }
+pub trait Poll {
+    fn poll(&mut self, file_descriptor: RawFd) -> io::Result<()>;
+}
+
+pub struct SelectPoller;
+
+impl Poll for SelectPoller {
+    fn poll(&mut self, file_descriptor: RawFd) -> io::Result<()> {
+        unsafe {
+            let mut set = MaybeUninit::<fd_set>::uninit();
+            FD_ZERO(set.as_mut_ptr());
+            let mut set = set.assume_init();
+            FD_SET(file_descriptor, &mut set);
+            if select(
+                file_descriptor + 1,
+                &mut set,
+                null_mut(),
+                null_mut(),
+                null_mut(),
+            ) < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::slice::from_raw_parts;
+    use std::{
+        slice::from_raw_parts,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
 
     use super::*;
 
+    struct PanickingPoller;
+
+    impl Poll for PanickingPoller {
+        fn poll(&mut self, _file_descriptor: RawFd) -> io::Result<()> {
+            panic!("should not be called");
+        }
+    }
+
+    struct ErroringPoller;
+
+    impl Poll for ErroringPoller {
+        fn poll(&mut self, file_descriptor: RawFd) -> io::Result<()> {
+            assert_eq!(file_descriptor, FIXED_FILE_DESCRIPTOR);
+            Err(ErrorKind::ConnectionAborted.into())
+        }
+    }
+
+    const FIXED_FILE_DESCRIPTOR: RawFd = 42;
+
+    #[derive(Default)]
+    struct CountingPoller {
+        number_of_polls: Arc<AtomicUsize>,
+    }
+
+    impl Poll for CountingPoller {
+        fn poll(&mut self, file_descriptor: RawFd) -> io::Result<()> {
+            assert_eq!(file_descriptor, FIXED_FILE_DESCRIPTOR);
+            self.number_of_polls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
     #[test]
-    fn error_is_returned() {
+    fn read_error_is_returned() {
         struct Reader;
         impl AsRawFd for Reader {
             fn as_raw_fd(&self) -> RawFd {
@@ -83,10 +168,31 @@ mod tests {
             }
         }
 
-        let mut double_buffered_reader = DoubleBufferedReader::default();
-        let result = double_buffered_reader.read(&mut Reader, |_file_descriptor| {
-            panic!("should not be called");
-        });
+        let mut double_buffered_reader =
+            DoubleBufferedReader::from_reader_and_poller(Reader, PanickingPoller);
+        let result = double_buffered_reader.drain();
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
+    }
+
+    #[test]
+    fn poll_error_is_returned() {
+        struct Reader;
+        impl AsRawFd for Reader {
+            fn as_raw_fd(&self) -> RawFd {
+                FIXED_FILE_DESCRIPTOR
+            }
+        }
+        impl Read for Reader {
+            fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+                Err(ErrorKind::WouldBlock.into())
+            }
+        }
+
+        let mut double_buffered_reader =
+            DoubleBufferedReader::from_reader_and_poller(Reader, ErroringPoller);
+        let result = double_buffered_reader.drain();
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
@@ -125,18 +231,16 @@ mod tests {
             received_at: 42.1337,
             ..Default::default()
         };
-        let mut double_buffered_reader = DoubleBufferedReader::default();
-        let result = double_buffered_reader.read(
-            &mut Reader {
+        let mut double_buffered_reader = DoubleBufferedReader::from_reader_and_poller(
+            Reader {
                 data,
                 returned: false,
             },
-            |_file_descriptor| {
-                panic!("should not be called");
-            },
+            PanickingPoller,
         );
+        let result = double_buffered_reader.drain();
         assert!(result.is_ok());
-        let read_data = double_buffered_reader.get_last();
+        let read_data = result.unwrap();
         assert_eq!(read_data, &data);
     }
 
@@ -179,17 +283,15 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let mut double_buffered_reader = DoubleBufferedReader::default();
-        let result = double_buffered_reader.read(
-            &mut Reader {
+        let mut double_buffered_reader = DoubleBufferedReader::from_reader_and_poller(
+            Reader {
                 reversed_items: reversed_items.clone(),
             },
-            |_file_descriptor| {
-                panic!("should not be called");
-            },
+            PanickingPoller,
         );
+        let result = double_buffered_reader.drain();
         assert!(result.is_ok());
-        let read_data = double_buffered_reader.get_last();
+        let read_data = result.unwrap();
         assert_eq!(read_data, reversed_items.first().unwrap());
     }
 
@@ -204,7 +306,7 @@ mod tests {
         }
         impl<'buffer> AsRawFd for Reader<'buffer> {
             fn as_raw_fd(&self) -> RawFd {
-                42
+                FIXED_FILE_DESCRIPTOR
             }
         }
         impl<'buffer> Read for Reader<'buffer> {
@@ -240,17 +342,17 @@ mod tests {
                 expected_buffer_size: size_of::<StateStorage>(),
             }),
         ];
-        let mut double_buffered_reader = DoubleBufferedReader::default();
-        let mut number_of_polls = 0;
-        let result =
-            double_buffered_reader.read(&mut Reader { reversed_items }, |file_descriptor| {
-                assert_eq!(file_descriptor, 42);
-                number_of_polls += 1;
-                Ok(())
-            });
+        let number_of_polls: Arc<AtomicUsize> = Default::default();
+        let mut double_buffered_reader = DoubleBufferedReader::from_reader_and_poller(
+            Reader { reversed_items },
+            CountingPoller {
+                number_of_polls: number_of_polls.clone(),
+            },
+        );
+        let result = double_buffered_reader.drain();
         assert!(result.is_ok());
-        assert_eq!(number_of_polls, 1);
-        let read_data = double_buffered_reader.get_last();
+        assert_eq!(number_of_polls.load(Ordering::SeqCst), 1);
+        let read_data = result.unwrap();
         assert_eq!(read_data, &data);
     }
 
@@ -265,7 +367,7 @@ mod tests {
         }
         impl<'buffer> AsRawFd for Reader<'buffer> {
             fn as_raw_fd(&self) -> RawFd {
-                42
+                FIXED_FILE_DESCRIPTOR
             }
         }
         impl<'buffer> Read for Reader<'buffer> {
@@ -313,17 +415,17 @@ mod tests {
                 expected_buffer_size: size_of::<StateStorage>(),
             }),
         ];
-        let mut double_buffered_reader = DoubleBufferedReader::default();
-        let mut number_of_polls = 0;
-        let result =
-            double_buffered_reader.read(&mut Reader { reversed_items }, |file_descriptor| {
-                assert_eq!(file_descriptor, 42);
-                number_of_polls += 1;
-                Ok(())
-            });
+        let number_of_polls: Arc<AtomicUsize> = Default::default();
+        let mut double_buffered_reader = DoubleBufferedReader::from_reader_and_poller(
+            Reader { reversed_items },
+            CountingPoller {
+                number_of_polls: number_of_polls.clone(),
+            },
+        );
+        let result = double_buffered_reader.drain();
         assert!(result.is_ok());
-        assert_eq!(number_of_polls, 1);
-        let read_data = double_buffered_reader.get_last();
+        assert_eq!(number_of_polls.load(Ordering::SeqCst), 1);
+        let read_data = result.unwrap();
         assert_eq!(read_data, &returned_data);
     }
 
@@ -338,7 +440,7 @@ mod tests {
         }
         impl<'buffer> AsRawFd for Reader<'buffer> {
             fn as_raw_fd(&self) -> RawFd {
-                42
+                FIXED_FILE_DESCRIPTOR
             }
         }
         impl<'buffer> Read for Reader<'buffer> {
@@ -395,17 +497,17 @@ mod tests {
                 expected_buffer_size: size_of::<StateStorage>(),
             }),
         ];
-        let mut double_buffered_reader = DoubleBufferedReader::default();
-        let mut number_of_polls = 0;
-        let result =
-            double_buffered_reader.read(&mut Reader { reversed_items }, |file_descriptor| {
-                assert_eq!(file_descriptor, 42);
-                number_of_polls += 1;
-                Ok(())
-            });
+        let number_of_polls: Arc<AtomicUsize> = Default::default();
+        let mut double_buffered_reader = DoubleBufferedReader::from_reader_and_poller(
+            Reader { reversed_items },
+            CountingPoller {
+                number_of_polls: number_of_polls.clone(),
+            },
+        );
+        let result = double_buffered_reader.drain();
         assert!(result.is_ok());
-        assert_eq!(number_of_polls, 1);
-        let read_data = double_buffered_reader.get_last();
+        assert_eq!(number_of_polls.load(Ordering::SeqCst), 1);
+        let read_data = result.unwrap();
         assert_eq!(read_data, &returned_data);
     }
 }

--- a/crates/hulk/src/nao/double_buffered_reader.rs
+++ b/crates/hulk/src/nao/double_buffered_reader.rs
@@ -45,7 +45,7 @@ impl DoubleBufferedReader {
                         buffers_swapped = true;
                     }
                 }
-                Err(ref error) if error.kind() == ErrorKind::Interrupted => {
+                Err(ref error) if error.kind() == ErrorKind::WouldBlock => {
                     if buffers_swapped {
                         return Ok(());
                     }
@@ -106,7 +106,7 @@ mod tests {
         impl Read for Reader {
             fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
                 if self.returned {
-                    return Err(ErrorKind::Interrupted.into());
+                    return Err(ErrorKind::WouldBlock.into());
                 }
                 assert_eq!(buffer.len(), size_of::<StateStorage>());
                 let data_slice = unsafe {
@@ -164,7 +164,7 @@ mod tests {
                         buffer.copy_from_slice(data_slice);
                         Ok(size_of::<StateStorage>())
                     }
-                    None => Err(ErrorKind::Interrupted.into()),
+                    None => Err(ErrorKind::WouldBlock.into()),
                 }
             }
         }
@@ -215,7 +215,7 @@ mod tests {
                         buffer[..item.buffer.len()].copy_from_slice(item.buffer);
                         Ok(item.buffer.len())
                     }
-                    None | Some(None) => Err(ErrorKind::Interrupted.into()),
+                    None | Some(None) => Err(ErrorKind::WouldBlock.into()),
                 }
             }
         }
@@ -276,7 +276,7 @@ mod tests {
                         buffer[..item.buffer.len()].copy_from_slice(item.buffer);
                         Ok(item.buffer.len())
                     }
-                    None | Some(None) => Err(ErrorKind::Interrupted.into()),
+                    None | Some(None) => Err(ErrorKind::WouldBlock.into()),
                 }
             }
         }
@@ -349,7 +349,7 @@ mod tests {
                         buffer[..item.buffer.len()].copy_from_slice(item.buffer);
                         Ok(item.buffer.len())
                     }
-                    None | Some(None) => Err(ErrorKind::Interrupted.into()),
+                    None | Some(None) => Err(ErrorKind::WouldBlock.into()),
                 }
             }
         }

--- a/crates/hulk/src/nao/double_buffered_reader.rs
+++ b/crates/hulk/src/nao/double_buffered_reader.rs
@@ -47,7 +47,7 @@ where
         self.number_of_read_bytes_in_active_buffer = 0;
     }
 
-    pub fn drain(&mut self) -> io::Result<&Item> {
+    pub fn draining_read(&mut self) -> io::Result<&Item> {
         let mut is_at_least_one_buffer_complete = false;
         loop {
             let buffer = unsafe {
@@ -170,7 +170,7 @@ mod tests {
 
         let mut double_buffered_reader =
             DoubleBufferedReader::<u16, _, _>::from_reader_and_poller(Reader, PanickingPoller);
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
@@ -192,7 +192,7 @@ mod tests {
 
         let mut double_buffered_reader =
             DoubleBufferedReader::<u16, _, _>::from_reader_and_poller(Reader, ErroringPoller);
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
@@ -232,7 +232,7 @@ mod tests {
             },
             PanickingPoller,
         );
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_ok());
         let read_data = result.unwrap();
         assert_eq!(read_data, &data);
@@ -271,7 +271,7 @@ mod tests {
             },
             PanickingPoller,
         );
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_ok());
         let read_data = result.unwrap();
         assert_eq!(read_data, reversed_items.first().unwrap());
@@ -328,7 +328,7 @@ mod tests {
                 number_of_polls: number_of_polls.clone(),
             },
         );
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_ok());
         assert_eq!(number_of_polls.load(Ordering::SeqCst), 1);
         let read_data = result.unwrap();
@@ -391,7 +391,7 @@ mod tests {
                 number_of_polls: number_of_polls.clone(),
             },
         );
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_ok());
         assert_eq!(number_of_polls.load(Ordering::SeqCst), 1);
         let read_data = result.unwrap();
@@ -463,7 +463,7 @@ mod tests {
                 number_of_polls: number_of_polls.clone(),
             },
         );
-        let result = double_buffered_reader.drain();
+        let result = double_buffered_reader.draining_read();
         assert!(result.is_ok());
         assert_eq!(number_of_polls.load(Ordering::SeqCst), 1);
         let read_data = result.unwrap();

--- a/crates/hulk/src/nao/double_buffered_reader.rs
+++ b/crates/hulk/src/nao/double_buffered_reader.rs
@@ -1,0 +1,411 @@
+use std::{
+    io::{self, ErrorKind, Read},
+    mem::size_of,
+    os::unix::{io::AsRawFd, prelude::RawFd},
+};
+
+use super::hula::StateStorage;
+
+pub struct DoubleBufferedReader {
+    buffers: [[u8; size_of::<StateStorage>()]; 2],
+    active_buffer_index: usize,
+    incomplete_offset: usize,
+}
+
+impl Default for DoubleBufferedReader {
+    fn default() -> Self {
+        Self {
+            buffers: [[0; size_of::<StateStorage>()]; 2],
+            active_buffer_index: Default::default(),
+            incomplete_offset: Default::default(),
+        }
+    }
+}
+
+impl DoubleBufferedReader {
+    fn swap_buffers(&mut self) {
+        self.incomplete_offset = 0;
+        self.active_buffer_index = (self.active_buffer_index + 1) % 2;
+    }
+
+    pub fn read(
+        &mut self,
+        reader: &mut (impl AsRawFd + Read),
+        mut poll_reader: impl FnMut(RawFd) -> io::Result<()>,
+    ) -> io::Result<()> {
+        let mut buffers_swapped = false;
+        loop {
+            match reader.read(&mut self.buffers[self.active_buffer_index][self.incomplete_offset..])
+            {
+                Ok(number_of_read_bytes) => {
+                    self.incomplete_offset += number_of_read_bytes;
+                    assert!(self.incomplete_offset <= self.buffers[self.active_buffer_index].len());
+                    if self.incomplete_offset == self.buffers[self.active_buffer_index].len() {
+                        self.swap_buffers();
+                        buffers_swapped = true;
+                    }
+                }
+                Err(ref error) if error.kind() == ErrorKind::Interrupted => {
+                    if buffers_swapped {
+                        return Ok(());
+                    }
+                    poll_reader(reader.as_raw_fd())?;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    /// Precondition: `read()` has been called once
+    pub fn get_last(&self) -> &StateStorage {
+        let inactive_buffer_index = (self.active_buffer_index + 1) % 2;
+        unsafe { &*(self.buffers[inactive_buffer_index].as_ptr() as *const StateStorage) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::slice::from_raw_parts;
+
+    use super::*;
+
+    #[test]
+    fn error_is_returned() {
+        struct Reader;
+        impl AsRawFd for Reader {
+            fn as_raw_fd(&self) -> RawFd {
+                panic!("should not be called");
+            }
+        }
+        impl Read for Reader {
+            fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+                Err(ErrorKind::ConnectionAborted.into())
+            }
+        }
+
+        let mut double_buffered_reader = DoubleBufferedReader::default();
+        let result = double_buffered_reader.read(&mut Reader, |_file_descriptor| {
+            panic!("should not be called");
+        });
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ConnectionAborted);
+    }
+
+    #[test]
+    fn complete_read_terminates() {
+        struct Reader {
+            data: StateStorage,
+            returned: bool,
+        }
+        impl AsRawFd for Reader {
+            fn as_raw_fd(&self) -> RawFd {
+                panic!("should not be called");
+            }
+        }
+        impl Read for Reader {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                if self.returned {
+                    return Err(ErrorKind::Interrupted.into());
+                }
+                assert_eq!(buffer.len(), size_of::<StateStorage>());
+                let data_slice = unsafe {
+                    from_raw_parts(
+                        &self.data as *const StateStorage as *const u8,
+                        size_of::<StateStorage>(),
+                    )
+                };
+                buffer.copy_from_slice(data_slice);
+                self.returned = true;
+                Ok(size_of::<StateStorage>())
+            }
+        }
+
+        let data = StateStorage {
+            received_at: 42.1337,
+            ..Default::default()
+        };
+        let mut double_buffered_reader = DoubleBufferedReader::default();
+        let result = double_buffered_reader.read(
+            &mut Reader {
+                data,
+                returned: false,
+            },
+            |_file_descriptor| {
+                panic!("should not be called");
+            },
+        );
+        assert!(result.is_ok());
+        let read_data = double_buffered_reader.get_last();
+        assert_eq!(read_data, &data);
+    }
+
+    #[test]
+    fn two_complete_reads_terminate_and_return_latest() {
+        struct Reader {
+            reversed_items: Vec<StateStorage>,
+        }
+        impl AsRawFd for Reader {
+            fn as_raw_fd(&self) -> RawFd {
+                panic!("should not be called");
+            }
+        }
+        impl Read for Reader {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                match self.reversed_items.pop() {
+                    Some(item) => {
+                        assert_eq!(buffer.len(), size_of::<StateStorage>());
+                        let data_slice = unsafe {
+                            from_raw_parts(
+                                &item as *const StateStorage as *const u8,
+                                size_of::<StateStorage>(),
+                            )
+                        };
+                        buffer.copy_from_slice(data_slice);
+                        Ok(size_of::<StateStorage>())
+                    }
+                    None => Err(ErrorKind::Interrupted.into()),
+                }
+            }
+        }
+
+        let reversed_items = vec![
+            StateStorage {
+                received_at: 42.1337,
+                ..Default::default()
+            },
+            StateStorage {
+                received_at: 1337.42,
+                ..Default::default()
+            },
+        ];
+        let mut double_buffered_reader = DoubleBufferedReader::default();
+        let result = double_buffered_reader.read(
+            &mut Reader {
+                reversed_items: reversed_items.clone(),
+            },
+            |_file_descriptor| {
+                panic!("should not be called");
+            },
+        );
+        assert!(result.is_ok());
+        let read_data = double_buffered_reader.get_last();
+        assert_eq!(read_data, reversed_items.first().unwrap());
+    }
+
+    #[test]
+    fn two_partial_reads_terminate() {
+        struct Item<'buffer> {
+            buffer: &'buffer [u8],
+            expected_buffer_size: usize,
+        }
+        struct Reader<'buffer> {
+            reversed_items: Vec<Option<Item<'buffer>>>,
+        }
+        impl<'buffer> AsRawFd for Reader<'buffer> {
+            fn as_raw_fd(&self) -> RawFd {
+                42
+            }
+        }
+        impl<'buffer> Read for Reader<'buffer> {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                match self.reversed_items.pop() {
+                    Some(Some(item)) => {
+                        assert_eq!(buffer.len(), item.expected_buffer_size);
+                        buffer[..item.buffer.len()].copy_from_slice(item.buffer);
+                        Ok(item.buffer.len())
+                    }
+                    None | Some(None) => Err(ErrorKind::Interrupted.into()),
+                }
+            }
+        }
+
+        let data = StateStorage {
+            received_at: 42.1337,
+            ..Default::default()
+        };
+        let reversed_items = vec![
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(
+                        (&data as *const StateStorage as *const u8).add(100),
+                        size_of::<StateStorage>() - 100,
+                    )
+                },
+                expected_buffer_size: size_of::<StateStorage>() - 100,
+            }),
+            None,
+            Some(Item {
+                buffer: unsafe { from_raw_parts(&data as *const StateStorage as *const u8, 100) },
+                expected_buffer_size: size_of::<StateStorage>(),
+            }),
+        ];
+        let mut double_buffered_reader = DoubleBufferedReader::default();
+        let mut number_of_polls = 0;
+        let result =
+            double_buffered_reader.read(&mut Reader { reversed_items }, |file_descriptor| {
+                assert_eq!(file_descriptor, 42);
+                number_of_polls += 1;
+                Ok(())
+            });
+        assert!(result.is_ok());
+        assert_eq!(number_of_polls, 1);
+        let read_data = double_buffered_reader.get_last();
+        assert_eq!(read_data, &data);
+    }
+
+    #[test]
+    fn four_partial_reads_terminate_and_return_previous_complete() {
+        struct Item<'buffer> {
+            buffer: &'buffer [u8],
+            expected_buffer_size: usize,
+        }
+        struct Reader<'buffer> {
+            reversed_items: Vec<Option<Item<'buffer>>>,
+        }
+        impl<'buffer> AsRawFd for Reader<'buffer> {
+            fn as_raw_fd(&self) -> RawFd {
+                42
+            }
+        }
+        impl<'buffer> Read for Reader<'buffer> {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                match self.reversed_items.pop() {
+                    Some(Some(item)) => {
+                        assert_eq!(buffer.len(), item.expected_buffer_size);
+                        buffer[..item.buffer.len()].copy_from_slice(item.buffer);
+                        Ok(item.buffer.len())
+                    }
+                    None | Some(None) => Err(ErrorKind::Interrupted.into()),
+                }
+            }
+        }
+
+        let returned_data = StateStorage {
+            received_at: 42.1337,
+            ..Default::default()
+        };
+        let incomplete_data = StateStorage {
+            received_at: 1337.42,
+            ..Default::default()
+        };
+        let reversed_items = vec![
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(&incomplete_data as *const StateStorage as *const u8, 100)
+                },
+                expected_buffer_size: size_of::<StateStorage>(),
+            }),
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(
+                        (&returned_data as *const StateStorage as *const u8).add(100),
+                        size_of::<StateStorage>() - 100,
+                    )
+                },
+                expected_buffer_size: size_of::<StateStorage>() - 100,
+            }),
+            None,
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(&returned_data as *const StateStorage as *const u8, 100)
+                },
+                expected_buffer_size: size_of::<StateStorage>(),
+            }),
+        ];
+        let mut double_buffered_reader = DoubleBufferedReader::default();
+        let mut number_of_polls = 0;
+        let result =
+            double_buffered_reader.read(&mut Reader { reversed_items }, |file_descriptor| {
+                assert_eq!(file_descriptor, 42);
+                number_of_polls += 1;
+                Ok(())
+            });
+        assert!(result.is_ok());
+        assert_eq!(number_of_polls, 1);
+        let read_data = double_buffered_reader.get_last();
+        assert_eq!(read_data, &returned_data);
+    }
+
+    #[test]
+    fn four_partial_reads_terminate_and_return_latest() {
+        struct Item<'buffer> {
+            buffer: &'buffer [u8],
+            expected_buffer_size: usize,
+        }
+        struct Reader<'buffer> {
+            reversed_items: Vec<Option<Item<'buffer>>>,
+        }
+        impl<'buffer> AsRawFd for Reader<'buffer> {
+            fn as_raw_fd(&self) -> RawFd {
+                42
+            }
+        }
+        impl<'buffer> Read for Reader<'buffer> {
+            fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+                match self.reversed_items.pop() {
+                    Some(Some(item)) => {
+                        assert_eq!(buffer.len(), item.expected_buffer_size);
+                        buffer[..item.buffer.len()].copy_from_slice(item.buffer);
+                        Ok(item.buffer.len())
+                    }
+                    None | Some(None) => Err(ErrorKind::Interrupted.into()),
+                }
+            }
+        }
+
+        let returned_data = StateStorage {
+            received_at: 42.1337,
+            ..Default::default()
+        };
+        let unused_data = StateStorage {
+            received_at: 1337.42,
+            ..Default::default()
+        };
+        let reversed_items = vec![
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(
+                        (&returned_data as *const StateStorage as *const u8).add(100),
+                        size_of::<StateStorage>() - 100,
+                    )
+                },
+                expected_buffer_size: size_of::<StateStorage>() - 100,
+            }),
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(&returned_data as *const StateStorage as *const u8, 100)
+                },
+                expected_buffer_size: size_of::<StateStorage>(),
+            }),
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(
+                        (&unused_data as *const StateStorage as *const u8).add(100),
+                        size_of::<StateStorage>() - 100,
+                    )
+                },
+                expected_buffer_size: size_of::<StateStorage>() - 100,
+            }),
+            None,
+            Some(Item {
+                buffer: unsafe {
+                    from_raw_parts(&unused_data as *const StateStorage as *const u8, 100)
+                },
+                expected_buffer_size: size_of::<StateStorage>(),
+            }),
+        ];
+        let mut double_buffered_reader = DoubleBufferedReader::default();
+        let mut number_of_polls = 0;
+        let result =
+            double_buffered_reader.read(&mut Reader { reversed_items }, |file_descriptor| {
+                assert_eq!(file_descriptor, 42);
+                number_of_polls += 1;
+                Ok(())
+            });
+        assert!(result.is_ok());
+        assert_eq!(number_of_polls, 1);
+        let read_data = double_buffered_reader.get_last();
+        assert_eq!(read_data, &returned_data);
+    }
+}

--- a/crates/hulk/src/nao/hula.rs
+++ b/crates/hulk/src/nao/hula.rs
@@ -379,7 +379,7 @@ pub struct ControlStorage {
 }
 
 pub fn read_from_hula<Reader, Poller>(
-    reader: &mut DoubleBufferedReader<Reader, Poller>,
+    reader: &mut DoubleBufferedReader<StateStorage, Reader, Poller>,
 ) -> Result<StateStorage>
 where
     Reader: AsRawFd + Read,

--- a/crates/hulk/src/nao/hula.rs
+++ b/crates/hulk/src/nao/hula.rs
@@ -385,7 +385,9 @@ where
     Reader: AsRawFd + Read,
     Poller: Poll,
 {
-    Ok(*reader.drain().wrap_err("failed to drain from stream")?)
+    Ok(*reader
+        .draining_read()
+        .wrap_err("failed to drain from stream")?)
 }
 
 pub fn write_to_hula(stream: &mut UnixStream, control_storage: ControlStorage) -> Result<()> {

--- a/crates/hulk/src/nao/hula_wrapper.rs
+++ b/crates/hulk/src/nao/hula_wrapper.rs
@@ -9,7 +9,7 @@ use types::{hardware::Ids, Joints, Leds, SensorData};
 
 use super::{
     double_buffered_reader::{DoubleBufferedReader, SelectPoller},
-    hula::{read_from_hula, write_to_hula, ControlStorage},
+    hula::{read_from_hula, write_to_hula, ControlStorage, StateStorage},
 };
 use constants::HULA_SOCKET_PATH;
 
@@ -17,7 +17,7 @@ pub struct HulaWrapper {
     now: SystemTime,
     ids: Ids,
     stream: UnixStream,
-    hula_reader: DoubleBufferedReader<UnixStream, SelectPoller>,
+    hula_reader: DoubleBufferedReader<StateStorage, UnixStream, SelectPoller>,
 }
 
 impl HulaWrapper {

--- a/crates/hulk/src/nao/mod.rs
+++ b/crates/hulk/src/nao/mod.rs
@@ -1,4 +1,5 @@
 mod camera;
+mod double_buffered_reader;
 mod hula;
 mod hula_wrapper;
 mod interface;


### PR DESCRIPTION
## Introduced Changes

This PR introduces Unix socket draining when reading from the HULA socket. This is needed because our HULK process connects very early to the Unix socket and HULA/LoLA immediately starts sending state messages to HULK which fills our read buffer. After the connection, we are further initializing the HardwareInterface, e.g. doing camera initialization/resetting. This may take a long time, filling up around 1 second of historic state messages in HULKs read buffer. Once the HardwareInterface has been initialized, the cyclers begin to run and the control cycler will rush to drain the accumulated messages, because the sensor data receiver has a lot of data available to feed the cycle. This results in a lot of messages being sent to HULA/LoLA containing historic (1 second old) control messages. But since HULA/LoLA only updates its shared memory and does not communicate directly with the hardware, this is usually not noticed and it will converge quickly to nearly no latency and drained buffers. This bug was discovered because the new HULA will communicate synchronously with the hardware thus needing this fix.

Changes in HULA are not needed. No worries, there is a lot of test code which accumulates a lot of added lines. :wink: 

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

The double buffering should have nearly 100% test coverage, but please test on a real NAO if everything works as intended. The chest button LED blinking frequency should be exactly one second immediately on startup which is a good indicator that everything works as intended.