### PR TITLE
Improve twix parameter save diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,7 +3121,6 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 name = "parameters"
 version = "0.1.0"
 dependencies = [
- "log",
  "serde",
  "serde_json",
  "serialize_hierarchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3545,6 +3545,7 @@ dependencies = [
  "futures-util",
  "glob",
  "home",
+ "parameters",
  "serde",
  "serde_json",
  "spl_network_messages",

--- a/crates/communication/src/messages.rs
+++ b/crates/communication/src/messages.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use parameters::directory::Scope;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
@@ -137,7 +138,7 @@ pub enum ParametersRequest {
     UnsubscribeEverything,
     Update { id: usize, path: Path, data: Value },
     LoadFromDisk { id: usize },
-    StoreToDisk { id: usize },
+    StoreToDisk { id: usize, scope: Scope, path: Path },
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/communication/src/server/parameters/mod.rs
+++ b/crates/communication/src/server/parameters/mod.rs
@@ -1,3 +1,4 @@
+use parameters::directory::Scope;
 use serde_json::Value;
 
 use crate::messages::Path;
@@ -22,5 +23,7 @@ pub enum StorageRequest {
     StoreToDisk {
         client: Client,
         id: usize,
+        scope: Scope,
+        path: Path,
     },
 }

--- a/crates/communication/src/server/parameters/storage.rs
+++ b/crates/communication/src/server/parameters/storage.rs
@@ -123,8 +123,21 @@ async fn handle_request<Parameters>(
             )
             .await;
         }
-        StorageRequest::StoreToDisk { client, id } => {
-            if let Err(error) = serialize(parameters, parameters_directory, body_id, head_id).await
+        StorageRequest::StoreToDisk {
+            client,
+            id,
+            scope,
+            path,
+        } => {
+            if let Err(error) = serialize(
+                parameters,
+                scope,
+                &path,
+                parameters_directory,
+                body_id,
+                head_id,
+            )
+            .await
             {
                 respond(
                     client,

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -6,7 +6,6 @@ license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
-log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serialize_hierarchy = { workspace = true }

--- a/crates/parameters/src/directory.rs
+++ b/crates/parameters/src/directory.rs
@@ -130,7 +130,7 @@ where
 
     let mut location_head_parameters = from_path(&location_head_file_path)
         .await
-        .map_err(DirectoryError::BodyParametersOfLocationNotGet)?;
+        .map_err(DirectoryError::HeadParametersOfLocationNotGet)?;
     merge_json(&mut location_head_parameters, &parameters);
 
     to_path(location_head_file_path, location_head_parameters)

--- a/crates/parameters/src/directory.rs
+++ b/crates/parameters/src/directory.rs
@@ -3,12 +3,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use log::debug;
-use serde::{de::DeserializeOwned, Serialize};
-use serde_json::{error, from_str, from_value, to_value, Value};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{error, from_str, from_value, to_string_pretty, to_value, Value};
 use tokio::fs::{read_to_string, write};
 
-use super::json::{merge_json, prune_equal_branches};
+use super::json::{copy_nested_value, merge_json, prune_equal_branches};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DirectoryError {
@@ -39,6 +38,8 @@ pub enum SerializationError {
     FileNotRead { source: io::Error, path: PathBuf },
     #[error("failed to parse {path:?}")]
     FileNotParsed { source: error::Error, path: PathBuf },
+    #[error("failed to serialize {path:?}")]
+    FileNotSerialized { source: error::Error, path: PathBuf },
     #[error("failed to write {path:?}")]
     FileNotWritten { source: io::Error, path: PathBuf },
 }
@@ -58,7 +59,7 @@ where
 
     let location_directory = parameters_root_path
         .as_ref()
-        .join(get_location_directory(head_id));
+        .join(location_directory_from_head_id(head_id));
 
     let location_default_file_path = location_directory.join("default.json");
     if location_default_file_path.exists() {
@@ -109,36 +110,91 @@ where
 
 pub async fn serialize<Parameters>(
     parameters: &Parameters,
+    scope: Scope,
+    path: &str,
     parameters_root_path: impl AsRef<Path>,
     body_id: &str,
     head_id: &str,
 ) -> Result<(), DirectoryError>
 where
-    Parameters: Serialize,
+    Parameters: DeserializeOwned + Serialize,
 {
     let mut parameters =
         to_value(parameters).map_err(DirectoryError::ParametersNotConvertedToJsonValue)?;
-    let stored_parameters = to_value(deserialize(&parameters_root_path, body_id, head_id).await?)
-        .map_err(DirectoryError::ParametersNotConvertedToJsonValue)?;
+    let stored_parameters = to_value(
+        deserialize::<Parameters>(&parameters_root_path, body_id, head_id)
+            .await
+            .map_err(|error| {
+                println!("{:?}", error);
+                error
+            })?,
+    )
+    .map_err(DirectoryError::ParametersNotConvertedToJsonValue)?;
 
     prune_equal_branches(&mut parameters, &stored_parameters);
 
-    let location_head_file_path = parameters_root_path
-        .as_ref()
-        .join(get_location_directory(head_id))
-        .join(format!("head.{}.json", head_id));
+    let Some(sparse_parameters_from_scope_path) = copy_nested_value(&parameters, path) else {
+        return Ok(());
+    };
+    let serialization_file_path =
+        file_path_from_scope(scope, parameters_root_path, body_id, head_id);
+    let mut parameters = if serialization_file_path.exists() {
+        from_path(&serialization_file_path)
+            .await
+            .map_err(DirectoryError::HeadParametersOfLocationNotGet)?
+    } else {
+        Value::Object(Default::default())
+    };
+    merge_json(&mut parameters, &sparse_parameters_from_scope_path);
 
-    let mut location_head_parameters = from_path(&location_head_file_path)
-        .await
-        .map_err(DirectoryError::HeadParametersOfLocationNotGet)?;
-    merge_json(&mut location_head_parameters, &parameters);
-
-    to_path(location_head_file_path, location_head_parameters)
+    to_path(serialization_file_path, parameters)
         .await
         .map_err(DirectoryError::HeadParametersOfLocationNotSet)
 }
 
-fn get_location_directory(head_id: &str) -> &'static str {
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Scope {
+    pub location: Location,
+    pub id: Id,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Location {
+    All,
+    Current,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Id {
+    All,
+    Body,
+    Head,
+}
+
+fn file_path_from_scope(
+    scope: Scope,
+    parameters_root_path: impl AsRef<Path>,
+    body_id: &str,
+    head_id: &str,
+) -> PathBuf {
+    let location_directory = parameters_root_path
+        .as_ref()
+        .join(location_directory_from_head_id(head_id));
+    match (scope.location, scope.id) {
+        (Location::All, Id::All) => parameters_root_path.as_ref().join("default.json"),
+        (Location::All, Id::Body) => parameters_root_path
+            .as_ref()
+            .join(format!("body.{}.json", body_id)),
+        (Location::All, Id::Head) => parameters_root_path
+            .as_ref()
+            .join(format!("head.{}.json", head_id)),
+        (Location::Current, Id::All) => location_directory.join("default.json"),
+        (Location::Current, Id::Body) => location_directory.join(format!("body.{}.json", body_id)),
+        (Location::Current, Id::Head) => location_directory.join(format!("head.{}.json", head_id)),
+    }
+}
+
+fn location_directory_from_head_id(head_id: &str) -> &'static str {
     let webots_id_found = head_id.starts_with("webots");
     let behavior_simulator_id_found = head_id.starts_with("behavior_simulator");
     if webots_id_found {
@@ -151,7 +207,6 @@ fn get_location_directory(head_id: &str) -> &'static str {
 }
 
 async fn from_path(file_path: impl AsRef<Path>) -> Result<Value, SerializationError> {
-    debug!("Reading {:?}...", file_path.as_ref());
     let file_contents =
         read_to_string(&file_path)
             .await
@@ -166,8 +221,11 @@ async fn from_path(file_path: impl AsRef<Path>) -> Result<Value, SerializationEr
 }
 
 async fn to_path(file_path: impl AsRef<Path>, value: Value) -> Result<(), SerializationError> {
-    debug!("Writing {:?}...", file_path.as_ref());
-    let file_contents = value.to_string();
+    let file_contents =
+        to_string_pretty(&value).map_err(|source| SerializationError::FileNotSerialized {
+            source,
+            path: file_path.as_ref().to_path_buf(),
+        })? + "\n";
     write(&file_path, file_contents.as_bytes())
         .await
         .map_err(|source| SerializationError::FileNotWritten {

--- a/crates/parameters/src/directory.rs
+++ b/crates/parameters/src/directory.rs
@@ -56,7 +56,9 @@ where
         .await
         .map_err(DirectoryError::DefaultParametersNotGet)?;
 
-    let location_directory = parameters_root_path.as_ref().join(get_location_directory(head_id));
+    let location_directory = parameters_root_path
+        .as_ref()
+        .join(get_location_directory(head_id));
 
     let location_default_file_path = location_directory.join("default.json");
     if location_default_file_path.exists() {
@@ -66,7 +68,9 @@ where
         merge_json(&mut parameters, &location_default_parameters);
     }
 
-    let body_file_path = parameters_root_path.as_ref().join(format!("body.{}.json", body_id));
+    let body_file_path = parameters_root_path
+        .as_ref()
+        .join(format!("body.{}.json", body_id));
     if body_file_path.exists() {
         let body_parameters = from_path(body_file_path)
             .await
@@ -74,7 +78,9 @@ where
         merge_json(&mut parameters, &body_parameters);
     }
 
-    let head_file_path = parameters_root_path.as_ref().join(format!("head.{}.json", head_id));
+    let head_file_path = parameters_root_path
+        .as_ref()
+        .join(format!("head.{}.json", head_id));
     if head_file_path.exists() {
         let head_parameters = from_path(head_file_path)
             .await

--- a/crates/parameters/src/json.rs
+++ b/crates/parameters/src/json.rs
@@ -35,7 +35,7 @@ pub fn prune_equal_branches(own: &mut Value, other: &Value) {
     }
 }
 
-pub fn copy_nested_value(value: &Value, path: &str) -> Option<Value> {
+pub fn clone_nested_value(value: &Value, path: &str) -> Option<Value> {
     if path.is_empty() {
         return Some(value.clone());
     }
@@ -46,10 +46,10 @@ pub fn copy_nested_value(value: &Value, path: &str) -> Option<Value> {
     match value {
         Value::Object(object) => {
             let nested_value = object.get(prefix)?;
-            let nested_copied_value = copy_nested_value(nested_value, suffix)?;
+            let nested_cloned_value = clone_nested_value(nested_value, suffix)?;
             Some(Value::Object(Map::from_iter([(
                 prefix.to_string(),
-                nested_copied_value,
+                nested_cloned_value,
             )])))
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Array(_) => {
@@ -106,7 +106,7 @@ mod tests {
     fn branches_matching_the_path_are_retained_others_are_removed() {
         let value = json!({"a":{"b":{"c":42},"d":{"e":1337}}});
 
-        let copied = copy_nested_value(&value, "a.b.c");
+        let copied = clone_nested_value(&value, "a.b.c");
 
         assert_eq!(copied, Some(json!({"a":{"b":{"c":42}}})));
     }
@@ -115,7 +115,7 @@ mod tests {
     fn branches_matching_parts_of_the_path_are_retained_others_are_removed() {
         let value = json!({"a":{"b":{"c":42},"d":{"e":1337}}});
 
-        let copied = copy_nested_value(&value, "a.b");
+        let copied = clone_nested_value(&value, "a.b");
 
         assert_eq!(copied, Some(json!({"a":{"b":{"c":42}}})));
     }
@@ -124,7 +124,7 @@ mod tests {
     fn all_branches_are_removed_for_non_existant_path() {
         let value = json!({"a":{"b":{"c":42},"d":{"e":1337}}});
 
-        let copied = copy_nested_value(&value, "not.matching");
+        let copied = clone_nested_value(&value, "not.matching");
 
         assert_eq!(copied, None);
     }
@@ -133,7 +133,7 @@ mod tests {
     fn all_branches_are_removed_for_too_long_path() {
         let value = json!({"a":{"b":{"c":42},"d":{"e":1337}}});
 
-        let copied = copy_nested_value(&value, "a.b.c.too.long");
+        let copied = clone_nested_value(&value, "a.b.c.too.long");
 
         assert_eq!(copied, None);
     }
@@ -142,7 +142,7 @@ mod tests {
     fn all_branches_are_retained_for_non_empty_path() {
         let value = json!({"a":{"b":{"c":42},"d":{"e":1337}}});
 
-        let copied = copy_nested_value(&value, "");
+        let copied = clone_nested_value(&value, "");
 
         assert_eq!(copied, Some(value));
     }

--- a/crates/parameters/src/lib.rs
+++ b/crates/parameters/src/lib.rs
@@ -1,2 +1,2 @@
 pub mod directory;
-pub mod json;
+pub mod json; // TODO: remove pub?

--- a/crates/parameters/src/lib.rs
+++ b/crates/parameters/src/lib.rs
@@ -1,2 +1,2 @@
 pub mod directory;
-pub mod json; // TODO: remove pub?
+mod json;

--- a/crates/parameters/src/lib.rs
+++ b/crates/parameters/src/lib.rs
@@ -1,2 +1,2 @@
 pub mod directory;
-mod json;
+pub mod json;

--- a/crates/repository/Cargo.toml
+++ b/crates/repository/Cargo.toml
@@ -11,6 +11,7 @@ constants = { workspace = true }
 glob = { workspace = true }
 futures-util = { workspace = true }
 home = { workspace = true }
+parameters = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spl_network_messages = { workspace = true }

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -46,6 +46,10 @@ impl Repository {
         }
     }
 
+    pub fn root_directory(&self) -> PathBuf {
+        self.root.clone()
+    }
+
     pub fn crates_directory(&self) -> PathBuf {
         self.root.join("crates")
     }

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -46,12 +46,12 @@ impl Repository {
         }
     }
 
-    pub fn root_directory(&self) -> PathBuf {
-        self.root.clone()
-    }
-
     pub fn crates_directory(&self) -> PathBuf {
         self.root.join("crates")
+    }
+
+    pub fn configuration_root(&self) -> PathBuf {
+        self.root.join("etc/configuration")
     }
 
     pub fn find_latest_file(&self, pattern: &str) -> Result<PathBuf> {
@@ -176,10 +176,6 @@ impl Repository {
             passthrough_arguments,
         )
         .await
-    }
-
-    fn configuration_root(&self) -> PathBuf {
-        self.root.join("etc/configuration")
     }
 
     fn head_configuration(&self, head_id: &str) -> PathBuf {

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -24,7 +24,7 @@ struct CameraParameterSubscriptions<DeserializedValueType> {
 
 pub struct ManualCalibrationPanel {
     nao: Arc<Nao>,
-    repository_parameters: Option<RepositoryParameters>,
+    repository_parameters: RepositoryParameters,
     extrinsic_rotation_subscriptions: [CameraParameterSubscriptions<Option<SubscribedType>>; 2],
 }
 
@@ -54,7 +54,7 @@ impl Panel for ManualCalibrationPanel {
 
         Self {
             nao,
-            repository_parameters: RepositoryParameters::try_default().ok(),
+            repository_parameters: RepositoryParameters::new(),
             extrinsic_rotation_subscriptions,
         }
     }
@@ -63,7 +63,7 @@ impl Panel for ManualCalibrationPanel {
 fn add_extrinsic_calibration_ui_components(
     ui: &mut Ui,
     nao: Arc<Nao>,
-    repository_parameters: &Option<RepositoryParameters>,
+    repository_parameters: &RepositoryParameters,
     extrinsic_rotations_subscription: &mut CameraParameterSubscriptions<Option<SubscribedType>>,
 ) {
     let extrinsic_rotations_buffer_option = &extrinsic_rotations_subscription.value_buffer;

--- a/tools/twix/src/repository_parameters.rs
+++ b/tools/twix/src/repository_parameters.rs
@@ -9,7 +9,6 @@ use repository::{get_repository_root, HardwareIds, Repository};
 use serde_json::{json, Value};
 use std::{collections::HashMap, net::Ipv4Addr};
 use tokio::runtime::Runtime;
-use types::hardware;
 
 pub struct RepositoryParameters {
     repository: Repository,

--- a/tools/twix/src/repository_parameters.rs
+++ b/tools/twix/src/repository_parameters.rs
@@ -3,9 +3,12 @@ use color_eyre::{
     Result,
 };
 use log::error;
-use parameters::directory::{serialize, Id, Location, Scope};
+use parameters::{
+    directory::{serialize, Id, Location, Scope},
+    json::nest_value_at_path,
+};
 use repository::{get_repository_root, HardwareIds, Repository};
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::{collections::HashMap, net::Ipv4Addr};
 use tokio::runtime::Runtime;
 
@@ -78,42 +81,4 @@ impl RepositoryParameters {
 
 fn last_octet_from_ip_address(ip_address: Ipv4Addr) -> u8 {
     ip_address.octets()[3]
-}
-
-fn nest_value_at_path(path: &str, value: Value) -> Value {
-    // ("a.b.c", value) -> { a: { b: { c: value } } }
-    path.split('.')
-        .rev()
-        .fold(value, |child_value, key| -> Value {
-            json!({ key: child_value })
-        })
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::nest_value_at_path;
-
-    #[test]
-    fn values_are_nested_at_paths() {
-        let dataset = [
-            (
-                ("config.a.b.c", json!(["p", "q", "r"])),
-                json!({"config":{"a":{"b":{"c":["p", "q", "r"]}}}}),
-            ),
-            (
-                ("top.rotations", json!([1, 2, 3])),
-                json!({"top":{"rotations":[1,2,3]}}),
-            ),
-            (
-                ("something.properties", json!({"k":"v"})),
-                json!({"something":{"properties":{"k":"v"}}}),
-            ),
-        ];
-
-        for ((path, value), expected_output) in dataset {
-            assert_eq!(nest_value_at_path(path, value), expected_output);
-        }
-    }
 }


### PR DESCRIPTION
REQUIRES #248 
## Introduced Changes

Fullfills the following.

```rust
let stored_value = json!({"a":{"b":[1,2,3], "c":10}, "x":1000});
let incoming_sparse_value = json!({"a":{"b":[1,4,3], "c":10}});

// Only "b" has changes.
let expected_diff = json!({"a":{"b":[1,4,3]}});

assert_eq!(
    get_diff_against_stored_value(&stored_value, &incoming_sparse_value),
    expected_diff
);
```
See the issue for further details.


Fixes #240 

## ToDo / Known Issues

We still directly write to head json of a particular robot. Locations are not respected (unlike `serialize()` of parameters crate (Moved from communication server in #248 ))

## Ideas for Next Iterations (Not This PR)

* Further refactoring on these crates and how they are used could be done.

## How to Test

Cargo test on twix should do the trick ;)
OR
Open twix open manual calibration, change only extrinsic parameters.
Once you click save, only extrinsic parameter changes should show up in the json file. (Before this fix, both intrinsic and extrinsic showed up.)