### PR TITLE
change last pose to ready_pose, avoid arm rotation

### DIFF
--- a/etc/motions/stand_up_back_dortmund_2022.json
+++ b/etc/motions/stand_up_back_dortmund_2022.json
@@ -768,76 +768,35 @@
               "pitch": 0.3490658503988659
             },
             "left_arm": {
-              "shoulder_pitch": 1.5707963267948966,
-              "shoulder_roll": 0.19198621771937624,
-              "elbow_yaw": 0.0,
-              "elbow_roll": 1.5707963267948966,
-              "wrist_yaw": -1.5707963267948966,
+              "shoulder_pitch": 1.57,
+              "shoulder_roll": 0.2,
+              "elbow_yaw": -1.57,
+              "elbow_roll": -0.008,
+              "wrist_yaw": 0.0,
               "hand": 0.0
             },
             "right_arm": {
-              "shoulder_pitch": 1.5707963267948966,
-              "shoulder_roll": -0.19198621771937624,
-              "elbow_yaw": 0.0,
-              "elbow_roll": -1.5707963267948966,
-              "wrist_yaw": 1.5707963267948966,
+              "shoulder_pitch": 1.57,
+              "shoulder_roll": -0.2,
+              "elbow_yaw": 1.57,
+              "elbow_roll": 0.008,
+              "wrist_yaw": 0.0,
               "hand": 0.0
             },
             "left_leg": {
-              "hip_yaw_pitch": 0.0,
+              "hip_yaw_pitch": 0.0138,
               "hip_roll": 0.0,
-              "hip_pitch": -0.3665191429188092,
-              "knee_pitch": 0.8552113334772213,
-              "ankle_pitch": -0.4799655442984406,
+              "hip_pitch": -0.3,
+              "knee_pitch": 0.93,
+              "ankle_pitch": -0.6,
               "ankle_roll": 0.0
             },
             "right_leg": {
-              "hip_yaw_pitch": 0.0,
+              "hip_yaw_pitch": 0.0138,
               "hip_roll": 0.0,
-              "hip_pitch": -0.3665191429188092,
-              "knee_pitch": 0.8552113334772213,
-              "ankle_pitch": -0.4799655442984406,
-              "ankle_roll": 0.0
-            }
-          }
-        },
-        {
-          "duration": 0.1,
-          "positions": {
-            "head": {
-              "yaw": 0.0,
-              "pitch": 0.3490658503988659
-            },
-            "left_arm": {
-              "shoulder_pitch": 1.5707963267948966,
-              "shoulder_roll": 0.19198621771937624,
-              "elbow_yaw": 0.0,
-              "elbow_roll": 1.5707963267948966,
-              "wrist_yaw": -1.5707963267948966,
-              "hand": 0.0
-            },
-            "right_arm": {
-              "shoulder_pitch": 1.5707963267948966,
-              "shoulder_roll": -0.19198621771937624,
-              "elbow_yaw": 0.0,
-              "elbow_roll": -1.5707963267948966,
-              "wrist_yaw": 1.5707963267948966,
-              "hand": 0.0
-            },
-            "left_leg": {
-              "hip_yaw_pitch": 0.0,
-              "hip_roll": 0.0,
-              "hip_pitch": -0.3665191429188092,
-              "knee_pitch": 0.8552113334772213,
-              "ankle_pitch": -0.4799655442984406,
-              "ankle_roll": 0.0
-            },
-            "right_leg": {
-              "hip_yaw_pitch": 0.0,
-              "hip_roll": 0.0,
-              "hip_pitch": -0.3665191429188092,
-              "knee_pitch": 0.8552113334772213,
-              "ankle_pitch": -0.4799655442984406,
+              "hip_pitch": -0.3,
+              "knee_pitch": 0.93,
+              "ankle_pitch": -0.6,
               "ankle_roll": 0.0
             }
           }


### PR DESCRIPTION
## Introduced Changes

Remove elbow joint rotation in the stand up motion, which was just introduced by a wrong keyframe. Therefore the robot stood up and rotated the elbow joint in one position and in the next frame rotate it back to the "ready_position". 

Fixes #

Remove last keyframe and change pre-last keyframe to "ready_pose" to have a smooth transition to walking again.

## How to Test

Compare the end of the previous stand_up_motion to the new one on a robot and see that there is a elbow joint rotation missing.
