### PR TITLE
Twix panel for Image Segmenter and Field Colour calibration

### DIFF
--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -357,6 +357,8 @@ pub enum EdgeDetectionSource {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
 pub struct ImageSegmenter {
+    pub horizontal_stride: usize,
+    pub vertical_stride: usize,
     pub vertical_edge_threshold: i16,
     pub vertical_edge_detection_source: EdgeDetectionSource,
     pub vertical_median_mode: MedianMode,

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -27,7 +27,7 @@ use nao::Nao;
 use panel::Panel;
 use panels::{
     BehaviorSimulatorPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel, ManualCalibrationPanel,
-    MapPanel, ParameterPanel, PlotPanel, TextPanel,
+    MapPanel, ParameterPanel, PlotPanel, SegmenterCalibrationPanel, TextPanel,
 };
 use serde_json::{from_str, to_string, Value};
 use tokio::sync::mpsc;
@@ -81,6 +81,7 @@ enum SelectablePanel {
     Parameter(ParameterPanel),
     ManualCalibration(ManualCalibrationPanel),
     LookAt(LookAtPanel),
+    SegmenterCalibration(SegmenterCalibrationPanel),
 }
 
 impl SelectablePanel {
@@ -109,6 +110,9 @@ impl SelectablePanel {
                 SelectablePanel::ManualCalibration(ManualCalibrationPanel::new(nao, value))
             }
             "look at" => SelectablePanel::LookAt(LookAtPanel::new(nao, value)),
+            "segmenter calibration" => {
+                SelectablePanel::SegmenterCalibration(SegmenterCalibrationPanel::new(nao, value))
+            }
 
             name => bail!("unexpected panel name: {name}"),
         })
@@ -125,6 +129,7 @@ impl SelectablePanel {
             SelectablePanel::Parameter(panel) => panel.save(),
             SelectablePanel::ManualCalibration(panel) => panel.save(),
             SelectablePanel::LookAt(panel) => panel.save(),
+            SelectablePanel::SegmenterCalibration(panel) => panel.save(),
         };
         value["_panel_type"] = Value::String(self.to_string());
 
@@ -144,6 +149,7 @@ impl Widget for &mut SelectablePanel {
             SelectablePanel::Parameter(panel) => panel.ui(ui),
             SelectablePanel::ManualCalibration(panel) => panel.ui(ui),
             SelectablePanel::LookAt(panel) => panel.ui(ui),
+            SelectablePanel::SegmenterCalibration(panel) => panel.ui(ui),
         }
     }
 }
@@ -160,6 +166,7 @@ impl Display for SelectablePanel {
             SelectablePanel::Parameter(_) => ParameterPanel::NAME,
             SelectablePanel::ManualCalibration(_) => ManualCalibrationPanel::NAME,
             SelectablePanel::LookAt(_) => LookAtPanel::NAME,
+            SelectablePanel::SegmenterCalibration(_) => LookAtPanel::NAME,
         };
         f.write_str(panel_name)
     }
@@ -299,6 +306,7 @@ impl App for TwixApp {
                             "Parameter".to_string(),
                             "Manual Calibration".to_string(),
                             "Look At".to_string(),
+                            "Segmenter Calibration".to_string(),
                         ],
                         "Panel",
                     )

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -166,7 +166,7 @@ impl Display for SelectablePanel {
             SelectablePanel::Parameter(_) => ParameterPanel::NAME,
             SelectablePanel::ManualCalibration(_) => ManualCalibrationPanel::NAME,
             SelectablePanel::LookAt(_) => LookAtPanel::NAME,
-            SelectablePanel::SegmenterCalibration(_) => LookAtPanel::NAME,
+            SelectablePanel::SegmenterCalibration(_) => SegmenterCalibrationPanel::NAME,
         };
         f.write_str(panel_name)
     }

--- a/tools/twix/src/panels/mod.rs
+++ b/tools/twix/src/panels/mod.rs
@@ -6,6 +6,7 @@ mod manual_camera_calibration;
 mod map;
 mod parameter;
 mod plot;
+mod segmenter_calibration;
 mod text;
 
 pub use self::behavior_simulator::BehaviorSimulatorPanel;
@@ -16,4 +17,5 @@ pub use manual_camera_calibration::ManualCalibrationPanel;
 pub use map::MapPanel;
 pub use parameter::ParameterPanel;
 pub use plot::PlotPanel;
+pub use segmenter_calibration::SegmenterCalibrationPanel;
 pub use text::TextPanel;

--- a/tools/twix/src/panels/segmenter_calibration.rs
+++ b/tools/twix/src/panels/segmenter_calibration.rs
@@ -28,6 +28,11 @@ pub struct SegmenterCalibrationPanel {
 const FIELD_COLOUR_KEY_BASE: &str = "field_color_detection.vision_";
 const IMAGE_SEGMENTER_KEY_BASE: &str = "image_segmenter.vision_";
 
+const STRIDE_RANGE: (usize, usize) = (1, 128);
+const VERTICAL_EDGE_THRESHOLD_RANGE: (i16, i16) = (-128, 128);
+const GREEN_CHROMACITY_RANGE: (f32, f32) = (0.0, 1.0);
+const GREEN_LUMINANCE_RANGE: (u8, u8) = (0, u8::MAX / 2);
+
 impl Panel for SegmenterCalibrationPanel {
     const NAME: &'static str = "Segmenter Calibration";
 
@@ -77,9 +82,6 @@ fn add_image_segmenter_ui_components(
     let label = &image_segmenter_subscription.human_friendly_label;
     let subscription_path = &image_segmenter_subscription.path;
 
-    let stride_range = (1usize, 128usize);
-    let vertical_edge_threshold_range = (-128i16, 128i16);
-
     ui.horizontal(|ui| {
         match buffer.parse_latest::<ImageSegmenter>() {
             Ok(value) => {
@@ -108,17 +110,14 @@ fn add_image_segmenter_ui_components(
 
     match &mut value_option {
         Some(value) => {
-            ui.label(format!(
-                "Strides [{}°, {}°]",
-                stride_range.0, stride_range.1
-            ));
+            ui.label(format!("Strides [{}, {}]", STRIDE_RANGE.0, STRIDE_RANGE.1));
             for (axis_value, axis_name) in [
                 (&mut value.horizontal_stride, "horizontal"),
                 (&mut value.vertical_stride, "vertical"),
             ] {
                 let slider = Slider::new(
                     axis_value,
-                    RangeInclusive::new(stride_range.0, stride_range.1),
+                    RangeInclusive::new(STRIDE_RANGE.0, STRIDE_RANGE.1),
                 )
                 .text(axis_name)
                 .smart_aim(false);
@@ -128,8 +127,8 @@ fn add_image_segmenter_ui_components(
             }
             {
                 ui.label(format!(
-                    "Vertical Edge [{}°, {}°]",
-                    vertical_edge_threshold_range.0, vertical_edge_threshold_range.1
+                    "Vertical Edge [{}, {}]",
+                    VERTICAL_EDGE_THRESHOLD_RANGE.0, VERTICAL_EDGE_THRESHOLD_RANGE.1
                 ));
                 let axis_value = &mut value.vertical_edge_threshold;
                 let axis_name = "threshold";
@@ -137,8 +136,8 @@ fn add_image_segmenter_ui_components(
                 let slider = Slider::new(
                     axis_value,
                     RangeInclusive::new(
-                        vertical_edge_threshold_range.0,
-                        vertical_edge_threshold_range.1,
+                        VERTICAL_EDGE_THRESHOLD_RANGE.0,
+                        VERTICAL_EDGE_THRESHOLD_RANGE.1,
                     ),
                 )
                 .text(axis_name)
@@ -176,9 +175,6 @@ fn add_field_color_ui_components(
     let label = &field_color_subscription.human_friendly_label;
     let subscription_path = &field_color_subscription.path;
 
-    let green_chromacity_range = (0.0f32, 1.0f32);
-    let green_luminance_range = (0u8, u8::MAX);
-
     ui.horizontal(|ui| {
         match buffer.parse_latest::<FieldColorDetection>() {
             Ok(value) => {
@@ -208,8 +204,8 @@ fn add_field_color_ui_components(
     match &mut field_color_option {
         Some(field_color_value) => {
             ui.label(format!(
-                "Green Chromacity Thresholds[{}°, {}°]",
-                green_chromacity_range.0, green_chromacity_range.1
+                "Green Chromacity Thresholds[{}, {}]",
+                GREEN_CHROMACITY_RANGE.0, GREEN_CHROMACITY_RANGE.1
             ));
             for (axis_value, axis_name) in [
                 (
@@ -223,7 +219,7 @@ fn add_field_color_ui_components(
             ] {
                 let slider = Slider::new(
                     axis_value,
-                    RangeInclusive::new(green_chromacity_range.0, green_chromacity_range.1),
+                    RangeInclusive::new(GREEN_CHROMACITY_RANGE.0, GREEN_CHROMACITY_RANGE.1),
                 )
                 .text(axis_name)
                 .smart_aim(false);
@@ -233,15 +229,15 @@ fn add_field_color_ui_components(
             }
             {
                 ui.label(format!(
-                    "Green Luminance Threshold [{}°, {}°]",
-                    green_luminance_range.0, green_luminance_range.1
+                    "Green Luminance Threshold [{}, {}]",
+                    GREEN_LUMINANCE_RANGE.0, GREEN_LUMINANCE_RANGE.1
                 ));
                 let axis_value = &mut field_color_value.green_luminance_threshold;
                 let axis_name = "threshold";
 
                 let slider = Slider::new(
                     axis_value,
-                    RangeInclusive::new(green_luminance_range.0, green_luminance_range.1),
+                    RangeInclusive::new(GREEN_LUMINANCE_RANGE.0, GREEN_LUMINANCE_RANGE.1),
                 )
                 .text(axis_name)
                 .smart_aim(false);

--- a/tools/twix/src/panels/segmenter_calibration.rs
+++ b/tools/twix/src/panels/segmenter_calibration.rs
@@ -196,7 +196,7 @@ fn add_field_color_ui_components(
             || {
                 let value = serde_json::to_value(&field_color_option)
                     .wrap_err("Conveting FieldColor to serde_json::Value failed.");
-                value.and_then(|mut value| {
+                value.map(|mut value| {
                     if let Some(object) = value.as_object_mut() {
                         for key in FIELD_COLOUR_SKIPPED_FIELDS {
                             if object.contains_key(*key) {
@@ -204,7 +204,7 @@ fn add_field_color_ui_components(
                             }
                         }
                     }
-                    Ok(value)
+                    value
                 })
             },
             nao.clone(),

--- a/tools/twix/src/panels/segmenter_calibration.rs
+++ b/tools/twix/src/panels/segmenter_calibration.rs
@@ -90,7 +90,7 @@ fn add_image_segmenter_ui_components(
             }
         }
 
-        ui.label(format!("{label:#} Camera"));
+        ui.label(format!("Image Segmenter {label:#}"));
 
         add_save_button(
             ui,
@@ -104,8 +104,6 @@ fn add_image_segmenter_ui_components(
         );
     });
 
-    ui.style_mut().spacing.slider_width = ui.available_size().x - 100.0;
-
     let mut changed = false;
 
     match &mut value_option {
@@ -115,8 +113,8 @@ fn add_image_segmenter_ui_components(
                 stride_range.0, stride_range.1
             ));
             for (axis_value, axis_name) in [
-                (&mut value.horizontal_stride, "horizontal_stride"),
-                (&mut value.vertical_stride, "vertical_stride"),
+                (&mut value.horizontal_stride, "horizontal"),
+                (&mut value.vertical_stride, "vertical"),
             ] {
                 let slider = Slider::new(
                     axis_value,
@@ -130,11 +128,11 @@ fn add_image_segmenter_ui_components(
             }
             {
                 ui.label(format!(
-                    "Vertical Edge Threshold [{}°, {}°]",
+                    "Vertical Edge [{}°, {}°]",
                     vertical_edge_threshold_range.0, vertical_edge_threshold_range.1
                 ));
                 let axis_value = &mut value.vertical_edge_threshold;
-                let axis_name = "green_luminance_threshold";
+                let axis_name = "threshold";
 
                 let slider = Slider::new(
                     axis_value,
@@ -151,7 +149,7 @@ fn add_image_segmenter_ui_components(
             }
         }
         _ => {
-            ui.label("Extrinsic parameters not recieved.");
+            ui.label("Image Segmenter parameters not recieved.");
         }
     };
     if changed {
@@ -191,7 +189,7 @@ fn add_field_color_ui_components(
             }
         }
 
-        ui.label(format!("{label:#} Camera"));
+        ui.label(format!("FieldColor {label:#}"));
 
         add_save_button(
             ui,
@@ -205,24 +203,22 @@ fn add_field_color_ui_components(
         );
     });
 
-    ui.style_mut().spacing.slider_width = ui.available_size().x - 100.0;
-
     let mut changed = false;
 
     match &mut field_color_option {
         Some(field_color_value) => {
             ui.label(format!(
-                "Green Chromacity [{}°, {}°]",
+                "Green Chromacity Thresholds[{}°, {}°]",
                 green_chromacity_range.0, green_chromacity_range.1
             ));
             for (axis_value, axis_name) in [
                 (
                     &mut field_color_value.lower_green_chromaticity_threshold,
-                    "lower_green_chromaticity_threshold",
+                    "lower",
                 ),
                 (
                     &mut field_color_value.upper_green_chromaticity_threshold,
-                    "upper_green_chromaticity_threshold",
+                    "upper",
                 ),
             ] {
                 let slider = Slider::new(
@@ -241,7 +237,7 @@ fn add_field_color_ui_components(
                     green_luminance_range.0, green_luminance_range.1
                 ));
                 let axis_value = &mut field_color_value.green_luminance_threshold;
-                let axis_name = "green_luminance_threshold";
+                let axis_name = "threshold";
 
                 let slider = Slider::new(
                     axis_value,
@@ -255,7 +251,7 @@ fn add_field_color_ui_components(
             }
         }
         _ => {
-            ui.label("Extrinsic parameters not recieved.");
+            ui.label("Field Colour parameters not recieved.");
         }
     };
     if changed {
@@ -276,23 +272,27 @@ impl Widget for &mut SegmenterCalibrationPanel {
             Ok(repository_parameters) => repository_parameters,
             Err(error) => return ui.label(format!("{error:#?}")),
         };
+        ui.style_mut().spacing.slider_width = ui.available_size().x - 150.0;
         ui.vertical(|ui| {
-            for subscription in &mut self.field_color_subscriptions {
+            for (field_color_subscription, image_segmenter_subscription) in &mut self
+                .field_color_subscriptions
+                .iter_mut()
+                .zip(&mut self.image_segmenter_subscriptions)
+            {
                 add_field_color_ui_components(
                     ui,
                     self.nao.clone(),
                     repository_parameters,
-                    subscription,
+                    field_color_subscription,
                 );
 
                 ui.separator();
-            }
-            for subscription in &mut self.image_segmenter_subscriptions {
+
                 add_image_segmenter_ui_components(
                     ui,
                     self.nao.clone(),
                     repository_parameters,
-                    subscription,
+                    image_segmenter_subscription,
                 );
 
                 ui.separator();

--- a/tools/twix/src/panels/segmenter_calibration.rs
+++ b/tools/twix/src/panels/segmenter_calibration.rs
@@ -1,31 +1,28 @@
 use color_eyre::eyre::{Context, Result};
 use eframe::egui::{Response, Slider, Ui, Widget};
 use log::{error, info};
-use nalgebra::Vector3;
 use serde_json::Value;
 use std::{ops::RangeInclusive, sync::Arc};
-use tokio::sync::mpsc;
-use types::FieldColor;
+use types::parameters::{FieldColorDetection, ImageSegmenter};
 
 use crate::{
     nao::Nao, panel::Panel, repository_parameters::RepositoryParameters, value_buffer::ValueBuffer,
 };
 
-use super::parameter::{add_save_button, subscribe};
+use super::parameter::add_save_button;
 
 struct ParameterSubscriptions<DeserializedValueType> {
     human_friendly_label: String,
     path: String,
     value_buffer: ValueBuffer,
     value: DeserializedValueType,
-    update_notify_receiver: mpsc::Receiver<()>,
 }
 
 pub struct SegmenterCalibrationPanel {
     nao: Arc<Nao>,
     repository_parameters: Result<RepositoryParameters>,
-    field_color_subscriptions: [ParameterSubscriptions<Option<FieldColor>>; 2],
-    image_segmenter_subscriptions: [ParameterSubscriptions<Option<serde_json::Value>>; 2],
+    field_color_subscriptions: [ParameterSubscriptions<Option<FieldColorDetection>>; 2],
+    image_segmenter_subscriptions: [ParameterSubscriptions<Option<ImageSegmenter>>; 2],
 }
 
 const FIELD_COLOUR_KEY_BASE: &str = "field_color_detection.vision_";
@@ -37,37 +34,25 @@ impl Panel for SegmenterCalibrationPanel {
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         let field_color_subscriptions = ["Top", "Bottom"].map(|name| {
             let path = FIELD_COLOUR_KEY_BASE.to_owned() + name.to_lowercase().as_str();
-
-            let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
-            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender)
-                .expect("ValudBuffer is None, subscription failed");
-
+            let value_buffer = nao.subscribe_parameter(&path);
             info!("Subscribing to path {}", path);
-
             ParameterSubscriptions {
                 human_friendly_label: name.to_string(),
                 path,
                 value_buffer,
                 value: None,
-                update_notify_receiver,
             }
         });
 
         let image_segmenter_subscriptions = ["Top", "Bottom"].map(|name| {
             let path = IMAGE_SEGMENTER_KEY_BASE.to_owned() + name.to_lowercase().as_str();
-
-            let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
-            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender)
-                .expect("ValudBuffer is None, subscription failed");
-
+            let value_buffer = nao.subscribe_parameter(&path);
             info!("Subscribing to path {}", path);
-
             ParameterSubscriptions {
                 human_friendly_label: name.to_string(),
                 path,
                 value_buffer,
                 value: None,
-                update_notify_receiver,
             }
         });
 
@@ -80,24 +65,124 @@ impl Panel for SegmenterCalibrationPanel {
     }
 }
 
+fn add_image_segmenter_ui_components(
+    ui: &mut Ui,
+    nao: Arc<Nao>,
+    repository_parameters: &RepositoryParameters,
+    image_segmenter_subscription: &mut ParameterSubscriptions<Option<ImageSegmenter>>,
+) {
+    let buffer = &image_segmenter_subscription.value_buffer;
+
+    let mut value_option = &mut image_segmenter_subscription.value;
+    let label = &image_segmenter_subscription.human_friendly_label;
+    let subscription_path = &image_segmenter_subscription.path;
+
+    let stride_range = (1usize, 128usize);
+    let vertical_edge_threshold_range = (-128i16, 128i16);
+
+    ui.horizontal(|ui| {
+        match buffer.parse_latest::<ImageSegmenter>() {
+            Ok(value) => {
+                *value_option = Some(value);
+            }
+            Err(error) => {
+                ui.label(format!("{error:#?}"));
+            }
+        }
+
+        ui.label(format!("{label:#} Camera"));
+
+        add_save_button(
+            ui,
+            subscription_path,
+            || {
+                serde_json::to_value(&value_option)
+                    .wrap_err("Conveting ImageSegmenter to serde_json::Value failed.")
+            },
+            nao.clone(),
+            repository_parameters,
+        );
+    });
+
+    ui.style_mut().spacing.slider_width = ui.available_size().x - 100.0;
+
+    let mut changed = false;
+
+    match &mut value_option {
+        Some(value) => {
+            ui.label(format!(
+                "Strides [{}°, {}°]",
+                stride_range.0, stride_range.1
+            ));
+            for (axis_value, axis_name) in [
+                (&mut value.horizontal_stride, "horizontal_stride"),
+                (&mut value.vertical_stride, "vertical_stride"),
+            ] {
+                let slider = Slider::new(
+                    axis_value,
+                    RangeInclusive::new(stride_range.0, stride_range.1),
+                )
+                .text(axis_name)
+                .smart_aim(false);
+                if ui.add(slider).changed() {
+                    changed = true
+                };
+            }
+            {
+                ui.label(format!(
+                    "Vertical Edge Threshold [{}°, {}°]",
+                    vertical_edge_threshold_range.0, vertical_edge_threshold_range.1
+                ));
+                let axis_value = &mut value.vertical_edge_threshold;
+                let axis_name = "green_luminance_threshold";
+
+                let slider = Slider::new(
+                    axis_value,
+                    RangeInclusive::new(
+                        vertical_edge_threshold_range.0,
+                        vertical_edge_threshold_range.1,
+                    ),
+                )
+                .text(axis_name)
+                .smart_aim(false);
+                if ui.add(slider).changed() {
+                    changed = true
+                };
+            }
+        }
+        _ => {
+            ui.label("Extrinsic parameters not recieved.");
+        }
+    };
+    if changed {
+        if let Some(field_color_value) = value_option {
+            match serde_json::value::to_value(field_color_value) {
+                Ok(value) => {
+                    nao.update_parameter_value(subscription_path, value);
+                }
+                Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
+            }
+        }
+    }
+}
+
 fn add_field_color_ui_components(
     ui: &mut Ui,
     nao: Arc<Nao>,
     repository_parameters: &RepositoryParameters,
-    field_color_subscription: &mut ParameterSubscriptions<Option<FieldColor>>,
+    field_color_subscription: &mut ParameterSubscriptions<Option<FieldColorDetection>>,
 ) {
     let buffer = &field_color_subscription.value_buffer;
 
     let mut field_color_option = &mut field_color_subscription.value;
     let label = &field_color_subscription.human_friendly_label;
     let subscription_path = &field_color_subscription.path;
-    let update_notify_reciever = &mut field_color_subscription.update_notify_receiver;
 
     let green_chromacity_range = (0.0f32, 1.0f32);
     let green_luminance_range = (0u8, u8::MAX);
 
     ui.horizontal(|ui| {
-        match buffer.parse_latest::<FieldColor>() {
+        match buffer.parse_latest::<FieldColorDetection>() {
             Ok(value) => {
                 *field_color_option = Some(value);
             }
@@ -194,6 +279,16 @@ impl Widget for &mut SegmenterCalibrationPanel {
         ui.vertical(|ui| {
             for subscription in &mut self.field_color_subscriptions {
                 add_field_color_ui_components(
+                    ui,
+                    self.nao.clone(),
+                    repository_parameters,
+                    subscription,
+                );
+
+                ui.separator();
+            }
+            for subscription in &mut self.image_segmenter_subscriptions {
+                add_image_segmenter_ui_components(
                     ui,
                     self.nao.clone(),
                     repository_parameters,

--- a/tools/twix/src/panels/segmenter_calibration.rs
+++ b/tools/twix/src/panels/segmenter_calibration.rs
@@ -32,7 +32,7 @@ const STRIDE_RANGE: (usize, usize) = (1, 20);
 const VERTICAL_EDGE_THRESHOLD_RANGE: (i16, i16) = (0, u8::MAX as i16);
 const GREEN_CHROMACITY_RANGE: (f32, f32) = (0.0, 1.0);
 const GREEN_LUMINANCE_RANGE: (u8, u8) = (0, u8::MAX);
-// Needed to avoid unnessesary diff creation at save-to-disk (f64->f32->f64 conversion)
+// Needed to avoid unnessesary diff creation at save-to-disk (caused by JSON: f64 -> struct: f32 -> JSON: f64 conversion)
 const FIELD_COLOUR_SKIPPED_FIELDS: &[&str] =
     &["red_chromaticity_threshold", "blue_chromaticity_threshold"];
 

--- a/tools/twix/src/panels/segmenter_calibration.rs
+++ b/tools/twix/src/panels/segmenter_calibration.rs
@@ -1,0 +1,208 @@
+use color_eyre::eyre::{Context, Result};
+use eframe::egui::{Response, Slider, Ui, Widget};
+use log::{error, info};
+use nalgebra::Vector3;
+use serde_json::Value;
+use std::{ops::RangeInclusive, sync::Arc};
+use tokio::sync::mpsc;
+use types::FieldColor;
+
+use crate::{
+    nao::Nao, panel::Panel, repository_parameters::RepositoryParameters, value_buffer::ValueBuffer,
+};
+
+use super::parameter::{add_save_button, subscribe};
+
+struct ParameterSubscriptions<DeserializedValueType> {
+    human_friendly_label: String,
+    path: String,
+    value_buffer: ValueBuffer,
+    value: DeserializedValueType,
+    update_notify_receiver: mpsc::Receiver<()>,
+}
+
+pub struct SegmenterCalibrationPanel {
+    nao: Arc<Nao>,
+    repository_parameters: Result<RepositoryParameters>,
+    field_color_subscriptions: [ParameterSubscriptions<Option<FieldColor>>; 2],
+    image_segmenter_subscriptions: [ParameterSubscriptions<Option<serde_json::Value>>; 2],
+}
+
+const FIELD_COLOUR_KEY_BASE: &str = "field_color_detection.vision_";
+const IMAGE_SEGMENTER_KEY_BASE: &str = "image_segmenter.vision_";
+
+impl Panel for SegmenterCalibrationPanel {
+    const NAME: &'static str = "Segmenter Calibration";
+
+    fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
+        let field_color_subscriptions = ["Top", "Bottom"].map(|name| {
+            let path = FIELD_COLOUR_KEY_BASE.to_owned() + name.to_lowercase().as_str();
+
+            let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender)
+                .expect("ValudBuffer is None, subscription failed");
+
+            info!("Subscribing to path {}", path);
+
+            ParameterSubscriptions {
+                human_friendly_label: name.to_string(),
+                path,
+                value_buffer,
+                value: None,
+                update_notify_receiver,
+            }
+        });
+
+        let image_segmenter_subscriptions = ["Top", "Bottom"].map(|name| {
+            let path = IMAGE_SEGMENTER_KEY_BASE.to_owned() + name.to_lowercase().as_str();
+
+            let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
+            let value_buffer = subscribe(nao.clone(), &path, update_notify_sender)
+                .expect("ValudBuffer is None, subscription failed");
+
+            info!("Subscribing to path {}", path);
+
+            ParameterSubscriptions {
+                human_friendly_label: name.to_string(),
+                path,
+                value_buffer,
+                value: None,
+                update_notify_receiver,
+            }
+        });
+
+        Self {
+            nao,
+            repository_parameters: RepositoryParameters::try_new(),
+            field_color_subscriptions,
+            image_segmenter_subscriptions,
+        }
+    }
+}
+
+fn add_field_color_ui_components(
+    ui: &mut Ui,
+    nao: Arc<Nao>,
+    repository_parameters: &RepositoryParameters,
+    field_color_subscription: &mut ParameterSubscriptions<Option<FieldColor>>,
+) {
+    let buffer = &field_color_subscription.value_buffer;
+
+    let mut field_color_option = &mut field_color_subscription.value;
+    let label = &field_color_subscription.human_friendly_label;
+    let subscription_path = &field_color_subscription.path;
+    let update_notify_reciever = &mut field_color_subscription.update_notify_receiver;
+
+    let green_chromacity_range = (0.0f32, 1.0f32);
+    let green_luminance_range = (0u8, u8::MAX);
+
+    ui.horizontal(|ui| {
+        match buffer.parse_latest::<FieldColor>() {
+            Ok(value) => {
+                *field_color_option = Some(value);
+            }
+            Err(error) => {
+                ui.label(format!("{error:#?}"));
+            }
+        }
+
+        ui.label(format!("{label:#} Camera"));
+
+        add_save_button(
+            ui,
+            subscription_path,
+            || {
+                serde_json::to_value(&field_color_option)
+                    .wrap_err("Conveting FieldColor to serde_json::Value failed.")
+            },
+            nao.clone(),
+            repository_parameters,
+        );
+    });
+
+    ui.style_mut().spacing.slider_width = ui.available_size().x - 100.0;
+
+    let mut changed = false;
+
+    match &mut field_color_option {
+        Some(field_color_value) => {
+            ui.label(format!(
+                "Green Chromacity [{}°, {}°]",
+                green_chromacity_range.0, green_chromacity_range.1
+            ));
+            for (axis_value, axis_name) in [
+                (
+                    &mut field_color_value.lower_green_chromaticity_threshold,
+                    "lower_green_chromaticity_threshold",
+                ),
+                (
+                    &mut field_color_value.upper_green_chromaticity_threshold,
+                    "upper_green_chromaticity_threshold",
+                ),
+            ] {
+                let slider = Slider::new(
+                    axis_value,
+                    RangeInclusive::new(green_chromacity_range.0, green_chromacity_range.1),
+                )
+                .text(axis_name)
+                .smart_aim(false);
+                if ui.add(slider).changed() {
+                    changed = true
+                };
+            }
+            {
+                ui.label(format!(
+                    "Green Luminance Threshold [{}°, {}°]",
+                    green_luminance_range.0, green_luminance_range.1
+                ));
+                let axis_value = &mut field_color_value.green_luminance_threshold;
+                let axis_name = "green_luminance_threshold";
+
+                let slider = Slider::new(
+                    axis_value,
+                    RangeInclusive::new(green_luminance_range.0, green_luminance_range.1),
+                )
+                .text(axis_name)
+                .smart_aim(false);
+                if ui.add(slider).changed() {
+                    changed = true
+                };
+            }
+        }
+        _ => {
+            ui.label("Extrinsic parameters not recieved.");
+        }
+    };
+    if changed {
+        if let Some(field_color_value) = field_color_option {
+            match serde_json::value::to_value(field_color_value) {
+                Ok(value) => {
+                    nao.update_parameter_value(subscription_path, value);
+                }
+                Err(error) => error!("Failed to serialize parameter value: {error:#?}"),
+            }
+        }
+    }
+}
+
+impl Widget for &mut SegmenterCalibrationPanel {
+    fn ui(self, ui: &mut Ui) -> Response {
+        let repository_parameters = match &self.repository_parameters {
+            Ok(repository_parameters) => repository_parameters,
+            Err(error) => return ui.label(format!("{error:#?}")),
+        };
+        ui.vertical(|ui| {
+            for subscription in &mut self.field_color_subscriptions {
+                add_field_color_ui_components(
+                    ui,
+                    self.nao.clone(),
+                    repository_parameters,
+                    subscription,
+                );
+
+                ui.separator();
+            }
+        })
+        .response
+    }
+}


### PR DESCRIPTION
## Introduced Changes

Introduces a rather hacky panel similar to the Manual (extrinsic) calibration with sliders to speed up Image Segmenter and Field Colour tuning.

Fixes #

## ToDo / Known Issues

- [x] Verify the ranges set for the sliders are valid.
- [x] Remove degree symbol in the label showing ranges 
- [x] Remove fields that show up in the diff (f32 -> f64 -> f32 reasons) which aren't actually modified in this panel

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Choose `Segmenter Calibration` in the Twix panel. It should appear like below.

![image](https://github.com/HULKs/hulk/assets/6742239/a6908365-4f40-44d8-9edb-d32dedd7b674)

