### PR TITLE
Turn off chest button LED in initial

### DIFF
--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -63,7 +63,7 @@ impl LedStatus {
             PrimaryState::Set => Rgb::YELLOW,
             PrimaryState::Playing => Rgb::GREEN,
             PrimaryState::Penalized => Rgb::RED,
-            PrimaryState::Finished => Rgb::WHITE,
+            PrimaryState::Finished => Rgb::BLACK,
             PrimaryState::Calibration => Rgb::PURPLE,
         };
 

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -58,7 +58,7 @@ impl LedStatus {
                 true => Rgb::BLUE,
                 false => Rgb::BLACK,
             },
-            PrimaryState::Initial => Rgb::WHITE,
+            PrimaryState::Initial => Rgb::BLACK,
             PrimaryState::Ready => Rgb::BLUE,
             PrimaryState::Set => Rgb::YELLOW,
             PrimaryState::Playing => Rgb::GREEN,


### PR DESCRIPTION
## Introduced Changes

The rules state, that the chest button should be "Off" in Initial and finished.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

press the chest button to reach the initial state. The robot's chest button led should be off in initial.

use a game controller to reach the finished state.