### PR TITLE
Add `pepsi aliveness --watch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "git+https://github.com/crossterm-rs/crossterm.git?rev=03c25178af94ae986677dfc178f94c931b96de66#03c25178af94ae986677dfc178f94c931b96de66"
+dependencies = [
+ "bitflags",
+ "libc",
+ "parking_lot",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,6 +3178,7 @@ dependencies = [
  "clap_complete",
  "color-eyre",
  "constants",
+ "crossterm",
  "futures-util",
  "indicatif",
  "nao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ constants = { path = "crates/constants" }
 context_attribute = { path = "crates/context_attribute" }
 control = { path = "crates/control" }
 convert_case = "0.6.0"
+crossterm = { git = "https://github.com/crossterm-rs/crossterm.git", rev = "03c25178af94ae986677dfc178f94c931b96de66", default-features = false }
 ctrlc = { version = "3.2.3", features = ["termination"] }
 cyclers = { path = "crates/cyclers" }
 eframe = { version = "0.21.0", features = ["persistence"] }

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -12,6 +12,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 color-eyre = { workspace = true }
 constants = { workspace = true }
+crossterm = { workspace = true }
 futures-util = { workspace = true }
 indicatif = { workspace = true }
 nao = { workspace = true }


### PR DESCRIPTION
## Introduced Changes

Add a `--watch` parameter to continually refresh the output of `pepsi aliveness`.
The refresh interval is configurable with `--interval` | `-i`.

For consistency, the `--timeout` parameter is changed to be in seconds instead of milliseconds.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Run `./pepsi aliveness --watch`, try the `--interval` parameter.
