### PR TITLE
Move kick off defender further away from center circle

### DIFF
--- a/crates/control/src/behavior/defend.rs
+++ b/crates/control/src/behavior/defend.rs
@@ -225,8 +225,10 @@ fn defend_kick_off_pose(
         None => Point2::origin(),
     };
     let position_to_defend = point![-field_dimensions.length / 2.0, 0.0];
+    let center_circle_radius = field_dimensions.center_circle_diameter / 2.0;
     let distance_to_target = distance(&position_to_defend, &absolute_ball_position)
-        - role_positions.striker_distance_to_non_free_ball;
+        - center_circle_radius
+        - role_positions.striker_distance_to_non_free_center_circle;
     let defend_pose = block_on_circle(
         absolute_ball_position,
         position_to_defend,

--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -110,7 +110,7 @@ pub struct RolePositions {
     pub striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free: f32,
     pub striker_supporter_minimum_x: f32,
     pub keeper_x_offset: f32,
-    pub striker_distance_to_non_free_ball: f32,
+    pub striker_distance_to_non_free_center_circle: f32,
     pub striker_set_position: Vector2<f32>,
 }
 

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -894,7 +894,7 @@
       "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free": -1.0,
       "striker_supporter_minimum_x": 2.0,
       "keeper_x_offset": 0.1,
-      "striker_distance_to_non_free_center_circle": 0.30,
+      "striker_distance_to_non_free_center_circle": 0.40,
       "striker_set_position": [-1.0, 0.0]
     },
     "dribbling": {

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -894,7 +894,7 @@
       "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free": -1.0,
       "striker_supporter_minimum_x": 2.0,
       "keeper_x_offset": 0.1,
-      "striker_distance_to_non_free_ball": 0.95,
+      "striker_distance_to_non_free_center_circle": 0.30,
       "striker_set_position": [-1.0, 0.0]
     },
     "dribbling": {


### PR DESCRIPTION
## Introduced Changes

Title.
This is to prevent a slightly delocalized kick off defending striker from accidentally entering the center circle, violating the rules.
Also makes the position relative to the center circle border instead of relative to the center of the field.

Fixes #243 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Do a kick off where the opponent has kick off. The defending striker should stand about 30cm away from the center circle.