### PR TITLE
Remote compilation

### DIFF
--- a/scripts/remote
+++ b/scripts/remote
@@ -67,23 +67,23 @@ remotePath="$(echo $remoteGitPath | sed 's/\.git/\//')"
 branch=remoteCompile
 git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
-ssh $address "sh -c \"\
+ssh $address "sh -c \" \
     cd "$remotePath" \
     && git checkout --force \\\$(git rev-parse $branch) \
     && git clean -d --force \
 \""
 # send all changes that aren't uncommitted yet
-git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL
+git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . "$remoteURL"
 
 # invoke compile script remotely
 ssh $address "sh -c \" \
     . '$HOME/.profile' \
-    && cd "$remotePath" \
-    && $@\" \
-"
+    && cd \"$remotePath\" \
+    && $@
+\""
 
 # fetch results
 echo Returning files
 printf '  %s\n' "${files[@]}"
-printf '%s\n' "${files[@]}" | rsync -a --info=progress --files-from=- $remoteURL .
+printf '%s\n' "${files[@]}" | rsync -a --info=progress --files-from=- "$remoteURL" .
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -70,7 +70,7 @@ git push $remote HEAD:$branch --force --no-verify
 ssh $address "
     cd $remotePath \
     && git checkout -f \$(git rev-parse $branch) \
-    && git clean -d \
+    && git clean -d -f \
 "
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL

--- a/scripts/remote
+++ b/scripts/remote
@@ -58,10 +58,10 @@ echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 
 # extract login information and remote path from git remote
 # assumes remote url of this format: `user@domain:path/to/hulks/repo.git`
-remoteURL=$(git remote get-url $remote)
-address=$(echo $remoteURL | cut -d':' -f 1)
-remoteGitPath=$(echo $remoteURL | cut -d':' -f 2-)
-remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
+remoteURL="$(git remote get-url $remote)"
+address="$(echo $remoteURL | cut -d':' -f 1)"
+remoteGitPath="$(echo $remoteURL | cut -d':' -f 2-)"
+remotePath="$(echo $remoteGitPath | sed 's/\.git/\//')"
 
 # push HEAD to compiler remote
 branch=remoteCompile

--- a/scripts/remote
+++ b/scripts/remote
@@ -67,9 +67,9 @@ remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 branch=remoteCompile
 git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
-ssh $address "sh -c \" \
-    cd \"$remotePath\" \
-    && git checkout --force \$(git rev-parse $branch) \
+ssh $address "sh -c \"set -x && \
+    cd "$remotePath" \
+    && git checkout --force \\\$(git rev-parse $branch) \
     && git clean -d --force \
 \""
 # send all changes that aren't uncommitted yet
@@ -78,7 +78,7 @@ git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --fil
 # invoke compile script remotely
 ssh $address "sh -c \" \
     . '$HOME/.profile' \
-    && cd $remotePath \
+    && cd "$remotePath" \
     && $@\" \
 "
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -67,11 +67,11 @@ remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 branch=remoteCompile
 git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
-ssh $address "
-    cd $remotePath \
+ssh $address "sh -c \" \
+    cd \"$remotePath\" \
     && git checkout --force \$(git rev-parse $branch) \
     && git clean -d --force \
-"
+\""
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -70,6 +70,7 @@ git push $remote HEAD:$branch --force --no-verify
 ssh $address "
     cd $remotePath \
     && git checkout -f \$(git rev-parse $branch) \
+    && git clean -d \
 "
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL

--- a/scripts/remote
+++ b/scripts/remote
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Get base directory for better referencing
+BASEDIR=`cd $(dirname $0); pwd -P`
+BASEDIR=${BASEDIR%/*}
+
+# print help
+case $1 in
+    -[h?] | --help)
+        cat <<-__helpText__
+Usage: $0 [--help] [remote] [command]
+
+Pushes local changes a remote repository and executes a command there.
+Afterwards, build artifacts are rsync'ed back.
+
+remote:  The git remote to use
+command: Command to execute on the remote machine
+         Example: \`$0 ./pepsi build\`
+
+This script assumes at least one git remote to exist with an url similar to this:
+
+    \`ssh://user@domain/path/to/nao/repo.git\`
+__helpText__
+        exit
+esac
+
+# if the first parameter is the name of a valid remote, use it as the compiler
+remote=compiler
+if git remote get-url $1 &> /dev/null;
+then
+    remote=$1
+    shift
+fi
+echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
+
+# extract login information and remote path from git remote
+# assumes remote url of this format: `ssh://user@domain/path/to/nao/repo.git`
+remoteURL=$(git remote get-url $remote)
+address=$(echo $remoteURL | cut -d'/' -f 3)
+remotePath=/$(echo $remoteURL | cut -d'/' -f 4- | sed 's/\.git/\//')
+
+# save current state in commits, aka. "gwip"
+git add -A
+git rm $(git ls-files --deleted) 2> /dev/null
+git commit --no-verify --no-gpg-sign --allow-empty -m "--wip--RemoteCompile [skip ci]"
+
+# push everything to compiler slave
+git push $remote HEAD:main --force
+
+# restore previous state, aka. "gunwip"
+git log -n 1 | grep -q -c "\-\-wip\-\-RemoteCompile" && git reset HEAD~1
+
+# invoke compile script remotely
+ssh $address "source ~/.profile && cd $remotePath && $@"
+
+# fetch compilation results
+rsync -a --info=progress $address:$remotePath'target' . --include="*/" --include="nao" --include="webots" --exclude="*"
+

--- a/scripts/remote
+++ b/scripts/remote
@@ -45,7 +45,7 @@ git rm $(git ls-files --deleted) 2> /dev/null
 git commit --no-verify --no-gpg-sign --allow-empty -m "--wip--RemoteCompile [skip ci]"
 
 # push everything to compiler slave
-git push $remote HEAD:main --force
+git push $remote HEAD:main --force --no-verify
 
 # restore previous state, aka. "gunwip"
 git log -n 1 | grep -q -c "\-\-wip\-\-RemoteCompile" && git reset HEAD~1

--- a/scripts/remote
+++ b/scripts/remote
@@ -69,8 +69,8 @@ git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
 ssh $address "
     cd $remotePath \
-    && git checkout -f \$(git rev-parse $branch) \
-    && git clean -d -f \
+    && git checkout --force \$(git rev-parse $branch) \
+    && git clean -d --force \
 "
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL

--- a/scripts/remote
+++ b/scripts/remote
@@ -37,18 +37,13 @@ echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 # assumes remote url of this format: `ssh://user@domain/path/to/hulks/repo.git`
 remoteURL=$(git remote get-url $remote)
 address=$(echo $remoteURL | cut -d'/' -f 3)
-remotePath=/$(echo $remoteURL | cut -d'/' -f 4- | sed 's/\.git/\//')
+remoteGitPath=/$(echo $remoteURL | cut -d'/' -f 4-)
+remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 
-# save current state in commits, aka. "gwip"
-git add -A
-git rm $(git ls-files --deleted) 2> /dev/null
-git commit --no-verify --no-gpg-sign --allow-empty -m "--wip--RemoteCompile [skip ci]"
-
-# push everything to compiler slave
+# push HEAD to compiler remote
 git push $remote HEAD:main --force --no-verify
-
-# restore previous state, aka. "gunwip"
-git log -n 1 | grep -q -c "\--wip--RemoteCompile" && git reset HEAD~1
+# send all changes that aren't uncommitted yet
+git status -s | cut -c 4- | rsync -a --delete-missing-args --files-from=- "$BASEDIR" $address:$remotePath
 
 # invoke compile script remotely
 ssh $address "source ~/.profile; cd $remotePath && $@"

--- a/scripts/remote
+++ b/scripts/remote
@@ -67,7 +67,7 @@ remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 branch=remoteCompile
 git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
-ssh $address "sh -c \"set -x && \
+ssh $address "sh -c \"\
     cd "$remotePath" \
     && git checkout --force \\\$(git rev-parse $branch) \
     && git clean -d --force \

--- a/scripts/remote
+++ b/scripts/remote
@@ -1,36 +1,56 @@
 #!/bin/bash
 
-# Get base directory for better referencing
+# cd to repository base directory for better referencing
 BASEDIR=`cd $(dirname $0); pwd -P`
 BASEDIR=${BASEDIR%/*}
+cd "$BASEDIR"
 
 # print help
-case $1 in
-    -[h?] | --help)
-        cat <<-__helpText__
-Usage: $0 [--help] [remote] [command]
+print_help() {
+    cat <<-__helpText__
+Usage: $0 [OPTIONS] <Command>
 
-Pushes local changes a remote repository and executes a command there.
-Afterwards, build artifacts are rsync'ed back.
+Send local changes to a remote repository and execute a command there.
+Optionally, files can be rsync'ed back after.
 
-remote:  The git remote to use
 command: Command to execute on the remote machine
          Example: \`$0 ./pepsi build\`
+
+Options:
+
+  --remote <remote>     The git remote to use
+  --return-file <file>  Path of file to be returned.
+                        The file path must be relative to the repository.
 
 This script assumes at least one git remote to exist with an url similar to this:
 
     \`ssh://user@domain/path/to/hulks/repo.git\`
 __helpText__
-        exit
-esac
+}
 
-# if the first parameter is the name of a valid remote, use it as the compiler
 remote=compiler
-if git remote get-url $1 &> /dev/null;
-then
-    remote=$1
+files=()
+while true; do
+    case "$1" in
+        -[h?] | --help)
+            print_help
+            exit
+            ;;
+        --remote)
+            shift
+            remote=$1
+            ;;
+        --return-file)
+            shift
+            files+=($1)
+            ;;
+
+        *)
+            break
+            ;;
+    esac
     shift
-fi
+done
 echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 
 # extract login information and remote path from git remote
@@ -45,11 +65,13 @@ git push $remote HEAD:main --force --no-verify
 # check out pushed branch on the remote
 ssh $address "git --work-tree=$remotePath --git-dir=$remoteGitPath checkout -f main"
 # send all changes that aren't uncommitted yet
-git status -s | cut -c 4- | rsync -a --delete-missing-args --files-from=- "$BASEDIR" $address:$remotePath
+git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $address:$remotePath
 
 # invoke compile script remotely
 ssh $address "source ~/.profile; cd $remotePath && $@"
 
-# fetch compilation results
-rsync -a --info=progress $address:$remotePath'target' . --include="*/" --include="nao" --include="webots" --exclude="*"
+# fetch results
+echo Returning files
+printf '  %s\n' "${files[@]}"
+printf '%s\n' "${files[@]}" | rsync -a --info=progress --files-from=- $address:$remotePath .
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -57,10 +57,10 @@ done
 echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 
 # extract login information and remote path from git remote
-# assumes remote url of this format: `ssh://user@domain/path/to/hulks/repo.git`
+# assumes remote url of this format: `user@domain:path/to/hulks/repo.git`
 remoteURL=$(git remote get-url $remote)
-address=$(echo $remoteURL | cut -d'/' -f 3)
-remoteGitPath=/$(echo $remoteURL | cut -d'/' -f 4-)
+address=$(echo $remoteURL | cut -d':' -f 1)
+remoteGitPath=$(echo $remoteURL | cut -d':' -f 2-)
 remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 
 # push HEAD to compiler remote
@@ -68,7 +68,7 @@ git push $remote HEAD:main --force --no-verify
 # check out pushed branch on the remote
 ssh $address "git --work-tree=$remotePath --git-dir=$remoteGitPath checkout -f main"
 # send all changes that aren't uncommitted yet
-git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $address:$remotePath
+git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL
 
 # invoke compile script remotely
 ssh $address "sh -c \". '$HOME/.profile' && cd $remotePath && $@"\"
@@ -76,5 +76,5 @@ ssh $address "sh -c \". '$HOME/.profile' && cd $remotePath && $@"\"
 # fetch results
 echo Returning files
 printf '  %s\n' "${files[@]}"
-printf '%s\n' "${files[@]}" | rsync -a --info=progress --files-from=- $address:$remotePath .
+printf '%s\n' "${files[@]}" | rsync -a --info=progress --files-from=- $remoteURL .
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -71,7 +71,7 @@ ssh $address "git --work-tree=$remotePath --git-dir=$remoteGitPath checkout -f m
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $address:$remotePath
 
 # invoke compile script remotely
-ssh $address "source ~/.profile; cd $remotePath && $@"
+ssh $address "sh -c \". '$HOME/.profile' && cd $remotePath && $@"\"
 
 # fetch results
 echo Returning files

--- a/scripts/remote
+++ b/scripts/remote
@@ -42,6 +42,8 @@ remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 
 # push HEAD to compiler remote
 git push $remote HEAD:main --force --no-verify
+# check out pushed branch on the remote
+ssh $address "git --work-tree=$remotePath --git-dir=$remoteGitPath checkout -f main"
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --delete-missing-args --files-from=- "$BASEDIR" $address:$remotePath
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -19,7 +19,7 @@ command: Command to execute on the remote machine
 
 This script assumes at least one git remote to exist with an url similar to this:
 
-    \`ssh://user@domain/path/to/nao/repo.git\`
+    \`ssh://user@domain/path/to/hulks/repo.git\`
 __helpText__
         exit
 esac
@@ -34,7 +34,7 @@ fi
 echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 
 # extract login information and remote path from git remote
-# assumes remote url of this format: `ssh://user@domain/path/to/nao/repo.git`
+# assumes remote url of this format: `ssh://user@domain/path/to/hulks/repo.git`
 remoteURL=$(git remote get-url $remote)
 address=$(echo $remoteURL | cut -d'/' -f 3)
 remotePath=/$(echo $remoteURL | cut -d'/' -f 4- | sed 's/\.git/\//')
@@ -51,7 +51,7 @@ git push $remote HEAD:main --force --no-verify
 git log -n 1 | grep -q -c "\--wip--RemoteCompile" && git reset HEAD~1
 
 # invoke compile script remotely
-ssh $address "source ~/.profile && cd $remotePath && $@"
+ssh $address "source ~/.profile; cd $remotePath && $@"
 
 # fetch compilation results
 rsync -a --info=progress $address:$remotePath'target' . --include="*/" --include="nao" --include="webots" --exclude="*"

--- a/scripts/remote
+++ b/scripts/remote
@@ -64,9 +64,10 @@ remoteGitPath=$(echo $remoteURL | cut -d':' -f 2-)
 remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 
 # push HEAD to compiler remote
-git push $remote HEAD:main --force --no-verify
+branch=remoteCompile
+git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
-ssh $address "git --work-tree=$remotePath --git-dir=$remoteGitPath checkout -f main"
+ssh $address "cd $remotePath && git checkout -f \$(git rev-parse $branch)"
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -48,7 +48,7 @@ git commit --no-verify --no-gpg-sign --allow-empty -m "--wip--RemoteCompile [ski
 git push $remote HEAD:main --force --no-verify
 
 # restore previous state, aka. "gunwip"
-git log -n 1 | grep -q -c "\-\-wip\-\-RemoteCompile" && git reset HEAD~1
+git log -n 1 | grep -q -c "\--wip--RemoteCompile" && git reset HEAD~1
 
 # invoke compile script remotely
 ssh $address "source ~/.profile && cd $remotePath && $@"

--- a/scripts/remote
+++ b/scripts/remote
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# exit on error
+set -e
+
 # cd to repository base directory for better referencing
 BASEDIR=`cd $(dirname $0); pwd -P`
 BASEDIR=${BASEDIR%/*}

--- a/scripts/remote
+++ b/scripts/remote
@@ -67,12 +67,19 @@ remotePath=$(echo $remoteGitPath | sed 's/\.git/\//')
 branch=remoteCompile
 git push $remote HEAD:$branch --force --no-verify
 # check out pushed branch on the remote
-ssh $address "cd $remotePath && git checkout -f \$(git rev-parse $branch)"
+ssh $address "
+    cd $remotePath \
+    && git checkout -f \$(git rev-parse $branch) \
+"
 # send all changes that aren't uncommitted yet
 git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . $remoteURL
 
 # invoke compile script remotely
-ssh $address "sh -c \". '$HOME/.profile' && cd $remotePath && $@"\"
+ssh $address "sh -c \" \
+    . '$HOME/.profile' \
+    && cd $remotePath \
+    && $@\" \
+"
 
 # fetch results
 echo Returning files

--- a/scripts/remote
+++ b/scripts/remote
@@ -60,8 +60,7 @@ echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 # assumes remote url of this format: `user@domain:path/to/hulks/repo.git`
 remoteURL="$(git remote get-url $remote)"
 address="$(echo $remoteURL | cut -d':' -f 1)"
-remoteGitPath="$(echo $remoteURL | cut -d':' -f 2-)"
-remotePath="$(echo $remoteGitPath | sed 's/\.git/\//')"
+remotePath="$(echo $remoteURL | cut -d':' -f 2-)"
 
 # push HEAD to compiler remote
 branch=remoteCompile

--- a/scripts/remote
+++ b/scripts/remote
@@ -21,13 +21,18 @@ command: Command to execute on the remote machine
 
 Options:
 
-  --remote <remote>     The git remote to use
+  --remote <remote>     The git remote to use. Defaults to \`compiler\`
   --return-file <file>  Path of file to be returned.
                         The file path must be relative to the repository.
+                        Can be repeated to return multiple files.
 
-This script assumes at least one git remote to exist with an url similar to this:
+This script expects a git remote with an url similar to this:
 
-    \`ssh://user@domain/path/to/hulks/repo.git\`
+    \`user@host:path/to/hulks/repo\`
+
+It is recommended to use a dedicated remote worktree for this since
+it will be cleaned and synchronized with the local changes without
+regard for possible unsaved changes on the remote.
 __helpText__
 }
 
@@ -57,7 +62,7 @@ done
 echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
 
 # extract login information and remote path from git remote
-# assumes remote url of this format: `user@domain:path/to/hulks/repo.git`
+# assumes remote url of this format: `user@domain:path/to/hulk/repo`
 remoteURL="$(git remote get-url $remote)"
 address="$(echo $remoteURL | cut -d':' -f 1)"
 remotePath="$(echo $remoteURL | cut -d':' -f 2-)"

--- a/scripts/remote
+++ b/scripts/remote
@@ -36,7 +36,7 @@ regard for possible unsaved changes on the remote.
 __helpText__
 }
 
-remote=compiler
+remote="${COMPILER_REMOTE:-compiler}"
 files=()
 while true; do
     case "$1" in

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -18,6 +18,7 @@ pub struct Arguments {
     /// Pass through arguments to cargo ... -- PASSTHROUGH_ARGUMENTS
     #[arg(last = true, value_parser)]
     pub passthrough_arguments: Vec<String>,
+    /// Use a remote machine for compilation, see ./scripts/remote for details
     #[arg(long)]
     pub remote: bool,
 }

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -52,7 +52,10 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
                 command.arg("--");
                 command.args(arguments.passthrough_arguments);
 
-                command.status().await.wrap_err("failed to execute remote script")?;
+                command
+                    .status()
+                    .await
+                    .wrap_err("failed to execute remote script")?;
 
                 return Ok(());
             }

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -119,7 +119,7 @@ pub async fn remote(arguments: Arguments, command: Command) -> Result<()> {
                 .await
                 .wrap_err("failed to execute remote script")?;
 
-            return Ok(());
+            Ok(())
         }
         Command::Check | Command::Clippy | Command::Run => {
             unimplemented!("remote option is not compatible with cargo command: {command:?}")

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -98,7 +98,7 @@ pub async fn remote(arguments: Arguments, command: Command) -> Result<()> {
             ]);
 
             command
-                .arg("pepsi")
+                .arg("./pepsi")
                 .arg("build")
                 .arg("--profile")
                 .arg(arguments.profile)

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -35,6 +35,20 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
         match command {
             Command::Build => {
                 let mut command = TokioCommand::new("./scripts/remote");
+
+                let profile_name = match arguments.profile.as_str() {
+                    "dev" => "debug",
+                    other => other,
+                };
+                let toolchain_name = match arguments.target.as_str() {
+                    "nao" => "x86_64-aldebaran-linux-gnu/",
+                    _ => "",
+                };
+                command.args([
+                    "--return-file",
+                    &format!("target/{toolchain_name}{profile_name}/{}", arguments.target),
+                ]);
+
                 command
                     .arg("pepsi")
                     .arg("build")

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -47,6 +47,7 @@ pub struct Arguments {
     /// The NAOs to upload to with player number assignments e.g. 20w:2 or 10.1.24.22:5 (player numbers start from 1)
     #[arg(required = true)]
     pub assignments: Vec<NaoAddressPlayerAssignment>,
+    /// Use a remote machine for compilation, see ./scripts/remote for details
     #[arg(long)]
     pub remote: bool,
 }

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -47,6 +47,8 @@ pub struct Arguments {
     /// The NAOs to upload to with player number assignments e.g. 20w:2 or 10.1.24.22:5 (player numbers start from 1)
     #[arg(required = true)]
     pub assignments: Vec<NaoAddressPlayerAssignment>,
+    #[arg(long)]
+    pub remote: bool,
 }
 
 pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<()> {
@@ -86,6 +88,7 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
             no_communication: !arguments.with_communication,
             skip_os_check: arguments.skip_os_check,
             naos: naos.clone(),
+            remote: arguments.remote,
         },
         repository,
     )

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -41,6 +41,7 @@ pub struct Arguments {
     /// The NAOs to upload to e.g. 20w or 10.1.24.22
     #[arg(required = true)]
     pub naos: Vec<NaoAddress>,
+    /// Use a remote machine for compilation, see ./scripts/remote for details
     #[arg(long)]
     pub remote: bool,
 }

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -41,6 +41,8 @@ pub struct Arguments {
     /// The NAOs to upload to e.g. 20w or 10.1.24.22
     #[arg(required = true)]
     pub naos: Vec<NaoAddress>,
+    #[arg(long)]
+    pub remote: bool,
 }
 
 fn get_head_id<'a>(
@@ -114,6 +116,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
                 target: "nao".to_string(),
                 no_sdk_installation: arguments.no_sdk_installation,
                 passthrough_arguments: Vec::new(),
+                remote: arguments.remote,
             },
             repository,
             Command::Build,


### PR DESCRIPTION
## Introduced Changes

Yes, its a hack, but pending a better distributed/remote compilation solution this has the potential to decrease build times by an order of magnitude.

Fixes #

## ToDo / Known Issues

- [x] The git shenanigans currently unstage staged but uncommitted changes. ~~Not sure if there is a way around this.~~
  - [x] ~~Use `git diff` / `git apply` and send a patch instead of gwip / gunwip~~
  - [x] ... or just rsync all uncommited changes
- [x] Move return channel from script to pepsi.
  - This would allow more selectively rsyncing compile artifacts because we know target and profile
  - Also prevents rsyncing artifacts when running commands that don't produce any directly via the script
- [x] Move checkout operation from post-update hook on the remote to script

## Ideas for Next Iterations (Not This PR)

## How to Test

clone bare repo to `path/to/repo.git` on the remote host. 
```sh
git remote add compiler user@host:path/to/repo.git
./pepsi upload <number> --remote
```
