### PR TITLE
reduce `falling_angle_threshold.y`

### DIFF
--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -575,7 +575,7 @@
     "angular_velocity_low_pass_factor": 0.2,
     "roll_pitch_low_pass_factor": 0.2,
     "gravitational_acceleration_threshold": 4.0,
-    "falling_angle_threshold": [0.52, 0.6],
+    "falling_angle_threshold": [0.52, 0.3],
     "fallen_timeout": {
       "nanos": 0,
       "secs": 1


### PR DESCRIPTION
## Introduced Changes

Reduce `falling_angle_threshold.y` to have more time for the fall motion and still high enough for stabilizing steps to take over.


## How to Test

Test on robot by jogging it.