### PR TITLE
Pepsi unstiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,9 @@ name = "nao"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "communication",
  "constants",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -19,6 +19,8 @@ pub struct CycleContext {
     pub filtered_game_state: Input<Option<FilteredGameState>, "filtered_game_state?">,
     pub game_controller_state: Input<Option<GameControllerState>, "game_controller_state?">,
 
+    pub injected_head_buttons_touched: Parameter<Option<bool>, "injected_head_buttons_touched?">,
+
     pub player_number: Parameter<PlayerNumber, "player_number">,
 }
 
@@ -45,7 +47,8 @@ impl PrimaryStateFilter {
 
         self.last_primary_state = match (
             self.last_primary_state,
-            context.buttons.head_buttons_touched,
+            context.buttons.head_buttons_touched
+                || context.injected_head_buttons_touched == Some(&true),
             context.buttons.is_chest_button_pressed,
             context.buttons.calibration_buttons_touched,
             context.filtered_game_state,

--- a/crates/nao/Cargo.toml
+++ b/crates/nao/Cargo.toml
@@ -7,5 +7,7 @@ homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 color-eyre = { workspace = true }
+communication = { workspace = true }
 constants = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -9,6 +9,7 @@ use constants::OS_VERSION;
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use nao::{Nao, SystemctlAction};
 use repository::{HardwareIds, Repository};
+use tokio::time::Duration;
 
 use crate::{
     cargo::{cargo, Arguments as CargoArguments, Command},
@@ -86,7 +87,7 @@ async fn upload_with_progress(
         .wrap_err_with(|| format!("failed to set communication enablement for {head_id}"))?;
 
     progress.set_message("Unstiffing...");
-    nao.unstiff().await?;
+    nao.unstiff(Duration::from_secs(1)).await?;
 
     progress.set_message("Stopping HULK...");
     nao.execute_systemctl(SystemctlAction::Stop, "hulk")

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -85,6 +85,9 @@ async fn upload_with_progress(
         .await
         .wrap_err_with(|| format!("failed to set communication enablement for {head_id}"))?;
 
+    progress.set_message("Unstiffing...");
+    nao.unstiff().await?;
+
     progress.set_message("Stopping HULK...");
     nao.execute_systemctl(SystemctlAction::Stop, "hulk")
         .await


### PR DESCRIPTION
## Introduced Changes

Simulates pressing the head buttons prior to upload.
If the robot is standing upright, this will cause it to sit down, otherwise it becomes unstiff immediately.
`hulk stop` is postponed until the robot is unstiff making the upload process wait until the sit down motion completes.
If the communication server on the robot cannot be reached for a given timeout duration, the upload process continues as usual.
This can happen if the hulk service is not running or communication is inactive.

Fixes #

## ToDo / Known Issues

- [ ] Add dedicated `pepsi sitdown`? `pepsi unstiff`? command.
- [ ] Discuss how to handle communication failure
  - Currently pepsi attempts to connect to the communication server and silently skips sit down if there was no response for one second.
- [ ] Allow skipping sit down via command line argument. May also be a solution to the point below.
- [ ] Figure out how to cleanly handle uploads to robots running older code
  - Since setting parameters is currently a fire-and-forget operation, the headbutton press is sent but fails because the parameter doesn't exist causing pepsi to wait for unstiff indefinitely.

## Ideas for Next Iterations (Not This PR)

- Replace all our `injected_.*` with with injected outputs, see https://github.com/HULKs/nao/pull/4065.
- Use RPCs instead of fiddling with parameters/injections, requires communication protocol changes.
- Make hula make the robot sit down gracefully if the robot is standing and the hulk process is stopped/crashes

## How to Test

Upload to nao without unstiffing first, it should sit down on its own.