### PR TITLE
Fix path oscillations

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -165,6 +165,7 @@ impl Behavior {
             context.field_dimensions,
             &world_state.obstacles,
             &context.parameters.path_planning,
+            &self.last_motion_command,
         );
         let walk_and_stand = WalkAndStand::new(
             world_state,

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -42,7 +42,8 @@ impl<'cycle> WalkPathPlanner<'cycle> {
         rule_obstacles: &[RuleObstacle],
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     ) -> Vec<PathSegment> {
-        let mut planner = PathPlanner::from_last_motion(
+        let mut planner = PathPlanner::default();
+        planner.with_last_motion(
             self.last_motion_command,
             self.parameters.rotation_penalty_factor,
         );

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -14,6 +14,7 @@ pub struct WalkPathPlanner<'cycle> {
     field_dimensions: &'cycle FieldDimensions,
     obstacles: &'cycle [Obstacle],
     parameters: &'cycle PathPlanningParameters,
+    last_motion_command: &'cycle MotionCommand,
 }
 
 impl<'cycle> WalkPathPlanner<'cycle> {
@@ -21,11 +22,13 @@ impl<'cycle> WalkPathPlanner<'cycle> {
         field_dimensions: &'cycle FieldDimensions,
         obstacles: &'cycle [Obstacle],
         parameters: &'cycle PathPlanningParameters,
+        last_motion_command: &'cycle MotionCommand,
     ) -> Self {
         Self {
             field_dimensions,
             obstacles,
             parameters,
+            last_motion_command,
         }
     }
     #[allow(clippy::too_many_arguments)]
@@ -39,7 +42,10 @@ impl<'cycle> WalkPathPlanner<'cycle> {
         rule_obstacles: &[RuleObstacle],
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     ) -> Vec<PathSegment> {
-        let mut planner = PathPlanner::default();
+        let mut planner = PathPlanner::from_last_motion(
+            self.last_motion_command,
+            self.parameters.rotation_penalty_factor,
+        );
         planner.with_obstacles(obstacles, self.parameters.robot_radius_at_hip_height);
         planner.with_rule_obstacles(
             robot_to_field.inverse(),

--- a/crates/control/src/dribble_path_planner.rs
+++ b/crates/control/src/dribble_path_planner.rs
@@ -1,110 +1,70 @@
-use color_eyre::Result;
-use context_attribute::context;
-use framework::{AdditionalOutput, MainOutput};
+use framework::AdditionalOutput;
 use nalgebra::Point2;
 use spl_network_messages::Team;
 use std::f32::consts::PI;
-use types::{
-    parameters::Behavior, FieldDimensions, GameControllerState, PathObstacle, PathSegment,
-    WorldState,
-};
+use types::{parameters::Dribbling, GameControllerState, PathObstacle, PathSegment, WorldState};
 
 use crate::behavior::walk_to_pose::WalkPathPlanner;
 
-#[context]
-pub struct CreationContext {}
+pub fn plan(
+    walk_path_planner: &WalkPathPlanner,
+    world_state: &WorldState,
+    dribbling_parameters: &Dribbling,
+    path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
+) -> Option<Vec<PathSegment>> {
+    let Some(kick_decisions) = world_state.kick_decisions.as_ref() else { return None };
+    let Some(best_kick_decision) = kick_decisions.first() else { return None };
+    let Some(ball) = world_state.ball else { return None };
+    let Some(robot_to_field) = world_state.robot.robot_to_field else { return None };
 
-#[context]
-pub struct CycleContext {
-    pub parameters: Parameter<Behavior, "behavior">,
-    pub field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
-    pub path_obstacles: AdditionalOutput<Vec<PathObstacle>, "time_to_reach_obstacles">,
-    pub world_state: Input<WorldState, "world_state">,
-}
+    let ball_position_in_ground = ball.ball_in_ground;
+    let ball_position_in_field = ball.ball_in_field;
+    let best_pose = best_kick_decision.kick_pose;
+    let robot_to_ball = ball_position_in_ground.coords;
+    let dribble_pose_to_ball = ball_position_in_ground.coords - best_pose.translation.vector;
 
-#[context]
-#[derive(Default)]
-pub struct MainOutputs {
-    pub dribble_path: MainOutput<Option<Vec<PathSegment>>>,
-}
+    let angle = robot_to_ball.angle(&dribble_pose_to_ball);
+    let should_avoid_ball = angle > dribbling_parameters.angle_to_approach_ball_from_threshold;
+    let ball_obstacle = should_avoid_ball.then_some(ball_position_in_ground);
 
-pub struct DribblePath {}
-impl DribblePath {
-    pub fn new(_context: CreationContext) -> Result<Self> {
-        Ok(Self {})
-    }
+    let ball_is_between_robot_and_own_goal =
+        ball_position_in_field.coords.x - robot_to_field.translation.x < 0.0f32;
+    let ball_obstacle_radius_factor = if ball_is_between_robot_and_own_goal {
+        1.0f32
+    } else {
+        (angle - dribbling_parameters.angle_to_approach_ball_from_threshold)
+            / (PI - dribbling_parameters.angle_to_approach_ball_from_threshold)
+    };
 
-    pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
-        let path_planning_parameters = &context.parameters.path_planning;
-        let field_dimensions = context.field_dimensions;
-        let dribbling_parameters = &context.parameters.dribbling;
-        let world_state = context.world_state;
+    let is_near_ball = matches!(
+        world_state.ball,
+        Some(ball) if ball.ball_in_ground.coords.norm() < dribbling_parameters.ignore_robot_when_near_ball_radius,
+    );
+    let obstacles = if is_near_ball {
+        &[]
+    } else {
+        world_state.obstacles.as_slice()
+    };
 
-        let path_obstacles_output = &mut context.path_obstacles;
-
-        let walk_path_planner = WalkPathPlanner::new(
-            field_dimensions,
-            &world_state.obstacles,
-            path_planning_parameters,
-        );
-
-        let Some(kick_decisions) = world_state.kick_decisions.as_ref() else { return Ok(MainOutputs::default()) };
-        let Some(best_kick_decision) = kick_decisions.first() else { return Ok(MainOutputs::default()) };
-        let (ball_position_in_ground, ball_position_in_field) = match world_state.ball {
-            Some(ball_position) => (ball_position.ball_in_ground, ball_position.ball_in_field),
-            None => return Ok(MainOutputs::default()),
-        };
-        let best_pose = best_kick_decision.kick_pose;
-        let Some(robot_to_field) = world_state.robot.robot_to_field else { return Ok(MainOutputs::default()) };
-        let robot_to_ball = ball_position_in_ground.coords;
-        let dribble_pose_to_ball = ball_position_in_ground.coords - best_pose.translation.vector;
-
-        let angle = robot_to_ball.angle(&dribble_pose_to_ball);
-        let should_avoid_ball = angle > dribbling_parameters.angle_to_approach_ball_from_threshold;
-        let ball_obstacle = should_avoid_ball.then_some(ball_position_in_ground);
-
-        let ball_is_between_robot_and_own_goal =
-            ball_position_in_field.coords.x - robot_to_field.translation.x < 0.0f32;
-        let ball_obstacle_radius_factor = if ball_is_between_robot_and_own_goal {
-            1.0f32
-        } else {
-            (angle - dribbling_parameters.angle_to_approach_ball_from_threshold)
-                / (PI - dribbling_parameters.angle_to_approach_ball_from_threshold)
-        };
-
-        let is_near_ball = matches!(
-            world_state.ball,
-            Some(ball) if ball.ball_in_ground.coords.norm() < dribbling_parameters.ignore_robot_when_near_ball_radius,
-        );
-        let obstacles = if is_near_ball {
-            &[]
-        } else {
-            world_state.obstacles.as_slice()
-        };
-
-        let rule_obstacles = if matches!(
-            world_state.game_controller_state,
-            Some(GameControllerState {
-                kicking_team: Team::Hulks,
-                ..
-            })
-        ) {
-            &[]
-        } else {
-            world_state.rule_obstacles.as_slice()
-        };
-
-        let path = Some(walk_path_planner.plan(
-            best_pose * Point2::origin(),
-            robot_to_field,
-            ball_obstacle,
-            ball_obstacle_radius_factor,
-            obstacles,
-            rule_obstacles,
-            path_obstacles_output,
-        ));
-        Ok(MainOutputs {
-            dribble_path: path.into(),
+    let rule_obstacles = if matches!(
+        world_state.game_controller_state,
+        Some(GameControllerState {
+            kicking_team: Team::Hulks,
+            ..
         })
-    }
+    ) {
+        &[]
+    } else {
+        world_state.rule_obstacles.as_slice()
+    };
+
+    Some(walk_path_planner.plan(
+        best_pose * Point2::origin(),
+        robot_to_field,
+        ball_obstacle,
+        ball_obstacle_radius_factor,
+        obstacles,
+        rule_obstacles,
+        path_obstacles_output,
+    ))
 }

--- a/crates/control/src/dribble_path_planner.rs
+++ b/crates/control/src/dribble_path_planner.rs
@@ -12,10 +12,10 @@ pub fn plan(
     dribbling_parameters: &Dribbling,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
 ) -> Option<Vec<PathSegment>> {
-    let Some(kick_decisions) = world_state.kick_decisions.as_ref() else { return None };
-    let Some(best_kick_decision) = kick_decisions.first() else { return None };
-    let Some(ball) = world_state.ball else { return None };
-    let Some(robot_to_field) = world_state.robot.robot_to_field else { return None };
+    let kick_decisions = world_state.kick_decisions.as_ref()?;
+    let best_kick_decision = kick_decisions.first()?;
+    let ball = world_state.ball?;
+    let robot_to_field = world_state.robot.robot_to_field?;
 
     let ball_position_in_ground = ball.ball_in_ground;
     let ball_position_in_field = ball.ball_in_field;

--- a/crates/control/src/motion/step_planner.rs
+++ b/crates/control/src/motion/step_planner.rs
@@ -74,7 +74,11 @@ impl StepPlanner {
                 let rotation = if direction.coords.norm_squared() < f32::EPSILON {
                     UnitComplex::identity()
                 } else {
-                    UnitComplex::from_cos_sin_unchecked(direction.x, direction.y)
+                    let normalized_direction = direction.coords.normalize();
+                    UnitComplex::from_cos_sin_unchecked(
+                        normalized_direction.x,
+                        normalized_direction.y,
+                    )
                 };
                 Isometry2::from_parts(line_segment.1.into(), rotation)
             }

--- a/crates/control/src/path_planner.rs
+++ b/crates/control/src/path_planner.rs
@@ -39,11 +39,12 @@ pub struct PathPlanner {
 }
 
 impl PathPlanner {
-    pub fn from_last_motion(
+    pub fn with_last_motion(
+        &mut self,
         last_motion_command: &MotionCommand,
         rotation_penalty_factor: f32,
-    ) -> Self {
-        let last_path_direction = match last_motion_command {
+    ) {
+        self.last_path_direction = match last_motion_command {
             MotionCommand::Walk {
                 orientation_mode,
                 path,
@@ -71,11 +72,7 @@ impl PathPlanner {
             _ => None,
         };
 
-        Self {
-            last_path_direction,
-            rotation_penalty_factor,
-            ..Default::default()
-        }
+        self.rotation_penalty_factor = rotation_penalty_factor;
     }
 
     pub fn with_obstacles(&mut self, obstacles: &[Obstacle], own_robot_radius: f32) {

--- a/crates/control/src/path_planner.rs
+++ b/crates/control/src/path_planner.rs
@@ -34,7 +34,7 @@ pub struct PathPlanner {
     /// The first node is always the start, the second the destination
     pub nodes: Vec<PathNode>,
     pub obstacles: Vec<PathObstacle>,
-    pub last_orientation: Option<UnitComplex<f32>>,
+    pub last_path_direction: Option<UnitComplex<f32>>,
     pub rotation_penalty_factor: f32,
 }
 
@@ -43,7 +43,7 @@ impl PathPlanner {
         last_motion_command: &MotionCommand,
         rotation_penalty_factor: f32,
     ) -> Self {
-        let last_orientation = match last_motion_command {
+        let last_path_direction = match last_motion_command {
             MotionCommand::Walk {
                 orientation_mode,
                 path,
@@ -72,7 +72,7 @@ impl PathPlanner {
         };
 
         Self {
-            last_orientation,
+            last_path_direction,
             rotation_penalty_factor,
             ..Default::default()
         }
@@ -478,7 +478,7 @@ impl DynamicMap for PathPlanner {
         let mut distance = direction.norm();
 
         if index1 == 0 && distance > 0.0 {
-            if let Some(current_rotation) = self.last_orientation {
+            if let Some(current_rotation) = self.last_path_direction {
                 let normalized_direction = direction.normalize();
                 let rotation = current_rotation.rotation_to(&UnitComplex::from_cos_sin_unchecked(
                     normalized_direction.x,

--- a/crates/control/src/path_planner.rs
+++ b/crates/control/src/path_planner.rs
@@ -48,7 +48,7 @@ impl PathPlanner {
                 orientation_mode,
                 path,
                 ..
-            } => match orientation_mode.clone() {
+            } => match *orientation_mode {
                 types::OrientationMode::AlignWithPath => path.first().map(|segment| {
                     let direction = match segment {
                         PathSegment::LineSegment(line_segment) => line_segment.1.coords,

--- a/crates/hulk/build.rs
+++ b/crates/hulk/build.rs
@@ -42,7 +42,6 @@ fn main() -> Result<()> {
                     "control::button_filter",
                     "control::camera_matrix_calculator",
                     "control::center_of_mass_provider",
-                    "control::dribble_path_planner",
                     "control::fall_state_estimation",
                     "control::game_controller_filter",
                     "control::game_state_filter",

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -193,6 +193,7 @@ pub struct PathPlanning {
     pub ball_obstacle_radius: f32,
     pub field_border_weight: f32,
     pub line_walking_speed: f32,
+    pub rotation_penalty_factor: f32,
     pub minimum_robot_radius_at_foot_height: f32,
     pub robot_radius_at_foot_height: f32,
     pub robot_radius_at_hip_height: f32,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -899,7 +899,8 @@
       "ball_obstacle_radius": 0.05,
       "field_border_weight": 0.15,
       "line_walking_speed": 0.25,
-      "arc_walking_speed": 0.2
+      "arc_walking_speed": 0.2,
+      "rotation_penalty_factor": 5.0
     },
     "search": {
       "position_reached_distance": 0.4,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -900,7 +900,7 @@
       "field_border_weight": 0.15,
       "line_walking_speed": 0.25,
       "arc_walking_speed": 0.2,
-      "rotation_penalty_factor": 5.0
+      "rotation_penalty_factor": 0.4
     },
     "search": {
       "position_reached_distance": 0.4,

--- a/tests/behavior/oscillating_obstacle.lua
+++ b/tests/behavior/oscillating_obstacle.lua
@@ -1,0 +1,36 @@
+function spawn_robot(number)
+  table.insert(state.robots, create_robot(number))
+end
+
+spawn_robot(2)
+
+state.filtered_game_state = {
+  Playing = {
+    ball_is_free = true,
+  },
+}
+
+function on_cycle()
+  if state.cycle_count == 100 then
+    state.ball = {
+      position = { 1.0, 0.0 },
+      velocity = { 0.0, 0.0 },
+    }
+    set_robot_pose(2, { -1.0, 0 }, 0)
+
+    create_obstacle(2, { 0.1, 0.0 }, 0.3)
+  end
+
+  if state.cycle_count > 100 and state.cycle_count % 10 == 0 then
+    clear_obstacles(2)
+    create_obstacle(2, { 0.1, math.random() * 0.05 }, 0.3)
+  end
+
+  if state.cycle_count == 5000 then
+    state.finished = true
+  end
+end
+
+function on_goal()
+  state.finished = true
+end

--- a/tests/behavior/oscillating_obstacle.lua
+++ b/tests/behavior/oscillating_obstacle.lua
@@ -2,7 +2,7 @@ function spawn_robot(number)
   table.insert(state.robots, create_robot(number))
 end
 
-spawn_robot(2)
+spawn_robot(7)
 
 state.filtered_game_state = {
   Playing = {
@@ -11,19 +11,19 @@ state.filtered_game_state = {
 }
 
 function on_cycle()
-  if state.cycle_count == 100 then
+  if state.cycle_count == 1 then
     state.ball = {
       position = { 1.0, 0.0 },
       velocity = { 0.0, 0.0 },
     }
-    set_robot_pose(2, { -1.0, 0 }, 0)
+    set_robot_pose(7, { -1.0, 0 }, 0)
 
-    create_obstacle(2, { 0.1, 0.0 }, 0.3)
+    create_obstacle(7, { 0.1, 0.0 }, 0.3)
   end
 
   if state.cycle_count > 100 and state.cycle_count % 10 == 0 then
-    clear_obstacles(2)
-    create_obstacle(2, { 0.1, math.random() * 0.05 }, 0.3)
+    clear_obstacles(7)
+    create_obstacle(7, { 0.1, math.random() * 0.05 }, 0.3)
   end
 
   if state.cycle_count == 5000 then

--- a/tools/behavior_simulator/build.rs
+++ b/tools/behavior_simulator/build.rs
@@ -19,7 +19,6 @@ fn main() -> Result<()> {
                     "control::active_vision",
                     "control::ball_state_composer",
                     "control::behavior::node",
-                    "control::dribble_path_planner",
                     "control::kick_selector",
                     "control::motion::look_around",
                     "control::role_assignment",

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -305,9 +305,9 @@ impl BehaviorCycler {
                         true,
                         &mut own_database.additional_outputs.active_action,
                     ),
-                    time_to_reach_obstacles: AdditionalOutput::new(
+                    dribble_path_obstacles: AdditionalOutput::new(
                         true,
-                        &mut own_database.additional_outputs.time_to_reach_obstacles,
+                        &mut own_database.additional_outputs.dribble_path_obstacles,
                     ),
                     world_state: &own_database.main_outputs.world_state,
                     cycle_time: &own_database.main_outputs.cycle_time,

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -129,6 +129,8 @@ impl State {
                         OrientationMode::Override(orientation) => *orientation,
                     };
 
+                    let previous_robot_to_field = robot_to_field.clone();
+
                     *robot_to_field = Isometry2::new(
                         robot_to_field.translation.vector + robot_to_field.rotation * step,
                         robot_to_field.rotation.angle()
@@ -137,6 +139,11 @@ impl State {
                                 std::f32::consts::FRAC_PI_4 * time_step.as_secs_f32(),
                             ),
                     );
+
+                    for obstacle in robot.database.main_outputs.obstacles.iter_mut() {
+                        obstacle.position =
+                            robot_to_field.inverse() * previous_robot_to_field * obstacle.position;
+                    }
 
                     head
                 }

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -129,7 +129,7 @@ impl State {
                         OrientationMode::Override(orientation) => *orientation,
                     };
 
-                    let previous_robot_to_field = robot_to_field.clone();
+                    let previous_robot_to_field = *robot_to_field;
 
                     *robot_to_field = Isometry2::new(
                         robot_to_field.translation.vector + robot_to_field.rotation * step,


### PR DESCRIPTION
## Introduced Changes

This PR introduces a `rotation_penalty_factor` to the path planner to reduce flipping between two similar paths, which can cause jockeling.
It also adds a scenario file for testing different values of `rotation_penalty_factor`.

Fixes #264.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

This is really hard to test outside of the behavior simulator, so I would suggest to watch closely within a game.
