### PR TITLE
Time to reach kick position with speeds

### DIFF
--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
@@ -35,6 +37,8 @@ pub struct MainOutputs {
     pub primary_state: MainOutput<PrimaryState>,
     pub robot_to_field: MainOutput<Option<Isometry2<f32>>>,
     pub sensor_data: MainOutput<SensorData>,
+    pub stand_up_front_remaining_duration: MainOutput<Duration>,
+    pub stand_up_back_remaining_duration: MainOutput<Duration>,
 }
 
 impl FakeData {

--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -37,8 +37,8 @@ pub struct MainOutputs {
     pub primary_state: MainOutput<PrimaryState>,
     pub robot_to_field: MainOutput<Option<Isometry2<f32>>>,
     pub sensor_data: MainOutput<SensorData>,
-    pub stand_up_front_remaining_duration: MainOutput<Duration>,
-    pub stand_up_back_remaining_duration: MainOutput<Duration>,
+    pub stand_up_front_estimated_remaining_duration: MainOutput<Option<Duration>>,
+    pub stand_up_back_estimated_remaining_duration: MainOutput<Option<Duration>>,
 }
 
 impl FakeData {

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -39,7 +39,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub stand_up_back_positions: MainOutput<Joints<f32>>,
-    pub stand_up_back_remaining_duration: MainOutput<Duration>,
+    pub stand_up_back_estimated_remaining_duration: MainOutput<Option<Duration>>,
 }
 
 impl StandUpBack {
@@ -68,16 +68,18 @@ impl StandUpBack {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let mut stand_up_back_remaining_duration = Duration::ZERO;
+        let mut stand_up_back_estimated_remaining_duration = None;
         if let MotionType::StandUpBack = context.motion_selection.current_motion {
             self.advance_interpolator(context);
-            stand_up_back_remaining_duration = self.interpolator.remaining_estimated_duration();
+            stand_up_back_estimated_remaining_duration =
+                Some(self.interpolator.remaining_estimated_duration());
         } else {
             self.interpolator.reset();
         };
         Ok(MainOutputs {
             stand_up_back_positions: self.interpolator.value().into(),
-            stand_up_back_remaining_duration: stand_up_back_remaining_duration.into(),
+            stand_up_back_estimated_remaining_duration: stand_up_back_estimated_remaining_duration
+                .into(),
         })
     }
 }

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -71,7 +71,7 @@ impl StandUpBack {
         let stand_up_back_estimated_remaining_duration =
             if let MotionType::StandUpBack = context.motion_selection.current_motion {
                 self.advance_interpolator(context);
-                Some(self.interpolator.remaining_estimated_duration())
+                Some(self.interpolator.estimated_remaining_duration())
             } else {
                 self.interpolator.reset();
                 None

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
@@ -37,6 +39,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub stand_up_back_positions: MainOutput<Joints<f32>>,
+    pub stand_up_back_remaining_duration: MainOutput<Duration>,
 }
 
 impl StandUpBack {
@@ -65,13 +68,16 @@ impl StandUpBack {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        let mut stand_up_back_remaining_duration = Duration::ZERO;
         if let MotionType::StandUpBack = context.motion_selection.current_motion {
             self.advance_interpolator(context);
+            stand_up_back_remaining_duration = self.interpolator.remaining_estimated_duration();
         } else {
             self.interpolator.reset();
         };
         Ok(MainOutputs {
             stand_up_back_positions: self.interpolator.value().into(),
+            stand_up_back_remaining_duration: stand_up_back_remaining_duration.into(),
         })
     }
 }

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -68,14 +68,14 @@ impl StandUpBack {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let mut stand_up_back_estimated_remaining_duration = None;
-        if let MotionType::StandUpBack = context.motion_selection.current_motion {
-            self.advance_interpolator(context);
-            stand_up_back_estimated_remaining_duration =
-                Some(self.interpolator.remaining_estimated_duration());
-        } else {
-            self.interpolator.reset();
-        };
+        let stand_up_back_estimated_remaining_duration =
+            if let MotionType::StandUpBack = context.motion_selection.current_motion {
+                self.advance_interpolator(context);
+                Some(self.interpolator.remaining_estimated_duration())
+            } else {
+                self.interpolator.reset();
+                None
+            };
         Ok(MainOutputs {
             stand_up_back_positions: self.interpolator.value().into(),
             stand_up_back_estimated_remaining_duration: stand_up_back_estimated_remaining_duration

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -67,14 +67,14 @@ impl StandUpFront {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let mut stand_up_front_estimated_remaining_duration = None;
-        if let MotionType::StandUpFront = context.motion_selection.current_motion {
-            self.advance_interpolator(context);
-            stand_up_front_estimated_remaining_duration =
-                Some(self.interpolator.remaining_estimated_duration());
-        } else {
-            self.interpolator.reset();
-        }
+        let stand_up_front_estimated_remaining_duration =
+            if let MotionType::StandUpFront = context.motion_selection.current_motion {
+                self.advance_interpolator(context);
+                Some(self.interpolator.remaining_estimated_duration())
+            } else {
+                self.interpolator.reset();
+                None
+            };
         Ok(MainOutputs {
             stand_up_front_positions: self.interpolator.value().into(),
             stand_up_front_estimated_remaining_duration:

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
@@ -38,6 +40,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub stand_up_front_positions: MainOutput<Joints<f32>>,
+    pub stand_up_front_remaining_duration: MainOutput<Duration>,
 }
 
 impl StandUpFront {
@@ -64,13 +67,16 @@ impl StandUpFront {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        let mut stand_up_front_remaining_duration = Duration::ZERO;
         if let MotionType::StandUpFront = context.motion_selection.current_motion {
             self.advance_interpolator(context);
+            stand_up_front_remaining_duration = self.interpolator.remaining_estimated_duration();
         } else {
             self.interpolator.reset();
         }
         Ok(MainOutputs {
             stand_up_front_positions: self.interpolator.value().into(),
+            stand_up_front_remaining_duration: stand_up_front_remaining_duration.into(),
         })
     }
 }

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -70,7 +70,7 @@ impl StandUpFront {
         let stand_up_front_estimated_remaining_duration =
             if let MotionType::StandUpFront = context.motion_selection.current_motion {
                 self.advance_interpolator(context);
-                Some(self.interpolator.remaining_estimated_duration())
+                Some(self.interpolator.estimated_remaining_duration())
             } else {
                 self.interpolator.reset();
                 None

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -40,7 +40,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub stand_up_front_positions: MainOutput<Joints<f32>>,
-    pub stand_up_front_remaining_duration: MainOutput<Duration>,
+    pub stand_up_front_estimated_remaining_duration: MainOutput<Option<Duration>>,
 }
 
 impl StandUpFront {
@@ -67,16 +67,18 @@ impl StandUpFront {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let mut stand_up_front_remaining_duration = Duration::ZERO;
+        let mut stand_up_front_estimated_remaining_duration = None;
         if let MotionType::StandUpFront = context.motion_selection.current_motion {
             self.advance_interpolator(context);
-            stand_up_front_remaining_duration = self.interpolator.remaining_estimated_duration();
+            stand_up_front_estimated_remaining_duration =
+                Some(self.interpolator.remaining_estimated_duration());
         } else {
             self.interpolator.reset();
         }
         Ok(MainOutputs {
             stand_up_front_positions: self.interpolator.value().into(),
-            stand_up_front_remaining_duration: stand_up_front_remaining_duration.into(),
+            stand_up_front_estimated_remaining_duration:
+                stand_up_front_estimated_remaining_duration.into(),
         })
     }
 }

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -68,7 +68,7 @@ impl TimeToReachKickPosition {
         context
             .time_to_reach_kick_position_output
             .fill_if_subscribed(|| time_to_reach_kick_position);
-        // 1800 seconds is 30 minutes, which is essentially max as it pertains to game time.
+        // 1800 seconds is 30 minutes, which is essentially maximum as it pertains to game time.
         // Prevents Duration::MAX from breaking the behavior simulator.
         *context.time_to_reach_kick_position = time_to_reach_kick_position
             .unwrap_or(Duration::MAX)

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -35,11 +35,14 @@ impl TimeToReachKickPosition {
             .map(|path| {
                 path.iter()
                     .map(|segment: &PathSegment| {
-                        if matches!(segment, PathSegment::LineSegment(..)) {
-                            segment.length()
-                                / context.configuration.path_planning.line_walking_speed
-                        } else {
-                            segment.length() / context.configuration.path_planning.arc_walking_speed
+                        let length = segment.length();
+                        match segment {
+                            PathSegment::LineSegment(_) => {
+                                length / context.configuration.path_planning.line_walking_speed
+                            }
+                            PathSegment::Arc(_, _) => {
+                                length / context.configuration.path_planning.arc_walking_speed
+                            }
                         }
                     })
                     .sum()

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -9,8 +9,10 @@ pub struct CycleContext {
     pub dribble_path: Input<Option<Vec<PathSegment>>, "dribble_path?">,
     pub time_to_reach_kick_position: PersistentState<Duration, "time_to_reach_kick_position">,
     pub configuration: Parameter<Behavior, "behavior">,
-    pub stand_up_back_remaining_duration: Input<Duration, "stand_up_back_remaining_duration">,
-    pub stand_up_front_remaining_duration: Input<Duration, "stand_up_front_remaining_duration">,
+    pub stand_up_back_estimated_remaining_duration:
+        Input<Option<Duration>, "stand_up_back_estimated_remaining_duration?">,
+    pub stand_up_front_estimated_remaining_duration:
+        Input<Option<Duration>, "stand_up_front_estimated_remaining_duration?">,
 }
 
 #[context]
@@ -45,8 +47,12 @@ impl TimeToReachKickPosition {
             .map(Duration::from_secs_f32);
         let time_to_reach_kick_position = (walk_time).map(|walk_time| {
             walk_time
-                + *context.stand_up_back_remaining_duration
-                + *context.stand_up_front_remaining_duration
+                + *context
+                    .stand_up_back_estimated_remaining_duration
+                    .unwrap_or(&Duration::ZERO)
+                + *context
+                    .stand_up_front_estimated_remaining_duration
+                    .unwrap_or(&Duration::ZERO)
         });
 
         *context.time_to_reach_kick_position =

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -1,5 +1,5 @@
 use color_eyre::Result;
-use types::{configuration::Behavior, PathSegment};
+use types::{parameters::Behavior, PathSegment};
 
 use std::time::Duration;
 

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -48,7 +48,7 @@ impl TimeToReachKickPosition {
                     .sum()
             })
             .map(Duration::from_secs_f32);
-        let time_to_reach_kick_position = (walk_time).map(|walk_time| {
+        let time_to_reach_kick_position = walk_time.map(|walk_time| {
             walk_time
                 + *context
                     .stand_up_back_estimated_remaining_duration

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -69,7 +69,7 @@ impl TimeToReachKickPosition {
             .time_to_reach_kick_position_output
             .fill_if_subscribed(|| time_to_reach_kick_position);
         // 1800 seconds is 30 minutes, which is essentially max as it pertains to game time.
-        // Prevents Duration::MAX from breaking the behavior sim.
+        // Prevents Duration::MAX from breaking the behavior simulator.
         *context.time_to_reach_kick_position = time_to_reach_kick_position
             .unwrap_or(Duration::MAX)
             .min(Duration::from_secs(1800));

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -58,10 +58,12 @@ impl TimeToReachKickPosition {
                     .unwrap_or(&Duration::ZERO)
         });
 
-        *context.time_to_reach_kick_position =
-            time_to_reach_kick_position.unwrap_or(Duration::from_secs(1800));
-        /*1800 seconds is 30 minutes, which is essentially max as it pertains to game time and prevents Duration::MAX from breaking the behavior sim
-         */
+        // 1800 seconds is 30 minutes, which is essentially max as it pertains to game time.
+        // Prevents Duration::MAX from breaking the behavior sim.
+        *context.time_to_reach_kick_position = time_to_reach_kick_position
+            .unwrap_or(Duration::MAX)
+            .min(Duration::from_secs(1800));
+
         Ok(MainOutputs {})
     }
 }

--- a/crates/motionfile/src/motion_interpolator.rs
+++ b/crates/motionfile/src/motion_interpolator.rs
@@ -229,7 +229,7 @@ impl<T: Debug + Interpolate<f32>> MotionInterpolator<T> {
         }
     }
 
-    pub fn remaining_estimated_duration(&self) -> Duration {
+    pub fn estimated_remaining_duration(&self) -> Duration {
         match self.current_state.current_frame_index() {
             Some(index) => {
                 let mut remaining = self

--- a/crates/motionfile/src/motion_interpolator.rs
+++ b/crates/motionfile/src/motion_interpolator.rs
@@ -243,7 +243,10 @@ impl<T: Debug + Interpolate<f32>> MotionInterpolator<T> {
                     State::CheckEntry { .. } => self.frames[index].spline.total_duration(),
                     State::InterpolateSpline {
                         time_since_start, ..
-                    } => self.frames[index].spline.total_duration() - time_since_start,
+                    } => Duration::saturating_sub(
+                        self.frames[index].spline.total_duration(),
+                        time_since_start,
+                    ),
                     State::CheckExit { .. } => Duration::ZERO,
                     State::Finished => Duration::ZERO,
                     State::Aborted { .. } => Duration::MAX,

--- a/crates/motionfile/src/motion_interpolator.rs
+++ b/crates/motionfile/src/motion_interpolator.rs
@@ -63,7 +63,6 @@ impl<T> State<T> {
         }
     }
 
-    #[must_use]
     fn is_aborted(&self) -> bool {
         matches!(self, Self::Aborted { .. })
     }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -188,13 +188,13 @@ pub struct InterceptBall {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
 pub struct PathPlanning {
-    pub robot_radius_at_foot_height: f32,
-    pub minimum_robot_radius_at_foot_height: f32,
-    pub robot_radius_at_hip_height: f32,
+    pub arc_walking_speed: f32,
     pub ball_obstacle_radius: f32,
     pub field_border_weight: f32,
     pub line_walking_speed: f32,
-    pub arc_walking_speed: f32,
+    pub minimum_robot_radius_at_foot_height: f32,
+    pub robot_radius_at_foot_height: f32,
+    pub robot_radius_at_hip_height: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -193,6 +193,8 @@ pub struct PathPlanning {
     pub robot_radius_at_hip_height: f32,
     pub ball_obstacle_radius: f32,
     pub field_border_weight: f32,
+    pub line_walking_speed: f32,
+    pub arc_walking_speed: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -822,7 +822,9 @@
       "robot_radius_at_foot_height": 0.2,
       "minimum_robot_radius_at_foot_height": 0.07,
       "ball_obstacle_radius": 0.05,
-      "field_border_weight": 0.15
+      "field_border_weight": 0.15,
+      "line_walking_speed": 0.25,
+      "arc_walking_speed": 0.2
     },
     "search": {
       "position_reached_distance": 0.4,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -369,6 +369,12 @@ impl BehaviorCycler {
                         .stand_up_front_estimated_remaining_duration
                         .as_ref(),
                     configuration: &parameters.behavior,
+                    time_to_reach_kick_position_output: framework::AdditionalOutput::new(
+                        true,
+                        &mut own_database
+                            .additional_outputs
+                            .time_to_reach_kick_position_output,
+                    ),
                 })
                 .wrap_err("failed to execute cycle of `TimeToReachKickPosition`");
         }

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -368,7 +368,7 @@ impl BehaviorCycler {
                         .main_outputs
                         .stand_up_front_estimated_remaining_duration
                         .as_ref(),
-                    configuration: &configuration.behavior,
+                    configuration: &parameters.behavior,
                 })
                 .wrap_err("failed to execute cycle of `TimeToReachKickPosition`");
         }

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -360,12 +360,14 @@ impl BehaviorCycler {
                         .persistent_state
                         .time_to_reach_kick_position,
                     dribble_path: own_database.main_outputs.dribble_path.as_ref(),
-                    stand_up_back_remaining_duration: &own_database
+                    stand_up_back_estimated_remaining_duration: own_database
                         .main_outputs
-                        .stand_up_back_remaining_duration,
-                    stand_up_front_remaining_duration: &own_database
+                        .stand_up_back_estimated_remaining_duration
+                        .as_ref(),
+                    stand_up_front_estimated_remaining_duration: own_database
                         .main_outputs
-                        .stand_up_front_remaining_duration,
+                        .stand_up_front_estimated_remaining_duration
+                        .as_ref(),
                     configuration: &configuration.behavior,
                 })
                 .wrap_err("failed to execute cycle of `TimeToReachKickPosition`");

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -360,6 +360,13 @@ impl BehaviorCycler {
                         .persistent_state
                         .time_to_reach_kick_position,
                     dribble_path: own_database.main_outputs.dribble_path.as_ref(),
+                    stand_up_back_remaining_duration: &own_database
+                        .main_outputs
+                        .stand_up_back_remaining_duration,
+                    stand_up_front_remaining_duration: &own_database
+                        .main_outputs
+                        .stand_up_front_remaining_duration,
+                    configuration: &configuration.behavior,
                 })
                 .wrap_err("failed to execute cycle of `TimeToReachKickPosition`");
         }


### PR DESCRIPTION
## Introduced Changes

Use configuration parameters for walking straight or arced paths. Add extra time to time to reach kick position based on fall state.

Based on #386 
Fixes #315 

## ToDo / Known Issues

The new config parameters may need to be further tuned.

## Ideas for Next Iterations (Not This PR)

~Does standup front take a different amount of time than standup back? If so split up.~
Also walking straight vs walking straight while slightly turning relative to robot local z axis might also have a different speed than just walking straight. (see Hybrid Alignment)

Long term goal: Robot detects own walking speed and time it takes to stand up and adjusts time to reach over the course of the game.

## How to Test

From #386
> Striker choosing behavior should appear different from current code. If a robot has to walk towards own goal to get behind the ball that path may now be longer than a robot that can just walk forwards in order to reach the ball, leading to more efficient striker selection. 

New to this PR:
A fallen robot closer to the ball should no longer be prioritized over a standing but slightly further away robot.
