### PR TITLE
Add instant kick decisions to own database to prevent action panic

### DIFF
--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -213,6 +213,8 @@ where
                         .wrap_err("failed to execute cycle of node `KickSelector`")?
                 };
                 own_database.main_outputs.kick_decisions = main_outputs.kick_decisions.value;
+                own_database.main_outputs.instant_kick_decisions =
+                    main_outputs.instant_kick_decisions.value;
             } else {
                 own_database.main_outputs.kick_decisions = Default::default();
             }


### PR DESCRIPTION
## Introduced Changes

As in title, instant kick decisions were not output to own_database in behavior simulator.

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Behavior sim works again as current main does not.