### PR TITLE
Remove intrinsic calibration panel from twix to keep things simple (a…

### DIFF
--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -1,16 +1,18 @@
 use color_eyre::eyre::Context;
 use eframe::egui::{Response, Slider, Ui, Widget};
 use log::{error, info};
+use nalgebra::Vector3;
 use serde_json::Value;
 use std::{ops::RangeInclusive, sync::Arc};
 use tokio::sync::mpsc;
-use types::configuration::CameraMatrixParameters;
 
 use crate::{
     nao::Nao, panel::Panel, repository_parameters::RepositoryParameters, value_buffer::ValueBuffer,
 };
 
 use super::parameter::{add_save_button, subscribe};
+
+type SubscribedType = Vector3<f64>;
 
 struct CameraParameterSubscriptions<DeserializedValueType> {
     human_friendly_label: String,
@@ -23,18 +25,18 @@ struct CameraParameterSubscriptions<DeserializedValueType> {
 pub struct ManualCalibrationPanel {
     nao: Arc<Nao>,
     repository_parameters: Option<RepositoryParameters>,
-    extrinsic_rotation_subscriptions:
-        [CameraParameterSubscriptions<Option<CameraMatrixParameters>>; 2],
+    extrinsic_rotation_subscriptions: [CameraParameterSubscriptions<Option<SubscribedType>>; 2],
 }
 
 const CAMERA_KEY_BASE: &str = "camera_matrix_parameters.vision_";
+const ROTATIONS: &str = ".extrinsic_rotations";
 
 impl Panel for ManualCalibrationPanel {
     const NAME: &'static str = "Manual Calibration";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         let extrinsic_rotation_subscriptions = ["Top", "Bottom"].map(|name| {
-            let path = CAMERA_KEY_BASE.to_owned() + name.to_lowercase().as_str();
+            let path = CAMERA_KEY_BASE.to_owned() + name.to_lowercase().as_str() + ROTATIONS;
 
             let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
             let value_buffer = subscribe(nao.clone(), &path, update_notify_sender);
@@ -62,28 +64,27 @@ fn add_extrinsic_calibration_ui_components(
     ui: &mut Ui,
     nao: Arc<Nao>,
     repository_parameters: &Option<RepositoryParameters>,
-    camera_matrix_parameters_subscription: &mut CameraParameterSubscriptions<
-        Option<CameraMatrixParameters>,
-    >,
+    extrinsic_rotations_subscription: &mut CameraParameterSubscriptions<Option<SubscribedType>>,
 ) {
-    let camera_parameter_buffer_option = &camera_matrix_parameters_subscription.value_buffer;
-    let mut camera_parameter_option = &mut camera_matrix_parameters_subscription.value;
-    let label = &camera_matrix_parameters_subscription.human_friendly_label;
-    let camera_matrix_subscription_path = &camera_matrix_parameters_subscription.path;
-    let rotations_update_notify_receiver =
-        &mut camera_matrix_parameters_subscription.update_notify_receiver;
+    let extrinsic_rotations_buffer_option = &extrinsic_rotations_subscription.value_buffer;
+    let mut extrinsic_rotations_option = &mut extrinsic_rotations_subscription.value;
+    let label = &extrinsic_rotations_subscription.human_friendly_label;
+    let extrinsic_rotations_subscription_path = &extrinsic_rotations_subscription.path;
+    let extrinsic_rotations_update_notify_receiver =
+        &mut extrinsic_rotations_subscription.update_notify_receiver;
 
-    let slider_minimum_decimals = 2;
-    let slider_maximum_decimals = 6;
     let extrinsic_maximum_degrees = 15.0;
 
     ui.horizontal(|ui| {
-        if let Some(buffer) = &camera_parameter_buffer_option {
+        if let Some(buffer) = &extrinsic_rotations_buffer_option {
             match buffer.get_latest() {
                 Ok(value) => {
-                    if rotations_update_notify_receiver.try_recv().is_ok() {
-                        *camera_parameter_option =
-                            serde_json::from_value::<CameraMatrixParameters>(value).ok();
+                    if extrinsic_rotations_update_notify_receiver
+                        .try_recv()
+                        .is_ok()
+                    {
+                        *extrinsic_rotations_option =
+                            serde_json::from_value::<SubscribedType>(value).ok();
                     }
                 }
                 Err(error) => {
@@ -96,9 +97,9 @@ fn add_extrinsic_calibration_ui_components(
 
         add_save_button(
             ui,
-            camera_matrix_subscription_path,
+            extrinsic_rotations_subscription_path,
             || {
-                serde_json::to_value(&camera_parameter_option)
+                serde_json::to_value(&extrinsic_rotations_option)
                     .wrap_err("Conveting CameraMatrixParameters to serde_json::Value failed.")
             },
             nao.clone(),
@@ -108,55 +109,13 @@ fn add_extrinsic_calibration_ui_components(
 
     ui.style_mut().spacing.slider_width = ui.available_size().x - 100.0;
     let mut changed = false;
-    ui.collapsing(
-        format!("Intrinsic Parameters {label:#}"),
-        |ui| match &mut camera_parameter_option {
-            Some(camera_parameter_value) => {
-                ui.label("Focal Lengths (Normalized)");
-                for (axis_value, axis_name) in camera_parameter_value
-                    .focal_lengths
-                    .iter_mut()
-                    .zip(["X", "Y"])
-                {
-                    let slider = Slider::new(axis_value, RangeInclusive::new(0.0, 2.0))
-                        .text(axis_name)
-                        .smart_aim(false)
-                        .min_decimals(slider_minimum_decimals)
-                        .max_decimals(slider_maximum_decimals);
-                    if ui.add(slider).changed() {
-                        changed = true
-                    };
-                }
-                ui.label("Optical Centre (Normalized)");
-                for (axis_value, axis_name) in camera_parameter_value
-                    .cc_optical_center
-                    .iter_mut()
-                    .zip(["X", "Y"])
-                {
-                    let slider = Slider::new(axis_value, RangeInclusive::new(0.0, 1.0))
-                        .text(axis_name)
-                        .smart_aim(false)
-                        .min_decimals(slider_minimum_decimals)
-                        .max_decimals(slider_maximum_decimals);
-                    if ui.add(slider).changed() {
-                        changed = true
-                    };
-                }
-            }
-            _ => {
-                ui.label("Intrinsic parameters not recieved.");
-            }
-        },
-    );
-
     ui.label(format!(
         "Extrinsic Rotations [{}°, {}°]",
         -extrinsic_maximum_degrees, extrinsic_maximum_degrees
     ));
-    match &mut camera_parameter_option {
+    match &mut extrinsic_rotations_option {
         Some(camera_parameter_value) => {
             for (axis_value, axis_name) in camera_parameter_value
-                .extrinsic_rotations
                 .iter_mut()
                 .zip(["Roll", "Pitch", "Yaw"])
             {
@@ -176,10 +135,10 @@ fn add_extrinsic_calibration_ui_components(
         }
     };
     if changed {
-        if let Some(camera_parameter_value) = camera_parameter_option {
+        if let Some(camera_parameter_value) = extrinsic_rotations_option {
             match serde_json::value::to_value(camera_parameter_value) {
                 Ok(value) => {
-                    nao.update_parameter_value(camera_matrix_subscription_path, value);
+                    nao.update_parameter_value(extrinsic_rotations_subscription_path, value);
                 }
                 Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
             }


### PR DESCRIPTION
While testing  #267, I noticed that the intrinsic parameters keep popping up in the json files although I only changed extrinsic.

This panel uses the `CameraMatrixParameters` struct with `f32` based vectors for serdes aspect.
In contrast, JSON specification uses `f64`, thus the JSON generated by serializing the crate can be different (kinda like lossy compression).

Since we also* realistically will not be using the intrinsic calibration feature (needs more precise setup + we never did intrinsic calibration yet :laughing: .

## Introduced Changes

Remove the intrinsic sliders, and change the subscribed type to `Vector3` instead of `CameraMatrix`.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

## How to Test

Extrinsic calibration should work as it used to work.