### PR TITLE
Check ball in upper camera

### DIFF
--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -184,13 +184,21 @@ impl BallFilter {
     ) {
         for hypothesis in self.hypotheses.iter_mut() {
             let ball_in_view = match (camera_matrices.as_ref(), projected_limbs.as_ref()) {
-                (Some(camera_matrices), Some(projected_limbs)) => is_visible_to_camera(
-                    hypothesis,
-                    &camera_matrices.bottom,
-                    ball_radius,
-                    &projected_limbs.limbs,
-                    configuration,
-                ),
+                (Some(camera_matrices), Some(projected_limbs)) => {
+                    is_visible_to_camera(
+                        hypothesis,
+                        &camera_matrices.bottom,
+                        ball_radius,
+                        &projected_limbs.limbs,
+                        configuration,
+                    ) || is_visible_to_camera(
+                        hypothesis,
+                        &camera_matrices.top,
+                        ball_radius,
+                        &[],
+                        configuration,
+                    )
+                }
                 _ => false,
             };
 


### PR DESCRIPTION
## Introduced Changes
The visibility of a ball is now also considered in the upper camera.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

* For some reason sometimes false negatives are returned from the `is_visible_to_camera` function.

## How to Test

* Make sure the steady state validity of a ball in the top camera is equal to the validity of a ball in the bottom camera
