### PR TITLE
Better kick targets

### DIFF
--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -127,6 +127,15 @@ pub struct InWalkKicks {
     pub side: InWalkKickInfo,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
+pub struct FindKickTargets {
+    pub distance_from_corner: f32,
+    pub corner_kick_target_distance_to_goal: f32,
+    pub emergency_kick_target_angles: Vec<f32>,
+    pub max_kick_around_obstacle_angle: f32,
+    pub ball_radius_for_kick_target_selection: f32,
+}
+
 impl Index<KickVariant> for InWalkKicks {
     type Output = InWalkKickInfo;
 

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -900,7 +900,14 @@
     "max_kick_around_obstacle_angle": 1.0,
     "kick_pose_obstacle_radius": 0.1,
     "ball_radius_for_kick_target_selection": 0.15,
-    "closer_threshold": 1.0
+    "closer_threshold": 1.0,
+    "find_kick_targets": {
+      "distance_from_corner": 1.5,
+      "corner_kick_target_distance_to_goal": 1.3,
+      "emergency_kick_target_angles": [-0.52, -0.26, 0.0, 0.26, 0.52],
+      "max_kick_around_obstacle_angle": 1.0,
+      "ball_radius_for_kick_target_selection": 0.15
+    }
   },
   "behavior": {
     "optional_roles": [

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -200,6 +200,7 @@ where
                                 .kick_selector
                                 .ball_radius_for_kick_target_selection,
                             closer_threshold: &configuration.kick_selector.closer_threshold,
+                            find_kick_targets: &configuration.kick_selector.find_kick_targets,
                             kick_targets: framework::AdditionalOutput::new(
                                 true,
                                 &mut own_database.additional_outputs.kick_targets,


### PR DESCRIPTION
## Introduced Changes

Rebase improved kick targets if the ball is in the opponents corners.

Based on #268 

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Deploy, let the robot walk into opponent half, place ball in the opponents corner and observe a single kick target at the penalty spot in Twix.