### PR TITLE
Pepsi Ping Pong

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
  "windows-sys 0.42.0",
 ]
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -2555,9 +2555,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -2769,6 +2769,7 @@ version = "0.1.0"
 dependencies = [
  "color-eyre",
  "constants",
+ "surge-ping",
  "tokio",
 ]
 
@@ -2865,6 +2866,12 @@ dependencies = [
  "libc",
  "static_assertions",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nohash-hasher"
@@ -3236,6 +3243,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "pnet_base"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872e46346144ebf35219ccaa64b1dffacd9c6f188cd7d012bd6977a2a838f42e"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d932134f32efd7834eb8b16d42418dac87086347d1bc7d142370ef078582bc"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde678bbd85cb1c2d99dc9fc596e57f03aa725f84f3168b0eaf33eeccb41706"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
 name = "png"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,15 +3522,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "repository"
@@ -3869,12 +3909,22 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4021,6 +4071,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "surge-ping"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af341b2be485d647b5dc4cfb2da99efac35b5c95748a08fb7233480fedc5ead3"
+dependencies = [
+ "hex",
+ "parking_lot",
+ "pnet_packet",
+ "rand",
+ "socket2 0.5.3",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,16 +4131,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall 0.2.16",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4097,22 +4162,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -4197,34 +4262,33 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "tracing",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.10",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ syn = { version = "1.0.101", features = ["full", "extra-traits"] }
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["full"] }
+surge-ping = "0.8.0"
 tokio-tungstenite = "0.17.2"
 tokio-util = "0.7.4"
 toml = "0.5.9"

--- a/crates/nao/Cargo.toml
+++ b/crates/nao/Cargo.toml
@@ -9,3 +9,4 @@ homepage = "https://github.com/hulks/hulk"
 color-eyre = { workspace = true }
 constants = { workspace = true }
 tokio = { workspace = true }
+surge-ping = { workspace = true }

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 
 use color_eyre::{
     eyre::{bail, eyre, WrapErr},
-    Result, Report,
+    Result,
 };
 use tokio::{process::Command, time};
 
@@ -27,7 +27,7 @@ impl Nao {
         let nao = Self::new(host);
 
         if !nao.is_reachable(PING_RETRIES, PING_TIMEOUT).await {
-            return Err(Report::msg(format!("{host} not reachable")))
+            bail!(format!("{host} not reachable"));
         }
 
         Ok(nao)

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -34,7 +34,7 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
         arguments.naos,
         "Uploading image...",
         |nao_address| async move {
-            let nao = Nao::new(nao_address.ip);
+            let nao = Nao::new_with_ping(nao_address.ip).await?;
             nao.flash_image(image_path)
                 .await
                 .wrap_err_with(|| format!("failed to flash image to {nao_address}"))

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -34,7 +34,7 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
         arguments.naos,
         "Uploading image...",
         |nao_address| async move {
-            let nao = Nao::new_with_ping(nao_address.ip).await?;
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.flash_image(image_path)
                 .await
                 .wrap_err_with(|| format!("failed to flash image to {nao_address}"))

--- a/tools/pepsi/src/hulk.rs
+++ b/tools/pepsi/src/hulk.rs
@@ -29,7 +29,7 @@ pub async fn hulk(arguments: Arguments) -> Result<()> {
         arguments.naos,
         "Executing systemctl hulk...",
         |nao_address| async move {
-            let nao = Nao::new_with_ping(nao_address.ip).await?;
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.execute_systemctl(arguments.action, "hulk")
                 .await
                 .wrap_err_with(|| format!("failed to execute systemctl hulk on {nao_address}"))

--- a/tools/pepsi/src/hulk.rs
+++ b/tools/pepsi/src/hulk.rs
@@ -29,7 +29,7 @@ pub async fn hulk(arguments: Arguments) -> Result<()> {
         arguments.naos,
         "Executing systemctl hulk...",
         |nao_address| async move {
-            let nao = Nao::new(nao_address.ip);
+            let nao = Nao::new_with_ping(nao_address.ip).await?;
             nao.execute_systemctl(arguments.action, "hulk")
                 .await
                 .wrap_err_with(|| format!("failed to execute systemctl hulk on {nao_address}"))

--- a/tools/pepsi/src/logs.rs
+++ b/tools/pepsi/src/logs.rs
@@ -29,7 +29,7 @@ pub async fn logs(arguments: Arguments) -> Result<()> {
     match arguments {
         Arguments::Delete { naos } => {
             ProgressIndicator::map_tasks(naos, "Deleting logs...", |nao_address| async move {
-                let nao = Nao::new(nao_address.ip);
+                let nao = Nao::new_with_ping(nao_address.ip).await?;
                 nao.delete_logs()
                     .await
                     .wrap_err_with(|| format!("failed to delete logs on {nao_address}"))
@@ -43,7 +43,7 @@ pub async fn logs(arguments: Arguments) -> Result<()> {
             ProgressIndicator::map_tasks(naos, "Downloading logs...", |nao_address| {
                 let log_directory = log_directory.join(nao_address.to_string());
                 async move {
-                    let nao = Nao::new(nao_address.ip);
+                    let nao = Nao::new_with_ping(nao_address.ip).await?;
                     nao.download_logs(log_directory)
                         .await
                         .wrap_err_with(|| format!("failed to download logs from {nao_address}"))

--- a/tools/pepsi/src/logs.rs
+++ b/tools/pepsi/src/logs.rs
@@ -29,7 +29,7 @@ pub async fn logs(arguments: Arguments) -> Result<()> {
     match arguments {
         Arguments::Delete { naos } => {
             ProgressIndicator::map_tasks(naos, "Deleting logs...", |nao_address| async move {
-                let nao = Nao::new_with_ping(nao_address.ip).await?;
+                let nao = Nao::try_new_with_ping(nao_address.ip).await?;
                 nao.delete_logs()
                     .await
                     .wrap_err_with(|| format!("failed to delete logs on {nao_address}"))
@@ -43,7 +43,7 @@ pub async fn logs(arguments: Arguments) -> Result<()> {
             ProgressIndicator::map_tasks(naos, "Downloading logs...", |nao_address| {
                 let log_directory = log_directory.join(nao_address.to_string());
                 async move {
-                    let nao = Nao::new_with_ping(nao_address.ip).await?;
+                    let nao = Nao::try_new_with_ping(nao_address.ip).await?;
                     nao.download_logs(log_directory)
                         .await
                         .wrap_err_with(|| format!("failed to download logs from {nao_address}"))

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -12,6 +12,7 @@ use gammaray::{gammaray, Arguments as GammarayArguments};
 use hulk::{hulk, Arguments as HulkArguments};
 use location::{location, Arguments as LocationArguments};
 use logs::{logs, Arguments as LogsArguments};
+use ping::{ping, Arguments as PingArguments};
 use player_number::{player_number, Arguments as PlayerNumberArguments};
 use post_game::{post_game, Arguments as PostGameArguments};
 use power_off::{power_off, Arguments as PoweroffArguments};
@@ -33,6 +34,7 @@ mod hulk;
 mod location;
 mod logs;
 mod parsers;
+mod ping;
 mod player_number;
 mod post_game;
 mod power_off;
@@ -91,6 +93,7 @@ async fn main() -> Result<()> {
         Command::Logs(arguments) => logs(arguments)
             .await
             .wrap_err("failed to execute logs command")?,
+        Command::Ping(arguments) => ping(arguments).await,
         Command::Playernumber(arguments) => player_number(arguments, &repository?)
             .await
             .wrap_err("failed to execute player_number command")?,
@@ -166,6 +169,8 @@ enum Command {
     Logs(LogsArguments),
     /// Change player numbers of the NAOs in local configuration
     Playernumber(PlayerNumberArguments),
+    /// Tries to ping the NAO
+    Ping(PingArguments),
     /// Disable NAOs after a game (downloads logs, unsets wireless network, etc.)
     Postgame(PostGameArguments),
     /// Power NAOs off

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -169,7 +169,7 @@ enum Command {
     Logs(LogsArguments),
     /// Change player numbers of the NAOs in local configuration
     Playernumber(PlayerNumberArguments),
-    /// Tries to ping the NAO
+    /// Ping NAOs
     Ping(PingArguments),
     /// Disable NAOs after a game (downloads logs, unsets wireless network, etc.)
     Postgame(PostGameArguments),

--- a/tools/pepsi/src/parsers.rs
+++ b/tools/pepsi/src/parsers.rs
@@ -49,6 +49,19 @@ pub struct NaoAddress {
     pub ip: Ipv4Addr,
 }
 
+impl NaoAddress {
+    pub fn short(&self) -> String {
+        let number_prefix = self.ip.octets()[3];
+
+        let connection_suffix = match self.ip.octets()[1] {
+            0 => "w",
+            _ => "",
+        };
+
+        format!("{number_prefix}{connection_suffix}")
+    }
+}
+
 impl FromStr for NaoAddress {
     type Err = Report;
 

--- a/tools/pepsi/src/parsers.rs
+++ b/tools/pepsi/src/parsers.rs
@@ -49,19 +49,6 @@ pub struct NaoAddress {
     pub ip: Ipv4Addr,
 }
 
-impl NaoAddress {
-    pub fn short(&self) -> String {
-        let number_prefix = self.ip.octets()[3];
-
-        let connection_suffix = match self.ip.octets()[1] {
-            0 => "w",
-            _ => "",
-        };
-
-        format!("{number_prefix}{connection_suffix}")
-    }
-}
-
 impl FromStr for NaoAddress {
     type Err = Report;
 

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use clap::Args;
+use color_eyre::{Report, owo_colors::OwoColorize};
+use futures_util::stream::FuturesUnordered;
+use futures_util::StreamExt;
+use nao::Nao;
+
+use crate::{parsers::NaoAddress, progress_indicator::ProgressIndicator};
+
+#[derive(Args)]
+pub struct Arguments {
+    /// Number of ping retries
+    #[arg(long, default_value = "1")]
+    pub retries: usize,
+    /// Time after which ping is aborted
+    #[arg(long, default_value = "2.0")]
+    pub timeout: f32,
+    /// The NAOs to upload to e.g. 20w or 10.1.24.22
+    #[arg(required = true)]
+    pub naos: Vec<NaoAddress>,
+}
+
+pub async fn ping(arguments: Arguments) {
+    let multi_progress = ProgressIndicator::new();
+
+    arguments
+        .naos
+        .iter()
+        .map(|nao_address| (nao_address, multi_progress.task(nao_address.to_string())))
+        .map(|(nao_address, progress)| async move {
+            let nao = Nao::new(nao_address.ip);
+            progress.set_message(format!("Pinging {}", nao_address.short().bold()));
+            match nao
+                .is_reachable(
+                    arguments.retries,
+                    Duration::from_secs_f32(arguments.timeout),
+                )
+                .await
+            {
+                true => progress.finish_with_success(format!("{} reachable", nao_address.short())),
+                false => {
+                    progress.finish_with_error(Report::msg(format!("{} unreachable", nao_address.short())))
+                }
+            }
+        })
+        .collect::<FuturesUnordered<_>>()
+        .collect::<Vec<_>>()
+        .await;
+}

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use clap::Args;
-use color_eyre::{Report, owo_colors::OwoColorize};
+use color_eyre::{owo_colors::OwoColorize, Report};
 use futures_util::stream::FuturesUnordered;
 use futures_util::StreamExt;
 use nao::Nao;
@@ -39,9 +39,8 @@ pub async fn ping(arguments: Arguments) {
                 .await
             {
                 true => progress.finish_with_success(format!("{} reachable", nao_address.short())),
-                false => {
-                    progress.finish_with_error(Report::msg(format!("{} unreachable", nao_address.short())))
-                }
+                false => progress
+                    .finish_with_error(Report::msg(format!("{} unreachable", nao_address.short()))),
             }
         })
         .collect::<FuturesUnordered<_>>()

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -5,7 +5,10 @@ use futures_util::stream::FuturesUnordered;
 use futures_util::StreamExt;
 use nao::Nao;
 
-use crate::{parsers::NaoAddress, progress_indicator::{ProgressIndicator, TaskMessage}};
+use crate::{
+    parsers::NaoAddress,
+    progress_indicator::{ProgressIndicator, TaskMessage},
+};
 
 #[derive(Args)]
 pub struct Arguments {
@@ -30,12 +33,13 @@ pub async fn ping(arguments: Arguments) {
         .map(|(nao_address, progress)| async move {
             progress.set_message("Pinging NAO...");
 
-            let ping_state =  Nao::try_new_with_ping_and_arguments(
+            let ping_state = Nao::try_new_with_ping_and_arguments(
                 nao_address.ip,
                 arguments.retries,
                 Duration::from_secs_f32(arguments.timeout),
             )
-            .await.map(|_| TaskMessage::EmptyMessage);
+            .await
+            .map(|_| TaskMessage::EmptyMessage);
             progress.finish_with(ping_state);
         })
         .collect::<FuturesUnordered<_>>()

--- a/tools/pepsi/src/power_off.rs
+++ b/tools/pepsi/src/power_off.rs
@@ -17,7 +17,7 @@ pub async fn power_off(arguments: Arguments) -> Result<()> {
         arguments.naos,
         "Powering off...",
         |nao_address| async move {
-            let nao = Nao::new(nao_address.ip);
+            let nao = Nao::new_with_ping(nao_address.ip).await?;
             nao.power_off()
                 .await
                 .wrap_err_with(|| format!("failed to power {nao_address} off"))

--- a/tools/pepsi/src/power_off.rs
+++ b/tools/pepsi/src/power_off.rs
@@ -17,7 +17,7 @@ pub async fn power_off(arguments: Arguments) -> Result<()> {
         arguments.naos,
         "Powering off...",
         |nao_address| async move {
-            let nao = Nao::new_with_ping(nao_address.ip).await?;
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.power_off()
                 .await
                 .wrap_err_with(|| format!("failed to power {nao_address} off"))

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, time::Duration};
 
-use color_eyre::{owo_colors::OwoColorize, Result, Report};
+use color_eyre::{owo_colors::OwoColorize, Report, Result};
 use futures_util::{stream::FuturesUnordered, Future, StreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, time::Duration};
 
-use color_eyre::{owo_colors::OwoColorize, Report, Result};
+use color_eyre::{owo_colors::OwoColorize, Result, Report};
 use futures_util::{stream::FuturesUnordered, Future, StreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -87,6 +87,16 @@ impl From<String> for TaskMessage {
     }
 }
 
+impl From<&str> for TaskMessage {
+    fn from(value: &str) -> Self {
+        if value.is_empty() {
+            Self::EmptyMessage
+        } else {
+            Self::Message(String::from(value))
+        }
+    }
+}
+
 impl Task {
     pub fn enable_steady_tick(&self) {
         self.progress.enable_steady_tick(Duration::from_millis(100));

--- a/tools/pepsi/src/reboot.rs
+++ b/tools/pepsi/src/reboot.rs
@@ -14,7 +14,7 @@ pub struct Arguments {
 
 pub async fn reboot(arguments: Arguments) -> Result<()> {
     ProgressIndicator::map_tasks(arguments.naos, "Rebooting...", |nao_address| async move {
-        let nao = Nao::new_with_ping(nao_address.ip).await?;
+        let nao = Nao::try_new_with_ping(nao_address.ip).await?;
         nao.reboot()
             .await
             .wrap_err_with(|| format!("failed to reboot {nao_address}"))

--- a/tools/pepsi/src/reboot.rs
+++ b/tools/pepsi/src/reboot.rs
@@ -14,7 +14,7 @@ pub struct Arguments {
 
 pub async fn reboot(arguments: Arguments) -> Result<()> {
     ProgressIndicator::map_tasks(arguments.naos, "Rebooting...", |nao_address| async move {
-        let nao = Nao::new(nao_address.ip);
+        let nao = Nao::new_with_ping(nao_address.ip).await?;
         nao.reboot()
             .await
             .wrap_err_with(|| format!("failed to reboot {nao_address}"))

--- a/tools/pepsi/src/shell.rs
+++ b/tools/pepsi/src/shell.rs
@@ -13,7 +13,7 @@ pub struct Arguments {
 }
 
 pub async fn shell(arguments: Arguments) -> Result<()> {
-    let nao = Nao::new_with_ping(arguments.nao.ip).await?;
+    let nao = Nao::try_new_with_ping(arguments.nao.ip).await?;
 
     nao.execute_shell()
         .await

--- a/tools/pepsi/src/shell.rs
+++ b/tools/pepsi/src/shell.rs
@@ -13,7 +13,7 @@ pub struct Arguments {
 }
 
 pub async fn shell(arguments: Arguments) -> Result<()> {
-    let nao = Nao::new(arguments.nao.ip);
+    let nao = Nao::new_with_ping(arguments.nao.ip).await?;
 
     nao.execute_shell()
         .await

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -69,7 +69,6 @@ async fn upload_with_progress(
     progress.set_message("Pinging Nao");
     let nao = Nao::new_with_ping(nao_address.ip).await?;
 
-
     if !arguments.skip_os_check {
         progress.set_message("Checking OS version...");
         let os_version = nao

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -66,8 +66,8 @@ async fn upload_with_progress(
     arguments: &Arguments,
     progress: &Task,
 ) -> Result<()> {
-    progress.set_message("Pinging Nao");
-    let nao = Nao::new_with_ping(nao_address.ip).await?;
+    progress.set_message("Pinging NAO...");
+    let nao = Nao::try_new_with_ping(nao_address.ip).await?;
 
     if !arguments.skip_os_check {
         progress.set_message("Checking OS version...");

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -66,7 +66,9 @@ async fn upload_with_progress(
     arguments: &Arguments,
     progress: &Task,
 ) -> Result<()> {
-    let nao = Nao::new(nao_address.ip);
+    progress.set_message("Pinging Nao");
+    let nao = Nao::new_with_ping(nao_address.ip).await?;
+
 
     if !arguments.skip_os_check {
         progress.set_message("Checking OS version...");

--- a/tools/pepsi/src/wireless.rs
+++ b/tools/pepsi/src/wireless.rs
@@ -54,7 +54,7 @@ async fn status(naos: Vec<NaoAddress>) {
         naos,
         "Retrieving network status...",
         |nao_address| async move {
-            let nao = Nao::new_with_ping(nao_address.ip).await?;
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.get_network_status()
                 .await
                 .wrap_err_with(|| format!("failed to get network status from {nao_address}"))
@@ -68,7 +68,7 @@ async fn available_networks(naos: Vec<NaoAddress>) {
         naos,
         "Retrieving available networks...",
         |nao_address| async move {
-            let nao = Nao::new_with_ping(nao_address.ip).await?;
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.get_available_networks()
                 .await
                 .wrap_err_with(|| format!("failed to get available networks from {nao_address}"))
@@ -79,7 +79,7 @@ async fn available_networks(naos: Vec<NaoAddress>) {
 
 async fn set(naos: Vec<NaoAddress>, network: Network) {
     ProgressIndicator::map_tasks(naos, "Setting network...", |nao_address| async move {
-        let nao = Nao::new_with_ping(nao_address.ip).await?;
+        let nao = Nao::try_new_with_ping(nao_address.ip).await?;
         nao.set_network(network)
             .await
             .wrap_err_with(|| format!("failed to set network on {nao_address}"))

--- a/tools/pepsi/src/wireless.rs
+++ b/tools/pepsi/src/wireless.rs
@@ -54,7 +54,7 @@ async fn status(naos: Vec<NaoAddress>) {
         naos,
         "Retrieving network status...",
         |nao_address| async move {
-            let nao = Nao::new(nao_address.ip);
+            let nao = Nao::new_with_ping(nao_address.ip).await?;
             nao.get_network_status()
                 .await
                 .wrap_err_with(|| format!("failed to get network status from {nao_address}"))
@@ -68,7 +68,7 @@ async fn available_networks(naos: Vec<NaoAddress>) {
         naos,
         "Retrieving available networks...",
         |nao_address| async move {
-            let nao = Nao::new(nao_address.ip);
+            let nao = Nao::new_with_ping(nao_address.ip).await?;
             nao.get_available_networks()
                 .await
                 .wrap_err_with(|| format!("failed to get available networks from {nao_address}"))
@@ -79,7 +79,7 @@ async fn available_networks(naos: Vec<NaoAddress>) {
 
 async fn set(naos: Vec<NaoAddress>, network: Network) {
     ProgressIndicator::map_tasks(naos, "Setting network...", |nao_address| async move {
-        let nao = Nao::new(nao_address.ip);
+        let nao = Nao::new_with_ping(nao_address.ip).await?;
         nao.set_network(network)
             .await
             .wrap_err_with(|| format!("failed to set network on {nao_address}"))


### PR DESCRIPTION
## Introduced Changes

QOL improvement for `pepsi`.
Tries to ping the robot before setting network/downloading logs/uploading/flashing/...
That way error messages are more user friendly.

As a nice side-effect, the ping timeout can now be set whereas previously the timeout was implicitly generated by `rsync` or `ssh`.

Furthermore, a `pepsi` ping subcommand is added which also allows setting timeout duration and retries, just to save users from typing the whole ip of a robot they wanted to ping.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Upload to a robot that is reachable over network, nothing is different
* Try to upload to a robot that is not reachable. A proper error message is generated.
