### PR TITLE
Make pepsi location symlink path relative

### DIFF
--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -363,7 +363,7 @@ impl Repository {
 
     pub async fn set_location(&self, target: &str, location: &str) -> Result<()> {
         let target_location = self.parameters_root().join(format!("{target}_location"));
-        let new_location = self.parameters_root().join(location);
+        let new_location = Path::new(location);
         let _ = remove_file(&target_location).await;
         symlink(&new_location, &target_location)
             .await


### PR DESCRIPTION
## Introduced Changes

What it says.
Prevents accidentally committing absolute paths including our local usernames.

Fixes #104 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

`pepsi location set <nao/webots> <location>`, check symlink at `etc/parameters/<nao/webots>`