### PR TITLE
Tune ball filter to improve interception

### DIFF
--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -1,16 +1,14 @@
-use nalgebra::{vector, Isometry2, Point2, UnitComplex, Vector2};
+use nalgebra::{Isometry2, Point2, UnitComplex};
 use spl_network_messages::{GamePhase, SubState};
 use types::{
-    parameters::InterceptBall, Arc, BallState, Circle, FilteredGameState, GameControllerState,
-    HeadMotion, Line, Line2, LineSegment, MotionCommand, Orientation, OrientationMode, PathSegment,
-    Step, WorldState,
+    parameters::InterceptBall, BallState, FilteredGameState, GameControllerState, HeadMotion, Line,
+    LineSegment, MotionCommand, OrientationMode, PathSegment, Step, WorldState,
 };
 
 pub fn execute(
     world_state: &WorldState,
     parameters: InterceptBall,
     maximum_step_size: Step,
-    current_step: Step,
 ) -> Option<MotionCommand> {
     if let Some(
         GameControllerState {
@@ -31,7 +29,7 @@ pub fn execute(
         world_state.robot.robot_to_field,
     ) {
         (
-            Some(FilteredGameState::Playing { ball_is_free: true }),
+            Some(FilteredGameState::Playing { ball_is_free: true }) | None,
             Some(ball),
             Some(robot_to_field),
         ) => {
@@ -53,19 +51,16 @@ pub fn execute(
                 ball.ball_in_ground,
                 ball.ball_in_ground + ball.ball_in_ground_velocity,
             );
-            let optimal_interception_point = ball_line.project_point(Point2::origin());
+            let interception_point = ball_line.project_point(Point2::origin());
 
-            if optimal_interception_point.coords.norm() > parameters.maximum_intercept_distance {
+            if interception_point.coords.norm() > parameters.maximum_intercept_distance {
                 return None;
             }
 
-            let walking_direction = vector![current_step.forward, current_step.left];
-            let path = get_interception_path(
-                optimal_interception_point,
-                ball_line,
-                walking_direction,
-                &parameters,
-            );
+            let path = vec![PathSegment::LineSegment(LineSegment(
+                Point2::origin(),
+                interception_point,
+            ))];
 
             Some(MotionCommand::Walk {
                 head: HeadMotion::LookAt {
@@ -102,114 +97,4 @@ fn ball_is_interception_candidate(
         && ball_is_moving
         && ball_is_moving_towards_robot
         && ball_is_moving_towards_own_half
-}
-
-fn get_interception_path(
-    optimal_interception_point: Point2<f32>,
-    ball_line: Line2,
-    walking_direction: Vector2<f32>,
-    parameters: &InterceptBall,
-) -> Vec<PathSegment> {
-    let arc_radius = walking_direction.norm();
-
-    let total_angle_change =
-        UnitComplex::rotation_between(&walking_direction, &optimal_interception_point.coords)
-            .angle();
-    let angle_change = total_angle_change.signum() * parameters.angle_change_factor / arc_radius;
-
-    let arc_too_small = arc_radius < parameters.minimum_velocity_for_arc;
-    let total_angle_change_too_lange =
-        total_angle_change.abs() >= parameters.maximum_angle_change_for_arc;
-    let angle_change_too_small = total_angle_change.abs() <= angle_change.abs();
-
-    if arc_too_small || total_angle_change_too_lange || angle_change_too_small {
-        return vec![PathSegment::LineSegment(LineSegment(
-            Point2::origin(),
-            optimal_interception_point,
-        ))];
-    }
-
-    // If the arc and angle changes are within range, rotate current direction by angle and bridge
-    // the path between current position and line segment to interception point by a tangent arc.
-    // This rotation is required because the step planner walks in the direction tangent to a arc
-    // and the arc is created tangent to the current direction, so we have to rotate the direction
-    // slightly for traversing the arc.
-    let direction = UnitComplex::new(angle_change) * walking_direction;
-
-    let (arc, arc_orientation) =
-        calculate_arc_tangent_to(direction, optimal_interception_point.coords, arc_radius);
-
-    let interception_point =
-        ball_line.project_point(optimal_interception_point + (arc.end - arc.start));
-
-    vec![
-        PathSegment::Arc(arc, arc_orientation),
-        PathSegment::LineSegment(LineSegment(arc.end, interception_point)),
-    ]
-}
-
-fn calculate_arc_tangent_to(
-    vector1: Vector2<f32>,
-    vector2: Vector2<f32>,
-    radius: f32,
-) -> (Arc, Orientation) {
-    let start = Point2::origin();
-
-    let orientation =
-        LineSegment::new(start, start + vector1).get_orientation(start + vector1 + vector2);
-
-    let normal_vector1 = orientation.rotate_vector_90_degrees(vector1).normalize();
-    let normal_vector2 = orientation.rotate_vector_90_degrees(vector2).normalize();
-
-    let arc_center = start + radius * normal_vector1;
-    let end_point = arc_center - radius * normal_vector2;
-
-    (
-        Arc::new(Circle::new(arc_center, radius), start, end_point),
-        orientation,
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use approx::assert_relative_eq;
-    use nalgebra::vector;
-    use types::{Arc, Orientation};
-
-    use super::calculate_arc_tangent_to;
-
-    #[test]
-    fn arc_is_tangent() {
-        let vector1 = vector![-1.4, 3.1];
-        let vector2 = vector![0.9, -2.1];
-
-        let (arc, _) = calculate_arc_tangent_to(vector1, vector2, 3.0);
-        let Arc { start, circle, end } = arc;
-        let center = circle.center;
-
-        assert_relative_eq!((start - center).dot(&vector1), 0.0, epsilon = 0.00001);
-        assert_relative_eq!((end - center).dot(&vector2), 0.0, epsilon = 0.00001);
-    }
-
-    #[test]
-    fn colinear_arc_has_same_start_end() {
-        let vector1 = vector![-3.1, 1.9];
-        let vector2 = vector![-6.2, 3.8];
-
-        let (arc, _) = calculate_arc_tangent_to(vector1, vector2, 3.0);
-
-        assert_relative_eq!(arc.start, arc.end);
-    }
-
-    #[test]
-    fn arc_orientation() {
-        let vector1 = vector![1.3, 4.8];
-        let vector2 = vector![1.2, 5.7];
-
-        let (_, orientation1) = calculate_arc_tangent_to(vector1, vector2, 3.0);
-        let (_, orientation2) = calculate_arc_tangent_to(vector2, vector1, 3.0);
-
-        assert_eq!(orientation1, Orientation::Counterclockwise);
-        assert_eq!(orientation2, Orientation::Clockwise);
-    }
 }

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -44,8 +44,6 @@ pub struct CycleContext {
     pub cycle_time: Input<CycleTime, "cycle_time">,
     pub dribble_path: Input<Option<Vec<PathSegment>>, "dribble_path?">,
 
-    pub current_step: PersistentState<Step, "current_step">,
-
     pub parameters: Parameter<BehaviorParameters, "behavior">,
     pub in_walk_kicks: Parameter<InWalkKicks, "in_walk_kicks">,
     pub field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
@@ -194,7 +192,6 @@ impl Behavior {
                         world_state,
                         *context.intercept_ball_parameters,
                         *context.maximum_step_size,
-                        *context.current_step,
                     ),
                     Action::Calibrate => calibrate::execute(world_state),
                     Action::DefendGoal => defend.goal(&mut context.path_obstacles),

--- a/crates/control/src/motion/walking_engine.rs
+++ b/crates/control/src/motion/walking_engine.rs
@@ -127,7 +127,6 @@ pub struct CycleContext {
 
     pub motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
     pub walk_return_offset: PersistentState<Step, "walk_return_offset">,
-    pub current_step: PersistentState<Step, "current_step">,
 
     pub motion_command: Input<MotionCommand, "motion_command">,
     pub robot_kinematics: Input<RobotKinematics, "robot_kinematics">,
@@ -331,7 +330,6 @@ impl WalkingEngine {
 
         context.motion_safe_exits[MotionType::Walk] =
             matches!(self.walk_state, WalkState::Standing);
-        *context.current_step = self.current_step;
 
         let leg_stiffness = match self.walk_state {
             WalkState::Standing => context.config.leg_stiffness_stand,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -185,9 +185,6 @@ pub struct InterceptBall {
     pub minimum_ball_velocity_towards_robot: f32,
     pub minimum_ball_velocity_towards_own_half: f32,
     pub maximum_intercept_distance: f32,
-    pub minimum_velocity_for_arc: f32,
-    pub maximum_angle_change_for_arc: f32,
-    pub angle_change_factor: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -280,7 +280,7 @@
     "measurement_matching_distance": 1.0,
     "hypothesis_merge_distance": 1.0,
     "process_noise": [0.005, 0.005, 0.2, 0.2],
-    "measurement_noise_moving": [3.0, 5.0],
+    "measurement_noise_moving": [0.5, 2.0],
     "measurement_noise_resting": [300.0, 500.0],
     "initial_covariance": [0.5, 0.5, 0.5, 0.5],
     "resting_ball_velocity_threshold": 0.12,
@@ -844,13 +844,10 @@
     },
     "intercept_ball": {
       "maximum_ball_distance": 3.0,
-      "minimum_ball_velocity": 0.2,
+      "minimum_ball_velocity": 0.4,
       "minimum_ball_velocity_towards_robot": 0.2,
       "minimum_ball_velocity_towards_own_half": 0.05,
-      "maximum_intercept_distance": 0.5,
-      "minimum_velocity_for_arc": 0.005,
-      "maximum_angle_change_for_arc": 1.5,
-      "angle_change_factor": 0.01
+      "maximum_intercept_distance": 0.5
     },
     "initial_lookaround_duration": {
       "nanos": 0,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -332,7 +332,6 @@ impl BehaviorCycler {
                     lost_ball_parameters: &parameters.behavior.lost_ball,
                     intercept_ball_parameters: &parameters.behavior.intercept_ball,
                     has_ground_contact: &true,
-                    current_step: &mut persistent_state.current_step,
                     maximum_step_size: &parameters.step_planner.max_step_size,
                 })
                 .wrap_err("failed to execute cycle of node `Behavior`")?;

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -12,7 +12,7 @@ use spl_network_messages::{GamePhase, GameState, HulkMessage, PlayerNumber, Team
 use types::{
     messages::{IncomingMessage, OutgoingMessage},
     BallPosition, FilteredGameState, GameControllerState, HeadMotion, KickVariant, LineSegment,
-    MotionCommand, OrientationMode, PathSegment, Players, PrimaryState, Side, Step,
+    MotionCommand, OrientationMode, PathSegment, Players, PrimaryState, Side,
 };
 
 use crate::{
@@ -136,12 +136,6 @@ impl State {
                                 std::f32::consts::FRAC_PI_4 * time_step.as_secs_f32(),
                             ),
                     );
-
-                    robot.persistent_state.current_step = Step {
-                        forward: 30.0 * step[0],
-                        left: 30.0 * step[1],
-                        turn: 0.0,
-                    };
 
                     head
                 }


### PR DESCRIPTION
## Introduced Changes

This PR tunes the ball interception and adjusts the moving ball filter to improve the ball interception. It also removes the unnecessary additional arc traversal for ball interception.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Upload to a NAO and test ball interceptions.
