### PR TITLE
Penalty keeper tuning and extra parameters

### DIFF
--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -15,13 +15,21 @@ pub struct PenaltyShotDirectionEstimation {
 }
 
 #[context]
-pub struct CreationContext {}
+pub struct CreationContext {
+    pub field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
+    pub moving_distance_threshold:
+        Parameter<f32, "penalty_shot_direction_estimation.moving_distance_threshold">,
+    pub minimum_velocity_threshold:
+        Parameter<f32, "penalty_shot_direction_estimation.minimum_velocity_threshold">,
+}
 
 #[context]
 pub struct CycleContext {
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
     moving_distance_threshold:
         Parameter<f32, "penalty_shot_direction_estimation.moving_distance_threshold">,
+    pub minimum_velocity_threshold:
+        Parameter<f32, "penalty_shot_direction_estimation.minimum_velocity_threshold">,
 
     ball_position: RequiredInput<Option<BallPosition>, "ball_position?">,
     game_controller_state: RequiredInput<Option<GameControllerState>, "game_controller_state?">,
@@ -56,6 +64,8 @@ impl PenaltyShotDirectionEstimation {
                         - context.field_dimensions.penalty_marker_distance)
                         .abs()
                         > *context.moving_distance_threshold
+                        && context.ball_position.velocity.norm()
+                            > *context.minimum_velocity_threshold
                     {
                         if context.ball_position.position.y >= 0.0 {
                             self.last_shot_direction = PenaltyShotDirection::Left;

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -62,7 +62,7 @@ impl PenaltyShotDirectionEstimation {
             }
             (PrimaryState::Playing, GamePhase::PenaltyShootout { .. }) => {
                 if let PenaltyShotDirection::NotMoving = self.last_shot_direction {
-                    let is_ball_position_exceeed_moving_distance_threshold =
+                    let is_ball_position_exceeding_moving_distance_threshold =
                         (context.ball_position.position.x
                             - context.field_dimensions.penalty_marker_distance)
                             .abs()

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -750,7 +750,8 @@
     }
   },
   "penalty_shot_direction_estimation": {
-    "moving_distance_threshold": 0.2
+    "moving_distance_threshold": 0.2,
+    "minimum_velocity_threshold": 0.1
   },
   "head_motion_limits": {
     "maximum_yaw": 2.076941809873252,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -751,7 +751,8 @@
   },
   "penalty_shot_direction_estimation": {
     "moving_distance_threshold": 0.2,
-    "minimum_velocity_threshold": 0.1
+    "minimum_velocity_threshold": 0.1,
+    "side_jump_threshold": 0.1
   },
   "head_motion_limits": {
     "maximum_yaw": 2.076941809873252,


### PR DESCRIPTION
## Introduced Changes

I tried to define some tuning possibilities with the observations in #477.

Also introduced a `side_jump_threshold` in order to not jump to the wrong direction by `ball_position.y >= 0.0` check alone (which caused a jump to the wrong direction in RC2023 penalty shootout against Runswift).

We used this branch (without the above-mentioned side jump threshold) and worked as expected -> less trigger-happy. 
## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)
- Discuss how we can do a test mode, extra motion (i.e. look at) or some other way like LEDs or audio.
- These parameters and the behaviour could be further tuned by more testing, as the keeper jumped too late in RC2023 (maybe the parameters or some other place is the reason).

## How to Test

The parameters reduce the trigger happiness by increasing the distance from the penalty marker the ball has to move.
