### PR TITLE
Add Opponent Gamestate

### DIFF
--- a/crates/control/src/game_state_filter.rs
+++ b/crates/control/src/game_state_filter.rs
@@ -279,7 +279,7 @@ impl State {
     ) -> FilteredGameState {
         let hulks_is_kicking_team = matches!(
             game_controller_state.kicking_team,
-            Team::Hulks | Team::Uncertain
+            Team::Hulks
         );
         self.construct_filtered_game_state(
             game_controller_state,

--- a/crates/control/src/game_state_filter.rs
+++ b/crates/control/src/game_state_filter.rs
@@ -277,10 +277,7 @@ impl State {
         ball_detected_far_from_kick_off_point: bool,
         config: &GameStateFilterParameters,
     ) -> FilteredGameState {
-        let hulks_is_kicking_team = matches!(
-            game_controller_state.kicking_team,
-            Team::Hulks
-        );
+        let hulks_is_kicking_team = matches!(game_controller_state.kicking_team, Team::Hulks);
         self.construct_filtered_game_state(
             game_controller_state,
             hulks_is_kicking_team,


### PR DESCRIPTION
## Introduced Changes

Adds the GameState of the opponents, assuming both teams hear the whistle.
This will be used in order to examine if the ball is free or not for the opponent team which
allows us to do shots with higher precision.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Start the game controller and examine the opponent game state, make sure the ball is free changes only for the kickoff team when a whistle is heard
