### PR TITLE
Gammaray follow symlinks

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -324,6 +324,7 @@ impl Nao {
     pub async fn flash_image(&self, image_path: impl AsRef<Path>) -> Result<()> {
         let status = self
             .rsync_with_nao(false)
+            .arg("--copy-links")
             .arg(image_path.as_ref().to_str().unwrap())
             .arg(format!("{}:/data/.image/", self.host))
             .status()


### PR DESCRIPTION
## Introduced Changes

What it says.
Yocto builds an image file with a rather verbose name. Since the name includes a timestamp, it also changes on every build.
There exists however a symlink to this file with a shorter name, only including the artifact name and version.
This change allows using this symlink for the `image-path` in `pepsi gammaray`.
Previously the symlink would simply be skipped by rsync as a "non-regular file" and the nao would reboot without flashing.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Run `pepsi gammaray --image-path ...` and point it at a symlink to an image.