### PR TITLE
Twixfix

### DIFF
--- a/tools/twix/src/completion_edit.rs
+++ b/tools/twix/src/completion_edit.rs
@@ -26,13 +26,15 @@ impl CompletionState {
 }
 
 pub struct CompletionEdit<'key> {
+    hint_text: &'static str,
     key: &'key mut String,
     completion_items: Vec<String>,
 }
 
 impl<'key> CompletionEdit<'key> {
-    pub fn new(key: &'key mut String, completion_items: Vec<String>) -> Self {
+    pub fn new(key: &'key mut String, completion_items: Vec<String>, hint_text: &'static str) -> Self {
         Self {
+            hint_text,
             key,
             completion_items,
         }
@@ -47,6 +49,7 @@ impl<'key> CompletionEdit<'key> {
         .collect();
 
         Self {
+            hint_text: "Address",
             key,
             completion_items,
         }
@@ -59,6 +62,7 @@ impl<'key> CompletionEdit<'key> {
             .unwrap_or_default();
 
         Self {
+            hint_text: "Subscription Key",
             key,
             completion_items,
         }
@@ -71,6 +75,7 @@ impl<'key> CompletionEdit<'key> {
             .unwrap_or_default();
 
         Self {
+            hint_text: "Parameter",
             key,
             completion_items,
         }
@@ -90,7 +95,7 @@ impl<'key> CompletionEdit<'key> {
 impl Widget for CompletionEdit<'_> {
     fn ui(self, ui: &mut Ui) -> Response {
         let mut response = TextEdit::singleline(self.key)
-            .hint_text("Subscription Key")
+            .hint_text(self.hint_text)
             .lock_focus(true)
             .ui(ui);
 

--- a/tools/twix/src/completion_edit.rs
+++ b/tools/twix/src/completion_edit.rs
@@ -141,13 +141,12 @@ impl Widget for CompletionEdit<'_> {
                         );
                     } else if input.consume_key(Modifiers::NONE, Key::ArrowUp)
                         || input.consume_key(eframe::egui::Modifiers::SHIFT, Key::Tab)
-                    {
+                    {   
                         state.selected_item = Some(
                             (state
                                 .selected_item
                                 .unwrap_or(completion_text_items.len() as i64)
-                                - 1)
-                                % (completion_text_items.len() as i64),
+                                - 1).rem_euclid(completion_text_items.len() as i64),
                         );
                     }
                 });

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -276,6 +276,7 @@ impl App for TwixApp {
                         "Parameter".to_string(),
                         "Manual Calibration".to_string(),
                     ],
+                    "Panel"
                 )
                 .ui(ui);
                 if ui.input_mut(|input| input.consume_key(Modifiers::CTRL, Key::P)) {


### PR DESCRIPTION
## Introduced Changes

Two small fixes for twix I noticed.
* The completion edit hint always showed `Subscription Key`. I changed this, so that e.g. the Panel completion edit shows `Panel` as hint.
* The arrow up functionality in the completion edit dialog allowed for negative indices, since in rust modulo != remainder (meaning -2 % 5 = -2). Now the correct function is used to compute the remainder.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Make sure that the mentioned changes are correct.
