### PR TITLE
Implement traits to convert YCbCr422Image to RGB

### DIFF
--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -25,6 +25,25 @@ pub struct YCbCr422Image {
     buffer: Arc<Vec<YCbCr422>>,
 }
 
+impl From<RgbImage> for YCbCr422Image {
+    fn from(rgb_image: RgbImage) -> Self {
+        let buffer = Arc::new(buffer_422_from_rgb_image(rgb_image));
+        let width_422 = rgb_image.width() / 2;
+        let height = rgb_image.height() / 2;
+        Self {
+            width_422,
+            height,
+            buffer,
+        }
+    }
+}
+
+impl Into<RgbImage> for YCbCr422Image {
+    fn into(self) -> RgbImage {
+        rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer)
+    }
+}
+
 impl EncodeJpeg for YCbCr422Image {
     const DEFAULT_QUALITY: u8 = 40;
     type Error = ImageError;

--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -35,9 +35,9 @@ impl From<RgbImage> for YCbCr422Image {
     }
 }
 
-impl Into<RgbImage> for YCbCr422Image {
-    fn into(self) -> RgbImage {
-        rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer)
+impl From<YCbCr422Image> for RgbImage {
+    fn from(val: YCbCr422Image) -> Self {
+        rgb_image_from_buffer_422(val.width_422, val.height, &val.buffer)
     }
 }
 

--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -35,9 +35,15 @@ impl From<RgbImage> for YCbCr422Image {
     }
 }
 
+impl From<&YCbCr422Image> for RgbImage {
+    fn from(val: &YCbCr422Image) -> Self {
+        rgb_image_from_buffer_422(val.width_422, val.height, &val.buffer)
+    }
+}
+
 impl From<YCbCr422Image> for RgbImage {
     fn from(val: YCbCr422Image) -> Self {
-        rgb_image_from_buffer_422(val.width_422, val.height, &val.buffer)
+        Self::from(&val)
     }
 }
 
@@ -46,7 +52,7 @@ impl EncodeJpeg for YCbCr422Image {
     type Error = ImageError;
 
     fn encode_as_jpeg(&self, quality: u8) -> Result<Vec<u8>, Self::Error> {
-        let rgb_image = rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer);
+        let rgb_image: RgbImage = self.into();
         let mut jpeg_buffer = vec![];
         let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buffer, quality);
         encoder.encode_image(&rgb_image)?;

--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -46,8 +46,7 @@ impl EncodeJpeg for YCbCr422Image {
     type Error = ImageError;
 
     fn encode_as_jpeg(&self, quality: u8) -> Result<Vec<u8>, Self::Error> {
-        let rgb_image: RgbImage =
-            rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer);
+        let rgb_image = rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer);
         let mut jpeg_buffer = vec![];
         let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buffer, quality);
         encoder.encode_image(&rgb_image)?;

--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -27,13 +27,10 @@ pub struct YCbCr422Image {
 
 impl From<RgbImage> for YCbCr422Image {
     fn from(rgb_image: RgbImage) -> Self {
-        let buffer = Arc::new(buffer_422_from_rgb_image(rgb_image));
-        let width_422 = rgb_image.width() / 2;
-        let height = rgb_image.height() / 2;
         Self {
-            width_422,
-            height,
-            buffer,
+            width_422: rgb_image.width() / 2,
+            height: rgb_image.height(),
+            buffer: Arc::new(buffer_422_from_rgb_image(rgb_image)),
         }
     }
 }
@@ -49,7 +46,8 @@ impl EncodeJpeg for YCbCr422Image {
     type Error = ImageError;
 
     fn encode_as_jpeg(&self, quality: u8) -> Result<Vec<u8>, Self::Error> {
-        let rgb_image = rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer);
+        let rgb_image: RgbImage =
+            rgb_image_from_buffer_422(self.width_422, self.height, &self.buffer);
         let mut jpeg_buffer = vec![];
         let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buffer, quality);
         encoder.encode_image(&rgb_image)?;
@@ -62,14 +60,7 @@ impl DecodeJpeg for YCbCr422Image {
 
     fn decode_from_jpeg(jpeg: Vec<u8>) -> Result<Self, Self::Error> {
         let rgb_image = load_from_memory_with_format(&jpeg, ImageFormat::Jpeg)?.into_rgb8();
-        let width_422 = rgb_image.width() / 2;
-        let height = rgb_image.height() / 2;
-        let buffer = Arc::new(buffer_422_from_rgb_image(rgb_image));
-        Ok(Self {
-            width_422,
-            height,
-            buffer,
-        })
+        Ok(rgb_image.into())
     }
 }
 


### PR DESCRIPTION
## Introduced Changes

The functionality to perform the conversion was already there but was not exposed in a reusable way.
I also fixed a logic error in the height calculation of `YCbCr422Image -> RgbImage` conversion.

*note*: ~`impl EncodeJpeg for YCbCr422Image` does not use the `YCbCr422Image::into()` as it requires a clone while `EncodeJpeg` only need a view. If the cloning overhead is considered negligible we can use the `into()` function.~ **Fixed**

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Add unit tests for these functions!
We already found a logic error (of height calculation) during this PR.

## How to Test

