### PR TITLE
Move kickoff pose back a little

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
-use nalgebra::{point, Point2};
+use nalgebra::{point, Point2, Vector2};
 use spl_network_messages::{GamePhase, GameState, SubState, Team};
 use types::{
     parameters::{Behavior as BehaviorParameters, InWalkKicks, InterceptBall, LostBall},
@@ -50,6 +50,8 @@ pub struct CycleContext {
     pub lost_ball_parameters: Parameter<LostBall, "behavior.lost_ball">,
     pub intercept_ball_parameters: Parameter<InterceptBall, "behavior.intercept_ball">,
     pub maximum_step_size: Parameter<Step, "step_planner.max_step_size">,
+    pub striker_set_position:
+        Parameter<Vector2<f32>, "behavior.role_positions.striker_set_position">,
 }
 
 #[context]
@@ -283,6 +285,7 @@ impl Behavior {
                         &walk_and_stand,
                         &look_action,
                         &mut context.path_obstacles,
+                        *context.striker_set_position,
                     ),
                     Action::WalkToPenaltyKick => walk_to_penalty_kick::execute(
                         world_state,

--- a/crates/control/src/behavior/walk_to_kick_off.rs
+++ b/crates/control/src/behavior/walk_to_kick_off.rs
@@ -11,7 +11,7 @@ pub fn execute(
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
 ) -> Option<MotionCommand> {
     let robot_to_field = world_state.robot.robot_to_field?;
-    let kick_off_pose = Isometry2::translation(-0.2, 0.0);
+    let kick_off_pose = Isometry2::translation(-0.3, 0.0);
     walk_and_stand.execute(
         robot_to_field.inverse() * kick_off_pose,
         look_action.execute(),

--- a/crates/control/src/behavior/walk_to_kick_off.rs
+++ b/crates/control/src/behavior/walk_to_kick_off.rs
@@ -1,5 +1,5 @@
 use framework::AdditionalOutput;
-use nalgebra::Isometry2;
+use nalgebra::{Translation2, Vector2};
 use types::{MotionCommand, PathObstacle, WorldState};
 
 use super::{head::LookAction, walk_to_pose::WalkAndStand};
@@ -9,11 +9,11 @@ pub fn execute(
     walk_and_stand: &WalkAndStand,
     look_action: &LookAction,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
+    striker_set_position: Vector2<f32>,
 ) -> Option<MotionCommand> {
     let robot_to_field = world_state.robot.robot_to_field?;
-    let kick_off_pose = Isometry2::translation(-0.3, 0.0);
     walk_and_stand.execute(
-        robot_to_field.inverse() * kick_off_pose,
+        robot_to_field.inverse() * Translation2::from(striker_set_position),
         look_action.execute(),
         path_obstacles_output,
     )

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -871,7 +871,7 @@
       "striker_supporter_minimum_x": 2.0,
       "keeper_x_offset": 0.1,
       "striker_distance_to_non_free_center_circle": 0.4,
-      "striker_set_position": [-1.0, 0.0]
+      "striker_set_position": [-0.3, 0.0]
     },
     "dribbling": {
       "hybrid_align_distance": 2.0,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -333,6 +333,7 @@ impl BehaviorCycler {
                     intercept_ball_parameters: &parameters.behavior.intercept_ball,
                     has_ground_contact: &true,
                     maximum_step_size: &parameters.step_planner.max_step_size,
+                    striker_set_position: &parameters.behavior.role_positions.striker_set_position,
                 })
                 .wrap_err("failed to execute cycle of node `Behavior`")?;
             own_database.main_outputs.motion_command = main_outputs.motion_command.value;


### PR DESCRIPTION
## Introduced Changes

Move the target position of the kickoff striker back a bit, to prevent accidentally walking onto/over the center point.

Fixes #313

## ToDo / Known Issues

ToDo: Test

## How to Test

Let a striker walk to the kick-off pose