### PR TITLE
Bump webots-rs for R2023b compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,9 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "webots"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3083408c9e5238ad2b2387b3aead4ab542c23099ffdad06e9b669bf54416eca8"
+version = "0.8.0"
 dependencies = [
  "thiserror",
  "webots-bindings",
@@ -5059,9 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "webots-bindings"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb9ce5f1071baa0f5ff18bd07e37743fef2aabc79895fd6381e7c9451b8f233"
+version = "0.8.0"
 dependencies = [
  "bindgen 0.63.0",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ uuid = { version = "1.1.2", features = ["v4"] }
 v4l = { version = "0.12.1", git = "https://github.com/HULKs/libv4l-rs", rev = "be65819073514b193d082dd37dbcc2cfac3f6183" }
 vision = { path = "crates/vision" }
 walkdir = "2.3.2"
-webots = { version = "0.7.0" }
+webots = { version = "0.8.0" }
 zbus = { version = "3.7.0", features = ["tokio"] }
 
 [profile.incremental]


### PR DESCRIPTION
## Introduced Changes

Requires 0.8.0 release of webots-rs on crates.io, @h3ndrk.
Webots R2023b changed some node ids which broke webots-rs.
The library was updated and this PR updates our dependency requirement to the new version.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

See if webots works again. Previously it would crash with an assert about mismatched node ids.