### PR TITLE
Fix binary names

### DIFF
--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -94,7 +94,7 @@ pub async fn remote(arguments: Arguments, command: Command) -> Result<()> {
             };
             command.args([
                 "--return-file",
-                &format!("target/{toolchain_name}{profile_name}/{}", arguments.target),
+                &format!("target/{toolchain_name}{profile_name}/hulk_{}", arguments.target),
             ]);
 
             command

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -94,7 +94,10 @@ pub async fn remote(arguments: Arguments, command: Command) -> Result<()> {
             };
             command.args([
                 "--return-file",
-                &format!("target/{toolchain_name}{profile_name}/hulk_{}", arguments.target),
+                &format!(
+                    "target/{toolchain_name}{profile_name}/hulk_{}",
+                    arguments.target
+                ),
             ]);
 
             command

--- a/webots/controllers/hulk/hulk
+++ b/webots/controllers/hulk/hulk
@@ -1,1 +1,1 @@
-../../../target/incremental/webots
+../../../target/incremental/hulk_webots


### PR DESCRIPTION
## Introduced Changes

#182  changed the binary names which wasn't taken into account by the remote compilation feature in pepsi.
The webots controller symlink was also still pointing to the old binary name.
Previously the binaries were called `webots` and `nao`, now they are `hulk_webots` and `hulk_nao`.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Remove left over binaries (or just `cargo clean`), build, and check if the non-extern webots file works again.
Same with `pepsi upload --remote`. Make sure to clean the remote repo beforehand.