### PR TITLE
Decay the ball velocity in the ball filter

### DIFF
--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -268,7 +268,8 @@
     "initial_covariance": [0.5, 0.5, 0.5, 0.5],
     "visible_validity_exponential_decay_factor": 0.96,
     "hidden_validity_exponential_decay_factor": 0.999,
-    "validity_discard_threshold": 0.5
+    "validity_discard_threshold": 0.5,
+    "velocity_decay_factor": 0.99
   },
   "button_filter": {
     "head_buttons_timeout": {


### PR DESCRIPTION
## Introduced Changes
During the games we had issues with the ball position, because the prediction step in the ball filter did not account for friction. In this PR, a decay factor for the velocity is introduced to model the friction of the ball.

Fixes #273 

## ToDo / Known Issues
- the velocity decay parameter has not been tested on the field

## Ideas for Next Iterations (Not This PR)
None

## How to Test

Deploy this branch to a robot and check the ball behavior through the map panel in Twix.
