### PR TITLE
1.70.0 Clippy Happyning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,7 +2823,7 @@ dependencies = [
  "bindgen 0.65.1",
  "i2cdev",
  "libc",
- "nix 0.26.2",
+ "nix 0.26.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -2887,6 +2896,19 @@ dependencies = [
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.1"
+source = "git+https://github.com/nix-rust/nix.git?rev=89b4976#89b4976fddf713ca54834612e351ae35d86c430a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.9.0",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ mlua = { version = "0.8.7", features = ["luajit", "serialize", "parking_lot"] }
 nalgebra = { version = "0.32.2", features = ["serde", "serde-serialize"] }
 nao = { path = "crates/nao" }
 nao_camera = { path = "crates/nao_camera" }
+# Pinned git version since the latest release does not contained https://github.com/nix-rust/nix/pull/2022 yet
 nix = { git = "https://github.com/nix-rust/nix.git", version = "0.26.1", rev = "89b4976" }
 motionfile = { path = "crates/motionfile" }
 ordered-float = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ mlua = { version = "0.8.7", features = ["luajit", "serialize", "parking_lot"] }
 nalgebra = { version = "0.32.2", features = ["serde", "serde-serialize"] }
 nao = { path = "crates/nao" }
 nao_camera = { path = "crates/nao_camera" }
-nix = "0.26.2"
+nix = { git = "https://github.com/nix-rust/nix.git", version = "0.26.1", rev = "89b4976" }
 motionfile = { path = "crates/motionfile" }
 ordered-float = "3.1.0"
 parking_lot = "0.12.1"

--- a/crates/framework/src/multiple_buffer.rs
+++ b/crates/framework/src/multiple_buffer.rs
@@ -209,6 +209,8 @@ mod tests {
             assert_eq!(*slot, 42);
         }
         {
+            // clippy bug, remove once fix is released
+            // https://github.com/rust-lang/rust-clippy/issues/10893
             #[allow(clippy::redundant_clone)]
             let reader2 = reader.clone();
             let slot = reader2.next();
@@ -219,6 +221,8 @@ mod tests {
             *slot = 1337;
         }
         {
+            // clippy bug, remove once fix is released
+            // https://github.com/rust-lang/rust-clippy/issues/10893
             #[allow(clippy::redundant_clone)]
             let reader3 = reader.clone();
             let slot = reader3.next();

--- a/crates/framework/src/multiple_buffer.rs
+++ b/crates/framework/src/multiple_buffer.rs
@@ -209,6 +209,7 @@ mod tests {
             assert_eq!(*slot, 42);
         }
         {
+            #[allow(clippy::redundant_clone)]
             let reader2 = reader.clone();
             let slot = reader2.next();
             assert_eq!(*slot, 42);
@@ -218,6 +219,7 @@ mod tests {
             *slot = 1337;
         }
         {
+            #[allow(clippy::redundant_clone)]
             let reader3 = reader.clone();
             let slot = reader3.next();
             assert_eq!(*slot, 1337);
@@ -253,6 +255,7 @@ mod tests {
     #[test]
     fn readers_share_same_slot() {
         let (_writer, reader) = multiple_buffer_with_slots([0, 1, 2]);
+        #[allow(clippy::redundant_clone)]
         let reader2 = reader.clone();
         let reader_slot = reader.next();
         let reader2_slot = reader2.next();


### PR DESCRIPTION
## Introduced Changes

Fixes/masks clippy lints that were added or changed in rust 1.70.0.
1. Added `allow(...)`s for borked lint: https://github.com/rust-lang/rust-clippy/issues/10893
2. Bumped `nix` dependency since clippy complained about a calculation in a macro from that crate. This has been fixed upstream in April, but there hasn't been a release yet, so I'm using a pinned git version.

Fixes #

## ToDo / Known Issues



## Ideas for Next Iterations (Not This PR)

Unmask redundant clone check once that is fixed upstream.

## How to Test

`pepsi clippy --workspace`