### PR TITLE
Pin v4l dependency with commit hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "v4l"
 version = "0.12.1"
-source = "git+https://github.com/HULKs/libv4l-rs?tag=0.12.1+hulks-2#be65819073514b193d082dd37dbcc2cfac3f6183"
+source = "git+https://github.com/HULKs/libv4l-rs?rev=be65819073514b193d082dd37dbcc2cfac3f6183#be65819073514b193d082dd37dbcc2cfac3f6183"
 dependencies = [
  "bitflags",
  "errno 0.2.8",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "v4l2-sys-mit"
 version = "0.2.0"
-source = "git+https://github.com/HULKs/libv4l-rs?tag=0.12.1+hulks-2#be65819073514b193d082dd37dbcc2cfac3f6183"
+source = "git+https://github.com/HULKs/libv4l-rs?rev=be65819073514b193d082dd37dbcc2cfac3f6183#be65819073514b193d082dd37dbcc2cfac3f6183"
 dependencies = [
  "bindgen 0.65.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ toml = "0.7.4"
 topological-sort = "0.2.2"
 types = { path = "crates/types" }
 uuid = { version = "1.1.2", features = ["v4"] }
-v4l = { version = "0.12.1", git = "https://github.com/HULKs/libv4l-rs", tag = "0.12.1+hulks-2" }
+v4l = { version = "0.12.1", git = "https://github.com/HULKs/libv4l-rs", rev = "be65819073514b193d082dd37dbcc2cfac3f6183" }
 walkdir = "2.3.2"
 webots = { version = "0.7.0" }
 vision = { path = "crates/vision" }


### PR DESCRIPTION
## Introduced Changes

It seems that cargo tries to pull out v4l git repository every time we build anything in our workspace since #353 was merged, causing builds to fail when no network connection is available.
This issue occurs when using a tag for selecting the commit but does not appear when using a commit hash.
However, we've been using a git dependency with a tag pin for a while now and it does **not** cause this issue.
I have no idea why they behave differently, but to restore Arbeitsfähigkeit, lets just use a commit hash for now.

Fixes #372 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

Find out what causes cargo to fetch the repo every time.

## How to Test

Disconnect from internet, try to build anything.