### PR TITLE
Bump proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
## Introduced Changes

Bump proc-macro2 to make it build with nightly again.
Ref: https://github.com/rust-lang/rust/issues/113152
Upgrading the crate to a version >= 1.0.60 fixes the issue.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Build with latest nightly.