### PR TITLE
Offset to glance

### DIFF
--- a/crates/control/src/motion/look_at.rs
+++ b/crates/control/src/motion/look_at.rs
@@ -32,7 +32,7 @@ pub struct CycleContext {
     pub glance_angle: Parameter<f32, "look_at.glance_angle">,
     pub glance_direction_toggle_interval:
         Parameter<Duration, "look_at.glance_direction_toggle_interval">,
-    pub offset_pixels: Parameter<Point2<f32>, "look_at.glance_center_offset_pixels">,
+    pub offset_in_image: Parameter<Point2<f32>, "look_at.glance_center_offset_in_image">,
     pub minimum_bottom_focus_pitch: Parameter<f32, "look_at.minimum_bottom_focus_pitch">,
 }
 
@@ -122,7 +122,7 @@ impl LookAt {
                 look_at_with_camera(
                     target,
                     head_to_camera * ground_to_zero_head,
-                    *context.offset_pixels,
+                    *context.offset_in_image,
                     focal_length.into(),
                 )
             }
@@ -130,7 +130,7 @@ impl LookAt {
                 context.sensor_data.positions,
                 ground_to_zero_head,
                 camera_matrices,
-                *context.offset_pixels,
+                *context.offset_in_image,
                 target,
                 *context.minimum_bottom_focus_pitch,
             ),
@@ -146,7 +146,7 @@ fn look_at(
     joint_angles: Joints<f32>,
     ground_to_zero_head: Isometry3<f32>,
     camera_matrices: &CameraMatrices,
-    offset_pixels: Point2<f32>,
+    offset_in_image: Point2<f32>,
     target: Point2<f32>,
     minimum_bottom_focus_pitch: f32,
 ) -> HeadJoints<f32> {
@@ -158,13 +158,13 @@ fn look_at(
     let top_focus_angles = look_at_with_camera(
         target,
         head_to_top_camera * ground_to_zero_head,
-        offset_pixels,
+        offset_in_image,
         focal_length_top.into(),
     );
     let bottom_focus_angles = look_at_with_camera(
         target,
         head_to_bottom_camera * ground_to_zero_head,
-        offset_pixels,
+        offset_in_image,
         focal_length_bottom.into(),
     );
 
@@ -183,13 +183,13 @@ fn look_at(
 fn look_at_with_camera(
     target: Point2<f32>,
     ground_to_camera: Isometry3<f32>,
-    offset_pixels: Point2<f32>,
+    offset_in_image: Point2<f32>,
     focal_length: Point2<f32>,
 ) -> HeadJoints<f32> {
     let target_in_camera = ground_to_camera * point![target.x, target.y, 0.0];
 
-    let yaw_offset = f32::atan2(offset_pixels.x, focal_length.x);
-    let pitch_offset = f32::atan2(offset_pixels.y, focal_length.y);
+    let yaw_offset = f32::atan2(offset_in_image.x, focal_length.x);
+    let pitch_offset = f32::atan2(offset_in_image.y, focal_length.y);
 
     let yaw = f32::atan2(target_in_camera.y, target_in_camera.x) + yaw_offset;
     let pitch = -f32::atan2(target_in_camera.z, target_in_camera.x) - pitch_offset;

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -709,7 +709,7 @@
       "secs": 1
     },
     "minimum_bottom_focus_pitch": 0.2,
-    "glance_center_offset": [0.0, 0.0]
+    "glance_center_offset_pixels": [0.0, 0.0]
   },
   "look_around": {
     "look_around_timeout": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -709,7 +709,7 @@
       "secs": 1
     },
     "minimum_bottom_focus_pitch": 0.2,
-    "glance_center_offset_pixels": [0.0, 0.0]
+    "glance_center_offset_pixels": [0.0, -100.0]
   },
   "look_around": {
     "look_around_timeout": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -709,7 +709,7 @@
       "secs": 1
     },
     "minimum_bottom_focus_pitch": 0.2,
-    "glance_center_offset_pixels": [0.0, -100.0]
+    "glance_center_offset_in_image": [0.0, -100.0]
   },
   "look_around": {
     "look_around_timeout": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -331,7 +331,7 @@
   },
   "role_assignment": {
     "forced_role": null,
-    "keeper_replacementkeeper_switch_time": { "nanos": 0, "secs":  12}
+    "keeper_replacementkeeper_switch_time": { "nanos": 0, "secs": 12 }
   },
   "stand_up": {
     "gyro_low_pass_filter_coefficient": 0.1,
@@ -708,7 +708,8 @@
       "nanos": 0,
       "secs": 1
     },
-    "minimum_bottom_focus_pitch": 0.2
+    "minimum_bottom_focus_pitch": 0.2,
+    "glance_center_offset": [0.0, 0.0]
   },
   "look_around": {
     "look_around_timeout": {


### PR DESCRIPTION
## Introduced Changes

Allows to set an offset to the glance direction of the robot.
Normally ball is kept in center of camera, now it is at the center + offset.

Fixes #
Allows the robot to have lower head pitch which will cause less light to get into the camera.

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* use the LookAt Panel in twix and change the offset parameter.
