### PR TITLE
Add SPL_HULKs support

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -3,5 +3,5 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "5.8.0";
+pub const OS_VERSION: &str = "5.8.1";
 pub const SDK_VERSION: &str = "5.8.0";

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -301,6 +301,7 @@ impl Nao {
             Network::SplD,
             Network::SplE,
             Network::SplF,
+            Network::SplHulks,
         ]
         .into_iter()
         .map(|possible_network| {
@@ -373,6 +374,7 @@ pub enum Network {
     SplD,
     SplE,
     SplF,
+    SplHulks,
 }
 
 impl Display for Network {
@@ -385,6 +387,7 @@ impl Display for Network {
             Network::SplD => formatter.write_str("SPL_D"),
             Network::SplE => formatter.write_str("SPL_E"),
             Network::SplF => formatter.write_str("SPL_F"),
+            Network::SplHulks => formatter.write_str("SPL_HULKs"),
         }
     }
 }

--- a/tools/pepsi/src/parsers.rs
+++ b/tools/pepsi/src/parsers.rs
@@ -28,8 +28,16 @@ pub fn parse_systemctl_action(systemctl_action: &str) -> Result<SystemctlAction>
     }
 }
 
-pub const NETWORK_POSSIBLE_VALUES: &[&str] =
-    &["None", "SPL_A", "SPL_B", "SPL_C", "SPL_D", "SPL_E", "SPL_F"];
+pub const NETWORK_POSSIBLE_VALUES: &[&str] = &[
+    "None",
+    "SPL_A",
+    "SPL_B",
+    "SPL_C",
+    "SPL_D",
+    "SPL_E",
+    "SPL_F",
+    "SPL_HULKs",
+];
 
 pub fn parse_network(network: &str) -> Result<Network> {
     match network {
@@ -40,6 +48,7 @@ pub fn parse_network(network: &str) -> Result<Network> {
         "SPL_D" => Ok(Network::SplD),
         "SPL_E" => Ok(Network::SplE),
         "SPL_F" => Ok(Network::SplF),
+        "SPL_HULKs" => Ok(Network::SplHulks),
         _ => bail!("unexpected network"),
     }
 }


### PR DESCRIPTION
## Introduced Changes

Bump OS version to 5.8.1 and add support for the SPL_HULKs access point.

## How to Test

`./pepsi gammaray $NAO_NUMBER && ./pepsi wireless set SPL_HULKs $NAO_NUMBER`