### PR TITLE
Ball interception v2

### DIFF
--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -64,6 +64,10 @@ pub fn execute(
             let interception_point = ball.ball_in_ground
                 - ball.ball_in_ground.coords.dot(&normalized_velocity) * normalized_velocity;
 
+            if interception_point.coords.norm() > parameters.maximum_intercept_distance {
+                return None;
+            }
+
             Some(MotionCommand::Walk {
                 head: HeadMotion::LookAt {
                     target: ball.ball_in_ground,

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -1,14 +1,16 @@
-use nalgebra::{Isometry2, Point2, UnitComplex};
+use nalgebra::{Isometry2, Point2, UnitComplex, Vector2};
 use spl_network_messages::{GamePhase, SubState};
 use types::{
-    parameters::InterceptBall, BallState, FilteredGameState, GameControllerState, HeadMotion,
-    LineSegment, MotionCommand, OrientationMode, PathSegment, Step, WorldState,
+    parameters::InterceptBall, Arc, BallState, Circle, FilteredGameState, GameControllerState,
+    HeadMotion, LineSegment, MotionCommand, Orientation, OrientationMode, PathSegment, Step,
+    WorldState,
 };
 
 pub fn execute(
     world_state: &WorldState,
     parameters: InterceptBall,
     maximum_step_size: Step,
+    current_step: Step,
 ) -> Option<MotionCommand> {
     if let Some(
         GameControllerState {
@@ -50,22 +52,46 @@ pub fn execute(
             let normalized_velocity = ball.ball_in_ground_velocity.normalize();
 
             // Find the point with the least distance from the line traversed by the ball
-            let interception_point = ball.ball_in_ground
+            let optimal_interception_point = ball.ball_in_ground
                 - ball.ball_in_ground.coords.dot(&normalized_velocity) * normalized_velocity;
 
-            if interception_point.coords.norm() > parameters.maximum_intercept_distance {
+            if optimal_interception_point.coords.norm() > parameters.maximum_intercept_distance {
                 return None;
             }
+
+            let walking_direction = Vector2::new(current_step.forward, current_step.left);
+            let path = if walking_direction.norm() < 0.1 {
+                vec![PathSegment::LineSegment(LineSegment(
+                    Point2::origin(),
+                    optimal_interception_point,
+                ))]
+            } else {
+                // If we are moving, we can not change the direction instantaneously without
+                // slowing down. Instead, traverse an Arc with radius dependent on the current
+                // speed until the direction is changed.
+                let arc_radius = walking_direction.norm();
+                let arc = calculate_arc_tangent_to(
+                    walking_direction,
+                    optimal_interception_point.coords,
+                    arc_radius,
+                );
+                let arc_orientation =
+                    Orientation::triangle_orientation(arc.circle.center, arc.start, arc.end);
+
+                let interception_point = optimal_interception_point + (arc.end - arc.circle.center);
+
+                vec![
+                    PathSegment::Arc(arc, arc_orientation),
+                    PathSegment::LineSegment(LineSegment(arc.end, interception_point)),
+                ]
+            };
 
             Some(MotionCommand::Walk {
                 head: HeadMotion::LookAt {
                     target: ball.ball_in_ground,
                     camera: None,
                 },
-                path: vec![PathSegment::LineSegment(LineSegment(
-                    Point2::origin(),
-                    interception_point,
-                ))],
+                path,
                 left_arm: types::ArmMotion::Swing,
                 right_arm: types::ArmMotion::Swing,
                 orientation_mode: OrientationMode::Override(UnitComplex::default()),
@@ -95,4 +121,17 @@ fn ball_is_interception_candidate(
         && ball_moving
         && ball_moving_towards_robot
         && ball_moving_towards_own_half
+}
+
+fn calculate_arc_tangent_to(vector1: Vector2<f32>, vector2: Vector2<f32>, radius: f32) -> Arc {
+    let normalized_vector1 = vector1.normalize();
+    let normalized_vector2 = vector2.normalize();
+    let sin1 = Vector2::new(1.0, 0.0).dot(&normalized_vector1);
+    let sin2 = Vector2::new(1.0, 0.0).dot(&normalized_vector2);
+    let cos1 = Vector2::new(0.0, 1.0).dot(&normalized_vector1);
+    let cos2 = Vector2::new(0.0, 1.0).dot(&normalized_vector2);
+
+    let arc_center = Point2::new(radius * -sin1, radius * cos1);
+    let end_point = Point2::new(radius * sin2, radius * (1.0 - cos2));
+    Arc::new(Circle::new(arc_center, radius), Point2::origin(), end_point)
 }

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -87,21 +87,21 @@ fn ball_is_interception_candidate(
     robot_to_field: Isometry2<f32>,
     parameters: &InterceptBall,
 ) -> bool {
-    let ball_in_front_of_robot = ball.ball_in_ground.coords.norm()
+    let ball_is_in_front_of_robot = ball.ball_in_ground.coords.norm()
         < parameters.maximum_ball_distance
         && ball.ball_in_ground.x > 0.0;
-    let ball_moving_towards_robot =
+    let ball_is_moving_towards_robot =
         ball.ball_in_ground_velocity.x < -parameters.minimum_ball_velocity_towards_robot;
 
     let ball_in_field_velocity = robot_to_field * ball.ball_in_ground_velocity;
-    let ball_moving = ball_in_field_velocity.norm() > parameters.minimum_ball_velocity;
-    let ball_moving_towards_own_half =
+    let ball_is_moving = ball_in_field_velocity.norm() > parameters.minimum_ball_velocity;
+    let ball_is_moving_towards_own_half =
         ball_in_field_velocity.x < -parameters.minimum_ball_velocity_towards_own_half;
 
-    ball_in_front_of_robot
-        && ball_moving
-        && ball_moving_towards_robot
-        && ball_moving_towards_own_half
+    ball_is_in_front_of_robot
+        && ball_is_moving
+        && ball_is_moving_towards_robot
+        && ball_is_moving_towards_own_half
 }
 
 fn get_interception_path(

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -157,3 +157,47 @@ fn calculate_arc_tangent_to(
         arc_orientation,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_relative_eq;
+    use nalgebra::vector;
+    use types::{Arc, Orientation};
+
+    use super::calculate_arc_tangent_to;
+
+    #[test]
+    fn arc_is_tangent() {
+        let vector1 = vector![-1.4, 3.1];
+        let vector2 = vector![0.9, -2.1];
+
+        let (arc, _) = calculate_arc_tangent_to(vector1, vector2, 3.0);
+        let Arc { start, circle, end } = arc;
+        let center = circle.center;
+
+        assert_relative_eq!((start - center).dot(&vector1), 0.0, epsilon = 0.00001);
+        assert_relative_eq!((end - center).dot(&vector2), 0.0, epsilon = 0.00001);
+    }
+
+    #[test]
+    fn colinear_arc_has_same_start_end() {
+        let vector1 = vector![-3.1, 1.9];
+        let vector2 = vector![-6.2, 3.8];
+
+        let (arc, _) = calculate_arc_tangent_to(vector1, vector2, 3.0);
+
+        assert_relative_eq!(arc.start, arc.end);
+    }
+
+    #[test]
+    fn arc_orientation() {
+        let vector1 = vector![1.3, 4.8];
+        let vector2 = vector![1.2, 5.7];
+
+        let (_, orientation1) = calculate_arc_tangent_to(vector1, vector2, 3.0);
+        let (_, orientation2) = calculate_arc_tangent_to(vector2, vector1, 3.0);
+
+        assert_eq!(orientation1, Orientation::Counterclockwise);
+        assert_eq!(orientation2, Orientation::Clockwise);
+    }
+}

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -153,7 +153,7 @@ fn calculate_arc_tangent_to(
     let start = Point2::origin();
 
     let orientation =
-        Orientation::triangle_orientation(start, start + vector1, start + vector1 + vector2);
+        LineSegment::new(start, start + vector1).get_orientation(start + vector1 + vector2);
 
     let normal_vector1 = orientation.rotate_vector_90_degrees(vector1).normalize();
     let normal_vector2 = orientation.rotate_vector_90_degrees(vector2).normalize();

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -35,7 +35,7 @@ pub fn execute(
             Some(ball),
             Some(robot_to_field),
         ) => {
-            if !ball_is_interception_candidate(ball, robot_to_field, parameters) {
+            if !ball_is_interception_candidate(ball, robot_to_field, &parameters) {
                 return None;
             }
 
@@ -60,7 +60,8 @@ pub fn execute(
             }
 
             let walking_direction = Vector2::new(current_step.forward, current_step.left);
-            let path = get_interception_path(optimal_interception_point, walking_direction);
+            let path =
+                get_interception_path(optimal_interception_point, walking_direction, &parameters);
 
             Some(MotionCommand::Walk {
                 head: HeadMotion::LookAt {
@@ -80,7 +81,7 @@ pub fn execute(
 fn ball_is_interception_candidate(
     ball: BallState,
     robot_to_field: Isometry2<f32>,
-    parameters: InterceptBall,
+    parameters: &InterceptBall,
 ) -> bool {
     let ball_in_front_of_robot = ball.ball_in_ground.coords.norm()
         < parameters.maximum_ball_distance
@@ -102,8 +103,9 @@ fn ball_is_interception_candidate(
 fn get_interception_path(
     optimal_interception_point: Point2<f32>,
     walking_direction: Vector2<f32>,
+    parameters: &InterceptBall,
 ) -> Vec<PathSegment> {
-    if walking_direction.norm() < 0.1 {
+    if walking_direction.norm() < parameters.minimum_arc_radius {
         vec![PathSegment::LineSegment(LineSegment(
             Point2::origin(),
             optimal_interception_point,

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -130,7 +130,10 @@ fn get_interception_path(
     }
 
     // If the arc and angle changes are within range, rotate current direction by angle and bridge
-    // the path between current position and line segment to interception point by a tangent arc
+    // the path between current position and line segment to interception point by a tangent arc.
+    // This rotation is required because the step planner walks in the direction tangent to a arc
+    // and the arc is created tangent to the current direction, so we have to rotate the direction
+    // slightly for traversing the arc.
     let direction = UnitComplex::new(angle_change) * walking_direction;
 
     let (arc, arc_orientation) =

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -38,10 +38,14 @@ pub fn execute(
                 && ball.ball_in_ground.x > 0.0;
             let ball_moving_towards_robot =
                 ball.ball_in_ground_velocity.x < -parameters.minimum_ball_velocity_towards_robot;
-            let ball_moving_towards_own_half = (robot_to_field * ball.ball_in_ground_velocity).x
-                < -parameters.minimum_ball_velocity_towards_own_half;
+
+            let ball_in_field_velocity = robot_to_field * ball.ball_in_ground_velocity;
+            let ball_moving = ball_in_field_velocity.norm() > parameters.minimum_ball_velocity;
+            let ball_moving_towards_own_half =
+                ball_in_field_velocity.x < -parameters.minimum_ball_velocity_towards_own_half;
 
             if !(ball_in_front_of_robot
+                && ball_moving
                 && ball_moving_towards_robot
                 && ball_moving_towards_own_half)
             {

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -8,7 +8,7 @@ use spl_network_messages::{GamePhase, GameState, SubState, Team};
 use types::{
     parameters::{Behavior as BehaviorParameters, InWalkKicks, InterceptBall, LostBall},
     Action, CycleTime, FieldDimensions, FilteredGameState, GameControllerState, MotionCommand,
-    PathObstacle, PathSegment, PrimaryState, Role, Side, WorldState,
+    PathObstacle, PathSegment, PrimaryState, Role, Side, Step, WorldState,
 };
 
 use super::{
@@ -49,6 +49,7 @@ pub struct CycleContext {
     pub field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
     pub lost_ball_parameters: Parameter<LostBall, "behavior.lost_ball">,
     pub intercept_ball_parameters: Parameter<InterceptBall, "behavior.intercept_ball">,
+    pub maximum_step_size: Parameter<Step, "step_planner.max_step_size">,
 }
 
 #[context]
@@ -187,9 +188,11 @@ impl Behavior {
                     }
                     Action::StandUp => stand_up::execute(world_state),
                     Action::LookAround => look_around::execute(world_state),
-                    Action::InterceptBall => {
-                        intercept_ball::execute(world_state, *context.intercept_ball_parameters)
-                    }
+                    Action::InterceptBall => intercept_ball::execute(
+                        world_state,
+                        *context.intercept_ball_parameters,
+                        *context.maximum_step_size,
+                    ),
                     Action::Calibrate => calibrate::execute(world_state),
                     Action::DefendGoal => defend.goal(&mut context.path_obstacles),
                     Action::DefendKickOff => defend.kick_off(&mut context.path_obstacles),

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -44,6 +44,8 @@ pub struct CycleContext {
     pub cycle_time: Input<CycleTime, "cycle_time">,
     pub dribble_path: Input<Option<Vec<PathSegment>>, "dribble_path?">,
 
+    pub current_step: PersistentState<Step, "current_step">,
+
     pub parameters: Parameter<BehaviorParameters, "behavior">,
     pub in_walk_kicks: Parameter<InWalkKicks, "in_walk_kicks">,
     pub field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
@@ -192,6 +194,7 @@ impl Behavior {
                         world_state,
                         *context.intercept_ball_parameters,
                         *context.maximum_step_size,
+                        *context.current_step,
                     ),
                     Action::Calibrate => calibrate::execute(world_state),
                     Action::DefendGoal => defend.goal(&mut context.path_obstacles),

--- a/crates/control/src/motion/walking_engine.rs
+++ b/crates/control/src/motion/walking_engine.rs
@@ -127,6 +127,7 @@ pub struct CycleContext {
 
     pub motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
     pub walk_return_offset: PersistentState<Step, "walk_return_offset">,
+    pub current_step: PersistentState<Step, "current_step">,
 
     pub motion_command: Input<MotionCommand, "motion_command">,
     pub robot_kinematics: Input<RobotKinematics, "robot_kinematics">,
@@ -330,6 +331,7 @@ impl WalkingEngine {
 
         context.motion_safe_exits[MotionType::Walk] =
             matches!(self.walk_state, WalkState::Standing);
+        *context.current_step = self.current_step;
 
         let leg_stiffness = match self.walk_state {
             WalkState::Standing => context.config.leg_stiffness_stand,

--- a/crates/types/src/geometry.rs
+++ b/crates/types/src/geometry.rs
@@ -20,26 +20,6 @@ impl Orientation {
             Orientation::Colinear => subject,
         }
     }
-
-    pub fn triangle_orientation(
-        point1: Point2<f32>,
-        point2: Point2<f32>,
-        point3: Point2<f32>,
-    ) -> Self {
-        let (x1, y1) = (point1.x, point1.y);
-        let (x2, y2) = (point2.x, point2.y);
-        let (x3, y3) = (point3.x, point3.y);
-
-        let orientation = x1 * y2 + x2 * y3 + x3 * y1 - x1 * y3 - x2 * y1 - x3 * y2;
-
-        if orientation == 0.0 {
-            Self::Colinear
-        } else if orientation.is_sign_negative() {
-            Self::Clockwise
-        } else {
-            Self::Counterclockwise
-        }
-    }
 }
 
 pub fn rotate_towards(origin: Point2<f32>, target: Point2<f32>) -> UnitComplex<f32> {
@@ -613,26 +593,6 @@ mod tests {
     use nalgebra::{point, Point2, UnitComplex};
 
     use super::*;
-
-    #[test]
-    fn triangle_orientation() {
-        let point1 = point![1.0, 0.0];
-        let point2 = point![3.5, -0.5];
-        let point3 = point![-2.3, -4.2];
-
-        assert_eq!(
-            Orientation::triangle_orientation(point1, point2, point3),
-            Orientation::Clockwise
-        );
-        assert_eq!(
-            Orientation::triangle_orientation(point1, point3, point2),
-            Orientation::Counterclockwise
-        );
-        assert_eq!(
-            Orientation::triangle_orientation(point1, point2, point2),
-            Orientation::Colinear
-        );
-    }
 
     #[test]
     fn arc_cost_90_degrees() {

--- a/crates/types/src/geometry.rs
+++ b/crates/types/src/geometry.rs
@@ -20,6 +20,26 @@ impl Orientation {
             Orientation::Colinear => subject,
         }
     }
+
+    pub fn triangle_orientation(
+        point1: Point2<f32>,
+        point2: Point2<f32>,
+        point3: Point2<f32>,
+    ) -> Self {
+        let (x1, y1) = (point1.x, point1.y);
+        let (x2, y2) = (point2.x, point2.y);
+        let (x3, y3) = (point3.x, point3.y);
+
+        let orientation = x1 * y2 + x2 * y3 + x3 * y1 - x1 * y3 - x2 * y1 - x3 * y2;
+
+        if orientation == 0.0 {
+            Self::Colinear
+        } else if orientation.is_sign_negative() {
+            Self::Clockwise
+        } else {
+            Self::Counterclockwise
+        }
+    }
 }
 
 pub fn rotate_towards(origin: Point2<f32>, target: Point2<f32>) -> UnitComplex<f32> {

--- a/crates/types/src/geometry.rs
+++ b/crates/types/src/geometry.rs
@@ -615,6 +615,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn triangle_orientation() {
+        let point1 = point![1.0, 0.0];
+        let point2 = point![3.5, -0.5];
+        let point3 = point![-2.3, -4.2];
+
+        assert_eq!(
+            Orientation::triangle_orientation(point1, point2, point3),
+            Orientation::Clockwise
+        );
+        assert_eq!(
+            Orientation::triangle_orientation(point1, point3, point2),
+            Orientation::Counterclockwise
+        );
+        assert_eq!(
+            Orientation::triangle_orientation(point1, point2, point2),
+            Orientation::Colinear
+        );
+    }
+
+    #[test]
     fn arc_cost_90_degrees() {
         let arc = Arc {
             circle: Circle {

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -185,7 +185,9 @@ pub struct InterceptBall {
     pub minimum_ball_velocity_towards_robot: f32,
     pub minimum_ball_velocity_towards_own_half: f32,
     pub maximum_intercept_distance: f32,
-    pub minimum_arc_radius: f32,
+    pub minimum_velocity_for_arc: f32,
+    pub maximum_angle_change_for_arc: f32,
+    pub angle_change_factor: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -185,6 +185,7 @@ pub struct InterceptBall {
     pub minimum_ball_velocity_towards_robot: f32,
     pub minimum_ball_velocity_towards_own_half: f32,
     pub maximum_intercept_distance: f32,
+    pub minimum_arc_radius: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -181,6 +181,7 @@ pub struct LostBall {
 #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
 pub struct InterceptBall {
     pub maximum_ball_distance: f32,
+    pub minimum_ball_velocity: f32,
     pub minimum_ball_velocity_towards_robot: f32,
     pub minimum_ball_velocity_towards_own_half: f32,
     pub maximum_intercept_distance: f32,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -842,7 +842,8 @@
       "minimum_ball_velocity": 0.2,
       "minimum_ball_velocity_towards_robot": 0.2,
       "minimum_ball_velocity_towards_own_half": 0.05,
-      "maximum_intercept_distance": 0.5
+      "maximum_intercept_distance": 0.5,
+      "minimum_arc_radius": 0.005
     },
     "initial_lookaround_duration": {
       "nanos": 0,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -838,9 +838,9 @@
       }
     },
     "intercept_ball": {
-      "maximum_ball_distance": 2.0,
-      "minimum_ball_velocity": 0.15,
-      "minimum_ball_velocity_towards_robot": 0.15,
+      "maximum_ball_distance": 3.0,
+      "minimum_ball_velocity": 0.2,
+      "minimum_ball_velocity_towards_robot": 0.2,
       "minimum_ball_velocity_towards_own_half": 0.05,
       "maximum_intercept_distance": 0.5
     },

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -843,7 +843,9 @@
       "minimum_ball_velocity_towards_robot": 0.2,
       "minimum_ball_velocity_towards_own_half": 0.05,
       "maximum_intercept_distance": 0.5,
-      "minimum_arc_radius": 0.005
+      "minimum_velocity_for_arc": 0.005,
+      "maximum_angle_change_for_arc": 1.5,
+      "angle_change_factor": 0.01
     },
     "initial_lookaround_duration": {
       "nanos": 0,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -839,6 +839,7 @@
     },
     "intercept_ball": {
       "maximum_ball_distance": 2.0,
+      "minimum_ball_velocity": 0.15,
       "minimum_ball_velocity_towards_robot": 0.15,
       "minimum_ball_velocity_towards_own_half": 0.05,
       "maximum_intercept_distance": 0.5

--- a/tests/behavior/ball_intercept.lua
+++ b/tests/behavior/ball_intercept.lua
@@ -1,30 +1,51 @@
-local inspect = require 'inspect'
-
 function spawn_robot(number)
   table.insert(state.robots, create_robot(number))
 end
 
+spawn_robot(1)
 spawn_robot(2)
-
-state.filtered_game_state = {
-  Playing = {
-    ball_is_free = true
-  }
-}
+spawn_robot(3)
 
 function on_cycle()
-  if state.cycle_count == 2000 then 
+  if state.cycle_count == 100 then
+    state.game_controller_state.game_state = "Ready"
+    state.filtered_game_state = {
+      Ready = {
+        kicking_team = "Hulks",
+      },
+    }
+  end
+
+  if state.cycle_count == 1600 then
+    state.filtered_game_state.game_state = "Set"
+    state.filtered_game_state = "Set"
     state.ball = {
       position = { 0.0, 0.0 },
       velocity = { 0.0, 0.0 },
     }
   end
 
-  if state.cycle_count == 3800 then
-    state.ball.velocity = { -1.0, -1.0 }
+  if state.cycle_count == 1700 then
+    state.filtered_game_state = {
+      Playing = {
+        ball_is_free = true,
+      },
+    }
+    state.ball.velocity = { -3.0, 0.1 }
   end
 
-  if state.cycle_count == 5000 then
+  if state.cycle_count == 1750 then
+    state.ball.velocity = { -2.0, 1.0 }
+  end
+
+  if state.cycle_count == 1900 then
+    state.ball = {
+      position = { -3.0, -0.1 },
+      velocity = { -2.0, -0.2 },
+    }
+  end
+
+  if state.cycle_count == 2000 then
     state.finished = true
   end
 end

--- a/tests/behavior/ball_intercept_striker.lua
+++ b/tests/behavior/ball_intercept_striker.lua
@@ -1,0 +1,41 @@
+function spawn_robot(number)
+  table.insert(state.robots, create_robot(number))
+end
+
+spawn_robot(7)
+
+function on_cycle()
+  if state.cycle_count == 100 then
+    state.game_controller_state.game_state = "Ready"
+    state.filtered_game_state = {
+      Ready = {
+        kicking_team = "Hulks",
+      },
+    }
+  end
+
+  if state.cycle_count == 1600 then
+    state.filtered_game_state.game_state = "Set"
+    state.filtered_game_state = "Set"
+    state.ball = {
+      position = { 2.0, 0.0 },
+      velocity = { 0.0, 0.0 },
+    }
+  end
+
+  if state.cycle_count == 1700 then
+    state.filtered_game_state = {
+      Playing = {
+        ball_is_free = true,
+      },
+    }
+  end
+
+  if state.cycle_count == 1800 then
+    state.ball.velocity = { -3.0, 0.7 }
+  end
+
+  if state.cycle_count == 1900 then
+    state.finished = true
+  end
+end

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -1,12 +1,5 @@
 use std::{collections::BTreeMap, sync::Arc, time::SystemTime};
 
-use crate::{
-    interfake::Interfake,
-    structs::{
-        control::{AdditionalOutputs, MainOutputs, PersistentState},
-        Parameters,
-    },
-};
 use color_eyre::{eyre::WrapErr, Result};
 use control::{
     active_vision::{self, ActiveVision},
@@ -20,11 +13,20 @@ use control::{
     time_to_reach_kick_position::{self, TimeToReachKickPosition},
     world_state_composer::{self, WorldStateComposer},
 };
+
 use framework::{AdditionalOutput, PerceptionInput};
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 use tokio::sync::Notify;
-use types::{messages::IncomingMessage, Step};
+use types::messages::IncomingMessage;
+
+use crate::{
+    interfake::Interfake,
+    structs::{
+        control::{AdditionalOutputs, MainOutputs, PersistentState},
+        Parameters,
+    },
+};
 
 #[derive(Clone, Default, Serialize, Deserialize, SerializeHierarchy)]
 pub struct Database {
@@ -41,7 +43,6 @@ pub struct BehaviorCycler {
     dribble_path: DribblePath,
     kick_selector: KickSelector,
     look_around: LookAround,
-    persistent_state: PersistentState,
     role_assignment: RoleAssignment,
     rule_obstacle_composer: RuleObstacleComposer,
     world_state_composer: WorldStateComposer,
@@ -54,7 +55,6 @@ impl BehaviorCycler {
         own_changed: Arc<Notify>,
         parameters: &Parameters,
     ) -> Result<Self> {
-        let persistent_state = PersistentState::default();
         let time_to_reach_kick_position =
             TimeToReachKickPosition::new(time_to_reach_kick_position::CreationContext {})
                 .wrap_err("failed to create node `TimeToReachKickPosition`")?;
@@ -102,7 +102,6 @@ impl BehaviorCycler {
             own_changed,
 
             active_vision,
-            persistent_state,
             time_to_reach_kick_position,
             ball_state_composer,
             behavior,
@@ -118,6 +117,7 @@ impl BehaviorCycler {
     pub fn cycle(
         &mut self,
         own_database: &mut Database,
+        persistent_state: &mut PersistentState,
         parameters: &Parameters,
         incoming_messages: BTreeMap<SystemTime, Vec<&IncomingMessage>>,
     ) -> Result<()> {
@@ -159,9 +159,7 @@ impl BehaviorCycler {
                     primary_state: &own_database.main_outputs.primary_state,
                     robot_to_field: own_database.main_outputs.robot_to_field.as_ref(),
                     cycle_time: &own_database.main_outputs.cycle_time,
-                    time_to_reach_kick_position: &mut self
-                        .persistent_state
-                        .time_to_reach_kick_position,
+                    time_to_reach_kick_position: &mut persistent_state.time_to_reach_kick_position,
                     field_dimensions: &parameters.field_dimensions,
                     forced_role: parameters.role_assignment.forced_role.as_ref(),
                     initial_poses: &parameters.localization.initial_poses,
@@ -331,12 +329,8 @@ impl BehaviorCycler {
                     lost_ball_parameters: &parameters.behavior.lost_ball,
                     intercept_ball_parameters: &parameters.behavior.intercept_ball,
                     has_ground_contact: &true,
-                    current_step: &mut Step {
-                        forward: 0.0,
-                        left: 0.0,
-                        turn: 0.0,
-                    },
-                    maximum_step_size: &configuration.step_planner.max_step_size,
+                    current_step: &mut persistent_state.current_step,
+                    maximum_step_size: &parameters.step_planner.max_step_size,
                 })
                 .wrap_err("failed to execute cycle of node `Behavior`")?;
             own_database.main_outputs.motion_command = main_outputs.motion_command.value;
@@ -362,9 +356,7 @@ impl BehaviorCycler {
             let _main_outputs = self
                 .time_to_reach_kick_position
                 .cycle(control::time_to_reach_kick_position::CycleContext {
-                    time_to_reach_kick_position: &mut self
-                        .persistent_state
-                        .time_to_reach_kick_position,
+                    time_to_reach_kick_position: &mut persistent_state.time_to_reach_kick_position,
                     dribble_path: own_database.main_outputs.dribble_path.as_ref(),
                 })
                 .wrap_err("failed to execute cycle of `TimeToReachKickPosition`");

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -24,7 +24,7 @@ use framework::{AdditionalOutput, PerceptionInput};
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 use tokio::sync::Notify;
-use types::messages::IncomingMessage;
+use types::{messages::IncomingMessage, Step};
 
 #[derive(Clone, Default, Serialize, Deserialize, SerializeHierarchy)]
 pub struct Database {
@@ -331,6 +331,12 @@ impl BehaviorCycler {
                     lost_ball_parameters: &parameters.behavior.lost_ball,
                     intercept_ball_parameters: &parameters.behavior.intercept_ball,
                     has_ground_contact: &true,
+                    current_step: &mut Step {
+                        forward: 0.0,
+                        left: 0.0,
+                        turn: 0.0,
+                    },
+                    maximum_step_size: &configuration.step_planner.max_step_size,
                 })
                 .wrap_err("failed to execute cycle of node `Behavior`")?;
             own_database.main_outputs.motion_command = main_outputs.motion_command.value;

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -12,7 +12,7 @@ use spl_network_messages::{GamePhase, GameState, HulkMessage, PlayerNumber, Team
 use types::{
     messages::{IncomingMessage, OutgoingMessage},
     BallPosition, FilteredGameState, GameControllerState, HeadMotion, KickVariant, LineSegment,
-    MotionCommand, OrientationMode, PathSegment, Players, PrimaryState, Side,
+    MotionCommand, OrientationMode, PathSegment, Players, PrimaryState, Side, Step,
 };
 
 use crate::{
@@ -115,6 +115,7 @@ impl State {
                     }
                     .coords
                     .cap_magnitude(0.3 * time_step.as_secs_f32());
+
                     let orientation = match orientation_mode {
                         OrientationMode::AlignWithPath => {
                             if step.norm_squared() < f32::EPSILON {
@@ -134,6 +135,12 @@ impl State {
                                 std::f32::consts::FRAC_PI_4 * time_step.as_secs_f32(),
                             ),
                     );
+
+                    robot.persistent_state.current_step = Step {
+                        forward: step[0],
+                        left: step[1],
+                        turn: 0.0,
+                    };
 
                     head
                 }

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -110,10 +110,11 @@ impl State {
                     ..
                 } => {
                     let step = match path[0] {
-                        PathSegment::LineSegment(LineSegment(_start, end)) => end,
-                        PathSegment::Arc(arc, _orientation) => arc.end,
+                        PathSegment::LineSegment(LineSegment(_start, end)) => end.coords,
+                        PathSegment::Arc(arc, orientation) => {
+                            orientation.rotate_vector_90_degrees(arc.start - arc.circle.center)
+                        }
                     }
-                    .coords
                     .cap_magnitude(0.3 * time_step.as_secs_f32());
 
                     let orientation = match orientation_mode {
@@ -137,8 +138,8 @@ impl State {
                     );
 
                     robot.persistent_state.current_step = Step {
-                        forward: step[0],
-                        left: step[1],
+                        forward: 30.0 * step[0],
+                        left: 30.0 * step[1],
                         turn: 0.0,
                     };
 


### PR DESCRIPTION
## Introduced Changes

This PR improves the ball interception by calculating the shortest path for intercepting the ball while considering the robot's current movement.

## ToDo / Known Issues

- [x] Write tests for geometric functions (`calculate_arc_tangent_to` and `triangle_orientation`)
- [x] Update the scenario file for testing with the behavior simulator
- [x] Parameter tuning

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Flash a NAO or execute the `ball_intercept.lua` or `ball_intercept_striker.lua` scenario in the behavior simulator.
