### PR TITLE
Falling threshold 2

### DIFF
--- a/etc/configuration/default.json
+++ b/etc/configuration/default.json
@@ -575,7 +575,7 @@
     "angular_velocity_low_pass_factor": 0.2,
     "roll_pitch_low_pass_factor": 0.2,
     "gravitational_acceleration_threshold": 4.0,
-    "falling_angle_threshold": [0.52, 0.3],
+    "falling_angle_threshold": [0.52, 0.45],
     "fallen_timeout": {
       "nanos": 0,
       "secs": 1


### PR DESCRIPTION
## Introduced Changes

Increase `falling_angle_threshold.y` again to avoid too fast forward falling.
Tested in test game.