### PR TITLE
Rename smoothing factor to roughness factor

### DIFF
--- a/crates/control/src/fall_state_estimation.rs
+++ b/crates/control/src/fall_state_estimation.rs
@@ -46,17 +46,17 @@ pub struct MainOutputs {
 impl FallStateEstimation {
     pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
-            roll_pitch_filter: LowPassFilter::with_smoothing_factor(
+            roll_pitch_filter: LowPassFilter::with_roughness_factor(
                 Vector2::zeros(),
                 context.fall_state_estimation.roll_pitch_low_pass_factor,
             ),
-            angular_velocity_filter: LowPassFilter::with_smoothing_factor(
+            angular_velocity_filter: LowPassFilter::with_roughness_factor(
                 Vector3::zeros(),
                 context
                     .fall_state_estimation
                     .angular_velocity_low_pass_factor,
             ),
-            linear_acceleration_filter: LowPassFilter::with_smoothing_factor(
+            linear_acceleration_filter: LowPassFilter::with_roughness_factor(
                 Vector3::zeros(),
                 context
                     .fall_state_estimation

--- a/crates/control/src/motion/condition_input_provider.rs
+++ b/crates/control/src/motion/condition_input_provider.rs
@@ -29,7 +29,7 @@ pub struct MainOutputs {
 impl ConditionInputProvider {
     pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
-            angular_velocity_filter: LowPassFilter::with_smoothing_factor(
+            angular_velocity_filter: LowPassFilter::with_roughness_factor(
                 Default::default(),
                 *context.angular_velocity_smoothing_factor,
             ),

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -49,7 +49,7 @@ impl StandUpBack {
         Ok(Self {
             interpolator: MotionFile::from_path("etc/motions/stand_up_back_dortmund_2022.json")?
                 .try_into()?,
-            filtered_gyro: LowPassFilter::with_smoothing_factor(
+            filtered_gyro: LowPassFilter::with_roughness_factor(
                 Vector2::zeros(),
                 *context.gyro_low_pass_filter_coefficient,
             ),

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -49,7 +49,7 @@ impl StandUpFront {
     pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
             interpolator: MotionFile::from_path("etc/motions/stand_up_front.json")?.try_into()?,
-            filtered_gyro: LowPassFilter::with_smoothing_factor(
+            filtered_gyro: LowPassFilter::with_roughness_factor(
                 Vector2::zeros(),
                 *context.gyro_low_pass_filter_coefficient,
             ),

--- a/crates/control/src/motion/walking_engine.rs
+++ b/crates/control/src/motion/walking_engine.rs
@@ -143,11 +143,11 @@ pub struct MainOutputs {
 impl WalkingEngine {
     pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
-            filtered_gyro_y: LowPassFilter::with_smoothing_factor(
+            filtered_gyro_y: LowPassFilter::with_roughness_factor(
                 0.0,
                 context.config.gyro_low_pass_factor,
             ),
-            filtered_robot_tilt_shift: LowPassFilter::with_smoothing_factor(
+            filtered_robot_tilt_shift: LowPassFilter::with_roughness_factor(
                 0.0,
                 context.config.tilt_shift_low_pass_factor,
             ),

--- a/crates/control/src/sole_pressure_filter.rs
+++ b/crates/control/src/sole_pressure_filter.rs
@@ -26,8 +26,8 @@ pub struct MainOutputs {
 impl SolePressureFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
-            left_sole_pressure: LowPassFilter::with_smoothing_factor(0.0, 0.5),
-            right_sole_pressure: LowPassFilter::with_smoothing_factor(0.0, 0.5),
+            left_sole_pressure: LowPassFilter::with_roughness_factor(0.0, 0.5),
+            right_sole_pressure: LowPassFilter::with_roughness_factor(0.0, 0.5),
         })
     }
 

--- a/crates/control/src/sonar_filter.rs
+++ b/crates/control/src/sonar_filter.rs
@@ -43,11 +43,11 @@ pub struct MainOutputs {
 impl SonarFilter {
     pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
-            filtered_sonar_left: LowPassFilter::with_smoothing_factor(
+            filtered_sonar_left: LowPassFilter::with_roughness_factor(
                 *context.maximal_detectable_distance,
                 *context.low_pass_filter_coefficient,
             ),
-            filtered_sonar_right: LowPassFilter::with_smoothing_factor(
+            filtered_sonar_right: LowPassFilter::with_roughness_factor(
                 *context.maximal_detectable_distance,
                 *context.low_pass_filter_coefficient,
             ),

--- a/crates/filtering/src/low_pass_filter.rs
+++ b/crates/filtering/src/low_pass_filter.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
 pub struct LowPassFilter<State> {
-    smoothing_factor: f32,
+    roughness_factor: f32,
     state: State,
 }
 
@@ -15,9 +15,9 @@ impl<State> LowPassFilter<State>
 where
     State: Copy + Add<Output = State> + Sub<Output = State> + Mul<f32, Output = State>,
 {
-    pub fn with_smoothing_factor(initial_state: State, smoothing_factor: f32) -> Self {
+    pub fn with_roughness_factor(initial_state: State, roughness_factor: f32) -> Self {
         Self {
-            smoothing_factor,
+            roughness_factor,
             state: initial_state,
         }
     }
@@ -26,15 +26,15 @@ where
     pub fn with_cutoff(initial_state: State, cutoff_frequency: f32, sampling_rate: f32) -> Self {
         let rc = 1.0 / (cutoff_frequency * 2.0 * PI);
         let dt = 1.0 / sampling_rate;
-        let smoothing_factor = dt / (rc + dt);
+        let roughness_factor = dt / (rc + dt);
         Self {
-            smoothing_factor,
+            roughness_factor,
             state: initial_state,
         }
     }
 
     pub fn update(&mut self, value: State) {
-        self.state = self.state + (value - self.state) * self.smoothing_factor;
+        self.state = self.state + (value - self.state) * self.roughness_factor;
     }
 
     pub fn state(&self) -> State {


### PR DESCRIPTION
## Introduced Changes

Previously, a value of 1.0 of the smoothing factor corresponded no smoothing of the measurements. In this PR, the smoothing factor is renamed to roughness factor to be consistent with its function.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)
None

## How to Test

Check whether the renaming is consistent.
