### PR TITLE
Add MotionType to execute an energy saving stand

### DIFF
--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -137,7 +137,12 @@ pub fn execute(
     best_kick_decisions_output.fill_if_subscribed(|| best_kick_decision.copied());
     let best_kick_decision = match best_kick_decision {
         Some(decision) => decision,
-        None => return Some(MotionCommand::Stand { head }),
+        None => {
+            return Some(MotionCommand::Stand {
+                head,
+                is_energy_saving: false,
+            })
+        }
     };
 
     let relative_best_pose = best_kick_decision.relative_kick_pose;

--- a/crates/control/src/behavior/penalize.rs
+++ b/crates/control/src/behavior/penalize.rs
@@ -2,7 +2,7 @@ use types::{MotionCommand, PrimaryState, WorldState};
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
-        PrimaryState::Penalized | PrimaryState::Initial => Some(MotionCommand::Penalized),
+        PrimaryState::Penalized => Some(MotionCommand::Penalized),
         _ => None,
     }
 }

--- a/crates/control/src/behavior/stand.rs
+++ b/crates/control/src/behavior/stand.rs
@@ -6,6 +6,7 @@ pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
         PrimaryState::Initial => Some(MotionCommand::Stand {
             head: HeadMotion::ZeroAngles,
+            is_energy_saving: true,
         }),
         PrimaryState::Set => {
             let robot_to_field = world_state.robot.robot_to_field?;
@@ -13,6 +14,7 @@ pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
                 head: HeadMotion::LookAt {
                     target: robot_to_field.inverse() * Point2::origin(),
                 },
+                is_energy_saving: true,
             })
         }
         PrimaryState::Playing => {
@@ -30,6 +32,7 @@ pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
                     None,
                 ) => Some(MotionCommand::Stand {
                     head: HeadMotion::Center,
+                    is_energy_saving: true,
                 }),
                 _ => None,
             }

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -153,7 +153,10 @@ impl<'cycle> WalkAndStand<'cycle> {
         );
 
         if is_reached {
-            Some(MotionCommand::Stand { head })
+            Some(MotionCommand::Stand {
+                head,
+                is_energy_saving: true,
+            })
         } else {
             let path = self.walk_path_planner.plan(
                 target_pose * Point2::origin(),

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -23,6 +23,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     pub arms_up_squat_joints_command: Input<JointsCommand<f32>, "arms_up_squat_joints_command">,
+    pub energy_saving_stand: Input<BodyJointsCommand<f32>, "energy_saving_stand_command">,
     pub jump_left_joints_command: Input<JointsCommand<f32>, "jump_left_joints_command">,
     pub jump_right_joints_command: Input<JointsCommand<f32>, "jump_right_joints_command">,
     pub motion_selection: Input<MotionSelection, "motion_selection">,
@@ -96,6 +97,10 @@ impl DispatchingInterpolator {
                 MotionType::Walk => Joints::from_head_and_body(
                     HeadJoints::fill(0.0),
                     context.walk_joints_command.positions,
+                ),
+                MotionType::EnergySavingStand => Joints::from_head_and_body(
+                    HeadJoints::fill(0.0),
+                    context.energy_saving_stand.positions,
                 ),
             };
 

--- a/crates/control/src/motion/energy_saving_stand.rs
+++ b/crates/control/src/motion/energy_saving_stand.rs
@@ -1,0 +1,50 @@
+use color_eyre::Result;
+use context_attribute::context;
+use framework::MainOutput;
+use types::{
+    ArmJoints, BodyJoints, BodyJointsCommand, CycleTime, Joints, LegJoints, MotionSelection,
+    SensorData,
+};
+
+pub struct EnergySavingStand {}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    pub cycle_time: Input<CycleTime, "cycle_time">,
+    pub motion_selection: Input<MotionSelection, "motion_selection">,
+    pub sensor_data: Input<SensorData, "sensor_data">,
+
+    pub arm_stiffness: Parameter<f32, "energy_saving_stand.arm_stiffness">,
+    pub leg_stiffness: Parameter<f32, "energy_saving_stand.leg_stiffness">,
+    pub penalized_pose: Parameter<Joints<f32>, "penalized_pose">,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub energy_saving_stand_command: MainOutput<BodyJointsCommand<f32>>,
+}
+
+impl EnergySavingStand {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        Ok(MainOutputs {
+            energy_saving_stand_command: BodyJointsCommand {
+                positions: BodyJoints::from(*context.penalized_pose),
+                stiffnesses: BodyJoints {
+                    left_arm: ArmJoints::fill(*context.arm_stiffness),
+                    right_arm: ArmJoints::fill(*context.arm_stiffness),
+                    left_leg: LegJoints::fill(*context.leg_stiffness),
+                    right_leg: LegJoints::fill(*context.leg_stiffness),
+                },
+            }
+            .into(),
+        })
+    }
+}

--- a/crates/control/src/motion/joint_command_sender.rs
+++ b/crates/control/src/motion/joint_command_sender.rs
@@ -23,6 +23,7 @@ pub struct CycleContext {
 
     pub arms_up_squat_joints_command: Input<JointsCommand<f32>, "arms_up_squat_joints_command">,
     pub dispatching_command: Input<JointsCommand<f32>, "dispatching_command">,
+    pub energy_saving_stand_command: Input<BodyJointsCommand<f32>, "energy_saving_stand_command">,
     pub fall_protection_command: Input<JointsCommand<f32>, "fall_protection_command">,
     pub head_joints_command: Input<HeadJointsCommand<f32>, "head_joints_command">,
     pub jump_left_joints_command: Input<JointsCommand<f32>, "jump_left_joints_command">,
@@ -82,6 +83,16 @@ impl JointCommandSender {
             MotionType::Walk => (
                 Joints::from_head_and_body(head_joints_command.positions, walk.positions),
                 Joints::from_head_and_body(head_joints_command.stiffnesses, walk.stiffnesses),
+            ),
+            MotionType::EnergySavingStand => (
+                Joints::from_head_and_body(
+                    head_joints_command.positions,
+                    context.energy_saving_stand_command.positions,
+                ),
+                Joints::from_head_and_body(
+                    head_joints_command.stiffnesses,
+                    context.energy_saving_stand_command.stiffnesses,
+                ),
             ),
         };
         context

--- a/crates/control/src/motion/look_at.rs
+++ b/crates/control/src/motion/look_at.rs
@@ -68,7 +68,7 @@ impl LookAt {
 
         let head_motion = match context.motion_command {
             MotionCommand::SitDown { head } => head,
-            MotionCommand::Stand { head } => head,
+            MotionCommand::Stand { head, .. } => head,
             MotionCommand::Walk { head, .. } => head,
             _ => return default_output,
         };

--- a/crates/control/src/motion/mod.rs
+++ b/crates/control/src/motion/mod.rs
@@ -1,5 +1,6 @@
 pub mod arms_up_squat;
 pub mod dispatching_interpolator;
+pub mod energy_saving_stand;
 pub mod fall_protector;
 pub mod head_motion;
 pub mod joint_command_sender;

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -76,7 +76,15 @@ fn motion_type_from_command(command: &MotionCommand) -> MotionType {
         },
         MotionCommand::Penalized => MotionType::Penalized,
         MotionCommand::SitDown { .. } => MotionType::SitDown,
-        MotionCommand::Stand { .. } => MotionType::Stand,
+        MotionCommand::Stand {
+            is_energy_saving, ..
+        } => {
+            if *is_energy_saving {
+                MotionType::EnergySavingStand
+            } else {
+                MotionType::Stand
+            }
+        }
         MotionCommand::StandUp { facing } => match facing {
             Facing::Down => MotionType::StandUpFront,
             Facing::Up => MotionType::StandUpBack,

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -25,6 +25,7 @@ pub enum MotionCommand {
     },
     Stand {
         head: HeadMotion,
+        is_energy_saving: bool,
     },
     StandUp {
         facing: Facing,
@@ -49,7 +50,7 @@ impl MotionCommand {
     pub fn head_motion(&self) -> Option<HeadMotion> {
         match self {
             MotionCommand::SitDown { head }
-            | MotionCommand::Stand { head }
+            | MotionCommand::Stand { head, .. }
             | MotionCommand::Walk { head, .. }
             | MotionCommand::InWalkKick { head, .. } => Some(*head),
             MotionCommand::Penalized => Some(HeadMotion::ZeroAngles),

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -13,6 +13,7 @@ pub struct MotionSelection {
 pub enum MotionType {
     ArmsUpSquat,
     Dispatching,
+    EnergySavingStand,
     FallProtection,
     JumpLeft,
     JumpRight,
@@ -35,6 +36,7 @@ impl Default for MotionType {
 pub struct MotionSafeExits {
     arms_up_squat: bool,
     dispatching: bool,
+    energy_saving_stand: bool,
     fall_protection: bool,
     jump_left: bool,
     jump_right: bool,
@@ -52,6 +54,7 @@ impl Default for MotionSafeExits {
         Self {
             arms_up_squat: true,
             dispatching: false,
+            energy_saving_stand: true,
             fall_protection: true,
             jump_left: false,
             jump_right: false,
@@ -73,6 +76,7 @@ impl Index<MotionType> for MotionSafeExits {
         match motion_type {
             MotionType::ArmsUpSquat => &self.arms_up_squat,
             MotionType::Dispatching => &self.dispatching,
+            MotionType::EnergySavingStand => &self.energy_saving_stand,
             MotionType::JumpLeft => &self.jump_left,
             MotionType::JumpRight => &self.jump_right,
             MotionType::FallProtection => &self.fall_protection,
@@ -92,6 +96,7 @@ impl IndexMut<MotionType> for MotionSafeExits {
         match motion_type {
             MotionType::ArmsUpSquat => &mut self.arms_up_squat,
             MotionType::Dispatching => &mut self.dispatching,
+            MotionType::EnergySavingStand => &mut self.energy_saving_stand,
             MotionType::JumpLeft => &mut self.jump_left,
             MotionType::JumpRight => &mut self.jump_right,
             MotionType::FallProtection => &mut self.fall_protection,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -188,6 +188,10 @@
       "minimum_samples_per_cluster": 3
     }
   },
+  "energy_saving_stand": {
+    "arm_stiffness": 0.1,
+    "leg_stiffness": 0.5
+  },
   "fall_protection": {
     "ground_impact_head_stiffness": 0.2,
     "left_arm_positions": {


### PR DESCRIPTION
## Introduced Changes

This introduces a new boolean flag, whether a standing motion should be "energy-saving".
An energy saving stand is executed by an independent motion node, which currently only publishes penalized angles. A normal stand is still done by walking.

Fixes #129 

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

- a more sophisticated version which actually uses control to save energy (e.g. gradually decreasing stiffness)
- lean the robot a bit to the front when penalized as it tends to fall backwards much easier than to the front

## How to Test

Testgame? Alternatively deploy the nao as the keeper, as it is standing with energy saving in the goal center without a ball
