### PR TITLE
move striker further back in penalty kick

### DIFF
--- a/crates/control/src/behavior/walk_to_penalty_kick.rs
+++ b/crates/control/src/behavior/walk_to_penalty_kick.rs
@@ -15,7 +15,7 @@ pub fn execute(
     let kick_off_pose = Isometry2::translation(
         field_dimensions.length / 2.0
             - field_dimensions.penalty_marker_distance
-            - field_dimensions.penalty_marker_size,
+            - field_dimensions.penalty_marker_size * 2.0,
         0.0,
     );
     walk_and_stand.execute(


### PR DESCRIPTION
## Introduced Changes

Move striker back by another penalty marker size to make sure he doesn't block the penalty mark during a penalty kick.

Fixes #252 

## ToDo / Known Issues

Could be changed to using a new parameter, but optimally should eventually use kick decisions and thus a new parameter would then be removed again. I'm open to discuss.

## Ideas for Next Iterations (Not This PR)

## How to Test
