### PR TITLE
Error message fix in pepsi ping

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 
 use color_eyre::{
     eyre::{bail, eyre, WrapErr},
-    Result,
+    Report, Result,
 };
 use tokio::{process::Command, time};
 
@@ -38,10 +38,12 @@ impl Nao {
                     return Ok(Nao::new(host));
                 };
             }
-            bail!("No route to {}", host);
+            bail!("No route to {host}")
         };
 
-        time::timeout(timeout, pinger).await?
+        time::timeout(timeout, pinger)
+            .await
+            .map_err(|_| Report::msg(format!("No route to {host}")))?
     }
 
     pub async fn get_os_version(&self) -> Result<String> {


### PR DESCRIPTION
## Introduced Changes

This PR corrects the cryptic error message `deadline has elapsed` which was introduced with `pepsi ping`

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Trigger the timeout by `pepsi ping 31 --timeout 0.1`, the error message now says `No route to {host}` instead of `deadline has elapsed`
