### PR TITLE
Interpolation Mode and Name

### DIFF
--- a/crates/motionfile/src/motion_file.rs
+++ b/crates/motionfile/src/motion_file.rs
@@ -4,19 +4,21 @@ use std::{fs::File, path::Path, time::Duration};
 use color_eyre::eyre::{Result, WrapErr};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::from_reader;
-use splines::Interpolate;
+use splines::{Interpolate, Interpolation};
 
 use crate::condition::ConditionType;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MotionFile<T> {
+    #[serde(default)]
+    pub interpolation_mode: Interpolation<Duration, T>,
     pub initial_positions: T,
     pub motion: Vec<MotionFileFrame<T>>,
 }
 
 impl<T> MotionFile<T>
 where
-    for<'de> T: Debug + Interpolate<f32> + Deserialize<'de>,
+    for<'de> T: Debug + Interpolate<f32> + Deserialize<'de> + Default,
 {
     pub fn from_path(motion_file_path: impl AsRef<Path>) -> Result<Self> {
         let file = File::open(&motion_file_path).wrap_err_with(|| {
@@ -33,6 +35,7 @@ where
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MotionFileFrame<T> {
+    pub name: Option<String>,
     pub entry_condition: Option<ConditionType>,
     pub keyframes: Vec<KeyFrame<T>>,
     pub exit_condition: Option<ConditionType>,

--- a/crates/motionfile/src/motion_interpolator.rs
+++ b/crates/motionfile/src/motion_interpolator.rs
@@ -163,6 +163,8 @@ impl<T: Debug + Interpolate<f32>> TryFrom<MotionFile<T>> for MotionInterpolator<
     type Error = Report;
 
     fn try_from(motion_file: MotionFile<T>) -> Result<Self> {
+        let interpolation_mode = motion_file.interpolation_mode;
+
         let first_frame = motion_file.motion.first().unwrap();
 
         let mut motion_frames = vec![ConditionedSpline {
@@ -170,6 +172,7 @@ impl<T: Debug + Interpolate<f32>> TryFrom<MotionFile<T>> for MotionInterpolator<
             spline: TimedSpline::try_new_with_start(
                 motion_file.initial_positions,
                 first_frame.keyframes.clone(),
+                interpolation_mode,
             )?,
             exit_condition: first_frame.exit_condition.clone(),
         }];
@@ -185,6 +188,7 @@ impl<T: Debug + Interpolate<f32>> TryFrom<MotionFile<T>> for MotionInterpolator<
                         spline: TimedSpline::try_new_with_start(
                             first_frame.keyframes.last().unwrap().positions,
                             second_frame.keyframes,
+                            interpolation_mode,
                         )?,
                         exit_condition: second_frame.exit_condition,
                     })

--- a/crates/motionfile/src/timed_spline.rs
+++ b/crates/motionfile/src/timed_spline.rs
@@ -109,13 +109,14 @@ where
     pub fn try_new_with_start(
         initial_position: T,
         keys: Vec<KeyFrame<T>>,
+        interpolation_mode: Interpolation<Duration, T>,
     ) -> Result<Self, InterpolatorError> {
         let mut time_since_start = Duration::ZERO;
 
         let mut spline_keys = vec![Key::new(
             time_since_start,
             initial_position,
-            Interpolation::Linear,
+            interpolation_mode,
         )];
         spline_keys.extend(
             keys.into_iter()
@@ -124,7 +125,7 @@ where
                     Ok(Key::new(
                         time_since_start,
                         frame.positions,
-                        Interpolation::Linear,
+                        interpolation_mode,
                     ))
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/etc/motions/stand_up_back_dortmund_2022.json
+++ b/etc/motions/stand_up_back_dortmund_2022.json
@@ -1,4 +1,5 @@
 {
+  "interpolation_mode": "linear",
   "initial_positions": {
     "head": {
       "yaw": 0.0,


### PR DESCRIPTION
## Introduced Changes
This PR adds two optional fields to the motionfile json.
* In the top scope it is now possible to set the interpolation mode to something else than linear
* In motion segments it is now possible to set a name for the current segment. Since there currently is no visualization of motionfiles this greatly helps remembering what different parts do. The value is not used anywhere in the rust code, however it will be used in future tooling regarding editing motionfiles.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

In the top scove of the motionfile, set the `interpolator_mode` key to e.g. `catmullrom`, the motion will be using this interpolation mode instead then.
In a motion segment, the `name` key can be set to any arbitrary string.
