### PR TITLE
Assign optional roles even without game controller

### DIFF
--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -110,21 +110,20 @@ impl RoleAssignment {
                 {
                     player_roles[striker] = Role::Striker;
                 }
-
-                role = match context.player_number {
-                    PlayerNumber::One => player_roles.one,
-                    PlayerNumber::Two => player_roles.two,
-                    PlayerNumber::Three => player_roles.three,
-                    PlayerNumber::Four => player_roles.four,
-                    PlayerNumber::Five => player_roles.five,
-                    PlayerNumber::Six => player_roles.six,
-                    PlayerNumber::Seven => player_roles.seven,
-                };
-
-                self.role_initialized = true;
-                self.last_received_spl_striker_message = Some(cycle_start_time);
-                self.team_ball = None;
             }
+            role = match context.player_number {
+                PlayerNumber::One => player_roles.one,
+                PlayerNumber::Two => player_roles.two,
+                PlayerNumber::Three => player_roles.three,
+                PlayerNumber::Four => player_roles.four,
+                PlayerNumber::Five => player_roles.five,
+                PlayerNumber::Six => player_roles.six,
+                PlayerNumber::Seven => player_roles.seven,
+            };
+
+            self.role_initialized = true;
+            self.last_received_spl_striker_message = Some(cycle_start_time);
+            self.team_ball = None;
         }
 
         let send_game_controller_return_message = self


### PR DESCRIPTION
## Introduced Changes

Fixes roles not being assigned when there is no game controller state.

Fixes #376

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Idk, I'm not sure this situation addressed here can ever occur. But we should still have this so the robots behave correctly when injecting primary state without a game controller.