### PR TITLE
Display role in LEDs

### DIFF
--- a/crates/types/src/color.rs
+++ b/crates/types/src/color.rs
@@ -125,6 +125,7 @@ impl Rgb {
     pub const BLUE: Rgb = Rgb::new(0, 0, 255);
     pub const YELLOW: Rgb = Rgb::new(255, 220, 0);
     pub const PURPLE: Rgb = Rgb::new(255, 0, 255);
+    pub const TURQUOISE: Rgb = Rgb::new(0, 255, 255);
     pub const WHITE: Rgb = Rgb::new(255, 255, 255);
 
     pub const fn new(r: u8, g: u8, b: u8) -> Self {


### PR DESCRIPTION
## Introduced Changes

This PR enables LED visualization for displaying the role in the eye.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Deploy on a robot and let it run over a field (maybe even with GameController) and look at the eye colors (the right eye, the left eye shows vision percepts).