### PR TITLE
Network and joint temperature via aliveness

### DIFF
--- a/crates/aliveness/src/lib.rs
+++ b/crates/aliveness/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use futures_util::{stream::FuturesUnordered, StreamExt};
+use hula_types::JointsArray;
 use tokio::{net::UdpSocket, time};
 
 pub use hula_types::Battery;
@@ -26,6 +27,8 @@ pub struct AlivenessState {
     pub body_id: Option<String>,
     pub head_id: Option<String>,
     pub battery: Option<Battery>,
+    pub network: Option<String>,
+    pub temperature: Option<JointsArray>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -38,7 +41,7 @@ pub enum AlivenessError {
     SocketNotBound(io::Error),
     #[error("failed to receive beacon response")]
     ReceiveFailed(io::Error),
-    #[error("failed to bind beacon socket")]
+    #[error("failed to deserialize JSON")]
     DeserializeFailed(serde_json::Error),
 }
 

--- a/docs/tooling/aliveness.md
+++ b/docs/tooling/aliveness.md
@@ -12,6 +12,8 @@ The following information can be queried from NAOs connected via Ethernet:
 - Battery charge state and current
 - Head ID
 - Body ID
+- Wireless network name
+- Joint temperatures
 - Name of the interface the beacon is received from (currently always enp4s0)
 
 ## Aliveness service

--- a/tools/aliveness/Cargo.lock
+++ b/tools/aliveness/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys",
 ]
 
@@ -1583,6 +1584,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
+ "lazy_static",
  "nix",
  "once_cell",
  "ordered-stream",
@@ -1591,6 +1593,7 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
+ "tokio",
  "tracing",
  "uds_windows",
  "winapi",

--- a/tools/aliveness/src/main.rs
+++ b/tools/aliveness/src/main.rs
@@ -20,7 +20,7 @@ use zbus::MessageStream;
 use zbus::MessageType;
 use zbus::Proxy;
 
-use crate::robot_info::RobotInfo;
+use crate::robot_info::{get_network, RobotInfo};
 
 mod robot_info;
 
@@ -227,6 +227,8 @@ async fn handle_beacon(
         body_id: robot_info.body_id().await.to_owned(),
         head_id: robot_info.head_id().await.to_owned(),
         battery: robot_info.battery().await.to_owned(),
+        temperature: robot_info.temperature().await.to_owned(),
+        network: get_network().await.ok().flatten(),
     };
     let send_buffer = serde_json::to_vec(&response).wrap_err("failed to serialize response")?;
     socket

--- a/tools/hula/proxy/src/dbus.rs
+++ b/tools/hula/proxy/src/dbus.rs
@@ -1,4 +1,4 @@
-use hula_types::Battery;
+use hula_types::{Battery, JointsArray};
 use std::sync::{Arc, Mutex};
 use zbus::{
     blocking::{Connection, ConnectionBuilder},
@@ -34,6 +34,10 @@ impl RobotInfo {
 
     fn battery(&self) -> Optional<Battery> {
         Optional::from(self.shared_state.lock().unwrap().battery)
+    }
+
+    fn temperature(&self) -> Optional<JointsArray> {
+        Optional::from(self.shared_state.lock().unwrap().temperature)
     }
 }
 

--- a/tools/hula/proxy/src/main.rs
+++ b/tools/hula/proxy/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use clap::Parser;
 use color_eyre::eyre::{Result, WrapErr};
-use hula_types::{Battery, RobotConfiguration};
+use hula_types::{Battery, JointsArray, RobotConfiguration};
 use log::{debug, LevelFilter};
 use systemd::daemon::{notify, STATE_READY};
 
@@ -26,6 +26,7 @@ struct Arguments {
 #[derive(Default)]
 pub struct SharedState {
     pub battery: Option<Battery>,
+    pub temperature: Option<JointsArray>,
     pub configuration: Option<RobotConfiguration>,
 }
 

--- a/tools/hula/proxy/src/proxy.rs
+++ b/tools/hula/proxy/src/proxy.rs
@@ -137,6 +137,7 @@ fn handle_lola_event(
     {
         let mut shared_state = shared_state.lock().unwrap();
         shared_state.battery = Some(robot_state.battery);
+        shared_state.temperature = Some(robot_state.temperature);
         if shared_state.configuration.is_none() {
             shared_state.configuration = Some(robot_state.robot_configuration);
         }

--- a/tools/hula/types/src/robot_state.rs
+++ b/tools/hula/types/src/robot_state.rs
@@ -147,7 +147,7 @@ pub struct SonarSensors {
     right: f32,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, Type)]
 #[repr(C)]
 pub struct JointsArray {
     head_yaw: f32,

--- a/tools/pepsi/src/aliveness.rs
+++ b/tools/pepsi/src/aliveness.rs
@@ -120,7 +120,7 @@ fn print_summary(states: &AlivenessList) {
         }
 
         if output.is_empty() {
-            output = format!("{}{:SPACING$}", ALL_OK_ICON.green().to_string(), "");
+            output = format!("{}{:SPACING$}", ALL_OK_ICON.green(), "");
         }
 
         let no_network = "None".to_owned();
@@ -184,18 +184,15 @@ fn print_verbose(states: &AlivenessList) {
                 temperatures.sort_unstable_by(f32::total_cmp);
 
                 let minimum_temperature = temperatures
-                    .iter()
-                    .next()
+                    .first()
                     .expect("temperature array should not be empty");
 
                 let maximum_temperature = temperatures
-                    .iter()
                     .last()
                     .expect("temperature array should not be empty");
 
                 let median_temperature = temperatures
-                    .iter()
-                    .nth(temperatures.len() / 2)
+                    .get(temperatures.len() / 2)
                     .expect("temperature array should not be empty");
 
                 format!(


### PR DESCRIPTION
## Introduced Changes

This PR exposes the current network and joint temperatures via aliveness.

Fixes #453 and fixes #470.

## ToDo / Known Issues

- [x] Update documentation

## Ideas for Next Iterations (Not This PR)

Maybe adding player number assignments when using pepsi aliveness

## How to Test

In HULKs repo:
```
. naosdk/5.8.0/environment-setup-corei7-64-aldebaran-linux
cd tools/aliveness
cargo build && scp target/x86_64-aldebaran-linux-gnu/debug/aliveness-service 10.1.24.36:
cd ../hula
cargo build && scp target/x86_64-aldebaran-linux-gnu/debug/hula 10.1.24.36:
pepsi shell 36
systemctl stop aliveness hula
./hula &
./aliveness-service
```
