### PR TITLE
take into account turning time

### DIFF
--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -1,4 +1,4 @@
-use std::{f32::consts::PI, time::Duration};
+use std::{f32::consts::FRAC_1_PI, time::Duration};
 
 use color_eyre::Result;
 use framework::AdditionalOutput;
@@ -82,10 +82,9 @@ impl TimeToReachKickPosition {
                 turning_angle_towards_path
             }
         };
-        let time_to_turn = Duration::from_secs_f32(match turning_angle {
-            Some(angle) => angle / PI * context.configuration.path_planning.half_turning_time,
-            None => 0.0f32,
-        });
+        let time_to_turn = Duration::from_secs_f32(turning_angle.map_or(0.0, |angle| {
+            angle * FRAC_1_PI * context.configuration.path_planning.half_turning_time
+        }));
         let time_to_reach_kick_position = walk_time.map(|walk_time| {
             [
                 walk_time,

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -69,15 +69,18 @@ impl TimeToReachKickPosition {
                 orientation_mode: OrientationMode::Override(orientation),
                 ..
             } => Some(orientation.angle().abs()),
-            _ => match context.dribble_path {
-                Some(path) => match path.first() {
-                    Some(PathSegment::LineSegment(line_segment)) => {
-                        Some(line_segment.1.coords().angle(Vector2::x_axis()).abs())
-                    }
+            _ => {
+                let turning_angle_towards_path = match context.dribble_path {
+                    Some(path) => match path.first() {
+                        Some(PathSegment::LineSegment(line_segment)) => {
+                            Some(line_segment.1.coords().angle(Vector2::x_axis()).abs())
+                        }
+                        _ => None,
+                    },
                     _ => None,
-                },
-                _ => None,
-            },
+                };
+                turning_angle_towards_path
+            }
         };
         let time_to_turn = Duration::from_secs_f32(match turning_angle {
             Some(angle) => angle / PI * context.configuration.path_planning.half_turning_time,

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -82,9 +82,13 @@ impl TimeToReachKickPosition {
                 turning_angle_towards_path
             }
         };
-        let time_to_turn = Duration::from_secs_f32(turning_angle.map_or(0.0, |angle| {
-            angle * FRAC_1_PI * context.configuration.path_planning.half_turning_time
-        }));
+        let time_to_turn = turning_angle.map_or(Duration::ZERO, |angle| {
+            context
+                .configuration
+                .path_planning
+                .half_rotation
+                .mul_f32(angle * FRAC_1_PI)
+        });
         let time_to_reach_kick_position = walk_time.map(|walk_time| {
             [
                 walk_time,

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -17,7 +17,7 @@ use context_attribute::context;
 #[context]
 pub struct CycleContext {
     dribble_path: Input<Option<Vec<PathSegment>>, "dribble_path?">,
-    motion_command: Input<MotionCommand, "motion_command?">,
+    motion_command: Input<MotionCommand, "motion_command">,
 
     time_to_turn: AdditionalOutput<Duration, "time_to_turn">,
     time_to_reach_kick_position_output:

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -157,6 +157,7 @@ pub struct PathPlanningParameters {
     pub minimum_robot_radius_at_foot_height: f32,
     pub robot_radius_at_foot_height: f32,
     pub robot_radius_at_hip_height: f32,
+    pub half_turning_time: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -157,7 +157,7 @@ pub struct PathPlanningParameters {
     pub minimum_robot_radius_at_foot_height: f32,
     pub robot_radius_at_foot_height: f32,
     pub robot_radius_at_hip_height: f32,
-    pub half_turning_time: f32,
+    pub half_rotation: Duration,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -893,7 +893,8 @@
       "field_border_weight": 0.15,
       "line_walking_speed": 0.25,
       "arc_walking_speed": 0.2,
-      "rotation_penalty_factor": 0.4
+      "rotation_penalty_factor": 0.4,
+      "half_turning_time": 5.0
     },
     "search": {
       "position_reached_distance": 0.4,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -894,7 +894,10 @@
       "line_walking_speed": 0.25,
       "arc_walking_speed": 0.2,
       "rotation_penalty_factor": 0.4,
-      "half_turning_time": 5.0
+      "half_rotation": {
+        "nanos": 0,
+        "secs": 3
+      }
     },
     "search": {
       "position_reached_distance": 0.4,

--- a/tests/behavior/turning_time.lua
+++ b/tests/behavior/turning_time.lua
@@ -1,0 +1,65 @@
+local inspect = require 'inspect'
+
+function spawn_robot(number)
+    table.insert(state.robots, create_robot(number))
+end
+
+spawn_robot(2)
+
+local game_end_time = 10000
+local goal_scored = false
+
+function on_goal()
+    print("Goal scored, resetting ball!")
+    print("Ball: " .. inspect(state.ball))
+    print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
+    state.ball = nil
+    goal_scored = true
+    game_end_time = state.cycle_count + 200
+end
+
+function on_cycle()
+    if state.cycle_count == 1000 then
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 2300 then
+        state.ball = {
+            position = { -3.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 1 then
+        state.game_controller_state.game_state = "Ready"
+        state.filtered_game_state = {
+            Ready = {
+                kicking_team = "Hulks",
+            }
+        }
+    end
+
+    if state.cycle_count == 1150 then
+        state.filtered_game_state.game_state = "Set"
+        state.filtered_game_state = "Set"
+    end
+
+    if state.cycle_count == 1200 then
+        state.filtered_game_state = {
+            Playing = {
+                ball_is_free = true,
+                kick_off = true
+            }
+        }
+    end
+
+    if state.cycle_count == game_end_time then
+        -- if not goal_scored then
+        --   error("No goal was scored!")
+        -- end
+        state.finished = true
+    end
+end

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -315,6 +315,11 @@ impl BehaviorCycler {
                 .time_to_reach_kick_position
                 .cycle(control::time_to_reach_kick_position::CycleContext::new(
                     own_database.main_outputs.dribble_path.as_ref(),
+                    &own_database.main_outputs.motion_command,
+                    framework::AdditionalOutput::new(
+                        true,
+                        &mut own_database.additional_outputs.time_to_turn,
+                    ),
                     framework::AdditionalOutput::new(
                         true,
                         &mut own_database


### PR DESCRIPTION
## Introduced Changes

Take into account angle relative to path to ball in time to reach kick position function.

Mitigates #484 

## ToDo / Known Issues

Turning speed currently only based on searcher turn speed, may need to be tuned.
In the game against BerlinUnited this caused strikers to sometimes walk away from the ball in an unnecessary fashion.

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Player facing away from ball will now not claim striker as easily. 
