### PR TITLE
Behavior simulator FOV

### DIFF
--- a/crates/types/src/camera_matrix.rs
+++ b/crates/types/src/camera_matrix.rs
@@ -80,7 +80,7 @@ impl CameraMatrix {
         }
     }
 
-    fn calculate_field_of_view(
+    pub fn calculate_field_of_view(
         focal_lengths: Vector2<f32>,
         image_size: Vector2<f32>,
     ) -> Vector2<f32> {

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -300,6 +300,10 @@ where
                         motion_command: &own_database.main_outputs.motion_command,
                         sensor_data: &own_database.main_outputs.sensor_data,
                         cycle_time: &own_database.main_outputs.cycle_time,
+                        current_mode: AdditionalOutput::new(
+                            true,
+                            &mut own_database.additional_outputs.look_around_mode,
+                        ),
                     })
                     .wrap_err("failed to execute cycle of node `LookAround`")?
             };

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -188,7 +188,7 @@ where
         }
         {
             if own_database.main_outputs.robot_to_field.as_ref().is_some()
-                && own_database.main_outputs.ball_position.as_ref().is_some()
+                && own_database.main_outputs.ball_state.as_ref().is_some()
             {
                 let main_outputs = {
                     self.kick_selector
@@ -236,6 +236,7 @@ where
                     main_outputs.instant_kick_decisions.value;
             } else {
                 own_database.main_outputs.kick_decisions = Default::default();
+                own_database.main_outputs.instant_kick_decisions = Default::default();
             }
         }
         {

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeMap, convert::Into, sync::Arc, time::SystemTime};
+use std::{
+    collections::BTreeMap,
+    convert::Into,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use color_eyre::{eyre::WrapErr, Result};
 use control::localization::generate_initial_pose;
@@ -16,6 +21,7 @@ pub struct Robot {
     pub database: Database,
     pub configuration: Configuration,
     pub is_penalized: bool,
+    pub last_kick_time: Duration,
 }
 
 impl Robot {
@@ -52,6 +58,7 @@ impl Robot {
             database,
             configuration,
             is_penalized: false,
+            last_kick_time: Duration::default(),
         })
     }
 

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -8,10 +8,11 @@ use std::{
 use color_eyre::{eyre::WrapErr, Result};
 use control::localization::generate_initial_pose;
 use cyclers::control::Database;
+use nalgebra::vector;
 use parameters::directory::deserialize;
 use spl_network_messages::PlayerNumber;
 use structs::Configuration;
-use types::messages::IncomingMessage;
+use types::{messages::IncomingMessage, CameraMatrix};
 
 use crate::{cycler::BehaviorCycler, interfake::Interfake};
 
@@ -65,6 +66,19 @@ impl Robot {
     pub fn cycle(&mut self, messages: BTreeMap<SystemTime, Vec<&IncomingMessage>>) -> Result<()> {
         self.cycler
             .cycle(&mut self.database, &self.configuration, messages)
+    }
+
+    pub fn field_of_view(&self) -> f32 {
+        let image_size = vector![640.0, 480.0];
+        let focal_lengths = self
+            .configuration
+            .camera_matrix_parameters
+            .vision_top
+            .focal_lengths;
+        let focal_lengths_scaled = image_size.component_mul(&focal_lengths);
+        let field_of_view = CameraMatrix::calculate_field_of_view(focal_lengths_scaled, image_size);
+
+        field_of_view.x
     }
 }
 

--- a/tools/behavior_simulator/src/server.rs
+++ b/tools/behavior_simulator/src/server.rs
@@ -15,7 +15,6 @@ use color_eyre::{
 };
 use cyclers::control::Database;
 use framework::{multiple_buffer_with_slots, Reader, Writer};
-use nalgebra::Point2;
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 use tokio::{net::ToSocketAddrs, select, sync::Notify, time::interval};

--- a/tools/behavior_simulator/src/simulator.rs
+++ b/tools/behavior_simulator/src/simulator.rs
@@ -1,6 +1,6 @@
 use std::{fs::read_to_string, path::Path, sync::Arc, time::Duration};
 
-use crate::robot::to_player_number;
+use crate::{robot::to_player_number, state::Ball};
 use color_eyre::{
     eyre::{eyre, WrapErr},
     Result,
@@ -19,6 +19,7 @@ use crate::{
 const SERIALIZE_OPTIONS: SerializeOptions = SerializeOptions::new().serialize_none_to_null(false);
 
 pub struct Frame {
+    pub ball: Option<Ball>,
     pub robots: Players<Option<Database>>,
 }
 
@@ -75,7 +76,10 @@ impl Simulator {
             for (player_number, robot) in &state.robots {
                 robots[*player_number] = Some(robot.database.clone())
             }
-            frames.push(Frame { robots });
+            frames.push(Frame {
+                robots,
+                ball: state.ball.clone(),
+            });
 
             if state.finished {
                 break;

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    f32::consts::PI,
     mem::take,
     time::{Duration, UNIX_EPOCH},
 };
@@ -179,7 +180,12 @@ impl State {
                 HeadMotion::Unstiff => 0.0,
             };
 
-            robot.database.main_outputs.sensor_data.positions.head.yaw = desired_head_yaw;
+            let max_head_rotation_per_cycle = PI * time_step.as_secs_f32();
+            let diff =
+                desired_head_yaw - robot.database.main_outputs.sensor_data.positions.head.yaw;
+            let movement = diff.clamp(-max_head_rotation_per_cycle, max_head_rotation_per_cycle);
+
+            robot.database.main_outputs.sensor_data.positions.head.yaw += movement;
         }
     }
 

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -155,7 +155,7 @@ impl State {
                                 KickVariant::Turn => vector![0.707, 0.707 * side],
                                 KickVariant::Side => vector![0.0, 1.0 * -side],
                             };
-                            ball.velocity += *robot_to_field * direction * *strength;
+                            ball.velocity += *robot_to_field * direction * *strength * 2.5;
                             robot.last_kick_time = self.time_elapsed;
                         };
                     }

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -150,13 +150,15 @@ impl State {
 
                         // TODO: Check if ball is even in range
                         // let kick_location = robot_to_field * ();
-
-                        let direction = match kick {
-                            KickVariant::Forward => vector![1.0, 0.0],
-                            KickVariant::Turn => vector![0.707, 0.707 * side],
-                            KickVariant::Side => vector![0.0, 1.0 * -side],
+                        if (self.time_elapsed - robot.last_kick_time).as_secs_f32() > 1.0 {
+                            let direction = match kick {
+                                KickVariant::Forward => vector![1.0, 0.0],
+                                KickVariant::Turn => vector![0.707, 0.707 * side],
+                                KickVariant::Side => vector![0.0, 1.0 * -side],
+                            };
+                            ball.velocity += *robot_to_field * direction * *strength;
+                            robot.last_kick_time = self.time_elapsed;
                         };
-                        ball.velocity += *robot_to_field * direction * *strength;
                     }
                     head
                 }

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -223,8 +223,12 @@ impl State {
                     last_seen: now,
                 })
                 .filter(|ball| {
-                    ball.position.coords.angle(&Vector2::x_axis()).abs() < FRAC_PI_8
-                        && ball.position.coords.norm() < 3.0
+                    let head_rotation = UnitComplex::from_angle(
+                        robot.database.main_outputs.sensor_data.positions.head.yaw,
+                    );
+                    let ball_in_head = head_rotation.inverse() * ball.position.coords;
+                    ball_in_head.angle(&Vector2::x_axis()).abs() < FRAC_PI_8
+                        && ball_in_head.norm() < 3.0
                 });
 
             robot.database.main_outputs.primary_state =

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -181,7 +181,8 @@ impl State {
                 HeadMotion::Unstiff => 0.0,
             };
 
-            let max_head_rotation_per_cycle = PI * time_step.as_secs_f32();
+            let max_head_rotation_per_cycle =
+                robot.configuration.head_motion.maximum_velocity.yaw * time_step.as_secs_f32();
             let diff =
                 desired_head_yaw - robot.database.main_outputs.sensor_data.positions.head.yaw;
             let movement = diff.clamp(-max_head_rotation_per_cycle, max_head_rotation_per_cycle);

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -171,8 +171,9 @@ impl State {
             let desired_head_yaw = match head_motion {
                 HeadMotion::ZeroAngles => 0.0,
                 HeadMotion::Center => 0.0,
-                HeadMotion::LookAround => f * 2.0,
-                HeadMotion::SearchForLostBall => f * 2.0,
+                HeadMotion::LookAround | HeadMotion::SearchForLostBall => {
+                    robot.database.main_outputs.look_around.yaw
+                }
                 HeadMotion::LookAt { target } => target.coords.angle(&Vector2::x_axis()),
                 HeadMotion::LookLeftAndRightOf { target } => {
                     target.coords.angle(&Vector2::x_axis()) + f

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    f32::consts::FRAC_PI_8,
     mem::take,
     time::{Duration, UNIX_EPOCH},
 };
@@ -227,8 +226,10 @@ impl State {
                         robot.database.main_outputs.sensor_data.positions.head.yaw,
                     );
                     let ball_in_head = head_rotation.inverse() * ball.position.coords;
-                    ball_in_head.angle(&Vector2::x_axis()).abs() < FRAC_PI_8
-                        && ball_in_head.norm() < 3.0
+                    let field_of_view = robot.field_of_view();
+                    let angle_to_ball = ball_in_head.angle(&Vector2::x_axis());
+
+                    angle_to_ball.abs() < field_of_view / 2.0 && ball_in_head.norm() < 3.0
                 });
 
             robot.database.main_outputs.primary_state =

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    f32::consts::PI,
+    f32::consts::{FRAC_PI_8, PI},
     mem::take,
     time::{Duration, UNIX_EPOCH},
 };
@@ -212,10 +212,16 @@ impl State {
 
             robot.database.main_outputs.cycle_time.start_time = now;
 
-            robot.database.main_outputs.ball_position =
-                self.ball.as_ref().map(|ball| BallPosition {
+            robot.database.main_outputs.ball_position = self
+                .ball
+                .as_ref()
+                .map(|ball| BallPosition {
                     position: robot_to_field.inverse() * ball.position,
                     last_seen: now,
+                })
+                .filter(|ball| {
+                    ball.position.coords.angle(&Vector2::x_axis()).abs() < FRAC_PI_8
+                        && ball.position.coords.norm() < 3.0
                 });
 
             robot.database.main_outputs.primary_state =

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -9,6 +9,7 @@ use color_eyre::Result;
 use cyclers::control::Database;
 use nalgebra::{vector, Isometry2, Point2, UnitComplex, Vector2};
 use serde::{Deserialize, Serialize};
+use serialize_hierarchy::SerializeHierarchy;
 use spl_network_messages::{GamePhase, GameState, HulkMessage, PlayerNumber, Team};
 use structs::{control::AdditionalOutputs, Configuration};
 use types::{
@@ -24,7 +25,7 @@ pub enum Event {
     Goal,
 }
 
-#[derive(Default, Clone, Deserialize, Serialize)]
+#[derive(Default, Clone, Deserialize, Serialize, SerializeHierarchy)]
 pub struct Ball {
     pub position: Point2<f32>,
     pub velocity: Vector2<f32>,

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    f32::consts::{FRAC_PI_8, PI},
+    f32::consts::FRAC_PI_8,
     mem::take,
     time::{Duration, UNIX_EPOCH},
 };

--- a/tools/twix/src/panels/behavior_simulator.rs
+++ b/tools/twix/src/panels/behavior_simulator.rs
@@ -95,8 +95,8 @@ impl Widget for &mut BehaviorSimulatorPanel {
                     };
                 });
                 if ui.checkbox(&mut self.playing, "Play").changed() || new_frame.is_some() {
-                    self.playing_start =
-                        ui.input(|input| input.time) - new_frame.unwrap_or(self.selected_frame) as f64 / 83.0;
+                    self.playing_start = ui.input(|input| input.time)
+                        - new_frame.unwrap_or(self.selected_frame) as f64 / 83.0;
                 };
             })
             .response;

--- a/tools/twix/src/panels/map/layers/behavior_simulator.rs
+++ b/tools/twix/src/panels/map/layers/behavior_simulator.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr, sync::Arc};
 use color_eyre::Result;
 use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
-use nalgebra::{point, Isometry2, UnitComplex, Point2};
+use nalgebra::{point, Isometry2, Point2, UnitComplex};
 use types::{FieldDimensions, MotionCommand};
 
 use crate::{


### PR DESCRIPTION
## Introduced Changes

- Adds head movement to behavior simulator
  - Includes running executing the look around motion node.
- Limits ball visibility by field of view

Other fixes:
- Makes simulation playback real time 
  - Now runs at 83 Hz instead of whatever refresh rate your monitor happens to run at
- Makes simulated kicks more consistent
  - Previously force was applied to the ball for every cycle where the robot requested a kick motion
- Adds ball position ground truth visualization to behavior simulator map layer
  - Since ball visibility is now limited, the map panel would only show the ball as seen (or not) by the currently selected robot.
- Fixes kick selector cycle invocation in behavior cycler

Fixes #

## ToDo / Known Issues

- [x] Make FOV depend on config parameters

## Ideas for Next Iterations (Not This PR)

- Readd a visualization for which robots see the ball

## How to Test

In behavior simulator scenarios, the robots should now be seen doing ball search even when a ball exists on the field.