### PR TITLE
Free kick rule obstacles

### DIFF
--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -65,7 +65,7 @@ impl RuleObstacleComposer {
             }
             (
                 GameControllerState {
-                    game_state: GameState::Playing,
+                    game_state: GameState::Set,
                     kicking_team: Team::Opponent | Team::Uncertain,
                     ..
                 },

--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -42,6 +42,7 @@ impl RuleObstacleComposer {
                             | SubState::GoalKick
                             | SubState::PushingFreeKick,
                         ),
+                    kicking_team: Team::Opponent | Team::Uncertain,
                     game_state: GameState::Playing,
                     ..
                 },

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -101,7 +101,11 @@ where
                             .as_ref()
                             .unwrap(),
                         ball_state: own_database.main_outputs.ball_state.as_ref(),
-                        filtered_game_state: own_database.main_outputs.filtered_game_state.as_ref().unwrap(),
+                        filtered_game_state: own_database
+                            .main_outputs
+                            .filtered_game_state
+                            .as_ref()
+                            .unwrap(),
                         field_dimensions: &configuration.field_dimensions,
                     })
                     .wrap_err("failed to execute cycle of node `RuleObstacleComposer`")?

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -100,6 +100,8 @@ where
                             .game_controller_state
                             .as_ref()
                             .unwrap(),
+                        ball_state: own_database.main_outputs.ball_state.as_ref(),
+                        filtered_game_state: own_database.main_outputs.filtered_game_state.as_ref().unwrap(),
                         field_dimensions: &configuration.field_dimensions,
                     })
                     .wrap_err("failed to execute cycle of node `RuleObstacleComposer`")?


### PR DESCRIPTION
## Introduced Changes

Spawn rule obstacle for kick in, corner kick, goal kick and pushing free kick.

Fixes #266 

## ToDo / Known Issues

- [x] fix behavior simulator

## Ideas for Next Iterations (Not This PR)

## How to Test

Robots should have obstacles during all kinds of opponent free kicks and walk around the ball during this time.