### PR TITLE
Re-enlist "look at" panel selection in Twix

### DIFF
--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -298,6 +298,7 @@ impl App for TwixApp {
                             "Map".to_string(),
                             "Parameter".to_string(),
                             "Manual Calibration".to_string(),
+                            "Look At".to_string(),
                         ],
                         "Panel",
                     )


### PR DESCRIPTION
## Introduced Changes

The Look At panel is no longer found in the list of panels, this happened during #370. This PR brings it back :)

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

We should have a better way to map the `SelectablePanel` enum to the string and be able to iterate to generate the drop down list instead of manually specifying the names in multiple places causing issues like this.

## How to Test

Open twix, the panel `Look At` should be in the panel selection list.