### PR TITLE
Recording of robotics nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
 name = "behavior_simulator"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "chrono",
  "clap 4.4.6",
  "code_generation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "framework",
  "hardware",
  "rustfft",
+ "serde",
  "types",
 ]
 
@@ -4838,6 +4839,7 @@ dependencies = [
  "ordered-float",
  "projection",
  "rand",
+ "serde",
  "types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,6 +2356,7 @@ name = "hulk"
 version = "0.1.0"
 dependencies = [
  "audio",
+ "bincode",
  "code_generation",
  "color-eyre",
  "communication",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ name = "framework"
 version = "0.1.0"
 dependencies = [
  "parking_lot",
+ "serde",
 ]
 
 [[package]]
@@ -2387,6 +2388,7 @@ dependencies = [
  "ctrlc",
  "enum-iterator",
  "fern",
+ "framework",
  "hardware",
  "hulk",
  "libc",
@@ -2411,6 +2413,7 @@ dependencies = [
  "color-eyre",
  "ctrlc",
  "fern",
+ "framework",
  "hardware",
  "hulk",
  "log",

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -12,4 +12,5 @@ filtering = { workspace = true }
 framework = { workspace = true }
 hardware = { workspace = true }
 rustfft = { workspace = true }
+serde = { workspace = true }
 types = { workspace = true }

--- a/crates/audio/src/microphone_recorder.rs
+++ b/crates/audio/src/microphone_recorder.rs
@@ -2,8 +2,10 @@ use color_eyre::{eyre::WrapErr, Result};
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::MicrophoneInterface;
+use serde::{Deserialize, Serialize};
 use types::samples::Samples;
 
+#[derive(Deserialize, Serialize)]
 pub struct MicrophoneRecorder {}
 
 #[context]

--- a/crates/audio/src/whistle_detection.rs
+++ b/crates/audio/src/whistle_detection.rs
@@ -3,12 +3,13 @@ use std::{f32::consts::PI, sync::Arc};
 use color_eyre::Result;
 use context_attribute::context;
 use filtering::statistics::{mean, standard_deviation};
-use framework::{AdditionalOutput, MainOutput};
+use framework::{deserialize_not_implemented, AdditionalOutput, MainOutput};
 use rustfft::{
     num_complex::{Complex32, ComplexFloat},
     num_traits::Zero,
     Fft, FftPlanner,
 };
+use serde::{Deserialize, Serialize};
 use types::{
     parameters::WhistleDetectionParameters,
     samples::Samples,
@@ -20,8 +21,11 @@ pub const NUMBER_OF_AUDIO_CHANNELS: usize = 4;
 pub const NUMBER_OF_AUDIO_SAMPLES: usize = 2048;
 const NUMBER_OF_FREQUENCY_SAMPLES: usize = NUMBER_OF_AUDIO_SAMPLES / 2;
 
+#[derive(Deserialize, Serialize)]
 pub struct WhistleDetection {
+    #[serde(skip, default = "deserialize_not_implemented")]
     fft: Arc<dyn Fft<f32>>,
+    #[serde(skip)]
     scratch: Vec<Complex32>,
 }
 

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -376,9 +376,8 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
         .cycle_nodes
         .iter()
         .map(|node| generate_node_execution(node, cycler, RecordingGeneration::Skip));
-    let required_cross_inputs = get_required_cross_inputs(cycler);
-    let required_cross_input_recordings =
-        generate_required_cross_inputs_recording(cycler, required_cross_inputs);
+    let cross_inputs = get_cross_inputs(cycler);
+    let cross_input_recordings = generate_cross_inputs_recording(cycler, cross_inputs);
 
     let post_setup = match cycler.kind {
         CyclerKind::Perception => quote! {
@@ -460,7 +459,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
                     let own_subscribed_outputs = self.own_subscribed_outputs_reader.next();
                     let parameters = self.parameters_reader.next();
                     #lock_readers
-                    #required_cross_input_recordings
+                    #cross_input_recordings
                     #(#cycle_node_executions)*
                 }
 
@@ -478,7 +477,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
     }
 }
 
-fn get_required_cross_inputs(cycler: &Cycler) -> HashSet<Field> {
+fn get_cross_inputs(cycler: &Cycler) -> HashSet<Field> {
     cycler
         .setup_nodes
         .iter()
@@ -507,11 +506,11 @@ fn get_required_cross_inputs(cycler: &Cycler) -> HashSet<Field> {
         .collect()
 }
 
-fn generate_required_cross_inputs_recording(
+fn generate_cross_inputs_recording(
     cycler: &Cycler,
-    required_inputs: impl IntoIterator<Item = Field>,
+    cross_inputs: impl IntoIterator<Item = Field>,
 ) -> TokenStream {
-    let recordings = required_inputs.into_iter().map(|field| {
+    let recordings = cross_inputs.into_iter().map(|field| {
         let error_message = match &field {
             Field::CyclerState { name, .. } => format!("failed to record cycler state {name}"),
             Field::Input { cycler_instance: Some(_), name, .. } => format!("failed to record input {name}"),

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -445,7 +445,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
                     own_database.deref_mut()
                 };
 
-                let enable_recording = self.enable_recording && self.hardware_interface.get_recording();
+                let enable_recording = self.enable_recording && self.hardware_interface.should_record();
                 let mut recording_frame = Vec::new(); // TODO: possible optimization: cache capacity
 
                 {

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -570,13 +570,13 @@ fn generate_required_inputs_recording(cycler: &Cycler, required_inputs: Vec<Fiel
             _ => panic!("unexpected field {field:?}"),
         };
         quote! {
-            if enable_recording {
-                bincode::serialize_into(&mut recording_frame, #value_to_be_recorded).wrap_err(#error_message)?;
-            }
+            bincode::serialize_into(&mut recording_frame, #value_to_be_recorded).wrap_err(#error_message)?;
         }
     });
     quote! {
-        #(#recordings)*
+        if enable_recording {
+            #(#recordings)*
+        }
     }
 }
 

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -602,7 +602,12 @@ fn generate_required_inputs_recording(cycler: &Cycler, required_inputs: Vec<Fiel
         quote! {
             bincode::serialize_into(&mut recording_frame, #value_to_be_recorded).wrap_err(#error_message)?;
         }
-    });
+    }).collect::<Vec<_>>();
+
+    if recordings.is_empty() {
+        return Default::default();
+    }
+
     quote! {
         if enable_recording {
             #(#recordings)*

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -107,6 +107,7 @@ fn generate_struct(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
             #input_output_fields
             #node_fields
             recording_sender: std::sync::mpsc::SyncSender<crate::cyclers::RecordingFrame>,
+            enable_recording: bool,
         }
     }
 }
@@ -210,6 +211,7 @@ fn generate_new_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
             parameters_reader: framework::Reader<crate::structs::Parameters>,
             #input_output_fields
             recording_sender: std::sync::mpsc::SyncSender<crate::cyclers::RecordingFrame>,
+            enable_recording: bool,
         ) -> color_eyre::Result<Self> {
             let parameters = parameters_reader.next().clone();
             let mut cycler_state = crate::structs::#cycler_module_name::CyclerState::default();
@@ -225,6 +227,7 @@ fn generate_new_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
                 #input_output_identifiers
                 #(#node_identifiers,)*
                 recording_sender,
+                enable_recording,
             })
         }
     }
@@ -443,7 +446,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
                     own_database.deref_mut()
                 };
 
-                let enable_recording = <HardwareInterface as hardware::RecordingInterface>::get_recording(&*self.hardware_interface);
+                let enable_recording = self.enable_recording && <HardwareInterface as hardware::RecordingInterface>::get_recording(&*self.hardware_interface);
                 let mut recording_duration = std::time::Duration::ZERO;
                 let mut recording_frame = Vec::new(); // TODO: possible optimization: cache capacity
 

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -444,7 +444,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
                     own_database.deref_mut()
                 };
 
-                let enable_recording = self.enable_recording && <HardwareInterface as hardware::RecordingInterface>::get_recording(&*self.hardware_interface);
+                let enable_recording = self.enable_recording && self.hardware_interface.get_recording();
                 let mut recording_frame = Vec::new(); // TODO: possible optimization: cache capacity
 
                 {

--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -29,6 +29,7 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
 
             #construct_multiple_buffers
             #construct_future_queues
+            let (recording_sender, recording_receiver) = std::sync::mpsc::sync_channel(420);
 
             let communication_server = communication::server::Runtime::start(
                 addresses, parameters_directory, body_id, head_id, #number_of_parameter_slots, keep_running.clone())
@@ -147,6 +148,7 @@ fn generate_cycler_constructors(cyclers: &Cyclers) -> TokenStream {
                 communication_server.get_parameters_reader(),
                 #own_producer_identifier
                 #(#other_cycler_inputs,)*
+                recording_sender.clone(),
             )
             .wrap_err(#error_message)?;
             communication_server.register_cycler_instance(

--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -24,6 +24,7 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
             body_id: String,
             head_id: String,
             keep_running: tokio_util::sync::CancellationToken,
+            cycler_instances_to_be_recorded: std::collections::HashSet<String>,
         ) -> color_eyre::Result<()>
         {
             use color_eyre::eyre::WrapErr;
@@ -199,6 +200,7 @@ fn generate_cycler_constructors(cyclers: &Cyclers) -> TokenStream {
                 #own_producer_identifier
                 #(#other_cycler_inputs,)*
                 recording_sender.clone(),
+                cycler_instances_to_be_recorded.contains(#cycler_instance_name),
             )
             .wrap_err(#error_message)?;
             communication_server.register_cycler_instance(

--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -116,10 +116,10 @@ fn generate_future_queues(cyclers: &Cyclers) -> TokenStream {
 fn generate_recording_thread(cyclers: &Cyclers) -> TokenStream {
     let file_creations = cyclers.instances().map(|(_cycler, instance)| {
         let instance_name_snake_case = format_ident!("{}", instance.to_case(Case::Snake));
-        let instance_name = format!("logs/{instance}.{{seconds}}.bincode");
+        let recording_file_path = format!("logs/{instance}.{{seconds}}.bincode");
         let error_message = format!("failed to create recording file for {instance}");
         quote! {
-            let mut #instance_name_snake_case = std::io::BufWriter::new(std::fs::File::create(format!(#instance_name)).wrap_err(#error_message)?);
+            let mut #instance_name_snake_case = std::io::BufWriter::new(std::fs::File::create(format!(#recording_file_path)).wrap_err(#error_message)?);
         }
     });
     let frame_writes = cyclers.instances().map(|(_cycler, instance)| {

--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -119,7 +119,7 @@ fn generate_recording_thread(cyclers: &Cyclers) -> TokenStream {
         let recording_file_path = format!("logs/{instance}.{{seconds}}.bincode");
         let error_message = format!("failed to create recording file for {instance}");
         quote! {
-            let mut #instance_name_snake_case = std::io::BufWriter::new(std::fs::File::create(format!(#recording_file_path)).wrap_err(#error_message)?);
+            let mut #instance_name_snake_case = std::io::BufWriter::new(std::fs::File::create(format!(#recording_file_path)).wrap_err(#error_message)?); // TODO: possible optimization: buffer size
         }
     });
     let frame_writes = cyclers.instances().map(|(_cycler, instance)| {

--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -190,6 +190,7 @@ fn generate_cycler_constructors(cyclers: &Cyclers) -> TokenStream {
                 Default::default(),
                 Default::default(),
             ]);
+            let enable_recording = cycler_instances_to_be_recorded.contains(#cycler_instance_name);
             let #cycler_variable_identifier = crate::cyclers::#cycler_module_name::Cycler::new(
                 crate::cyclers::#cycler_module_name::CyclerInstance::#cycler_instance_name_identifier,
                 hardware_interface.clone(),
@@ -200,7 +201,7 @@ fn generate_cycler_constructors(cyclers: &Cyclers) -> TokenStream {
                 #own_producer_identifier
                 #(#other_cycler_inputs,)*
                 recording_sender.clone(),
-                cycler_instances_to_be_recorded.contains(#cycler_instance_name),
+                enable_recording,
             )
             .wrap_err(#error_message)?;
             communication_server.register_cycler_instance(

--- a/crates/code_generation/src/structs.rs
+++ b/crates/code_generation/src/structs.rs
@@ -31,9 +31,9 @@ pub fn generate_structs(structs: &Structs) -> TokenStream {
                 format_ident!("AdditionalOutputs"),
                 &derives,
             );
-            let persistent_state = hierarchy_to_token_stream(
-                &cycler_structs.persistent_state,
-                format_ident!("PersistentState"),
+            let cycler_state = hierarchy_to_token_stream(
+                &cycler_structs.cycler_state,
+                format_ident!("CyclerState"),
                 &derives,
             );
 
@@ -41,7 +41,7 @@ pub fn generate_structs(structs: &Structs) -> TokenStream {
                 pub mod #cycler_module_identifier {
                     #main_outputs
                     #additional_outputs
-                    #persistent_state
+                    #cycler_state
                 }
             }
         });

--- a/crates/context_attribute/src/lib.rs
+++ b/crates/context_attribute/src/lib.rs
@@ -19,15 +19,15 @@ pub fn context(_attributes: TokenStream, input: TokenStream) -> TokenStream {
 
     let struct_name = struct_item.ident.to_string();
     let allowed_member_types = match struct_name.as_str() {
-        "CreationContext" => ["HardwareInterface", "Parameter", "PersistentState"].as_slice(),
+        "CreationContext" => ["CyclerState", "HardwareInterface", "Parameter"].as_slice(),
         "CycleContext" => [
             "AdditionalOutput",
+            "CyclerState",
             "HardwareInterface",
             "HistoricInput",
             "Input",
             "Parameter",
             "PerceptionInput",
-            "PersistentState",
             "RequiredInput",
         ]
         .as_slice(),
@@ -91,13 +91,13 @@ pub fn context(_attributes: TokenStream, input: TokenStream) -> TokenStream {
                             "expected exactly two or three generic parameters"
                         ),
                     },
-                    "Parameter" | "PersistentState" => match &mut first_segment.arguments {
+                    "CyclerState" | "Parameter" => match &mut first_segment.arguments {
                         PathArguments::AngleBracketed(arguments) if arguments.args.len() == 2 => {
                             pop_string_argument(arguments);
                             let data_type = get_data_type(arguments);
                             into_reference_with_lifetime(
                                 data_type,
-                                (first_segment.ident == "PersistentState").then(Mut::default),
+                                (first_segment.ident == "CyclerState").then(Mut::default),
                             );
                             requires_lifetime_parameter = true;
                             field.ty = data_type.clone();

--- a/crates/control/src/active_vision.rs
+++ b/crates/control/src/active_vision.rs
@@ -5,6 +5,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{point, Isometry2, Point2, UnitComplex, Vector2};
 use ordered_float::NotNan;
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime,
     field_dimensions::FieldDimensions,
@@ -14,6 +15,7 @@ use types::{
     world_state::BallState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct ActiveVision {
     field_mark_positions: Vec<Point2<f32>>,
     last_point_of_interest_switch: Option<SystemTime>,

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -6,6 +6,7 @@ use filtering::kalman_filter::KalmanFilter;
 use framework::{AdditionalOutput, HistoricInput, MainOutput, PerceptionInput};
 use nalgebra::{matrix, vector, Isometry2, Matrix2, Matrix2x4, Matrix4, Matrix4x2, Point2};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     ball::Ball,
     ball_filter::Hypothesis,
@@ -19,6 +20,7 @@ use types::{
     parameters::BallFilterParameters,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct BallFilter {
     hypotheses: Vec<Hypothesis>,
 }

--- a/crates/control/src/ball_state_composer.rs
+++ b/crates/control/src/ball_state_composer.rs
@@ -5,6 +5,7 @@ use context_attribute::context;
 use filtering::hysteresis::greater_than_with_hysteresis;
 use framework::MainOutput;
 use nalgebra::{point, Isometry2, Point2, Vector2};
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{SubState, Team};
 use types::{
     ball_position::BallPosition, cycle_time::CycleTime, field_dimensions::FieldDimensions,
@@ -12,6 +13,7 @@ use types::{
     primary_state::PrimaryState, support_foot::Side, world_state::BallState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct BallStateComposer {
     last_ball_field_side: Side,
 }

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -4,6 +4,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{point, Point2, Vector2};
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{GamePhase, GameState, SubState, Team};
 use types::{
     action::Action,
@@ -36,6 +37,7 @@ use super::{
     walk_to_pose::{WalkAndStand, WalkPathPlanner},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct Behavior {
     last_motion_command: MotionCommand,
     absolute_last_known_ball_position: Point2<f32>,

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -4,8 +4,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use filtering::tap_detector::TapDetector;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{buttons::Buttons, cycle_time::CycleTime, sensor_data::SensorData};
 
+#[derive(Deserialize, Serialize)]
 pub struct ButtonFilter {
     chest_button_tap_detector: TapDetector,
     head_buttons_touched: SystemTime,

--- a/crates/control/src/camera_matrix_calculator.rs
+++ b/crates/control/src/camera_matrix_calculator.rs
@@ -31,9 +31,9 @@ pub struct CycleContext {
     top_camera_matrix_parameters:
         Parameter<CameraMatrixParameters, "camera_matrix_parameters.vision_top">,
 
-    correction_in_camera_top: PersistentState<Rotation3<f32>, "correction_in_camera_top">,
-    correction_in_camera_bottom: PersistentState<Rotation3<f32>, "correction_in_camera_bottom">,
-    correction_in_robot: PersistentState<Rotation3<f32>, "correction_in_robot">,
+    correction_in_camera_top: CyclerState<Rotation3<f32>, "correction_in_camera_top">,
+    correction_in_camera_bottom: CyclerState<Rotation3<f32>, "correction_in_camera_bottom">,
+    correction_in_robot: CyclerState<Rotation3<f32>, "correction_in_robot">,
 }
 
 #[context]

--- a/crates/control/src/camera_matrix_calculator.rs
+++ b/crates/control/src/camera_matrix_calculator.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{point, vector, Isometry3, Rotation3, UnitQuaternion, Vector3};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::{CameraMatrices, CameraMatrix, ProjectedFieldLines},
     camera_position::CameraPosition,
@@ -13,6 +14,7 @@ use types::{
     robot_kinematics::RobotKinematics,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct CameraMatrixCalculator {}
 
 #[context]

--- a/crates/control/src/center_of_mass_provider.rs
+++ b/crates/control/src/center_of_mass_provider.rs
@@ -2,8 +2,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{Point, Point3};
+use serde::{Deserialize, Serialize};
 use types::{robot_kinematics::RobotKinematics, robot_masses::RobotMass};
 
+#[derive(Deserialize, Serialize)]
 pub struct CenterOfMassProvider {}
 
 #[context]

--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -4,6 +4,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::Isometry2;
+use serde::{Deserialize, Serialize};
 use spl_network_messages::HulkMessage;
 use types::{
     ball_position::BallPosition,
@@ -19,6 +20,7 @@ use types::{
     sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct FakeData {}
 
 #[context]

--- a/crates/control/src/fall_state_estimation.rs
+++ b/crates/control/src/fall_state_estimation.rs
@@ -5,6 +5,7 @@ use context_attribute::context;
 use filtering::low_pass_filter::LowPassFilter;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{vector, Isometry3, Translation3, UnitQuaternion, Vector2, Vector3};
+use serde::{Deserialize, Serialize};
 use types::{
     fall_state::FallState,
     motion_command::{Facing, FallDirection},
@@ -12,6 +13,7 @@ use types::{
     sensor_data::{InertialMeasurementUnitData, SensorData},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct FallStateEstimation {
     roll_pitch_filter: LowPassFilter<Vector2<f32>>,
     angular_velocity_filter: LowPassFilter<Vector3<f32>>,

--- a/crates/control/src/game_controller_filter.rs
+++ b/crates/control/src/game_controller_filter.rs
@@ -3,10 +3,12 @@ use std::time::SystemTime;
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{MainOutput, PerceptionInput};
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime, game_controller_state::GameControllerState, messages::IncomingMessage,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct GameControllerFilter {
     game_controller_state: Option<GameControllerState>,
     last_game_state_change: Option<SystemTime>,

--- a/crates/control/src/game_state_filter.rs
+++ b/crates/control/src/game_state_filter.rs
@@ -4,6 +4,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{distance, Isometry2, Point2, Vector2};
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{GamePhase, GameState, Team};
 use types::{
     ball_position::BallPosition, cycle_time::CycleTime, field_dimensions::FieldDimensions,
@@ -11,6 +12,7 @@ use types::{
     game_controller_state::GameControllerState, parameters::GameStateFilterParameters,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct GameStateFilter {
     state: State,
     opponent_state: State,
@@ -217,7 +219,7 @@ fn in_kick_off_grace_period(
         < kick_off_grace_period
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 enum State {
     Initial,
     Ready,

--- a/crates/control/src/game_state_filter.rs
+++ b/crates/control/src/game_state_filter.rs
@@ -29,7 +29,7 @@ pub struct CycleContext {
     config: Parameter<GameStateFilterParameters, "game_state_filter">,
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
 
-    robot_to_field: PersistentState<Isometry2<f32>, "robot_to_field">,
+    robot_to_field: CyclerState<Isometry2<f32>, "robot_to_field">,
 }
 
 #[context]

--- a/crates/control/src/ground_contact_detector.rs
+++ b/crates/control/src/ground_contact_detector.rs
@@ -4,8 +4,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use filtering::hysteresis::greater_than_with_hysteresis;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{cycle_time::CycleTime, sole_pressure::SolePressure};
 
+#[derive(Deserialize, Serialize)]
 pub struct GroundContactDetector {
     last_has_pressure: bool,
     last_time_switched: SystemTime,

--- a/crates/control/src/ground_provider.rs
+++ b/crates/control/src/ground_provider.rs
@@ -2,12 +2,14 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{vector, Isometry3, Translation, Vector3};
+use serde::{Deserialize, Serialize};
 use types::{
     robot_kinematics::RobotKinematics,
     sensor_data::SensorData,
     support_foot::{Side, SupportFoot},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct GroundProvider {}
 
 #[context]

--- a/crates/control/src/kick_selector.rs
+++ b/crates/control/src/kick_selector.rs
@@ -6,6 +6,7 @@ use framework::{AdditionalOutput, MainOutput};
 use itertools::iproduct;
 use nalgebra::{distance, point, vector, Isometry2, Point2, UnitComplex, Vector2};
 use ordered_float::NotNan;
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime,
     field_dimensions::FieldDimensions,
@@ -19,6 +20,7 @@ use types::{
     world_state::BallState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct KickSelector {}
 
 #[context]

--- a/crates/control/src/kinematics_provider.rs
+++ b/crates/control/src/kinematics_provider.rs
@@ -12,10 +12,12 @@ use kinematics::{
     right_upper_arm_to_right_shoulder, right_wrist_to_right_forearm,
 };
 use nalgebra::{Isometry3, Translation};
+use serde::{Deserialize, Serialize};
 use types::{
     robot_dimensions::RobotDimensions, robot_kinematics::RobotKinematics, sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct KinematicsProvider {}
 
 #[context]

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{MainOutput, PerceptionInput};
+use serde::{Deserialize, Serialize};
 use types::{
     ball::Ball,
     color::Rgb,
@@ -15,6 +16,7 @@ use types::{
     sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct LedStatus {
     blink_state: bool,
     last_blink_toggle: SystemTime,

--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -89,7 +89,7 @@ pub struct CycleContext {
     line_data_bottom: PerceptionInput<Option<LineData>, "VisionBottom", "line_data?">,
     line_data_top: PerceptionInput<Option<LineData>, "VisionTop", "line_data?">,
 
-    robot_to_field: PersistentState<Isometry2<f32>, "robot_to_field">,
+    robot_to_field: CyclerState<Isometry2<f32>, "robot_to_field">,
 }
 
 #[context]

--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -13,6 +13,7 @@ use nalgebra::{
     Translation2, Vector2, Vector3,
 };
 use ordered_float::NotNan;
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{GamePhase, Penalty, PlayerNumber, Team};
 use types::{
     field_dimensions::FieldDimensions,
@@ -28,6 +29,7 @@ use types::{
     support_foot::Side,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct Localization {
     field_marks: Vec<FieldMark>,
     last_primary_state: PrimaryState,

--- a/crates/control/src/localization_recorder.rs
+++ b/crates/control/src/localization_recorder.rs
@@ -15,7 +15,9 @@ use types::{
     game_controller_state::GameControllerState, line_data::LineData, primary_state::PrimaryState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct LocalizationRecorder {
+    #[serde(skip)]
     recording: Option<BufWriter<File>>,
 }
 

--- a/crates/control/src/motion/arms_up_squat.rs
+++ b/crates/control/src/motion/arms_up_squat.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -10,6 +11,7 @@ use types::{
     motion_selection::{MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct ArmsUpSquat {
     interpolator: MotionInterpolator<Joints<f32>>,
 }

--- a/crates/control/src/motion/condition_input_provider.rs
+++ b/crates/control/src/motion/condition_input_provider.rs
@@ -3,9 +3,10 @@ use context_attribute::context;
 use filtering::low_pass_filter::LowPassFilter;
 use framework::MainOutput;
 use nalgebra::Vector3;
+use serde::{Deserialize, Serialize};
 use types::{condition_input::ConditionInput, fall_state::FallState, sensor_data::SensorData};
 
-#[derive(Default)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct ConditionInputProvider {
     angular_velocity_filter: LowPassFilter<Vector3<f32>>,
 }

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -37,7 +37,7 @@ pub struct CycleContext {
 
     penalized_pose: Parameter<Joints<f32>, "penalized_pose">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 
     transition_time: AdditionalOutput<Option<Duration>, "transition_time">,
 }

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -4,13 +4,15 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use motionfile::{SplineInterpolator, TimedSpline};
-use types::joints::{BodyJointsCommand, HeadJoints, JointsCommand};
-use types::motion_selection::{MotionSafeExits, MotionType};
+use serde::{Deserialize, Serialize};
 use types::{
-    cycle_time::CycleTime, joints::Joints, motion_selection::MotionSelection,
+    cycle_time::CycleTime,
+    joints::{BodyJointsCommand, HeadJoints, Joints, JointsCommand},
+    motion_selection::{MotionSafeExits, MotionSelection, MotionType},
     sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct DispatchingInterpolator {
     interpolator: SplineInterpolator<Joints<f32>>,
     stiffnesses: Joints<f32>,

--- a/crates/control/src/motion/energy_saving_stand.rs
+++ b/crates/control/src/motion/energy_saving_stand.rs
@@ -1,8 +1,10 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::joints::{ArmJoints, BodyJoints, BodyJointsCommand, Joints, LegJoints};
 
+#[derive(Deserialize, Serialize)]
 pub struct EnergySavingStand {}
 
 #[context]

--- a/crates/control/src/motion/fall_protector.rs
+++ b/crates/control/src/motion/fall_protector.rs
@@ -44,7 +44,7 @@ pub struct CycleContext {
 
     fall_protection: Parameter<FallProtectionParameters, "fall_protection">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 }
 
 #[context]

--- a/crates/control/src/motion/fall_protector.rs
+++ b/crates/control/src/motion/fall_protector.rs
@@ -8,6 +8,7 @@ use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
 use nalgebra::Vector2;
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -19,6 +20,7 @@ use types::{
     sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct FallProtector {
     start_time: SystemTime,
     interpolator: MotionInterpolator<Joints<f32>>,

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -3,6 +3,7 @@ use std::f32::consts::PI;
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime,
     joints::{HeadJoints, HeadJointsCommand},
@@ -10,7 +11,7 @@ use types::{
     sensor_data::SensorData,
 };
 
-#[derive(Default)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct HeadMotion {
     last_positions: HeadJoints<f32>,
 }

--- a/crates/control/src/motion/joint_command_sender.rs
+++ b/crates/control/src/motion/joint_command_sender.rs
@@ -22,7 +22,7 @@ pub struct CycleContext {
     stiffnesses: AdditionalOutput<Joints<f32>, "stiffnesses">,
     motion_safe_exits_output: AdditionalOutput<MotionSafeExits, "motion_safe_exits_output">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 
     joint_calibration_offsets: Parameter<Joints<f32>, "joint_calibration_offsets">,
     penalized_pose: Parameter<Joints<f32>, "penalized_pose">,

--- a/crates/control/src/motion/joint_command_sender.rs
+++ b/crates/control/src/motion/joint_command_sender.rs
@@ -2,6 +2,7 @@ use color_eyre::{eyre::WrapErr, Result};
 use context_attribute::context;
 use framework::AdditionalOutput;
 use hardware::ActuatorInterface;
+use serde::{Deserialize, Serialize};
 use types::{
     joints::{BodyJointsCommand, HeadJointsCommand, Joints, JointsCommand},
     led::Leds,
@@ -9,6 +10,7 @@ use types::{
     sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct JointCommandSender {}
 
 #[context]

--- a/crates/control/src/motion/jump_left.rs
+++ b/crates/control/src/motion/jump_left.rs
@@ -21,7 +21,7 @@ pub struct CreationContext {
 
 #[context]
 pub struct CycleContext {
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 
     condition_input: Input<ConditionInput, "condition_input">,
     cycle_time: Input<CycleTime, "cycle_time">,

--- a/crates/control/src/motion/jump_left.rs
+++ b/crates/control/src/motion/jump_left.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -10,6 +11,7 @@ use types::{
     motion_selection::{MotionSafeExits, MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct JumpLeft {
     interpolator: MotionInterpolator<JointsCommand<f32>>,
 }

--- a/crates/control/src/motion/jump_right.rs
+++ b/crates/control/src/motion/jump_right.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -10,6 +11,7 @@ use types::{
     motion_selection::{MotionSafeExits, MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct JumpRight {
     interpolator: MotionInterpolator<JointsCommand<f32>>,
 }

--- a/crates/control/src/motion/jump_right.rs
+++ b/crates/control/src/motion/jump_right.rs
@@ -21,7 +21,7 @@ pub struct CreationContext {
 
 #[context]
 pub struct CycleContext {
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 
     condition_input: Input<ConditionInput, "condition_input">,
     cycle_time: Input<CycleTime, "cycle_time">,

--- a/crates/control/src/motion/look_around.rs
+++ b/crates/control/src/motion/look_around.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime,
     initial_look_around::Mode,
@@ -12,6 +13,7 @@ use types::{
     support_foot::Side,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct LookAround {
     current_mode: Mode,
     last_mode_switch: SystemTime,

--- a/crates/control/src/motion/look_at.rs
+++ b/crates/control/src/motion/look_at.rs
@@ -5,12 +5,17 @@ use context_attribute::context;
 use framework::MainOutput;
 use kinematics::{head_to_neck, neck_to_robot};
 use nalgebra::{distance, point, vector, Isometry3, Point2};
-use types::motion_command::{GlanceDirection, HeadMotion};
+use serde::{Deserialize, Serialize};
 use types::{
-    camera_matrix::CameraMatrices, camera_position::CameraPosition, cycle_time::CycleTime,
-    joints::HeadJoints, joints::Joints, motion_command::MotionCommand, sensor_data::SensorData,
+    camera_matrix::CameraMatrices,
+    camera_position::CameraPosition,
+    cycle_time::CycleTime,
+    joints::{HeadJoints, Joints},
+    motion_command::{GlanceDirection, HeadMotion, MotionCommand},
+    sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct LookAt {
     current_glance_direction: GlanceDirection,
     last_glance_direction_toggle: Option<SystemTime>,

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -19,7 +19,7 @@ pub struct CycleContext {
     motion_command: Input<MotionCommand, "motion_command">,
     has_ground_contact: Input<bool, "has_ground_contact">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 
     enable_energy_saving_stand: Parameter<bool, "energy_saving_stand.enabled">,
 }

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -1,11 +1,13 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{
     motion_command::{Facing, JumpDirection, MotionCommand},
     motion_selection::{MotionSafeExits, MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct MotionSelector {
     current_motion: MotionType,
     dispatching_motion: Option<MotionType>,

--- a/crates/control/src/motion/sit_down.rs
+++ b/crates/control/src/motion/sit_down.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -10,6 +11,7 @@ use types::{
     motion_selection::{MotionSafeExits, MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct SitDown {
     interpolator: MotionInterpolator<Joints<f32>>,
 }

--- a/crates/control/src/motion/sit_down.rs
+++ b/crates/control/src/motion/sit_down.rs
@@ -25,7 +25,7 @@ pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
     motion_selection: Input<MotionSelection, "motion_selection">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 }
 
 #[context]

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -5,6 +5,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -12,6 +13,7 @@ use types::{
     motion_selection::{MotionSafeExits, MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct StandUpBack {
     interpolator: MotionInterpolator<Joints<f32>>,
 }

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -27,7 +27,7 @@ pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
     motion_selection: Input<MotionSelection, "motion_selection">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 }
 
 #[context]

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -27,7 +27,7 @@ pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
     motion_selection: Input<MotionSelection, "motion_selection">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
 }
 
 #[context]

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -5,6 +5,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{MotionFile, MotionInterpolator};
+use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -12,6 +13,7 @@ use types::{
     motion_selection::{MotionSafeExits, MotionSelection, MotionType},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct StandUpFront {
     interpolator: MotionInterpolator<Joints<f32>>,
 }

--- a/crates/control/src/motion/step_planner.rs
+++ b/crates/control/src/motion/step_planner.rs
@@ -23,7 +23,7 @@ pub struct CycleContext {
     rotation_exponent: Parameter<f32, "step_planner.rotation_exponent">,
     translation_exponent: Parameter<f32, "step_planner.translation_exponent">,
 
-    walk_return_offset: PersistentState<Step, "walk_return_offset">,
+    walk_return_offset: CyclerState<Step, "walk_return_offset">,
 }
 
 #[context]

--- a/crates/control/src/motion/step_planner.rs
+++ b/crates/control/src/motion/step_planner.rs
@@ -2,12 +2,14 @@ use color_eyre::{eyre::eyre, Result};
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{Isometry2, UnitComplex};
+use serde::{Deserialize, Serialize};
 use types::{
     motion_command::{MotionCommand, OrientationMode},
     planned_path::PathSegment,
     step_plan::Step,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct StepPlanner {}
 
 #[context]

--- a/crates/control/src/motion/walk_manager.rs
+++ b/crates/control/src/motion/walk_manager.rs
@@ -1,6 +1,7 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{
     motion_command::MotionCommand,
     motion_selection::{MotionSelection, MotionType},
@@ -8,6 +9,7 @@ use types::{
     walk_command::WalkCommand,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct WalkManager {}
 
 #[context]

--- a/crates/control/src/motion/walking_engine.rs
+++ b/crates/control/src/motion/walking_engine.rs
@@ -134,8 +134,8 @@ pub struct CycleContext {
     step_planner_config: Parameter<StepPlannerParameters, "step_planner">,
     kick_steps: Parameter<KickStepsParameters, "kick_steps">,
 
-    motion_safe_exits: PersistentState<MotionSafeExits, "motion_safe_exits">,
-    walk_return_offset: PersistentState<Step, "walk_return_offset">,
+    motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
+    walk_return_offset: CyclerState<Step, "walk_return_offset">,
 
     motion_command: Input<MotionCommand, "motion_command">,
     robot_kinematics: Input<RobotKinematics, "robot_kinematics">,

--- a/crates/control/src/obstacle_filter.rs
+++ b/crates/control/src/obstacle_filter.rs
@@ -6,6 +6,7 @@ use filtering::kalman_filter::KalmanFilter;
 use framework::{AdditionalOutput, HistoricInput, MainOutput, PerceptionInput};
 use itertools::{chain, iproduct};
 use nalgebra::{distance, point, Isometry2, Matrix2, Point2};
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime,
     detected_feet::DetectedFeet,
@@ -19,6 +20,7 @@ use types::{
     sonar_obstacle::SonarObstacle,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct ObstacleFilter {
     hypotheses: Vec<Hypothesis>,
     last_primary_state: PrimaryState,

--- a/crates/control/src/odometry.rs
+++ b/crates/control/src/odometry.rs
@@ -2,11 +2,13 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{Isometry2, Translation2, UnitComplex, Vector2};
+use serde::{Deserialize, Serialize};
 use types::{
     robot_kinematics::RobotKinematics,
     support_foot::{Side, SupportFoot},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct Odometry {
     last_orientation: UnitComplex<f32>,
     last_left_sole_to_right_sole: Vector2<f32>,

--- a/crates/control/src/orientation_filter.rs
+++ b/crates/control/src/orientation_filter.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use filtering::orientation_filtering::OrientationFiltering;
 use framework::MainOutput;
 use nalgebra::UnitComplex;
+use serde::{Deserialize, Serialize};
 use types::{
     cycle_time::CycleTime,
     orientation_filter::{Parameters, State},
@@ -10,7 +11,7 @@ use types::{
     sole_pressure::SolePressure,
 };
 
-#[derive(Default)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct OrientationFilter {
     state: State,
 }

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -1,6 +1,7 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use spl_network_messages::GamePhase;
 use types::{
     ball_position::BallPosition, field_dimensions::FieldDimensions,
@@ -8,6 +9,7 @@ use types::{
     primary_state::PrimaryState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct PenaltyShotDirectionEstimation {
     last_shot_direction: PenaltyShotDirection,
 }

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -96,7 +96,7 @@ impl PrimaryStateFilter {
             (_, _, _, _, _) => self.last_primary_state,
         };
 
-        context.hardware_interface.set_recording(matches!(
+        context.hardware_interface.set_whether_to_record(matches!(
             self.last_primary_state,
             PrimaryState::Ready | PrimaryState::Set | PrimaryState::Playing,
         ));

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::SpeakerInterface;
+use serde::{Deserialize, Serialize};
 use spl_network_messages::PlayerNumber;
 use types::{
     audio::{Sound, SpeakerRequest},
@@ -11,6 +12,7 @@ use types::{
     primary_state::PrimaryState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct PrimaryStateFilter {
     last_primary_state: PrimaryState,
 }

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::{MainOutput, PerceptionInput};
 use hardware::NetworkInterface;
 use nalgebra::{Isometry2, Point2, Vector2};
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{
     GameControllerReturnMessage, GamePhase, HulkMessage, Penalty, PlayerNumber, Team,
 };
@@ -23,6 +24,7 @@ use types::{
 
 use crate::localization::generate_initial_pose;
 
+#[derive(Deserialize, Serialize)]
 pub struct RoleAssignment {
     last_received_spl_striker_message: Option<SystemTime>,
     last_system_time_transmitted_game_controller_return_message: Option<SystemTime>,

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -45,7 +45,7 @@ pub struct CycleContext {
     robot_to_field: Input<Option<Isometry2<f32>>, "robot_to_field?">,
     cycle_time: Input<CycleTime, "cycle_time">,
     network_message: PerceptionInput<IncomingMessage, "SplNetwork", "message">,
-    time_to_reach_kick_position: PersistentState<Duration, "time_to_reach_kick_position">,
+    time_to_reach_kick_position: CyclerState<Duration, "time_to_reach_kick_position">,
 
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
     forced_role: Parameter<Option<Role>, "role_assignment.forced_role?">,

--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{point, vector, Point2};
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{GameState, SubState, Team};
 use types::{
     field_dimensions::FieldDimensions,
@@ -12,6 +13,7 @@ use types::{
     world_state::BallState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct RuleObstacleComposer {}
 
 #[context]

--- a/crates/control/src/sensor_data_receiver.rs
+++ b/crates/control/src/sensor_data_receiver.rs
@@ -4,8 +4,10 @@ use color_eyre::{eyre::WrapErr, Result};
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use hardware::{SensorInterface, TimeInterface};
+use serde::{Deserialize, Serialize};
 use types::{cycle_time::CycleTime, joints::Joints, sensor_data::SensorData};
 
+#[derive(Deserialize, Serialize)]
 pub struct SensorDataReceiver {
     last_cycle_start: SystemTime,
 }

--- a/crates/control/src/sole_pressure_filter.rs
+++ b/crates/control/src/sole_pressure_filter.rs
@@ -2,8 +2,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use filtering::low_pass_filter::LowPassFilter;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{sensor_data::SensorData, sole_pressure::SolePressure};
 
+#[derive(Deserialize, Serialize)]
 pub struct SolePressureFilter {
     left_sole_pressure: LowPassFilter<f32>,
     right_sole_pressure: LowPassFilter<f32>,

--- a/crates/control/src/sonar_filter.rs
+++ b/crates/control/src/sonar_filter.rs
@@ -3,11 +3,13 @@ use context_attribute::context;
 use filtering::low_pass_filter::LowPassFilter;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::point;
+use serde::{Deserialize, Serialize};
 use types::{
     fall_state::FallState, sensor_data::SensorData, sonar_obstacle::SonarObstacle,
     sonar_values::SonarValues,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct SonarFilter {
     filtered_sonar_left: LowPassFilter<f32>,
     filtered_sonar_right: LowPassFilter<f32>,

--- a/crates/control/src/support_foot_estimation.rs
+++ b/crates/control/src/support_foot_estimation.rs
@@ -2,11 +2,13 @@ use color_eyre::Result;
 use context_attribute::context;
 use filtering::hysteresis::greater_than_with_hysteresis;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{
     sensor_data::SensorData,
     support_foot::{Side, SupportFoot},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct SupportFootEstimation {
     last_support_side: Side,
 }

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -12,7 +12,7 @@ pub struct CycleContext {
     time_to_reach_kick_position_output:
         AdditionalOutput<Option<Duration>, "time_to_reach_kick_position_output">,
 
-    time_to_reach_kick_position: PersistentState<Duration, "time_to_reach_kick_position">,
+    time_to_reach_kick_position: CyclerState<Duration, "time_to_reach_kick_position">,
 
     configuration: Parameter<BehaviorParameters, "behavior">,
 

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -1,8 +1,12 @@
+use std::time::Duration;
+
 use color_eyre::Result;
 use framework::AdditionalOutput;
+use serde::{Deserialize, Serialize};
 use types::{parameters::BehaviorParameters, planned_path::PathSegment};
 
-use std::time::Duration;
+#[derive(Deserialize, Serialize)]
+pub struct TimeToReachKickPosition {}
 
 use context_attribute::context;
 #[context]
@@ -27,8 +31,6 @@ pub struct CreationContext {}
 
 #[context]
 pub struct MainOutputs {}
-
-pub struct TimeToReachKickPosition {}
 
 impl TimeToReachKickPosition {
     pub fn new(_: CreationContext) -> Result<Self> {

--- a/crates/control/src/visual_referee_filter.rs
+++ b/crates/control/src/visual_referee_filter.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 use color_eyre::{eyre::Context, Result};
 use context_attribute::context;
 use hardware::NetworkInterface;
+use serde::{Deserialize, Serialize};
 use spl_network_messages::{PlayerNumber, VisualRefereeDecision, VisualRefereeMessage};
 use types::{
     cycle_time::CycleTime, filtered_whistle::FilteredWhistle, messages::OutgoingMessage,
     primary_state::PrimaryState,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct VisualRefereeFilter {
     last_primary_state: PrimaryState,
 }

--- a/crates/control/src/whistle_filter.rs
+++ b/crates/control/src/whistle_filter.rs
@@ -3,8 +3,10 @@ use std::{collections::VecDeque, time::SystemTime};
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{MainOutput, PerceptionInput};
+use serde::{Deserialize, Serialize};
 use types::{cycle_time::CycleTime, filtered_whistle::FilteredWhistle, whistle::Whistle};
 
+#[derive(Deserialize, Serialize)]
 pub struct WhistleFilter {
     pub detection_buffer: VecDeque<bool>,
     pub was_detected_last_cycle: bool,

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{Isometry2, Point2};
+use serde::{Deserialize, Serialize};
 use spl_network_messages::PlayerNumber;
 use types::{
     fall_state::FallState,
@@ -15,6 +16,7 @@ use types::{
     world_state::{BallState, RobotState, WorldState},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct WorldStateComposer {}
 
 #[context]

--- a/crates/filtering/src/tap_detector.rs
+++ b/crates/filtering/src/tap_detector.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Deserialize, Serialize)]
 /// Detects an falling edge of two state sensor reading
-#[derive(Default)]
 pub struct TapDetector {
     last_reading: bool,
     is_single_tapped: bool,

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -7,3 +7,4 @@ homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 parking_lot = { workspace = true }
+serde = { workspace = true }

--- a/crates/framework/src/lib.rs
+++ b/crates/framework/src/lib.rs
@@ -5,6 +5,7 @@ mod historic_input;
 mod main_output;
 mod multiple_buffer;
 mod panic;
+mod parameters;
 mod perception_databases;
 mod perception_input;
 
@@ -15,5 +16,6 @@ pub use historic_input::HistoricInput;
 pub use main_output::MainOutput;
 pub use multiple_buffer::{multiple_buffer_with_slots, Reader, ReaderGuard, Writer, WriterGuard};
 pub use panic::deserialize_not_implemented;
+pub use parameters::Parameters;
 pub use perception_databases::PerceptionDatabases;
 pub use perception_input::PerceptionInput;

--- a/crates/framework/src/lib.rs
+++ b/crates/framework/src/lib.rs
@@ -4,6 +4,7 @@ mod historic_databases;
 mod historic_input;
 mod main_output;
 mod multiple_buffer;
+mod panic;
 mod perception_databases;
 mod perception_input;
 
@@ -13,5 +14,6 @@ pub use historic_databases::HistoricDatabases;
 pub use historic_input::HistoricInput;
 pub use main_output::MainOutput;
 pub use multiple_buffer::{multiple_buffer_with_slots, Reader, ReaderGuard, Writer, WriterGuard};
+pub use panic::deserialize_not_implemented;
 pub use perception_databases::PerceptionDatabases;
 pub use perception_input::PerceptionInput;

--- a/crates/framework/src/panic.rs
+++ b/crates/framework/src/panic.rs
@@ -1,3 +1,3 @@
 pub fn deserialize_not_implemented<T>() -> T {
-    panic!("deserialize not implemented")
+    unimplemented!("deserialize not implemented")
 }

--- a/crates/framework/src/panic.rs
+++ b/crates/framework/src/panic.rs
@@ -1,0 +1,3 @@
+pub fn deserialize_not_implemented<T>() -> T {
+    panic!("deserialize not implemented")
+}

--- a/crates/framework/src/parameters.rs
+++ b/crates/framework/src/parameters.rs
@@ -1,10 +1,11 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Parameters {
     pub communication_addresses: Option<String>,
+    pub cycler_instances_to_be_recorded: HashSet<String>,
     pub hardware_parameters: PathBuf,
     pub parameters_directory: PathBuf,
 }

--- a/crates/framework/src/parameters.rs
+++ b/crates/framework/src/parameters.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Parameters {
+    pub communication_addresses: Option<String>,
+    pub hardware_parameters: PathBuf,
+    pub parameters_directory: PathBuf,
+}

--- a/crates/hardware/src/lib.rs
+++ b/crates/hardware/src/lib.rs
@@ -43,6 +43,11 @@ pub trait PathsInterface {
     fn get_paths(&self) -> Paths;
 }
 
+pub trait RecordingInterface {
+    fn get_recording(&self) -> bool;
+    fn set_recording(&self, enable: bool);
+}
+
 pub trait SensorInterface {
     fn read_from_sensors(&self) -> Result<SensorData>;
 }

--- a/crates/hardware/src/lib.rs
+++ b/crates/hardware/src/lib.rs
@@ -45,8 +45,8 @@ pub trait PathsInterface {
 }
 
 pub trait RecordingInterface {
-    fn get_recording(&self) -> bool;
-    fn set_recording(&self, enable: bool);
+    fn should_record(&self) -> bool;
+    fn set_whether_to_record(&self, enable: bool);
 }
 
 pub trait SensorInterface {

--- a/crates/hardware/src/lib.rs
+++ b/crates/hardware/src/lib.rs
@@ -2,9 +2,10 @@ use std::time::SystemTime;
 
 use color_eyre::eyre::Result;
 use types::camera_position::CameraPosition;
+use types::hardware::Ids;
 use types::{
     audio::SpeakerRequest,
-    hardware::{Ids, Paths},
+    hardware::Paths,
     joints::Joints,
     led::Leds,
     messages::{IncomingMessage, OutgoingMessage},

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 audio = { workspace = true }
+bincode = { workspace = true }
 color-eyre = { workspace = true }
 communication = { workspace = true, features = ["server"] }
 control = { workspace = true }

--- a/crates/hulk/src/lib.rs
+++ b/crates/hulk/src/lib.rs
@@ -2,7 +2,7 @@
 
 use hardware::{
     ActuatorInterface, CameraInterface, IdInterface, MicrophoneInterface, NetworkInterface,
-    PathsInterface, SensorInterface, SpeakerInterface, TimeInterface,
+    PathsInterface, RecordingInterface, SensorInterface, SpeakerInterface, TimeInterface,
 };
 
 pub trait HardwareInterface:
@@ -10,8 +10,9 @@ pub trait HardwareInterface:
     + CameraInterface
     + IdInterface
     + MicrophoneInterface
-    + PathsInterface
     + NetworkInterface
+    + PathsInterface
+    + RecordingInterface
     + SensorInterface
     + SpeakerInterface
     + TimeInterface

--- a/crates/hulk_nao/Cargo.toml
+++ b/crates/hulk_nao/Cargo.toml
@@ -13,6 +13,7 @@ constants = { workspace = true }
 ctrlc = { workspace = true }
 enum-iterator = { workspace = true }
 fern = { workspace = true }
+framework = { workspace = true }
 hardware = { workspace = true }
 hulk = { workspace = true }
 libc = { workspace = true }

--- a/crates/hulk_nao/src/hardware_interface.rs
+++ b/crates/hulk_nao/src/hardware_interface.rs
@@ -46,7 +46,6 @@ use super::{
 pub struct Parameters {
     pub camera_top: nao_camera::Parameters,
     pub camera_bottom: nao_camera::Parameters,
-    pub communication_addresses: Option<String>,
     pub microphones: microphones::Parameters,
     pub paths: Paths,
     pub speakers: speakers::Parameters,

--- a/crates/hulk_nao/src/hardware_interface.rs
+++ b/crates/hulk_nao/src/hardware_interface.rs
@@ -174,11 +174,11 @@ impl PathsInterface for HardwareInterface {
 }
 
 impl RecordingInterface for HardwareInterface {
-    fn get_recording(&self) -> bool {
+    fn should_record(&self) -> bool {
         self.enable_recording.load(Ordering::SeqCst)
     }
 
-    fn set_recording(&self, enable: bool) {
+    fn set_whether_to_record(&self, enable: bool) {
         self.enable_recording.store(enable, Ordering::SeqCst)
     }
 }

--- a/crates/hulk_nao/src/main.rs
+++ b/crates/hulk_nao/src/main.rs
@@ -6,8 +6,9 @@ use color_eyre::{
     install,
 };
 use ctrlc::set_handler;
-use hardware::{IdInterface, PathsInterface};
-use hardware_interface::{HardwareInterface, Parameters};
+use framework::Parameters as FrameworkParameters;
+use hardware::IdInterface;
+use hardware_interface::{HardwareInterface, Parameters as HardwareParameters};
 use hulk::run::run;
 use serde_json::from_reader;
 use tokio_util::sync::CancellationToken;
@@ -41,9 +42,9 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
 fn main() -> Result<()> {
     setup_logger()?;
     install()?;
-    let hardware_parameters_path = args()
+    let framework_parameters_path = args()
         .nth(1)
-        .unwrap_or("etc/parameters/hardware.json".to_string());
+        .unwrap_or("etc/parameters/framework.json".to_string());
     let keep_running = CancellationToken::new();
     set_handler({
         let keep_running = keep_running.clone();
@@ -51,19 +52,26 @@ fn main() -> Result<()> {
             keep_running.cancel();
         }
     })?;
+
     let file =
-        File::open(hardware_parameters_path).wrap_err("failed to open hardware parameters")?;
-    let hardware_parameters: Parameters =
+        File::open(framework_parameters_path).wrap_err("failed to open framework parameters")?;
+    let framework_parameters: FrameworkParameters =
+        from_reader(file).wrap_err("failed to parse framework parameters")?;
+
+    let file = File::open(framework_parameters.hardware_parameters)
+        .wrap_err("failed to open hardware parameters")?;
+    let hardware_parameters: HardwareParameters =
         from_reader(file).wrap_err("failed to parse hardware parameters")?;
-    let communication_addresses = hardware_parameters.communication_addresses.clone();
+
     let hardware_interface = HardwareInterface::new(keep_running.clone(), hardware_parameters)
         .wrap_err("failed to create hardware interface")?;
+
     let ids = hardware_interface.get_ids();
-    let paths = hardware_interface.get_paths();
+
     run(
         Arc::new(hardware_interface),
-        communication_addresses,
-        paths.parameters,
+        framework_parameters.communication_addresses,
+        framework_parameters.parameters_directory,
         ids.body_id,
         ids.head_id,
         keep_running,

--- a/crates/hulk_nao/src/main.rs
+++ b/crates/hulk_nao/src/main.rs
@@ -75,5 +75,6 @@ fn main() -> Result<()> {
         ids.body_id,
         ids.head_id,
         keep_running,
+        framework_parameters.cycler_instances_to_be_recorded,
     )
 }

--- a/crates/hulk_webots/Cargo.toml
+++ b/crates/hulk_webots/Cargo.toml
@@ -10,6 +10,7 @@ chrono = { workspace = true }
 color-eyre = { workspace = true }
 ctrlc = { workspace = true }
 fern = { workspace = true }
+framework = { workspace = true }
 hardware = { workspace = true }
 hulk = { workspace = true }
 log = { workspace = true }

--- a/crates/hulk_webots/src/hardware_interface.rs
+++ b/crates/hulk_webots/src/hardware_interface.rs
@@ -46,7 +46,6 @@ pub const SIMULATION_TIME_STEP: i32 = 10;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Parameters {
-    pub communication_addresses: Option<String>,
     pub paths: Paths,
     pub spl_network_ports: Ports,
 }

--- a/crates/hulk_webots/src/hardware_interface.rs
+++ b/crates/hulk_webots/src/hardware_interface.rs
@@ -13,7 +13,7 @@ use color_eyre::{
 };
 use hardware::{
     ActuatorInterface, CameraInterface, IdInterface, MicrophoneInterface, NetworkInterface,
-    PathsInterface, SensorInterface, SpeakerInterface, TimeInterface,
+    PathsInterface, RecordingInterface, SensorInterface, SpeakerInterface, TimeInterface,
 };
 use serde::Deserialize;
 use spl_network::endpoint::{Endpoint, Ports};
@@ -66,6 +66,7 @@ pub struct HardwareInterface {
     paths: Paths,
     spl_network_endpoint: Endpoint,
     async_runtime: Runtime,
+    enable_recording: AtomicBool,
     keep_running: CancellationToken,
     simulator_audio_synchronization: Barrier,
 }
@@ -94,6 +95,7 @@ impl HardwareInterface {
                 .block_on(Endpoint::new(parameters.spl_network_ports))
                 .wrap_err("failed to initialize SPL network")?,
             async_runtime: runtime,
+            enable_recording: AtomicBool::new(false),
             keep_running,
             simulator_audio_synchronization: Barrier::new(2),
         })
@@ -346,6 +348,16 @@ impl NetworkInterface for HardwareInterface {
 impl PathsInterface for HardwareInterface {
     fn get_paths(&self) -> Paths {
         self.paths.clone()
+    }
+}
+
+impl RecordingInterface for HardwareInterface {
+    fn get_recording(&self) -> bool {
+        self.enable_recording.load(Ordering::SeqCst)
+    }
+
+    fn set_recording(&self, enable: bool) {
+        self.enable_recording.store(enable, Ordering::SeqCst)
     }
 }
 

--- a/crates/hulk_webots/src/hardware_interface.rs
+++ b/crates/hulk_webots/src/hardware_interface.rs
@@ -351,11 +351,11 @@ impl PathsInterface for HardwareInterface {
 }
 
 impl RecordingInterface for HardwareInterface {
-    fn get_recording(&self) -> bool {
+    fn should_record(&self) -> bool {
         self.enable_recording.load(Ordering::SeqCst)
     }
 
-    fn set_recording(&self, enable: bool) {
+    fn set_whether_to_record(&self, enable: bool) {
         self.enable_recording.store(enable, Ordering::SeqCst)
     }
 }

--- a/crates/hulk_webots/src/main.rs
+++ b/crates/hulk_webots/src/main.rs
@@ -74,5 +74,6 @@ fn main() -> Result<()> {
         ids.body_id,
         ids.head_id,
         keep_running,
+        framework_parameters.cycler_instances_to_be_recorded,
     )
 }

--- a/crates/motionfile/src/motion_interpolator.rs
+++ b/crates/motionfile/src/motion_interpolator.rs
@@ -8,10 +8,11 @@ use crate::{
 };
 use color_eyre::{Report, Result};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use splines::Interpolate;
 use types::condition_input::ConditionInput;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct ConditionedSpline<T> {
     pub entry_condition: Option<DiscreteConditionType>,
     pub interrupt_conditions: Vec<ContinuousConditionType>,
@@ -19,13 +20,13 @@ pub struct ConditionedSpline<T> {
     pub exit_condition: Option<DiscreteConditionType>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Deserialize, Serialize)]
 pub struct MotionInterpolator<T> {
     frames: Vec<ConditionedSpline<T>>,
     current_state: State<T>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 enum State<T> {
     CheckEntry {
         current_frame_index: usize,

--- a/crates/source_analyzer/src/pretty.rs
+++ b/crates/source_analyzer/src/pretty.rs
@@ -91,13 +91,13 @@ impl ToWriterPretty for Field {
     fn to_writer_pretty(&self, writer: &mut impl Write) -> fmt::Result {
         match self {
             Field::AdditionalOutput { name, .. } => write!(writer, "{name}: AdditfmtnalOutput"),
+            Field::CyclerState { name, .. } => write!(writer, "{name}: CyclerState"),
             Field::HardwareInterface { name, .. } => write!(writer, "{name}: HardwareInterface"),
             Field::HistoricInput { name, .. } => write!(writer, "{name}: HistoricInput"),
             Field::Input { name, .. } => write!(writer, "{name}: Input"),
             Field::MainOutput { name, .. } => write!(writer, "{name}: MainOutput"),
             Field::Parameter { name, .. } => write!(writer, "{name}: Parameter"),
             Field::PerceptionInput { name, .. } => write!(writer, "{name}: PerceptfmtnInput"),
-            Field::PersistentState { name, .. } => write!(writer, "{name}: PersistentState"),
             Field::RequiredInput { name, .. } => write!(writer, "{name}: RequiredInput"),
         }
     }

--- a/crates/source_analyzer/src/structs.rs
+++ b/crates/source_analyzer/src/structs.rs
@@ -74,6 +74,12 @@ impl Structs {
                                 cycler_structs.additional_outputs.insert(insertion_rules)?;
                             }
                         }
+                        Field::CyclerState {
+                            data_type, path, ..
+                        } => {
+                            let insertion_rules = path_to_insertion_rules(path, data_type);
+                            cycler_structs.cycler_state.insert(insertion_rules)?;
+                        }
                         Field::Parameter {
                             data_type, path, ..
                         } => {
@@ -87,12 +93,6 @@ impl Structs {
                                 let insertion_rules = path_to_insertion_rules(&path, &data_type);
                                 structs.parameters.insert(insertion_rules)?;
                             }
-                        }
-                        Field::PersistentState {
-                            data_type, path, ..
-                        } => {
-                            let insertion_rules = path_to_insertion_rules(path, data_type);
-                            cycler_structs.persistent_state.insert(insertion_rules)?;
                         }
                         Field::MainOutput { name, .. } => {
                             return Err(Error::UnexpectedField(format!(
@@ -132,7 +132,7 @@ fn add_main_outputs(field: &Field, cycler_structs: &mut CyclerStructs) {
 pub struct CyclerStructs {
     pub main_outputs: StructHierarchy,
     pub additional_outputs: StructHierarchy,
-    pub persistent_state: StructHierarchy,
+    pub cycler_state: StructHierarchy,
 }
 
 fn path_to_insertion_rules<'path>(

--- a/crates/spl_network/src/message_receiver.rs
+++ b/crates/spl_network/src/message_receiver.rs
@@ -2,8 +2,10 @@ use color_eyre::{eyre::WrapErr, Result};
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::NetworkInterface;
+use serde::{Deserialize, Serialize};
 use types::messages::IncomingMessage;
 
+#[derive(Deserialize, Serialize)]
 pub struct MessageReceiver {}
 
 #[context]

--- a/crates/types/src/hardware.rs
+++ b/crates/types/src/hardware.rs
@@ -10,7 +10,6 @@ pub struct Ids {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Paths {
-    pub parameters: PathBuf,
     pub motions: PathBuf,
     pub neural_networks: PathBuf,
     pub sounds: PathBuf,

--- a/crates/vision/Cargo.toml
+++ b/crates/vision/Cargo.toml
@@ -19,4 +19,5 @@ nalgebra = { workspace = true }
 ordered-float = { workspace = true }
 projection = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 types = { workspace = true }

--- a/crates/vision/src/ball_detection.rs
+++ b/crates/vision/src/ball_detection.rs
@@ -1,10 +1,11 @@
 use color_eyre::Result;
 use compiled_nn::CompiledNN;
 use context_attribute::context;
-use framework::{AdditionalOutput, MainOutput};
+use framework::{deserialize_not_implemented, AdditionalOutput, MainOutput};
 use hardware::PathsInterface;
 use nalgebra::{point, vector, Vector2};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     ball::{Ball, CandidateEvaluation},
     camera_matrix::CameraMatrix,
@@ -31,7 +32,9 @@ struct BallCluster<'a> {
     members: Vec<&'a CandidateEvaluation>,
 }
 
+#[derive(Deserialize, Serialize)]
 pub struct BallDetection {
+    #[serde(skip, default = "deserialize_not_implemented")]
     neural_networks: NeuralNetworks,
 }
 

--- a/crates/vision/src/camera_matrix_extractor.rs
+++ b/crates/vision/src/camera_matrix_extractor.rs
@@ -1,11 +1,13 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::{CameraMatrices, CameraMatrix},
     camera_position::CameraPosition,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct CameraMatrixExtractor {}
 
 #[context]

--- a/crates/vision/src/feet_detection.rs
+++ b/crates/vision/src/feet_detection.rs
@@ -8,6 +8,7 @@ use framework::{AdditionalOutput, MainOutput};
 use itertools::Itertools;
 use nalgebra::{distance, point, Point2};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     ball::Ball,
     camera_matrix::CameraMatrix,
@@ -17,6 +18,7 @@ use types::{
     line_data::LineData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct FeetDetection {}
 
 #[context]

--- a/crates/vision/src/field_border_detection.rs
+++ b/crates/vision/src/field_border_detection.rs
@@ -3,6 +3,7 @@ use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{point, Point2, Vector2};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::CameraMatrix,
     color::Intensity,
@@ -14,6 +15,7 @@ use types::{
 
 use crate::ransac::Ransac;
 
+#[derive(Deserialize, Serialize)]
 pub struct FieldBorderDetection {}
 
 #[context]

--- a/crates/vision/src/field_color_detection.rs
+++ b/crates/vision/src/field_color_detection.rs
@@ -2,8 +2,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::Isometry2;
+use serde::{Deserialize, Serialize};
 use types::{field_color::FieldColor, interpolated::Interpolated};
 
+#[derive(Deserialize, Serialize)]
 pub struct FieldColorDetection {
     robot_to_field_of_home_after_coin_toss_before_second_half: Isometry2<f32>,
 }

--- a/crates/vision/src/image_receiver.rs
+++ b/crates/vision/src/image_receiver.rs
@@ -2,8 +2,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::CameraInterface;
+use serde::{Deserialize, Serialize};
 use types::{camera_position::CameraPosition, ycbcr422_image::YCbCr422Image};
 
+#[derive(Deserialize, Serialize)]
 pub struct ImageReceiver {}
 
 #[context]

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -4,6 +4,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{point, Isometry2};
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::CameraMatrix,
     color::{Intensity, Rgb, RgbChannel, YCbCr444},
@@ -16,6 +17,7 @@ use types::{
     ycbcr422_image::YCbCr422Image,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct ImageSegmenter {
     robot_to_field_of_home_after_coin_toss_before_second_half: Isometry2<f32>,
 }

--- a/crates/vision/src/limb_projector.rs
+++ b/crates/vision/src/limb_projector.rs
@@ -3,12 +3,14 @@ use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{Isometry3, Matrix2, Point2, Point3};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::CameraMatrix,
     limb::{Limb, ProjectedLimbs},
     robot_kinematics::RobotKinematics,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct LimbProjector {}
 
 #[context]

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -6,6 +6,7 @@ use framework::{AdditionalOutput, MainOutput};
 use nalgebra::{distance, point, vector, Point2, Vector2};
 use ordered_float::NotNan;
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::CameraMatrix,
     filtered_segments::FilteredSegments,
@@ -17,6 +18,7 @@ use types::{
 
 use crate::ransac::{Ransac, RansacResult};
 
+#[derive(Deserialize, Serialize)]
 pub struct LineDetection {}
 
 #[context]

--- a/crates/vision/src/perspective_grid_candidates_provider.rs
+++ b/crates/vision/src/perspective_grid_candidates_provider.rs
@@ -5,6 +5,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{point, vector, Point2, Vector2};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::CameraMatrix,
     filtered_segments::FilteredSegments,
@@ -21,6 +22,7 @@ struct Row {
     center_y: f32,
 }
 
+#[derive(Deserialize, Serialize)]
 pub struct PerspectiveGridCandidatesProvider {}
 
 #[context]

--- a/crates/vision/src/robot_detection.rs
+++ b/crates/vision/src/robot_detection.rs
@@ -6,11 +6,12 @@ use context_attribute::context;
 use fast_image_resize::{
     DynamicImageView, FilterType, ImageBufferError, ImageView, ResizeAlg, Resizer,
 };
-use framework::{AdditionalOutput, MainOutput};
+use framework::{deserialize_not_implemented, AdditionalOutput, MainOutput};
 use hardware::PathsInterface;
 use itertools::Itertools;
 use nalgebra::{vector, Isometry3, Vector2};
 use projection::Projection;
+use serde::{Deserialize, Serialize};
 use types::{
     camera_matrix::CameraMatrix,
     detected_robots::{BoundingBox, DetectedRobots},
@@ -28,7 +29,9 @@ const BOX_SCALINGS: [Vector2<f32>; NUMBER_OF_SCALINGS] = [
 ];
 const OUTPUT_SCALING: f32 = 10.0;
 
+#[derive(Deserialize, Serialize)]
 pub struct RobotDetection {
+    #[serde(skip, default = "deserialize_not_implemented")]
     neural_network: CompiledNN,
 }
 

--- a/crates/vision/src/segment_filter.rs
+++ b/crates/vision/src/segment_filter.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::point;
+use serde::{Deserialize, Serialize};
 use types::{
     color::Intensity,
     field_border::FieldBorder,
@@ -9,6 +10,7 @@ use types::{
     image_segments::{ImageSegments, ScanGrid, ScanLine, Segment},
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct SegmentFilter {}
 
 #[context]

--- a/etc/parameters/framework.json
+++ b/etc/parameters/framework.json
@@ -1,0 +1,5 @@
+{
+  "communication_addresses": "[::]:1337",
+  "hardware_parameters": "etc/parameters/hardware.json",
+  "parameters_directory": "etc/parameters"
+}

--- a/etc/parameters/framework.json
+++ b/etc/parameters/framework.json
@@ -1,6 +1,6 @@
 {
   "communication_addresses": "[::]:1337",
-  "cycler_instances_to_be_recorded": [],
+  "cycler_instances_to_be_recorded": ["Control"],
   "hardware_parameters": "etc/parameters/hardware.json",
   "parameters_directory": "etc/parameters"
 }

--- a/etc/parameters/framework.json
+++ b/etc/parameters/framework.json
@@ -1,6 +1,6 @@
 {
   "communication_addresses": "[::]:1337",
-  "cycler_instances_to_be_recorded": ["Control"],
+  "cycler_instances_to_be_recorded": [],
   "hardware_parameters": "etc/parameters/hardware.json",
   "parameters_directory": "etc/parameters"
 }

--- a/etc/parameters/framework.json
+++ b/etc/parameters/framework.json
@@ -1,5 +1,6 @@
 {
   "communication_addresses": "[::]:1337",
+  "cycler_instances_to_be_recorded": ["Control"],
   "hardware_parameters": "etc/parameters/hardware.json",
   "parameters_directory": "etc/parameters"
 }

--- a/etc/parameters/hardware.json
+++ b/etc/parameters/hardware.json
@@ -96,7 +96,6 @@
   "paths": {
     "motions": "etc/motions",
     "neural_networks": "etc/neural_networks",
-    "parameters": "etc/parameters",
     "sounds": "etc/sounds"
   },
   "speakers": {

--- a/tools/behavior_simulator/Cargo.toml
+++ b/tools/behavior_simulator/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 name = "behavior_simulator"
 
 [dependencies]
+bincode = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -22,7 +22,7 @@ use types::messages::IncomingMessage;
 use crate::{
     interfake::Interfake,
     structs::{
-        control::{AdditionalOutputs, MainOutputs, PersistentState},
+        control::{AdditionalOutputs, CyclerState, MainOutputs},
         Parameters,
     },
 };
@@ -99,7 +99,7 @@ impl BehaviorCycler {
     pub fn cycle(
         &mut self,
         own_database: &mut Database,
-        persistent_state: &mut PersistentState,
+        cycler_state: &mut CyclerState,
         parameters: &Parameters,
         incoming_messages: BTreeMap<SystemTime, Vec<&IncomingMessage>>,
     ) -> Result<()> {

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -145,7 +145,7 @@ impl BehaviorCycler {
                         persistent: incoming_messages,
                         temporary: Default::default(),
                     },
-                    &mut persistent_state.time_to_reach_kick_position,
+                    &mut cycler_state.time_to_reach_kick_position,
                     &parameters.field_dimensions,
                     parameters.role_assignment.forced_role.as_ref(),
                     &parameters
@@ -317,7 +317,7 @@ impl BehaviorCycler {
                             .additional_outputs
                             .time_to_reach_kick_position_output,
                     ),
-                    &mut persistent_state.time_to_reach_kick_position,
+                    &mut cycler_state.time_to_reach_kick_position,
                     &parameters.behavior,
                     own_database
                         .main_outputs

--- a/tools/behavior_simulator/src/interfake.rs
+++ b/tools/behavior_simulator/src/interfake.rs
@@ -24,11 +24,11 @@ impl NetworkInterface for Interfake {
 }
 
 impl RecordingInterface for Interfake {
-    fn get_recording(&self) -> bool {
+    fn should_record(&self) -> bool {
         false
     }
 
-    fn set_recording(&self, _enable: bool) {}
+    fn set_whether_to_record(&self, _enable: bool) {}
 }
 
 impl Interfake {

--- a/tools/behavior_simulator/src/interfake.rs
+++ b/tools/behavior_simulator/src/interfake.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use color_eyre::Result;
-use hardware::NetworkInterface;
+use hardware::{NetworkInterface, RecordingInterface};
 use types::messages::{IncomingMessage, OutgoingMessage};
 
 #[derive(Default)]
@@ -21,6 +21,14 @@ impl NetworkInterface for Interfake {
         self.messages.lock().unwrap().push(message);
         Ok(())
     }
+}
+
+impl RecordingInterface for Interfake {
+    fn get_recording(&self) -> bool {
+        false
+    }
+
+    fn set_recording(&self, _enable: bool) {}
 }
 
 impl Interfake {

--- a/tools/behavior_simulator/src/lib.rs
+++ b/tools/behavior_simulator/src/lib.rs
@@ -1,4 +1,4 @@
-use hardware::{NetworkInterface, TimeInterface};
+use hardware::{NetworkInterface, RecordingInterface, TimeInterface};
 
 pub mod cycler;
 pub mod interfake;
@@ -9,4 +9,4 @@ pub mod state;
 
 include!(concat!(env!("OUT_DIR"), "/generated_code.rs"));
 
-pub trait HardwareInterface: TimeInterface + NetworkInterface {}
+pub trait HardwareInterface: TimeInterface + NetworkInterface + RecordingInterface {}

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -15,14 +15,14 @@ use types::{camera_matrix::CameraMatrix, messages::IncomingMessage};
 use crate::{
     cycler::{BehaviorCycler, Database},
     interfake::Interfake,
-    structs::{control::PersistentState, Parameters},
+    structs::{control::CyclerState, Parameters},
 };
 
 pub struct Robot {
     pub interface: Arc<Interfake>,
     pub cycler: BehaviorCycler,
     pub database: Database,
-    pub persistent_state: PersistentState,
+    pub cycler_state: CyclerState,
     pub parameters: Parameters,
     pub is_penalized: bool,
     pub last_kick_time: Duration,
@@ -57,13 +57,13 @@ impl Robot {
             &parameter.field_dimensions,
         ));
 
-        let persistent_state = Default::default();
+        let cycler_state = Default::default();
 
         Ok(Self {
             interface,
             cycler,
             database,
-            persistent_state,
+            cycler_state,
             parameters: parameter,
             is_penalized: false,
             last_kick_time: Duration::default(),
@@ -74,7 +74,7 @@ impl Robot {
     pub fn cycle(&mut self, messages: BTreeMap<SystemTime, Vec<&IncomingMessage>>) -> Result<()> {
         self.cycler.cycle(
             &mut self.database,
-            &mut self.persistent_state,
+            &mut self.cycler_state,
             &self.parameters,
             messages,
         )

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -18,6 +18,7 @@ use post_game::{post_game, Arguments as PostGameArguments};
 use power_off::{power_off, Arguments as PoweroffArguments};
 use pre_game::{pre_game, Arguments as PreGameArguments};
 use reboot::{reboot, Arguments as RebootArguments};
+use recording::{recording, Arguments as RecordingArguments};
 use repository::{get_repository_root, Repository};
 use sdk::{sdk, Arguments as SdkArguments};
 use shell::{shell, Arguments as ShellArguments};
@@ -41,6 +42,7 @@ mod power_off;
 mod pre_game;
 mod progress_indicator;
 mod reboot;
+mod recording;
 mod sdk;
 mod shell;
 mod upload;
@@ -109,6 +111,9 @@ async fn main() -> Result<()> {
         Command::Reboot(arguments) => reboot(arguments)
             .await
             .wrap_err("failed to execute reboot command")?,
+        Command::Recording(arguments) => recording(arguments, &repository?)
+            .await
+            .wrap_err("failed to execute recording command")?,
         Command::Run(arguments) => cargo(arguments, &repository?, CargoCommand::Run)
             .await
             .wrap_err("failed to execute run command")?,
@@ -179,6 +184,8 @@ enum Command {
     Pregame(PreGameArguments),
     /// Reboot NAOs
     Reboot(RebootArguments),
+    /// Set cycler instances to be recorded
+    Recording(RecordingArguments),
     /// Runs the code for a target
     Run(CargoArguments),
     /// Manage the NAO SDK

--- a/tools/pepsi/src/recording.rs
+++ b/tools/pepsi/src/recording.rs
@@ -1,0 +1,21 @@
+use std::collections::HashSet;
+
+use clap::Args;
+use color_eyre::{eyre::WrapErr, Result};
+
+use repository::Repository;
+
+#[derive(Args)]
+pub struct Arguments {
+    /// Cycler instances to record e.g. Control or VisionBottom (call without cycler instances to disable recording)
+    pub cycler_instances_to_be_recorded: Vec<String>,
+}
+
+pub async fn recording(arguments: Arguments, repository: &Repository) -> Result<()> {
+    repository
+        .set_cycler_instances_to_be_recorded(HashSet::from_iter(
+            arguments.cycler_instances_to_be_recorded,
+        ))
+        .await
+        .wrap_err("failed to set recording enablement")
+}


### PR DESCRIPTION
## Introduced Changes

- `PersistentState` is renamed to `CyclerState` because it stores state in a cycler
- Node states, setup main outputs, and cross-inputs (from other cyclers) are recorded by serializing to Bincode and writing it to disk
- `hardware.json` is split into `framework.json` and `hardware.json`
- Recording can be enabled by changing the `framework.json`

## ToDo / Known Issues

- Naming of the structs?
- Fix Pepsi parameter setting

## Ideas for Next Iterations (Not This PR)

- Delete localization recording
- Change pixel storage
- Reuce frequency
- Same seconds in `launchHULK` log files and recording file names
- Reduce recording interleavement
- Add channel directly from robotics domain to "runtime" framework

## How to Test

Deploy to a NAO, check that the cyclers are enabled for recording. When the NAO is in playing primary state, the NAO records to `logs` directory in Bincode format.