### PR TITLE
Behavior simulator ball model

### DIFF
--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -6,7 +6,7 @@ use framework::MainOutput;
 use nalgebra::Isometry2;
 use spl_network_messages::HulkMessage;
 use types::{
-    parameters::CameraMatrixParameters, BallPosition, CycleTime, FallState, FilteredGameState,
+    parameters::{CameraMatrixParameters, BallFilter}, BallPosition, CycleTime, FallState, FilteredGameState,
     GameControllerState, HeadJoints, Obstacle, PenaltyShotDirection, PrimaryState, SensorData,
 };
 
@@ -17,6 +17,8 @@ pub struct CreationContext {
     pub maximum_velocity: Parameter<HeadJoints<f32>, "head_motion.maximum_velocity">,
     pub top_camera_matrix_parameters:
         Parameter<CameraMatrixParameters, "camera_matrix_parameters.vision_top">,
+    pub ball_filter:
+        Parameter<BallFilter, "ball_filter">,
 }
 
 #[context]

--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -6,8 +6,9 @@ use framework::MainOutput;
 use nalgebra::Isometry2;
 use spl_network_messages::HulkMessage;
 use types::{
-    parameters::{CameraMatrixParameters, BallFilter}, BallPosition, CycleTime, FallState, FilteredGameState,
-    GameControllerState, HeadJoints, Obstacle, PenaltyShotDirection, PrimaryState, SensorData,
+    parameters::{BallFilter, CameraMatrixParameters, LookAt},
+    BallPosition, CycleTime, FallState, FilteredGameState, GameControllerState, HeadJoints,
+    Obstacle, PenaltyShotDirection, PrimaryState, SensorData,
 };
 
 pub struct FakeData {}
@@ -17,12 +18,13 @@ pub struct CreationContext {
     pub maximum_velocity: Parameter<HeadJoints<f32>, "head_motion.maximum_velocity">,
     pub top_camera_matrix_parameters:
         Parameter<CameraMatrixParameters, "camera_matrix_parameters.vision_top">,
-    pub ball_filter:
-        Parameter<BallFilter, "ball_filter">,
+    pub ball_filter: Parameter<BallFilter, "ball_filter">,
 }
 
 #[context]
-pub struct CycleContext {}
+pub struct CycleContext {
+    pub look_at: Parameter<LookAt, "look_at">,
+}
 
 #[context]
 #[derive(Default)]

--- a/tests/behavior/golden_goal.lua
+++ b/tests/behavior/golden_goal.lua
@@ -13,7 +13,7 @@ spawn_robot(5)
 spawn_robot(6)
 spawn_robot(7)
 
-local game_end_time = -1.0
+local game_end_time = 10000
 
 function on_goal()
     print("Goal scored, resetting ball!")

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -10,7 +10,7 @@ use control::localization::generate_initial_pose;
 use nalgebra::vector;
 use parameters::directory::deserialize;
 use spl_network_messages::PlayerNumber;
-use types::{messages::IncomingMessage, CameraMatrix};
+use types::{messages::IncomingMessage, BallPosition, CameraMatrix};
 
 use crate::{
     cycler::{BehaviorCycler, Database},
@@ -26,6 +26,7 @@ pub struct Robot {
     pub parameters: Parameters,
     pub is_penalized: bool,
     pub last_kick_time: Duration,
+    pub last_seen_ball_in_field: Option<BallPosition>,
 }
 
 impl Robot {
@@ -66,6 +67,7 @@ impl Robot {
             parameters: parameter,
             is_penalized: false,
             last_kick_time: Duration::default(),
+            last_seen_ball_in_field: None,
         })
     }
 

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -10,7 +10,7 @@ use control::localization::generate_initial_pose;
 use nalgebra::vector;
 use parameters::directory::deserialize;
 use spl_network_messages::PlayerNumber;
-use types::{messages::IncomingMessage, BallPosition, CameraMatrix};
+use types::{messages::IncomingMessage, CameraMatrix};
 
 use crate::{
     cycler::{BehaviorCycler, Database},
@@ -26,7 +26,7 @@ pub struct Robot {
     pub parameters: Parameters,
     pub is_penalized: bool,
     pub last_kick_time: Duration,
-    pub last_seen_ball_in_field: Option<BallPosition>,
+    pub last_seen_ball_in_field: Option<SystemTime>,
 }
 
 impl Robot {

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -26,7 +26,7 @@ pub struct Robot {
     pub parameters: Parameters,
     pub is_penalized: bool,
     pub last_kick_time: Duration,
-    pub last_seen_ball_in_field: Option<SystemTime>,
+    pub ball_last_seen: Option<SystemTime>,
 }
 
 impl Robot {
@@ -67,7 +67,7 @@ impl Robot {
             parameters: parameter,
             is_penalized: false,
             last_kick_time: Duration::default(),
-            last_seen_ball_in_field: None,
+            ball_last_seen: None,
         })
     }
 

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -237,10 +237,10 @@ impl State {
                 angle_to_ball.abs() < field_of_view / 2.0 && ball_in_head.coords.norm() < 3.0
             });
             if ball_visible {
-                robot.last_seen_ball_in_field = Some(now);
+                robot.ball_last_seen = Some(now);
             }
             robot.database.main_outputs.ball_position =
-                if robot.last_seen_ball_in_field.is_some_and(|last_seen| {
+                if robot.ball_last_seen.is_some_and(|last_seen| {
                     now.duration_since(last_seen).expect("Time ran backwards")
                         < robot.parameters.ball_filter.hypothesis_timeout
                 }) {

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -181,7 +181,6 @@ impl State {
                 _ => &HeadMotion::Center,
             };
 
-            let f = self.time_elapsed.as_secs_f32().sin();
             let desired_head_yaw = match head_motion {
                 HeadMotion::ZeroAngles => 0.0,
                 HeadMotion::Center => 0.0,
@@ -190,8 +189,9 @@ impl State {
                 }
                 HeadMotion::LookAt { target, .. } => target.coords.angle(&Vector2::x_axis()),
                 HeadMotion::LookLeftAndRightOf { target } => {
+                    let glance_factor = self.time_elapsed.as_secs_f32().sin();
                     target.coords.angle(&Vector2::x_axis())
-                        + f * robot.parameters.look_at.glance_angle
+                        + glance_factor * robot.parameters.look_at.glance_angle
                 }
                 HeadMotion::Unstiff => 0.0,
             };

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -242,7 +242,7 @@ impl State {
             }
             robot.database.main_outputs.ball_position =
                 if robot.ball_last_seen.is_some_and(|last_seen| {
-                    now.duration_since(last_seen).expect("Time ran backwards")
+                    now.duration_since(last_seen).expect("time ran backwards")
                         < robot.parameters.ball_filter.hypothesis_timeout
                 }) {
                     self.ball.as_ref().map(|ball| BallPosition {

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -190,7 +190,8 @@ impl State {
                 }
                 HeadMotion::LookAt { target, .. } => target.coords.angle(&Vector2::x_axis()),
                 HeadMotion::LookLeftAndRightOf { target } => {
-                    target.coords.angle(&Vector2::x_axis()) + f
+                    target.coords.angle(&Vector2::x_axis())
+                        + f * robot.parameters.look_at.glance_angle
                 }
                 HeadMotion::Unstiff => 0.0,
             };

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -209,13 +209,6 @@ impl State {
         let incoming_messages = take(&mut self.messages);
 
         for (player_number, robot) in self.robots.iter_mut() {
-            let robot_to_field = robot
-                .database
-                .main_outputs
-                .robot_to_field
-                .as_mut()
-                .expect("simulated robots should always have a known pose");
-
             let incoming_messages: Vec<_> = incoming_messages
                 .iter()
                 .filter_map(|(sender, message)| {
@@ -227,14 +220,9 @@ impl State {
 
             robot.database.main_outputs.cycle_time.start_time = now;
 
-            robot.database.main_outputs.ball_position = self
+            robot.last_seen_ball_in_field = self
                 .ball
-                .as_ref()
-                .map(|ball| BallPosition {
-                    position: robot_to_field.inverse() * ball.position,
-                    velocity: robot_to_field.inverse() * ball.velocity,
-                    last_seen: now,
-                })
+                .clone()
                 .filter(|ball| {
                     let head_rotation = UnitComplex::from_angle(
                         robot.database.main_outputs.sensor_data.positions.head.yaw,
@@ -244,8 +232,32 @@ impl State {
                     let angle_to_ball = ball_in_head.angle(&Vector2::x_axis());
 
                     angle_to_ball.abs() < field_of_view / 2.0 && ball_in_head.norm() < 3.0
+                })
+                .map(|ball| {
+                    BallPosition {
+                        position: ball.position,
+                        velocity: ball.velocity,
+                        last_seen: now,
+                    }
+                })
+                .or(robot.last_seen_ball_in_field)
+                .filter(|ball| {
+                    now.duration_since(ball.last_seen)
+                        .expect("Time ran backwards")
+                        < robot.parameters.ball_filter.hypothesis_timeout
                 });
-
+            let robot_to_field = robot
+                .database
+                .main_outputs
+                .robot_to_field
+                .as_mut()
+                .expect("simulated robots should always have a known pose");
+            robot.database.main_outputs.ball_position =
+                robot.last_seen_ball_in_field.map(|ball| BallPosition {
+                    position: robot_to_field.inverse() * ball.position,
+                    velocity: robot_to_field.inverse() * ball.velocity,
+                    last_seen: ball.last_seen,
+                });
             robot.database.main_outputs.primary_state =
                 match (robot.is_penalized, self.filtered_game_state) {
                     (true, _) => PrimaryState::Penalized,


### PR DESCRIPTION
## Introduced Changes

On main, the behavior simulator is in a soft-broken state since robots keep losing the ball when they become striker.
This is because they look too far left and right of the ball without having a ball model. That means they immediately lose the ball once it leaves their field of view.

This PR both fixes the simulated glance angle as well as introducing a simplified ball model.
As opposed to the real world, the robot's ball model keeps getting updates with the true position of the ball for some time after the ball leaves the field of view of the robot.
In the real world, noisy percepts are filtered and a physical model is applied to simulate movement of the ball when it is not seen.
In this implementation, a robot would be able to detect a change of the ball's velocity, e.g. due to a kick, without the ball currently being inside the field of view.
This saves us from having to keep separate ball models for each robot that would be updated by simulated percepts and while also simulating the ball physics.
I think this is a reasonable simplification. 

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Run any scene in the behavior simulator, e.g. golden goal.
The robots should be able to score goals again without requiring half a dozen striker switches.