### PR TITLE
Bump OS_VERSION

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -3,5 +3,5 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "5.7.3";
+pub const OS_VERSION: &str = "5.7.4";
 pub const SDK_VERSION: &str = "5.7.0";


### PR DESCRIPTION
## Introduced Changes

This PR bumps the `OS_VERSION` to 5.7.4

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Gammaray a NAO and upload to it. Observe the OS check.
