### PR TITLE
remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,17 +1031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,7 +1844,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdd7b0849075e79ee9a1836df22c717d1eba30451796fdc631b04565dd11e2a"
 dependencies = [
- "colored 1.9.3",
+ "colored",
  "log",
 ]
 
@@ -3178,7 +3167,6 @@ dependencies = [
  "clap 4.2.4",
  "clap_complete",
  "color-eyre",
- "colored 2.0.0",
  "constants",
  "futures-util",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ clap = { version = "4.2.4", features = ["derive"] }
 clap_complete = "4.2.1"
 code_generation = { path = "crates/code_generation" }
 color-eyre = "0.6.2"
-colored = "2.0.0"
 communication = { path = "crates/communication" }
 compiled-nn = "0.12.0"
 constants = { path = "crates/constants" }

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -11,7 +11,6 @@ bat = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 color-eyre = { workspace = true }
-colored = { workspace = true }
 constants = { workspace = true }
 futures-util = { workspace = true }
 indicatif = { workspace = true }

--- a/tools/pepsi/src/aliveness.rs
+++ b/tools/pepsi/src/aliveness.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, net::IpAddr, num::ParseIntError, time::Duration};
 
 use clap::{arg, Args};
-use colored::Colorize;
+use color_eyre::owo_colors::OwoColorize;
 
 use crate::parsers::NaoAddress;
 use aliveness::{


### PR DESCRIPTION
## Introduced Changes

Remove the dependency on `colored`, because `owo_colors` already offers the same functionality and is used elsewhere already.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Compile.
