### PR TITLE
Tune falling parameters

### DIFF
--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -443,8 +443,6 @@ pub struct FallStateEstimation {
     pub roll_pitch_low_pass_factor: f32,
     pub gravitational_acceleration_threshold: f32,
     pub falling_angle_threshold: Vector2<f32>,
-    pub minimum_angular_velocity: Vector2<f32>,
-    pub maximum_angular_velocity: Vector2<f32>,
     pub fallen_timeout: Duration,
 }
 

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -661,7 +661,7 @@
     "angular_velocity_low_pass_factor": 0.2,
     "roll_pitch_low_pass_factor": 0.2,
     "gravitational_acceleration_threshold": 4.0,
-    "falling_angle_threshold": [0.5, 0.45],
+    "falling_angle_threshold": [0.52, 0.6],
     "fallen_timeout": {
       "nanos": 0,
       "secs": 1

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -662,8 +662,6 @@
     "roll_pitch_low_pass_factor": 0.2,
     "gravitational_acceleration_threshold": 4.0,
     "falling_angle_threshold": [0.5, 0.45],
-    "minimum_angular_velocity": [-0.233, -0.61],
-    "maximum_angular_velocity": [0.233, 0.317],
     "fallen_timeout": {
       "nanos": 0,
       "secs": 1


### PR DESCRIPTION
## Introduced Changes

The values of two parameters were changed, namely, left-right and forward-backward angles of falling angle threshold. 

Fixes #134 

## How to Test

Push the robots front-back and left-right using the new parameters in comparison to the old ones and observe the difference.

For forward-backward angle, there is a difference of about 8.5 degrees (0.15 rad) from the previous value. With this new value, the fall protection is triggered later than the previous value but it still remains to be early enough before the robot reaches the ground. 

For left-right angle, the previous value was 0.5 and the new value is 0.52, which is a difference of only 1 degree and though the difference could hardly be noticed, but 0.52 is approximately the average value of 0.5 and 0.55, where 0.5 was stated to be too early and 0.55 seemed to be too late from observation. 
