### PR TITLE
Stops FallProtection in Inital

### DIFF
--- a/crates/control/src/behavior/action.rs
+++ b/crates/control/src/behavior/action.rs
@@ -2,6 +2,7 @@ pub enum Action {
     Unstiff,
     SitDown,
     Penalize,
+    Initial,
     FallSafely,
     StandUp,
     Stand,

--- a/crates/control/src/behavior/inital.rs
+++ b/crates/control/src/behavior/inital.rs
@@ -3,7 +3,7 @@ use types::{HeadMotion, MotionCommand, PrimaryState, WorldState};
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
         PrimaryState::Initial => Some(MotionCommand::Stand {
-            head: HeadMotion::Center,
+            head: HeadMotion::ZeroAngles,
             is_energy_saving: true,
         }),
         _ => None,

--- a/crates/control/src/behavior/inital.rs
+++ b/crates/control/src/behavior/inital.rs
@@ -1,0 +1,11 @@
+use types::{HeadMotion, MotionCommand, PrimaryState, WorldState};
+
+pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
+    match world_state.robot.primary_state {
+        PrimaryState::Initial => Some(MotionCommand::Stand {
+            head: HeadMotion::Center,
+            is_energy_saving: true,
+        }),
+        _ => None,
+    }
+}

--- a/crates/control/src/behavior/mod.rs
+++ b/crates/control/src/behavior/mod.rs
@@ -3,6 +3,7 @@ mod defend;
 mod dribble;
 mod fall_safely;
 mod head;
+mod inital;
 mod jump;
 mod look_around;
 mod lost_ball;

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -16,8 +16,8 @@ use super::{
     defend::Defend,
     dribble, fall_safely,
     head::LookAction,
-    jump, look_around, lost_ball, penalize, prepare_jump, search, sit_down, stand, stand_up,
-    support, unstiff, walk_to_kick_off,
+    inital, jump, look_around, lost_ball, penalize, prepare_jump, search, sit_down, stand,
+    stand_up, support, unstiff, walk_to_kick_off,
     walk_to_pose::{WalkAndStand, WalkPathPlanner},
 };
 
@@ -98,6 +98,7 @@ impl Behavior {
             Action::Unstiff,
             Action::SitDown,
             Action::Penalize,
+            Action::Initial,
             Action::FallSafely,
             Action::StandUp,
             Action::Stand,
@@ -170,6 +171,7 @@ impl Behavior {
                 Action::Unstiff => unstiff::execute(world_state),
                 Action::SitDown => sit_down::execute(world_state),
                 Action::Penalize => penalize::execute(world_state),
+                Action::Initial => inital::execute(world_state),
                 Action::FallSafely => {
                     fall_safely::execute(world_state, *context.has_ground_contact)
                 }


### PR DESCRIPTION
## Introduced Changes

Add Initial.rs to Actions in order to disable FallProtection from happening during Initial

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Push the robot over after standing up from sit down/unstiff and check if hes trying to stand up
