### PR TITLE
Add pepsi logs show

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -169,6 +169,7 @@ impl Nao {
 
         let status = self
             .rsync_with_nao(true)
+            .arg("-q")
             .arg(format!("{}:hulk/logs/", self.host))
             .arg(local_directory.as_ref().to_str().unwrap())
             .status()

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -169,7 +169,7 @@ impl Nao {
 
         let status = self
             .rsync_with_nao(true)
-            .arg("-q")
+            .arg("--quiet")
             .arg(format!("{}:hulk/logs/", self.host))
             .arg(local_directory.as_ref().to_str().unwrap())
             .status()
@@ -186,7 +186,8 @@ impl Nao {
     pub async fn retrieve_logs(&self) -> Result<String> {
         let output = self
             .ssh_to_nao()
-            .arg("cat")
+            .arg("tail")
+            .arg("-n+1")
             .arg("hulk/logs/hulk.{out,err}")
             .output()
             .await

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -183,11 +183,11 @@ impl Nao {
         Ok(())
     }
 
-    pub async fn retrieve_file(&self, file: &str) -> Result<String> {
+    pub async fn retrieve_logs(&self) -> Result<String> {
         let output = self
             .ssh_to_nao()
             .arg("cat")
-            .arg(file)
+            .arg("hulk/logs/hulk.{out,err}")
             .output()
             .await
             .wrap_err("failed to execute cat command")?;
@@ -197,19 +197,6 @@ impl Nao {
         }
 
         String::from_utf8(output.stdout).wrap_err("failed to decode UTF-8")
-    }
-
-    pub async fn retrieve_logs(&self) -> Result<String> {
-        let mut hulk_out = self
-            .retrieve_file("hulk/logs/hulk.out")
-            .await
-            .wrap_err("failed to retrieve hulk.out")?;
-        let hulk_err = self
-            .retrieve_file("hulk/logs/hulk.err")
-            .await
-            .wrap_err("failed to retrieve hulk.err")?;
-        hulk_out.push_str(&hulk_err);
-        Ok(hulk_out)
     }
 
     pub async fn power_off(&self) -> Result<()> {

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -72,12 +72,13 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const COMPLETION_SUBCOMMANDS: [(&str, &str); 13] = [
+            const COMPLETION_SUBCOMMANDS: [(&str, &str); 14] = [
                 ("aliveness", ""),
                 ("gammaray", ""),
                 ("hulk", ""),
                 ("logs", "delete"),
                 ("logs", "downloads"),
+                ("logs", "show"),
                 ("postgame", ""),
                 ("poweroff", ""),
                 ("reboot", ""),

--- a/tools/pepsi/src/logs.rs
+++ b/tools/pepsi/src/logs.rs
@@ -9,17 +9,23 @@ use crate::{parsers::NaoAddress, progress_indicator::ProgressIndicator};
 
 #[derive(Subcommand)]
 pub enum Arguments {
-    // Delete logs on the NAOs
+    /// Delete logs on the NAOs
     Delete {
         /// The NAOs to delete logs from e.g. 20w or 10.1.24.22
         #[arg(required = true)]
         naos: Vec<NaoAddress>,
     },
-    // Download logs from the NAOs
+    /// Download logs from the NAOs
     Download {
         /// Directory where to store the downloaded logs (will be created if not existing)
         log_directory: PathBuf,
         /// The NAOs to download logs from e.g. 20w or 10.1.24.22
+        #[arg(required = true)]
+        naos: Vec<NaoAddress>,
+    },
+    /// Show logs from NAOs
+    Show {
+        /// The NAO to show logs from e.g. 20w or 10.1.24.22
         #[arg(required = true)]
         naos: Vec<NaoAddress>,
     },
@@ -48,6 +54,15 @@ pub async fn logs(arguments: Arguments) -> Result<()> {
                         .await
                         .wrap_err_with(|| format!("failed to download logs from {nao_address}"))
                 }
+            })
+            .await
+        }
+        Arguments::Show { naos } => {
+            ProgressIndicator::map_tasks(naos, "Retrieving logs...", |nao_address| async move {
+                let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+                nao.retrieve_logs()
+                    .await
+                    .wrap_err("failed to retrieve logs")
             })
             .await
         }

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, time::Duration};
 
+use bat::{Input, PagingMode, PrettyPrinter};
 use color_eyre::{owo_colors::OwoColorize, Report, Result};
 use futures_util::{stream::FuturesUnordered, Future, StreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -46,17 +47,39 @@ impl ProgressIndicator {
         M: Into<TaskOutput>,
     {
         let multi_progress = Self::new();
-        items
+        let outputs = items
             .into_iter()
             .map(|item| (multi_progress.task(item.to_string()), item))
             .map(|(progress, item)| {
                 progress.enable_steady_tick();
                 progress.set_message(message);
-                async move { progress.finish_with(task(item).await) }
+                async move { (item.to_string(), progress.finish_with(task(item).await)) }
             })
             .collect::<FuturesUnordered<_>>()
             .collect::<Vec<_>>()
             .await;
+
+        let inputs: Vec<_> = outputs
+            .iter()
+            .filter_map(|(title, output)| match output {
+                TaskOutput::EmptyOutput => None,
+                TaskOutput::Message(value) => {
+                    Some(Input::from_bytes(value.as_bytes()).title(title))
+                }
+            })
+            .collect();
+
+        if !inputs.is_empty() {
+            PrettyPrinter::new()
+                .inputs(inputs)
+                .grid(true)
+                .header(true)
+                .line_numbers(true)
+                .paging_mode(PagingMode::Always)
+                .rule(true)
+                .print()
+                .expect("failed to print log");
+        }
     }
 }
 

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -43,7 +43,7 @@ impl ProgressIndicator {
     ) where
         T: ToString,
         F: Future<Output = Result<M>>,
-        M: Into<TaskOutput>,
+        M: Into<TaskMessage>,
     {
         let multi_progress = Self::new();
         items
@@ -66,31 +66,31 @@ pub struct Task {
     error_style: ProgressStyle,
 }
 
-pub enum TaskOutput {
-    EmptyOutput,
+pub enum TaskMessage {
+    EmptyMessage,
     Message(String),
 }
 
-impl From<()> for TaskOutput {
+impl From<()> for TaskMessage {
     fn from(_: ()) -> Self {
-        Self::EmptyOutput
+        Self::EmptyMessage
     }
 }
 
-impl From<String> for TaskOutput {
+impl From<String> for TaskMessage {
     fn from(value: String) -> Self {
         if value.is_empty() {
-            Self::EmptyOutput
+            Self::EmptyMessage
         } else {
             Self::Message(value)
         }
     }
 }
 
-impl From<&str> for TaskOutput {
+impl From<&str> for TaskMessage {
     fn from(value: &str) -> Self {
         if value.is_empty() {
-            Self::EmptyOutput
+            Self::EmptyMessage
         } else {
             Self::Message(String::from(value))
         }
@@ -106,25 +106,25 @@ impl Task {
         self.progress.set_message(message)
     }
 
-    pub fn finish_with_success(&self) {
-        let icon = "✔".green();
+    pub fn finish_with_success(&self, message: impl Into<TaskMessage>) {
         self.progress.set_style(self.success_style.clone());
-        self.progress.finish_with_message(icon.to_string());
+        let icon = "✔".green();
+        let message = match message.into() {
+            TaskMessage::EmptyMessage => icon.to_string(),
+            TaskMessage::Message(message) => format!("{icon}\n{message}"),
+        };
+        self.progress.finish_with_message(message);
     }
 
-    pub fn finish_with_error<'a>(&self, report: Report) -> TaskOutput {
+    pub fn finish_with_error(&self, report: Report) {
         self.progress.set_style(self.error_style.clone());
         self.progress
             .finish_with_message(format!("{}{report:?}", "✗".red()));
-        TaskOutput::EmptyOutput
     }
 
-    pub fn finish_with<'a>(&self, result: Result<impl Into<TaskOutput>>) -> TaskOutput {
+    pub fn finish_with(&self, result: Result<impl Into<TaskMessage>>) {
         match result {
-            Ok(message) => {
-                self.finish_with_success();
-                message.into()
-            }
+            Ok(message) => self.finish_with_success(message),
             Err(report) => self.finish_with_error(report),
         }
     }


### PR DESCRIPTION
## Introduced Changes

This PR introduces a `pepsi logs show` subcommand for outputting the logs (hulk.out and hulk.err) of one or multiple NAOs.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

Filtering the log output may be interesting, though this may rather be done with an external tool.

## How to Test

Execute e.g. `./pepsi logs show 21`.
