### PR TITLE
Update whistle filter for fix in 5.7.3

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -3,5 +3,5 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "5.7.2";
+pub const OS_VERSION: &str = "5.7.3";
 pub const SDK_VERSION: &str = "5.7.0";

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -341,8 +341,8 @@
     "inside_turn_ratio": 0.1
   },
   "whistle_filter": {
-    "buffer_length": 40,
-    "minimum_detections": 8
+    "buffer_length": 20,
+    "minimum_detections": 2
   },
   "walking_engine": {
     "arm_stiffness": 0.8,


### PR DESCRIPTION
## Introduced Changes

With the workaround for #275 in the 5.7.3 image, only two of the four microphones are available. This PR halves the minimum detection number in the whistle filter accordingly. It also updates the `OS_VERSION` within pepsi to `5.7.3`.

Fixes #271.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Flash the new 5.7.3 image to a NAO and upload to it. Observe the whistle detection.