### PR TITLE
Use alternative static ball model

### DIFF
--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -15,6 +15,7 @@ use types::{
 
 pub struct BallFilter {
     hypotheses: Vec<Hypothesis>,
+    persistent_hypotheses: Vec<Hypothesis>,
 }
 
 #[context]
@@ -59,6 +60,7 @@ impl BallFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             hypotheses: Vec::new(),
+            persistent_hypotheses: Vec::new(),
         })
     }
 

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -9,7 +9,7 @@ use nalgebra::{
 };
 use projection::Projection;
 use types::{
-    ball_filter::Hypothesis, configuration::BallFilterConfiguration, is_above_limbs,
+    ball_filter::Hypothesis, configuration::BallFilter as BallFilterConfiguration, is_above_limbs,
     multivariate_normal_distribution::MultivariateNormalDistribution, Ball, BallPosition,
     CameraMatrices, CameraMatrix, Circle, CycleTime, FieldDimensions, Limb, ProjectedLimbs,
     SensorData,
@@ -40,7 +40,7 @@ pub struct CycleContext {
     pub cycle_time: Input<CycleTime, "cycle_time">,
 
     pub field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
-    pub ball_filter_configuration: Parameter<BallFilterConfiguration, "ball_filter_configuration">,
+    pub ball_filter_configuration: Parameter<BallFilterConfiguration, "ball_filter">,
 
     pub balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
     pub balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -264,6 +264,10 @@ impl BallFilter {
             Matrix2::from_diagonal(&configuration.measurement_noise_resting)
                 * detected_position.coords.norm_squared(),
         );
+
+        if !hypothesis.is_resting(configuration) {
+            hypothesis.resting_state.mean = hypothesis.moving_state.mean;
+        }
         hypothesis.last_update = detection_time;
         hypothesis.validity += 1.0;
     }

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -30,6 +30,7 @@ pub struct CycleContext {
     pub filtered_balls_in_image_bottom:
         AdditionalOutput<Vec<Circle>, "filtered_balls_in_image_bottom">,
     pub filtered_balls_in_image_top: AdditionalOutput<Vec<Circle>, "filtered_balls_in_image_top">,
+    pub chooses_resting_model: AdditionalOutput<bool, "chooses_resting_model">,
 
     pub current_odometry_to_last_odometry:
         HistoricInput<Option<Isometry2<f32>>, "current_odometry_to_last_odometry?">,

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -25,10 +25,11 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     pub ball_filter_hypotheses: AdditionalOutput<Vec<Hypothesis>, "ball_filter_hypotheses">,
+    pub best_ball_hypothesis: AdditionalOutput<Option<Hypothesis>, "best_ball_hypothesis">,
+    pub chooses_resting_model: AdditionalOutput<bool, "chooses_resting_model">,
     pub filtered_balls_in_image_bottom:
         AdditionalOutput<Vec<Circle>, "filtered_balls_in_image_bottom">,
     pub filtered_balls_in_image_top: AdditionalOutput<Vec<Circle>, "filtered_balls_in_image_top">,
-    pub chooses_resting_model: AdditionalOutput<bool, "chooses_resting_model">,
 
     pub current_odometry_to_last_odometry:
         HistoricInput<Option<Isometry2<f32>>, "current_odometry_to_last_odometry?">,
@@ -152,6 +153,10 @@ impl BallFilter {
                     })
                     .collect()
             });
+
+        context
+            .best_ball_hypothesis
+            .fill_if_subscribed(|| self.find_best_hypothesis().cloned());
 
         let ball_position = self.find_best_hypothesis().map(|hypothesis| {
             context

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -15,7 +15,6 @@ use types::{
 
 pub struct BallFilter {
     hypotheses: Vec<Hypothesis>,
-    persistent_hypotheses: Vec<Hypothesis>,
 }
 
 #[context]
@@ -31,7 +30,6 @@ pub struct CycleContext {
     pub filtered_balls_in_image_bottom:
         AdditionalOutput<Vec<Circle>, "filtered_balls_in_image_bottom">,
     pub filtered_balls_in_image_top: AdditionalOutput<Vec<Circle>, "filtered_balls_in_image_top">,
-    pub chooses_resting_model: AdditionalOutput<bool, "chooses_resting_model">,
 
     pub current_odometry_to_last_odometry:
         HistoricInput<Option<Isometry2<f32>>, "current_odometry_to_last_odometry?">,
@@ -60,7 +58,6 @@ impl BallFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             hypotheses: Vec::new(),
-            persistent_hypotheses: Vec::new(),
         })
     }
 
@@ -192,7 +189,7 @@ impl BallFilter {
                     &camera_matrices.bottom,
                     ball_radius,
                     &projected_limbs.limbs,
-                    configuration
+                    configuration,
                 ),
                 _ => false,
             };
@@ -421,7 +418,7 @@ fn is_visible_to_camera(
     hypothesis: &Hypothesis,
     camera_matrix: &CameraMatrix,
     ball_radius: f32,
-    projected_limbs_bottom: &[Limb],
+    projected_limbs: &[Limb],
     configuration: &BallFilterConfiguration,
 ) -> bool {
     let position_on_ground = hypothesis.selected_ball_position(configuration).position;
@@ -432,5 +429,5 @@ fn is_visible_to_camera(
         };
     (0.0..640.0).contains(&position_in_image.x)
         && (0.0..480.0).contains(&position_in_image.y)
-        && is_above_limbs(position_in_image, projected_limbs_bottom)
+        && is_above_limbs(position_in_image, projected_limbs)
 }

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -4,9 +4,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use filtering::kalman_filter::KalmanFilter;
 use framework::{AdditionalOutput, HistoricInput, MainOutput, PerceptionInput};
-use nalgebra::{
-    matrix, vector, Isometry2, Matrix2, Matrix2x4, Matrix4, Matrix4x2, Point2,
-};
+use nalgebra::{matrix, vector, Isometry2, Matrix2, Matrix2x4, Matrix4, Matrix4x2, Point2};
 use projection::Projection;
 use types::{
     ball_filter::Hypothesis, configuration::BallFilter as BallFilterConfiguration, is_above_limbs,
@@ -142,7 +140,7 @@ impl BallFilter {
             .hypotheses
             .iter()
             .map(|hypothesis| hypothesis.selected_ball_position(context.ball_filter_configuration))
-            .collect();
+            .collect::<Vec<_>>();
         context.filtered_balls_in_image_top.fill_if_subscribed(|| {
             project_to_image(&ball_positions, &context.camera_matrices.top, ball_radius)
         });
@@ -162,7 +160,7 @@ impl BallFilter {
 
         context.best_ball_state.fill_if_subscribed(|| {
             self.find_best_hypothesis()
-                .map(|hypothesis| hypothesis.selected_state(&context.ball_filter_configuration))
+                .map(|hypothesis| hypothesis.selected_state(context.ball_filter_configuration))
         });
 
         let ball_position = self.find_best_hypothesis().map(|hypothesis| {
@@ -395,7 +393,7 @@ impl BallFilter {
 }
 
 fn project_to_image(
-    ball_position: &Vec<BallPosition>,
+    ball_position: &[BallPosition],
     camera_matrix: &CameraMatrix,
     ball_radius: f32,
 ) -> Vec<Circle> {

--- a/crates/types/src/ball_filter.rs
+++ b/crates/types/src/ball_filter.rs
@@ -23,19 +23,24 @@ impl Hypothesis {
         self.moving_state.mean.rows(2, 2).norm() < configuration.resting_ball_velocity_threshold
     }
 
-    pub fn selected_ball_position(&self, configuration: &BallFilterConfiguration) -> BallPosition {
+    pub fn selected_state(
+        &self,
+        configuration: &BallFilterConfiguration,
+    ) -> MultivariateNormalDistribution<4> {
         if self.is_resting(configuration) {
-            BallPosition {
-                position: Point2::from(self.moving_state.mean.xy()),
-                velocity: vector![self.resting_state.mean.z, self.resting_state.mean.w],
-                last_seen: self.last_update,
-            }
+            self.resting_state
         } else {
-            BallPosition {
-                position: Point2::from(self.moving_state.mean.xy()),
-                velocity: vector![self.moving_state.mean.z, self.moving_state.mean.w],
-                last_seen: self.last_update,
-            }
+            self.moving_state
+        }
+    }
+
+    pub fn selected_ball_position(&self, configuration: &BallFilterConfiguration) -> BallPosition {
+        let selected_state = self.selected_state(configuration);
+
+        BallPosition {
+            position: Point2::from(selected_state.mean.xy()),
+            velocity: vector![selected_state.mean.z, selected_state.mean.w],
+            last_seen: self.last_update,
         }
     }
 }

--- a/crates/types/src/ball_filter.rs
+++ b/crates/types/src/ball_filter.rs
@@ -2,13 +2,14 @@ use std::time::SystemTime;
 
 use nalgebra::{vector, Point2};
 use serde::{Deserialize, Serialize};
+use serialize_hierarchy::SerializeHierarchy;
 
 use crate::{
     configuration::BallFilterConfiguration,
     multivariate_normal_distribution::MultivariateNormalDistribution, BallPosition,
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, SerializeHierarchy)]
 pub struct Hypothesis {
     pub moving_state: MultivariateNormalDistribution<4>,
     pub resting_state: MultivariateNormalDistribution<4>,

--- a/crates/types/src/ball_filter.rs
+++ b/crates/types/src/ball_filter.rs
@@ -6,7 +6,9 @@ use crate::multivariate_normal_distribution::MultivariateNormalDistribution;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Hypothesis {
-    pub state: MultivariateNormalDistribution<4>,
+    pub moving_state: MultivariateNormalDistribution<4>,
+    pub resting_state: MultivariateNormalDistribution<4>,
+
     pub validity: f32,
     pub last_update: SystemTime,
 }

--- a/crates/types/src/ball_filter.rs
+++ b/crates/types/src/ball_filter.rs
@@ -1,8 +1,12 @@
 use std::time::SystemTime;
 
+use nalgebra::{vector, Point2};
 use serde::{Deserialize, Serialize};
 
-use crate::multivariate_normal_distribution::MultivariateNormalDistribution;
+use crate::{
+    configuration::BallFilterConfiguration,
+    multivariate_normal_distribution::MultivariateNormalDistribution, BallPosition,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Hypothesis {
@@ -11,4 +15,26 @@ pub struct Hypothesis {
 
     pub validity: f32,
     pub last_update: SystemTime,
+}
+
+impl Hypothesis {
+    pub fn is_resting(&self, configuration: &BallFilterConfiguration) -> bool {
+        self.moving_state.mean.rows(2, 2).norm() < configuration.resting_ball_velocity_threshold
+    }
+
+    pub fn selected_ball_position(&self, configuration: &BallFilterConfiguration) -> BallPosition {
+        if self.is_resting(configuration) {
+            BallPosition {
+                position: Point2::from(self.resting_state.mean.xy()),
+                velocity: vector![self.resting_state.mean.z, self.resting_state.mean.w],
+                last_seen: self.last_update,
+            }
+        } else {
+            BallPosition {
+                position: Point2::from(self.moving_state.mean.xy()),
+                velocity: vector![self.moving_state.mean.z, self.moving_state.mean.w],
+                last_seen: self.last_update,
+            }
+        }
+    }
 }

--- a/crates/types/src/ball_filter.rs
+++ b/crates/types/src/ball_filter.rs
@@ -25,7 +25,7 @@ impl Hypothesis {
     pub fn selected_ball_position(&self, configuration: &BallFilterConfiguration) -> BallPosition {
         if self.is_resting(configuration) {
             BallPosition {
-                position: Point2::from(self.resting_state.mean.xy()),
+                position: Point2::from(self.moving_state.mean.xy()),
                 velocity: vector![self.resting_state.mean.z, self.resting_state.mean.w],
                 last_seen: self.last_update,
             }

--- a/crates/types/src/ball_filter.rs
+++ b/crates/types/src/ball_filter.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 
 use crate::{
-    configuration::BallFilterConfiguration,
+    configuration::BallFilter as BallFilterConfiguration,
     multivariate_normal_distribution::MultivariateNormalDistribution, BallPosition,
 };
 

--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -415,16 +415,19 @@ pub struct LineDetection {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
-pub struct BallFilter {
+pub struct BallFilterConfiguration {
     pub hypothesis_timeout: Duration,
     pub measurement_matching_distance: f32,
     pub hypothesis_merge_distance: f32,
     pub process_noise: Vector4<f32>,
-    pub measurement_noise: Vector2<f32>,
+    pub measurement_noise_moving: Vector2<f32>,
+    pub measurement_noise_resting: Vector2<f32>,
     pub initial_covariance: Vector4<f32>,
     pub visible_validity_exponential_decay_factor: f32,
     pub hidden_validity_exponential_decay_factor: f32,
     pub validity_discard_threshold: f32,
+    pub velocity_decay_factor: f32,
+    pub resting_ball_velocity_threshold: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -415,7 +415,7 @@ pub struct LineDetection {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
-pub struct BallFilterConfiguration {
+pub struct BallFilter {
     pub hypothesis_timeout: Duration,
     pub measurement_matching_distance: f32,
     pub hypothesis_merge_distance: f32,

--- a/crates/types/src/configuration.rs
+++ b/crates/types/src/configuration.rs
@@ -415,7 +415,7 @@ pub struct LineDetection {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
-pub struct BallFilter {
+pub struct BallFilterConfiguration {
     pub hypothesis_timeout: Duration,
     pub measurement_matching_distance: f32,
     pub hypothesis_merge_distance: f32,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -281,7 +281,7 @@
     "measurement_noise_moving": [3.0, 5.0],
     "measurement_noise_resting": [300.0, 500.0],
     "initial_covariance": [0.5, 0.5, 0.5, 0.5],
-    "resting_ball_velocity_threshold": 0.2,
+    "resting_ball_velocity_threshold": 0.12,
     "visible_validity_exponential_decay_factor": 0.96,
     "hidden_validity_exponential_decay_factor": 0.999,
     "validity_discard_threshold": 0.5,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -270,7 +270,7 @@
     "arm_stiffness": 0.8,
     "leg_stiffness": 0.2
   },
-  "ball_filter": {
+  "ball_filter_configuration": {
     "hypothesis_timeout": {
       "nanos": 0,
       "secs": 5

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -270,7 +270,7 @@
     "arm_stiffness": 0.8,
     "leg_stiffness": 0.2
   },
-  "ball_filter": {
+  "ball_filter_configuration": {
     "hypothesis_timeout": {
       "nanos": 0,
       "secs": 5
@@ -278,8 +278,10 @@
     "measurement_matching_distance": 1.0,
     "hypothesis_merge_distance": 1.0,
     "process_noise": [0.005, 0.005, 0.2, 0.2],
-    "measurement_noise": [3.0, 5.0],
+    "measurement_noise_moving": [3.0, 5.0],
+    "measurement_noise_resting": [300.0, 500.0],
     "initial_covariance": [0.5, 0.5, 0.5, 0.5],
+    "resting_ball_velocity_threshold": 0.2,
     "visible_validity_exponential_decay_factor": 0.96,
     "hidden_validity_exponential_decay_factor": 0.999,
     "validity_discard_threshold": 0.5,

--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -270,7 +270,7 @@
     "arm_stiffness": 0.8,
     "leg_stiffness": 0.2
   },
-  "ball_filter_configuration": {
+  "ball_filter": {
     "hypothesis_timeout": {
       "nanos": 0,
       "secs": 5

--- a/tools/twix/src/panels/map/layers/ball_filter.rs
+++ b/tools/twix/src/panels/map/layers/ball_filter.rs
@@ -42,10 +42,10 @@ impl Layer for BallFilter {
         let ball_hypotheses: Vec<Hypothesis> = self.ball_hypotheses.parse_latest()?;
 
         for hypothesis in ball_hypotheses.iter() {
-            let position =
-                robot_to_field.unwrap_or_default() * Point2::from(hypothesis.state.mean.xy());
+            let position = robot_to_field.unwrap_or_default()
+                * Point2::from(hypothesis.moving_state.mean.xy());
             let covariance = hypothesis
-                .state
+                .moving_state
                 .covariance
                 .fixed_view::<2, 2>(0, 0)
                 .into_owned();

--- a/tools/twix/src/panels/map/layers/ball_filter.rs
+++ b/tools/twix/src/panels/map/layers/ball_filter.rs
@@ -4,7 +4,10 @@ use color_eyre::Result;
 use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{Isometry2, Point2};
-use types::{ball_filter::Hypothesis, FieldDimensions};
+use types::{
+    multivariate_normal_distribution::MultivariateNormalDistribution,
+    FieldDimensions,
+};
 
 use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
@@ -12,7 +15,7 @@ use crate::{
 
 pub struct BallFilter {
     robot_to_field: ValueBuffer,
-    ball_hypotheses: ValueBuffer,
+    ball_state: ValueBuffer,
 }
 
 impl Layer for BallFilter {
@@ -28,27 +31,23 @@ impl Layer for BallFilter {
         let ball_hypotheses = nao.subscribe_output(CyclerOutput {
             cycler: Cycler::Control,
             output: Output::Additional {
-                path: "ball_filter_hypotheses".to_string(),
+                path: "best_ball_state".to_string(),
             },
         });
         Self {
             robot_to_field,
-            ball_hypotheses,
+            ball_state: ball_hypotheses,
         }
     }
 
     fn paint(&self, painter: &TwixPainter, _field_dimensions: &FieldDimensions) -> Result<()> {
         let robot_to_field: Option<Isometry2<f32>> = self.robot_to_field.parse_latest()?;
-        let ball_hypotheses: Vec<Hypothesis> = self.ball_hypotheses.parse_latest()?;
+        let best_ball_state: Option<MultivariateNormalDistribution<4>> =
+            self.ball_state.parse_latest()?;
 
-        for hypothesis in ball_hypotheses.iter() {
-            let position = robot_to_field.unwrap_or_default()
-                * Point2::from(hypothesis.moving_state.mean.xy());
-            let covariance = hypothesis
-                .moving_state
-                .covariance
-                .fixed_view::<2, 2>(0, 0)
-                .into_owned();
+        if let Some(state) = best_ball_state {
+            let position = robot_to_field.unwrap_or_default() * Point2::from(state.mean.xy());
+            let covariance = state.covariance.fixed_view::<2, 2>(0, 0).into_owned();
             let stroke = Stroke::new(0.01, Color32::BLACK);
             let fill_color = Color32::from_rgba_unmultiplied(255, 255, 0, 100);
             painter.covariance(position, covariance, stroke, fill_color);

--- a/tools/twix/src/panels/map/layers/ball_filter.rs
+++ b/tools/twix/src/panels/map/layers/ball_filter.rs
@@ -4,10 +4,7 @@ use color_eyre::Result;
 use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{Isometry2, Point2};
-use types::{
-    multivariate_normal_distribution::MultivariateNormalDistribution,
-    FieldDimensions,
-};
+use types::{multivariate_normal_distribution::MultivariateNormalDistribution, FieldDimensions};
 
 use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,


### PR DESCRIPTION
## Introduced Changes

We noticed that the robot can shoot significantly better when the ball model does not jitter.
This PR adds a resting equivalent to each hypothesis, which has higher velocity measurement noise and therefore is slower and doesn't have as much position noise.
The switch between moving and resting ball is determined depending on the velocity of the moving ball.


Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Observe the `chooses_resting_model` additional output to see when the robot switches between the models.
* The robot should make a kick decision faster when the ball is steady (given the robot is properly localized)
