### PR TITLE
Add the options to disable different filters in robot detection

### DIFF
--- a/crates/vision/src/robot_detection.rs
+++ b/crates/vision/src/robot_detection.rs
@@ -47,8 +47,8 @@ pub struct CycleContext {
     pub luminance_image: AdditionalOutput<GrayscaleImage, "robot_detection.luminance_image">,
     pub object_threshold: Parameter<f32, "robot_detection.$cycler_instance.object_threshold">,
     pub enable: Parameter<bool, "robot_detection.$cycler_instance.enable">,
-    pub enable_filtered_detections:
-        Parameter<bool, "robot_detection.$cycler_instance.enable_filtered_detections">,
+    pub enable_filter_by_size:
+        Parameter<bool, "robot_detection.$cycler_instance.enable_filter_by_size">,
     pub enable_filter_by_pixel_position:
         Parameter<bool, "robot_detection.$cycler_instance.enable_filter_by_pixel_position">,
     pub lowest_bottom_pixel_position:
@@ -107,7 +107,7 @@ impl RobotDetection {
             );
         }
 
-        if *context.enable_filtered_detections {
+        if *context.enable_filter_by_size {
             filtered_detections = filter_by_size(
                 filtered_detections,
                 context.camera_matrix,

--- a/crates/vision/src/robot_detection.rs
+++ b/crates/vision/src/robot_detection.rs
@@ -47,6 +47,10 @@ pub struct CycleContext {
     pub luminance_image: AdditionalOutput<GrayscaleImage, "robot_detection.luminance_image">,
     pub object_threshold: Parameter<f32, "robot_detection.$cycler_instance.object_threshold">,
     pub enable: Parameter<bool, "robot_detection.$cycler_instance.enable">,
+    pub enable_filtered_detections:
+        Parameter<bool, "robot_detection.$cycler_instance.enable_filtered_detections">,
+    pub enable_filter_by_pixel_position:
+        Parameter<bool, "robot_detection.$cycler_instance.enable_filter_by_pixel_position">,
     pub lowest_bottom_pixel_position:
         Parameter<f32, "robot_detection.$cycler_instance.lowest_bottom_pixel_position">,
     pub allowed_projected_robot_height:
@@ -94,15 +98,23 @@ impl RobotDetection {
             *context.object_threshold,
         );
 
-        let filtered_detections =
-            filter_by_pixel_position(grid_boxes, *context.lowest_bottom_pixel_position);
+        let mut filtered_detections = grid_boxes;
 
-        let filtered_detections = filter_by_size(
-            filtered_detections,
-            context.camera_matrix,
-            context.robot_to_ground,
-            context.allowed_projected_robot_height,
-        );
+        if *context.enable_filter_by_pixel_position {
+            filtered_detections = filter_by_pixel_position(
+                filtered_detections,
+                *context.lowest_bottom_pixel_position,
+            );
+        }
+
+        if *context.enable_filtered_detections {
+            filtered_detections = filter_by_size(
+                filtered_detections,
+                context.camera_matrix,
+                context.robot_to_ground,
+                context.allowed_projected_robot_height,
+            );
+        }
 
         let on_ground = filtered_detections
             .iter()

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -153,8 +153,8 @@
   "robot_detection": {
     "vision_top": {
       "enable": true,
-      "enable_filtered_detections": true,
-      "enable_filter_by_pixel_position": true,
+      "enable_filter_by_size": false,
+      "enable_filter_by_pixel_position": false,
       "neural_network": "etc/neural_networks/robot_detector.hdf5",
       "object_threshold": 0.9,
       "lowest_bottom_pixel_position": 480,
@@ -165,6 +165,8 @@
     },
     "vision_bottom": {
       "enable": false,
+      "enable_filter_by_size": false,
+      "enable_filter_by_pixel_position": false,
       "neural_network": "etc/neural_networks/robot_detector.hdf5",
       "object_threshold": 0.9,
       "lowest_bottom_pixel_position": 480,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -153,6 +153,8 @@
   "robot_detection": {
     "vision_top": {
       "enable": true,
+      "enable_filtered_detections": true,
+      "enable_filter_by_pixel_position": true,
       "neural_network": "etc/neural_networks/robot_detector.hdf5",
       "object_threshold": 0.9,
       "lowest_bottom_pixel_position": 480,
@@ -260,7 +262,7 @@
     "initial_covariance": [0.25, 0.25],
     "measurement_count_threshold": 10,
     "use_feet_detection_measurements": true,
-    "use_robot_detection_measurements": false,
+    "use_robot_detection_measurements": true,
     "use_sonar_measurements": true,
     "robot_obstacle_radius_at_hip_height": 0.2,
     "robot_obstacle_radius_at_foot_height": 0.2,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -260,7 +260,7 @@
     "initial_covariance": [0.25, 0.25],
     "measurement_count_threshold": 10,
     "use_feet_detection_measurements": true,
-    "use_robot_detection_measurements": true,
+    "use_robot_detection_measurements": false,
     "use_sonar_measurements": true,
     "robot_obstacle_radius_at_hip_height": 0.2,
     "robot_obstacle_radius_at_foot_height": 0.2,


### PR DESCRIPTION
## Introduced Changes

Adds options to disable filtering in robot detection
Disables use_robot_detection_measurements 

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Look at robot detection and compare the results with enabled and disabled filters
