### PR TITLE
Add behavior action for PrimaryState::Calibration

### DIFF
--- a/crates/control/src/behavior/calibrate.rs
+++ b/crates/control/src/behavior/calibrate.rs
@@ -1,0 +1,11 @@
+use types::{MotionCommand, PrimaryState, WorldState};
+
+pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
+    match world_state.robot.primary_state {
+        PrimaryState::Calibration => Some(MotionCommand::Stand {
+            head: types::HeadMotion::Unstiff,
+            is_energy_saving: false,
+        }),
+        _ => None,
+    }
+}

--- a/crates/control/src/behavior/mod.rs
+++ b/crates/control/src/behavior/mod.rs
@@ -1,3 +1,4 @@
+mod calibrate;
 mod defend;
 mod dribble;
 mod fall_safely;

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -12,6 +12,7 @@ use types::{
 };
 
 use super::{
+    calibrate,
     defend::Defend,
     dribble, fall_safely,
     head::LookAction,
@@ -100,6 +101,7 @@ impl Behavior {
             Action::StandUp,
             Action::Stand,
             Action::InterceptBall,
+            Action::Calibrate,
         ];
 
         if let Some(active_since) = self.active_since {
@@ -189,6 +191,7 @@ impl Behavior {
                     Action::InterceptBall => {
                         intercept_ball::execute(world_state, *context.intercept_ball_parameters)
                     }
+                    Action::Calibrate => calibrate::execute(world_state),
                     Action::DefendGoal => defend.goal(&mut context.path_obstacles),
                     Action::DefendKickOff => defend.kick_off(&mut context.path_obstacles),
                     Action::DefendLeft => defend.left(&mut context.path_obstacles),

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -97,21 +97,22 @@ impl HeadMotion {
     }
 
     pub fn joints_from_motion(context: &CycleContext) -> HeadJointsCommand<f32> {
+        let stiffnesses = HeadJoints::fill(0.8);
         match context.motion_command.head_motion() {
             Some(HeadMotionCommand::Center) => HeadJointsCommand {
                 positions: *context.center_head_position,
-                stiffnesses: HeadJoints::fill(0.8),
+                stiffnesses,
             },
             Some(HeadMotionCommand::LookAround | HeadMotionCommand::SearchForLostBall) => {
                 HeadJointsCommand {
                     positions: *context.look_around,
-                    stiffnesses: HeadJoints::fill(0.8),
+                    stiffnesses,
                 }
             }
             Some(HeadMotionCommand::LookAt { .. })
             | Some(HeadMotionCommand::LookLeftAndRightOf { .. }) => HeadJointsCommand {
                 positions: *context.look_at,
-                stiffnesses: HeadJoints::fill(0.8),
+                stiffnesses,
             },
             Some(HeadMotionCommand::Unstiff) => HeadJointsCommand {
                 positions: context.sensor_data.positions.head,
@@ -119,7 +120,7 @@ impl HeadMotion {
             },
             Some(HeadMotionCommand::ZeroAngles) | None => HeadJointsCommand {
                 positions: Default::default(),
-                stiffnesses: HeadJoints::fill(0.8),
+                stiffnesses,
             },
         }
     }

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -67,11 +67,11 @@ impl HeadMotion {
             *context.maximum_velocity * context.cycle_time.last_cycle_duration.as_secs_f32();
 
         let controlled_positions = HeadJoints {
-            yaw: self.last_positions.head.yaw
-                + (raw_positions.yaw - self.last_positions.head.yaw)
+            yaw: self.last_positions.yaw
+                + (raw_positions.yaw - self.last_positions.yaw)
                     .clamp(-maximum_movement.yaw, maximum_movement.yaw),
-            pitch: self.last_positions.head.pitch
-                + (raw_positions.pitch - self.last_positions.head.pitch)
+            pitch: self.last_positions.pitch
+                + (raw_positions.pitch - self.last_positions.pitch)
                     .clamp(-maximum_movement.pitch, maximum_movement.pitch),
         };
 

--- a/crates/types/src/action.rs
+++ b/crates/types/src/action.rs
@@ -12,6 +12,7 @@ pub enum Action {
     Stand,
     LookAround,
     InterceptBall,
+    Calibrate,
     Dribble,
     DefendGoal,
     DefendKickOff,


### PR DESCRIPTION
## Introduced Changes

What it says. Currently when entering the calibration primary state, the HULK will crash because there is no action available. To allow to use this action for manual calibration, for the moment, in primary state calibration we will stand and have an unstiff head which allows to rotate it by hand.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

If testing in Webots, cherry pick #363. If testing on the NAO, just deploy this branch.

Then enter the calibration mode by holding the front head button in initial and holding the chest button for 1 second. The chest button should change color, as the rules require that. The robot should transition into a stand motion with an unstiff head.