### PR TITLE
Walkaroundball

### DIFF
--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::PI;
+
 use framework::AdditionalOutput;
 use nalgebra::{Isometry2, Point2};
 use spl_network_messages::Team;
@@ -70,6 +72,8 @@ pub fn execute(
     let angle = robot_to_ball.angle(&dribble_pose_to_ball);
     let should_avoid_ball = angle > parameters.angle_to_approach_ball_from_threshold;
     let ball_obstacle = should_avoid_ball.then_some(ball_position);
+    let ball_obstacle_radius_factor = (angle - parameters.angle_to_approach_ball_from_threshold)
+        / (PI - parameters.angle_to_approach_ball_from_threshold)*0.75 + 0.25;
 
     let is_near_ball = matches!(
         world_state.ball,
@@ -96,6 +100,7 @@ pub fn execute(
         best_pose * Point2::origin(),
         robot_to_field,
         ball_obstacle,
+        ball_obstacle_radius_factor,
         obstacles,
         rule_obstacles,
         path_obstacles_output,

--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -73,7 +73,7 @@ pub fn execute(
     let should_avoid_ball = angle > parameters.angle_to_approach_ball_from_threshold;
     let ball_obstacle = should_avoid_ball.then_some(ball_position);
     let ball_obstacle_radius_factor = (angle - parameters.angle_to_approach_ball_from_threshold)
-        / (PI - parameters.angle_to_approach_ball_from_threshold)*0.75 + 0.25;
+        / (PI - parameters.angle_to_approach_ball_from_threshold);
 
     let is_near_ball = matches!(
         world_state.ball,

--- a/crates/control/src/behavior/lost_ball.rs
+++ b/crates/control/src/behavior/lost_ball.rs
@@ -24,6 +24,7 @@ pub fn execute(
         walk_target,
         robot_to_field,
         None,
+        1.0,
         &world_state.obstacles,
         &world_state.rule_obstacles,
         path_obstacles_output,

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -69,6 +69,7 @@ pub fn execute(
             search_position,
             robot_to_field,
             None,
+            1.0,
             &world_state.obstacles,
             &world_state.rule_obstacles,
             path_obstacles_output,

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -56,11 +56,14 @@ impl<'cycle> WalkPathPlanner<'cycle> {
         );
         planner.with_goal_support_structures(robot_to_field.inverse(), self.field_dimensions);
         if let Some(ball_position) = ball_obstacle {
-
+            let foot_proportion = self.configuration.minimum_robot_radius_at_foot_height
+                / self.configuration.robot_radius_at_foot_height;
+            let foot_length = self.configuration.robot_radius_at_foot_height
+                * ((ball_obstacle_radius_factor * (1.0 - foot_proportion)) + foot_proportion);
             planner.with_ball(
                 ball_position,
                 self.configuration.ball_obstacle_radius,
-                self.configuration.robot_radius_at_foot_height * ball_obstacle_radius_factor,
+                foot_length,
             );
         }
 

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -29,11 +29,13 @@ impl<'cycle> WalkPathPlanner<'cycle> {
             configuration,
         }
     }
+    #[allow(clippy::too_many_arguments)]
     pub fn plan(
         &self,
         target_in_robot: Point2<f32>,
         robot_to_field: Isometry2<f32>,
         ball_obstacle: Option<Point2<f32>>,
+        ball_obstacle_radius_factor: f32,
         obstacles: &[Obstacle],
         rule_obstacles: &[RuleObstacle],
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
@@ -54,10 +56,11 @@ impl<'cycle> WalkPathPlanner<'cycle> {
         );
         planner.with_goal_support_structures(robot_to_field.inverse(), self.field_dimensions);
         if let Some(ball_position) = ball_obstacle {
+
             planner.with_ball(
                 ball_position,
                 self.configuration.ball_obstacle_radius,
-                self.configuration.robot_radius_at_foot_height,
+                self.configuration.robot_radius_at_foot_height * ball_obstacle_radius_factor,
             );
         }
 
@@ -169,6 +172,7 @@ impl<'cycle> WalkAndStand<'cycle> {
                 target_pose * Point2::origin(),
                 robot_to_field,
                 self.world_state.ball.map(|ball| ball.ball_in_ground),
+                1.0,
                 &self.world_state.obstacles,
                 &self.world_state.rule_obstacles,
                 path_obstacles_output,

--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -181,6 +181,7 @@ pub struct LostBall {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
 pub struct PathPlanning {
     pub robot_radius_at_foot_height: f32,
+    pub minimum_robot_radius_at_foot_height: f32,
     pub robot_radius_at_hip_height: f32,
     pub ball_obstacle_radius: f32,
     pub field_border_weight: f32,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -800,6 +800,7 @@
     "path_planning": {
       "robot_radius_at_hip_height": 0.15,
       "robot_radius_at_foot_height": 0.2,
+      "minimum_robot_radius_at_foot_height": 0.07,
       "ball_obstacle_radius": 0.05,
       "field_border_weight": 0.15
     },

--- a/tests/behavior/walkaroundball.lua
+++ b/tests/behavior/walkaroundball.lua
@@ -1,0 +1,61 @@
+local inspect = require 'inspect'
+print("Hello world from lua!")
+
+function spawn_robot(number)
+    table.insert(state.robots, create_robot(number))
+end
+
+spawn_robot(7)
+
+local game_end_time = -1.0
+
+function on_goal()
+    print("Goal scored, resetting ball!")
+    print("Ball: " .. inspect(state.ball))
+    print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
+    state.ball = nil
+    game_end_time = state.cycle_count + 200
+end
+
+function on_cycle()
+    if state.ball == nil and state.cycle_count % 1000 == 0 then
+        print(inspect(state))
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 100 then
+        state.game_controller_state.game_state = "Ready"
+        state.filtered_game_state = {
+            Ready = {
+                kicking_team = "Hulks"
+            }
+        }
+    end
+
+    if state.cycle_count == 1400 then
+        state.filtered_game_state.game_state = "Set"
+        state.filtered_game_state = "Set"
+    end
+
+    if state.cycle_count == 1600 then
+        state.filtered_game_state = {
+            Playing = {
+                ball_is_free = true
+            }
+        }
+    end
+
+    if state.cycle_count == 2200 then
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == game_end_time then
+        state.finished = true
+    end
+end


### PR DESCRIPTION
## Introduced Changes

Scale ball obstacle radius when striker and getting close to correct kick angle, leading to faster positioning for kick.

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Potential improvements to how robot turns when approaching ball.
Instant kick while still walking around ball when detecting opponent robot that would reach ball first, even if such a kick is just along the y axis on field.

## How to Test

Place ball between own goal and robot, forcing robot to walk around ball in order to kick into correct direction.
Robot will be closer to ball quicker in order to not leave open space for opponent to kick.
