### PR TITLE
Revert "adjust hip yaw pitch"

### DIFF
--- a/etc/configuration/head.P0000074A06S9A900006.json
+++ b/etc/configuration/head.P0000074A06S9A900006.json
@@ -14,13 +14,5 @@
         1.244167685508728
       ]
     }
-  },
-  "joint_calibration_offsets": {
-    "left_leg": {
-      "hip_yaw_pitch": -0.2
-    },
-    "right_leg": {
-      "hip_yaw_pitch": -0.2
-    }
   }
 }


### PR DESCRIPTION
The legs of 31 are mysteriously parallel again without any offset. This reverts the previous PR.

This reverts commit 921e3f93fc071624fdb4b1852bffae4c52004a58.

## Introduced Changes

*Describe here what this pull request does*

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
