### PR TITLE
change fall_protection threshold back to original

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -593,7 +593,7 @@
     "angular_velocity_low_pass_factor": 0.2,
     "roll_pitch_low_pass_factor": 0.2,
     "gravitational_acceleration_threshold": 4.0,
-    "falling_angle_threshold": [0.52, 0.45],
+    "falling_angle_threshold": [0.52, 0.6],
     "fallen_timeout": {
       "nanos": 0,
       "secs": 1


### PR DESCRIPTION
## Introduced Changes

As described in the post game meeting, the threshold to trigger the fall protection is now back on the value from GORE. 

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
