### PR TITLE
Adds new ear signs

### DIFF
--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -225,9 +225,10 @@ impl LedStatus {
         }
 
         let minimum_temperature = 30.0;
+        let maximum_temperature = 105.0;
 
         let relative_temperature = (current_maximum_temperature - minimum_temperature)
-            / (105.0 - minimum_temperature).floor();
+            / (maximum_temperature - minimum_temperature).floor();
 
         Ear::percentage_ears(1.0, relative_temperature)
     }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -212,15 +212,10 @@ impl LedStatus {
         }
 
         if last_game_controller_message.is_some_and(|timestamp| {
-            if cycle_start_time
+            cycle_start_time
                 .duration_since(timestamp)
                 .expect("time ran backwards")
                 > Duration::from_millis(5000)
-            {
-                true
-            } else {
-                false
-            }
         }) {
             if blink_state {
                 return Ear::full_ears(1.0);

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -231,8 +231,8 @@ impl LedStatus {
 
         let minimum_temperature = 30.0;
 
-        let relative_temperature = ((current_maximum_temperature - minimum_temperature)
-            / (105.0 - minimum_temperature).floor()) as i32;
+        let relative_temperature = (current_maximum_temperature - minimum_temperature)
+            / (105.0 - minimum_temperature).floor();
 
         Ear::percentage_ears(1.0, relative_temperature)
     }

--- a/crates/types/src/led.rs
+++ b/crates/types/src/led.rs
@@ -71,18 +71,18 @@ impl Ear {
         }
     }
 
-    pub fn percentage_ears(intensity: f32, percentage: i32) -> Self {
+    pub fn percentage_ears(intensity: f32, ear_fraction: f32) -> Self {
         Self {
-            intensity_at_0: if percentage > 0 { intensity } else { 0.0 },
-            intensity_at_36: if percentage > 10 { intensity } else { 0.0 },
-            intensity_at_72: if percentage > 20 { intensity } else { 0.0 },
-            intensity_at_108: if percentage > 30 { intensity } else { 0.0 },
-            intensity_at_144: if percentage > 40 { intensity } else { 0.0 },
-            intensity_at_180: if percentage > 50 { intensity } else { 0.0 },
-            intensity_at_216: if percentage > 60 { intensity } else { 0.0 },
-            intensity_at_252: if percentage > 70 { intensity } else { 0.0 },
-            intensity_at_288: if percentage > 80 { intensity } else { 0.0 },
-            intensity_at_324: if percentage > 90 { intensity } else { 0.0 },
+            intensity_at_0: if ear_fraction > 0.0 { intensity } else { 0.0 },
+            intensity_at_36: if ear_fraction > 0.1 { intensity } else { 0.0 },
+            intensity_at_72: if ear_fraction > 0.2 { intensity } else { 0.0 },
+            intensity_at_108: if ear_fraction > 0.3 { intensity } else { 0.0 },
+            intensity_at_144: if ear_fraction > 0.4 { intensity } else { 0.0 },
+            intensity_at_180: if ear_fraction > 0.5 { intensity } else { 0.0 },
+            intensity_at_216: if ear_fraction > 0.6 { intensity } else { 0.0 },
+            intensity_at_252: if ear_fraction > 0.7 { intensity } else { 0.0 },
+            intensity_at_288: if ear_fraction > 0.8 { intensity } else { 0.0 },
+            intensity_at_324: if ear_fraction > 0.9 { intensity } else { 0.0 },
         }
     }
 }

--- a/crates/types/src/led.rs
+++ b/crates/types/src/led.rs
@@ -55,8 +55,8 @@ pub struct Ear {
     pub intensity_at_324: f32,
 }
 
-impl From<f32> for Ear {
-    fn from(intensity: f32) -> Self {
+impl Ear {
+    pub fn full_ears(intensity: f32) -> Self {
         Self {
             intensity_at_0: intensity,
             intensity_at_36: intensity,
@@ -68,6 +68,21 @@ impl From<f32> for Ear {
             intensity_at_252: intensity,
             intensity_at_288: intensity,
             intensity_at_324: intensity,
+        }
+    }
+
+    pub fn percentage_ears(intensity: f32, percentage: i32) -> Self {
+        Self {
+            intensity_at_0: if percentage > 0 { intensity } else { 0.0 },
+            intensity_at_36: if percentage > 10 { intensity } else { 0.0 },
+            intensity_at_72: if percentage > 20 { intensity } else { 0.0 },
+            intensity_at_108: if percentage > 30 { intensity } else { 0.0 },
+            intensity_at_144: if percentage > 40 { intensity } else { 0.0 },
+            intensity_at_180: if percentage > 50 { intensity } else { 0.0 },
+            intensity_at_216: if percentage > 60 { intensity } else { 0.0 },
+            intensity_at_252: if percentage > 70 { intensity } else { 0.0 },
+            intensity_at_288: if percentage > 80 { intensity } else { 0.0 },
+            intensity_at_324: if percentage > 90 { intensity } else { 0.0 },
         }
     }
 }


### PR DESCRIPTION
## Introduced Changes

This PR shows in the first place the whistle (as usual) and adds the charging status and in case there are no game controller message for 5 seconds, when a first message has arrived. It also shows the maximum temperature on the ears in percent.

Fixes #

## Ideas for Next Iterations (Not This PR)

## How to Test

Run this with game controller. Let it send message, stop it see if it blinks. See if the whistle works. Let the robot walk and see if the temperature increases.