### PR TITLE
Hotfix for dispatching transition

### DIFF
--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -104,10 +104,10 @@ impl DispatchingInterpolator {
                 ),
             };
 
-            self.interpolator = SplineInterpolator::try_new_transition_with_velocity(
+            self.interpolator = SplineInterpolator::try_new_transition_timed(
                 context.sensor_data.positions,
                 target_position,
-                *context.maximum_velocity,
+                Duration::from_secs_f32(1.0)
             )?;
             self.stiffnesses = Joints::fill(0.8);
         }

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -107,7 +107,7 @@ impl DispatchingInterpolator {
             self.interpolator = SplineInterpolator::try_new_transition_timed(
                 context.sensor_data.positions,
                 target_position,
-                Duration::from_secs_f32(1.0)
+                Duration::from_secs_f32(1.0),
             )?;
             self.stiffnesses = Joints::fill(0.8);
         }


### PR DESCRIPTION
## Introduced Changes
Hotfix for falling robots in the dispatching interpolator using the maximum velocity approach.
For know switch back to static duration 1.0s for every transition

Fixes #

## ToDo / Known Issues

This will be dealt with properly when I have some time again :)

## Ideas for Next Iterations (Not This PR)

Konrad mentioned that I also wrongly assumed linear interpolation, instead an interpolation mode aware maximum velocity is required.

## How to Test
Transition Penalized to Walking, Robot should not be falling anymore.
We saw this in action in the testgame on April 26 at CFEL.
