### PR TITLE
Add serialize_hierarchy(bound="...") attribute

### DIFF
--- a/crates/serialize_hierarchy_derive/src/lib.rs
+++ b/crates/serialize_hierarchy_derive/src/lib.rs
@@ -1,15 +1,12 @@
 use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
-use proc_macro_error::proc_macro_error;
-use quote::quote;
-use quote::ToTokens;
+use proc_macro_error::{abort, proc_macro_error};
+use quote::{quote, ToTokens};
 use syn::{
     parse_macro_input, punctuated::Punctuated, Data, DataStruct, DeriveInput, Generics, Ident, Lit,
-    Meta, NestedMeta, Token, WherePredicate,
+    Meta, MetaNameValue, NestedMeta, Token, Type, WherePredicate,
 };
-use syn::{MetaNameValue, Type};
 
 #[proc_macro_derive(SerializeHierarchy, attributes(serialize_hierarchy))]
 #[proc_macro_error]

--- a/crates/serialize_hierarchy_derive/src/lib.rs
+++ b/crates/serialize_hierarchy_derive/src/lib.rs
@@ -158,7 +158,8 @@ fn extend_where_clause_from_attributes(
                 TypeAttribute::Bounds { predicates } => Some(predicates),
                 _ => None,
             })
-            .flat_map(|predicates| predicates.to_vec())
+            .flatten()
+            .cloned()
     });
 }
 


### PR DESCRIPTION
## Introduced Changes

Adds a new type attribute to specify where predicates for generics.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

- add some logic to infer the trait bounds based on the given type parameters and generics and use `bound = ...` only to overwrite this guess.

## How to Test

Derive `SerializeHierarchy` to any generic struct and use `#[serialize_hierarchy(bound="...")` to specify the necessary trait bounds.
