### PR TITLE
Remove incremental target in CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,14 +56,14 @@ jobs:
           lfs: true
       - name: Test
         run: |
-          cargo test --profile incremental --all-features --workspace
+          cargo test --all-features --workspace
   build:
     name: Build
     strategy:
       fail-fast: true
       matrix:
         target: [nao, webots]
-        profile: [release, incremental, dev]
+        profile: [release, dev]
     runs-on:
       - self-hosted
       - v2
@@ -97,7 +97,7 @@ jobs:
       - name: Build
         run: |
           cd ${{ matrix.path }}
-          cargo build --profile incremental --all-features
+          cargo build --all-features
   build_aliveness:
     name: Build Aliveness
     runs-on:


### PR DESCRIPTION
## Introduced Changes

When e.g. a format runner fails, the CI terminates the other runners as well. In the case of the incremental target, this can result in an invalid cache resulting in runs of e.g. other PRs failing.

This PR removes the incremental targets, since the CI already builds for release and dev.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Observe the CI targets.
