### PR TITLE
Fix X legs on 31

### DIFF
--- a/etc/configuration/head.P0000074A06S9A900006.json
+++ b/etc/configuration/head.P0000074A06S9A900006.json
@@ -14,5 +14,13 @@
         1.244167685508728
       ]
     }
+  },
+  "joint_calibration_offsets": {
+    "left_leg": {
+      "hip_yaw_pitch": -0.2
+    },
+    "right_leg": {
+      "hip_yaw_pitch": -0.2
+    }
   }
 }


### PR DESCRIPTION
## Introduced Changes
There seems to be a fault in the hip yaw pitch joints of the robot which makes walking unstable.
This PR adjusts the hip yaw pitch values so that the legs are parallel again.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
