### PR TITLE
Fix #393 player number parameter scope

### DIFF
--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -191,7 +191,7 @@ impl Repository {
             &parameters,
             Scope {
                 location: Location::All,
-                id: Id::All,
+                id: Id::Head,
             },
             path,
             self.configuration_root(),


### PR DESCRIPTION

## Introduced Changes

What it says, now the player number is stored in the head configuration again.

Fixes #393

Developed on my iPhone.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Try setting a player number via Pepsi and observe that only the head parameters of that robot changed.