### PR TITLE
check for shootout when lookaround

### DIFF
--- a/crates/control/src/behavior/look_around.rs
+++ b/crates/control/src/behavior/look_around.rs
@@ -1,11 +1,18 @@
-use types::{MotionCommand, PrimaryState, WorldState};
+use spl_network_messages::GamePhase;
+use types::{GameControllerState, MotionCommand, PrimaryState, WorldState};
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
-    match world_state.robot.primary_state {
-        PrimaryState::Ready | PrimaryState::Playing => Some(MotionCommand::Stand {
-            head: types::HeadMotion::LookAround,
-            is_energy_saving: false,
-        }),
-        _ => None,
+    match world_state.game_controller_state {
+        Some(GameControllerState {
+            game_phase: GamePhase::PenaltyShootout { .. },
+            ..
+        }) => None,
+        _ => match world_state.robot.primary_state {
+            PrimaryState::Ready | PrimaryState::Playing => Some(MotionCommand::Stand {
+                head: types::HeadMotion::LookAround,
+                is_energy_saving: false,
+            }),
+            _ => None,
+        },
     }
 }

--- a/crates/control/src/behavior/look_around.rs
+++ b/crates/control/src/behavior/look_around.rs
@@ -2,17 +2,21 @@ use spl_network_messages::GamePhase;
 use types::{GameControllerState, MotionCommand, PrimaryState, WorldState};
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
-    match world_state.game_controller_state {
-        Some(GameControllerState {
-            game_phase: GamePhase::PenaltyShootout { .. },
-            ..
-        }) => None,
-        _ => match world_state.robot.primary_state {
-            PrimaryState::Ready | PrimaryState::Playing => Some(MotionCommand::Stand {
-                head: types::HeadMotion::LookAround,
-                is_energy_saving: false,
+    match (
+        world_state.game_controller_state,
+        world_state.robot.primary_state,
+    ) {
+        (
+            Some(GameControllerState {
+                game_phase: GamePhase::PenaltyShootout { .. },
+                ..
             }),
-            _ => None,
-        },
+            _,
+        ) => None,
+        (_, PrimaryState::Ready | PrimaryState::Playing) => Some(MotionCommand::Stand {
+            head: types::HeadMotion::LookAround,
+            is_energy_saving: false,
+        }),
+        _ => None,
     }
 }

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -103,13 +103,7 @@ impl Behavior {
         if let Some(active_since) = self.active_since {
             if now.duration_since(active_since)? < context.configuration.initial_lookaround_duration
             {
-                match world_state.game_controller_state {
-                    Some(GameControllerState {
-                        game_phase: GamePhase::PenaltyShootout { .. },
-                        ..
-                    }) => (),
-                    _ => actions.push(Action::LookAround),
-                }
+                actions.push(Action::LookAround);
             }
         }
 

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -103,7 +103,13 @@ impl Behavior {
         if let Some(active_since) = self.active_since {
             if now.duration_since(active_since)? < context.configuration.initial_lookaround_duration
             {
-                actions.push(Action::LookAround);
+                match world_state.game_controller_state {
+                    Some(GameControllerState {
+                        game_phase: GamePhase::PenaltyShootout { .. },
+                        ..
+                    }) => (),
+                    _ => actions.push(Action::LookAround),
+                }
             }
         }
 


### PR DESCRIPTION
## Introduced Changes

Only do lookaround if not in penalty shootout.

Fixes #345 

## ToDo / Known Issues

This applies to both the keeper and the striker, although the bug report states that it does not negatively influence the strikers behavior. Please feel free to discuss.

## Ideas for Next Iterations (Not This PR)

## How to Test

Test penalty shootout
