### PR TITLE
Sit down fix

### DIFF
--- a/crates/control/src/ground_contact_detector.rs
+++ b/crates/control/src/ground_contact_detector.rs
@@ -67,7 +67,7 @@ impl GroundContactDetector {
         self.last_has_pressure = has_pressure;
 
         Ok(MainOutputs {
-            has_ground_contact: has_pressure.into(),
+            has_ground_contact: self.has_ground_contact.into(),
         })
     }
 }

--- a/crates/control/src/motion/sit_down.rs
+++ b/crates/control/src/motion/sit_down.rs
@@ -55,11 +55,7 @@ impl SitDown {
                     .interpolator
                     .value()
                     .wrap_err("error computing interpolation in sit_down")?,
-                stiffnesses: Joints::fill(if self.interpolator.is_finished() {
-                    0.0
-                } else {
-                    0.8
-                }),
+                stiffnesses: Joints::fill(0.8),
             }
             .into(),
         })

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -18,7 +18,6 @@ pub struct CycleContext {
     pub buttons: Input<Buttons, "buttons">,
     pub filtered_game_state: Input<Option<FilteredGameState>, "filtered_game_state?">,
     pub game_controller_state: Input<Option<GameControllerState>, "game_controller_state?">,
-    pub has_ground_contact: Input<bool, "has_ground_contact">,
 
     pub player_number: Parameter<PlayerNumber, "player_number">,
 }
@@ -50,20 +49,18 @@ impl PrimaryStateFilter {
             context.buttons.is_chest_button_pressed,
             context.buttons.calibration_buttons_touched,
             context.filtered_game_state,
-            context.has_ground_contact,
         ) {
             // Unstiff transitions (entering and exiting)
-            (_, true, _, _, _, true) => PrimaryState::Finished,
-            (_, true, _, _, _, false) => PrimaryState::Unstiff,
+            (_, true, _, _, _) => PrimaryState::Unstiff,
 
-            (PrimaryState::Initial, _, _, true, _, _) => PrimaryState::Calibration,
+            (PrimaryState::Initial, _, _, true, _) => PrimaryState::Calibration,
 
             // GameController transitions (entering listening mode and staying within)
-            (PrimaryState::Unstiff, _, true, _, Some(game_state), _)
-            | (PrimaryState::Finished, _, true, _, Some(game_state), _) => {
+            (PrimaryState::Unstiff, _, true, _, Some(game_state))
+            | (PrimaryState::Finished, _, true, _, Some(game_state)) => {
                 Self::game_state_to_primary_state(*game_state, is_penalized)
             }
-            (_, _, _, _, Some(game_state), _)
+            (_, _, _, _, Some(game_state))
                 if self.last_primary_state != PrimaryState::Unstiff
                     && self.last_primary_state != PrimaryState::Finished =>
             {
@@ -71,13 +68,13 @@ impl PrimaryStateFilter {
             }
 
             // non-GameController transitions
-            (PrimaryState::Unstiff, _, true, _, None, _) => PrimaryState::Initial,
-            (PrimaryState::Finished, _, true, _, None, _) => PrimaryState::Initial,
-            (PrimaryState::Initial, _, true, _, None, _) => PrimaryState::Penalized,
-            (PrimaryState::Penalized, _, true, _, None, _) => PrimaryState::Playing,
-            (PrimaryState::Playing, _, true, _, None, _) => PrimaryState::Penalized,
+            (PrimaryState::Unstiff, _, true, _, None) => PrimaryState::Initial,
+            (PrimaryState::Finished, _, true, _, None) => PrimaryState::Initial,
+            (PrimaryState::Initial, _, true, _, None) => PrimaryState::Penalized,
+            (PrimaryState::Penalized, _, true, _, None) => PrimaryState::Playing,
+            (PrimaryState::Playing, _, true, _, None) => PrimaryState::Penalized,
 
-            (_, _, _, _, _, _) => self.last_primary_state,
+            (_, _, _, _, _) => self.last_primary_state,
         };
 
         Ok(MainOutputs {


### PR DESCRIPTION
## Introduced Changes

This PR fixes the state transition to unstiff. Previously, by pressing the head buttons we used PrimaryState::Finish to request a sit down. Now, we request unstiff and transition to sit down before going to unstiff.


## How to Test

- deploy the code and check whether the sit down motion gets executed correctly in various states
