### PR TITLE
Reduce max allowed adjustment velocity of walk step adjustment

### DIFF
--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -378,7 +378,7 @@
     },
     "max_number_of_timeouted_steps": 3,
     "max_number_of_unstable_steps": 3,
-    "max_step_adjustment": 0.004,
+    "max_step_adjustment": 0.0018,
     "maximal_step_duration": { "nanos": 0, "secs": 1 },
     "minimal_step_duration": { "nanos": 150000000, "secs": 0 },
     "number_of_stabilizing_steps": 3,


### PR DESCRIPTION
## Introduced Changes

Reduce max allowed adjustment velocity of walk step adjustment. This should make the walking in extreme situations (tilting backward, tilting forward) more stable.

Fixes #

## ToDo / Known Issues

-

## Ideas for Next Iterations (Not This PR)

-

## How to Test

- Let a robot walk towards a ball -> should behave normal
- Let a robot walk towards a ball and give it small pushes from the front and back, with some time inbetween. -> robot should balance the disturbance out a lot better and be more stable than before. The feet should no longer move opposite of the "fall" direction a lot when switching the support foot.
  - For example when pushing from the front to tilt the robot backward, at the moment of a support foot switch the new swing foot should not move by a large distance forward, only by a few cm.
- Let a robot walk in place (so something like a walking speed of 0.00001 forward, 0 side and 0 turn) and give it a few pushes from the front and back
  - Robot should be more stable than before