### PR TITLE
Use discrete temperature levels

### DIFF
--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -208,7 +208,7 @@ impl LedStatus {
         current_maximum_temperature: f32,
     ) -> Ear {
         if filter_whistle_detected {
-            return Ear::full_ears(1.0);
+            return Ear::full_ears(1.0); // invertieren
         }
 
         if last_game_controller_message.is_some_and(|timestamp| {
@@ -224,13 +224,21 @@ impl LedStatus {
             }
         }
 
-        let minimum_temperature = 30.0;
-        let maximum_temperature = 105.0;
+        let temperature_level_one = 76.0;
+        let temperature_level_two = 80.0;
+        let temperature_level_three = 90.0;
 
-        let relative_temperature = (current_maximum_temperature - minimum_temperature)
-            / (maximum_temperature - minimum_temperature).floor();
+        let discrete_temperature = if current_maximum_temperature > temperature_level_one {
+            0.33
+        } else if current_maximum_temperature > temperature_level_two {
+            0.66
+        } else if current_maximum_temperature > temperature_level_three {
+            1.0
+        } else {
+            0.0
+        };
 
-        Ear::percentage_ears(1.0, relative_temperature)
+        Ear::percentage_ears(1.0, discrete_temperature)
     }
 
     fn get_eyes(

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -16,6 +16,11 @@ pub struct LedStatus {
     last_game_controller_message: Option<SystemTime>,
 }
 
+// values, at which the stiffness gets automatically reduced by the motors
+const TEMPERATURE_LEVEL_ONE: f32 = 76.0;
+const TEMPERATURE_LEVEL_TWO: f32 = 80.0;
+const TEMPERATURE_LEVEL_THREE: f32 = 90.0;
+
 #[context]
 pub struct CreationContext {}
 
@@ -207,11 +212,6 @@ impl LedStatus {
         blink_state: bool,
         current_maximum_temperature: f32,
     ) -> Ear {
-        let temperature_level_one = 76.0;
-        let temperature_level_two = 80.0;
-        let temperature_level_three = 90.0;
-        // values, at which the stiffness gets reduced
-
         let mut ear = if last_game_controller_message.is_some_and(|timestamp| {
             cycle_start_time
                 .duration_since(timestamp)
@@ -224,11 +224,11 @@ impl LedStatus {
                 Ear::full_ears(0.0)
             }
         } else {
-            let discrete_temperature = if current_maximum_temperature > temperature_level_one {
+            let discrete_temperature = if current_maximum_temperature > TEMPERATURE_LEVEL_ONE {
                 0.33
-            } else if current_maximum_temperature > temperature_level_two {
+            } else if current_maximum_temperature > TEMPERATURE_LEVEL_TWO {
                 0.66
-            } else if current_maximum_temperature > temperature_level_three {
+            } else if current_maximum_temperature > TEMPERATURE_LEVEL_THREE {
                 1.0
             } else {
                 0.0

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -240,7 +240,7 @@ impl LedStatus {
             ear = ear.invert();
         }
 
-        return ear;
+        ear
     }
 
     fn get_eyes(

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -16,11 +16,6 @@ pub struct LedStatus {
     last_game_controller_message: Option<SystemTime>,
 }
 
-// values, at which the stiffness gets automatically reduced by the motors
-const TEMPERATURE_LEVEL_ONE: f32 = 76.0;
-const TEMPERATURE_LEVEL_TWO: f32 = 80.0;
-const TEMPERATURE_LEVEL_THREE: f32 = 90.0;
-
 #[context]
 pub struct CreationContext {}
 
@@ -224,7 +219,12 @@ impl LedStatus {
                 Ear::full_ears(0.0)
             }
         } else {
-            let discrete_temperature = if current_maximum_temperature > TEMPERATURE_LEVEL_ONE {
+            // values, at which the stiffness gets automatically reduced by the motors
+            const TEMPERATURE_LEVEL_ONE: f32 = 76.0;
+            const TEMPERATURE_LEVEL_TWO: f32 = 80.0;
+            const TEMPERATURE_LEVEL_THREE: f32 = 90.0;
+
+            let ear_fraction = if current_maximum_temperature > TEMPERATURE_LEVEL_ONE {
                 0.33
             } else if current_maximum_temperature > TEMPERATURE_LEVEL_TWO {
                 0.66
@@ -233,7 +233,7 @@ impl LedStatus {
             } else {
                 0.0
             };
-            Ear::percentage_ears(1.0, discrete_temperature)
+            Ear::percentage_ears(1.0, ear_fraction)
         };
 
         if filter_whistle_detected {

--- a/crates/types/src/led.rs
+++ b/crates/types/src/led.rs
@@ -1,4 +1,3 @@
-use nalgebra::abs;
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 

--- a/crates/types/src/led.rs
+++ b/crates/types/src/led.rs
@@ -1,3 +1,4 @@
+use nalgebra::abs;
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 
@@ -83,6 +84,21 @@ impl Ear {
             intensity_at_252: if ear_fraction > 0.7 { intensity } else { 0.0 },
             intensity_at_288: if ear_fraction > 0.8 { intensity } else { 0.0 },
             intensity_at_324: if ear_fraction > 0.9 { intensity } else { 0.0 },
+        }
+    }
+
+    pub fn invert(self) -> Self {
+        Self {
+            intensity_at_0: (1.0 - self.intensity_at_0).abs(),
+            intensity_at_36: (1.0 - self.intensity_at_36).abs(),
+            intensity_at_72: (1.0 - self.intensity_at_72).abs(),
+            intensity_at_108: (1.0 - self.intensity_at_108).abs(),
+            intensity_at_144: (1.0 - self.intensity_at_144).abs(),
+            intensity_at_180: (1.0 - self.intensity_at_180).abs(),
+            intensity_at_216: (1.0 - self.intensity_at_216).abs(),
+            intensity_at_252: (1.0 - self.intensity_at_252).abs(),
+            intensity_at_288: (1.0 - self.intensity_at_288).abs(),
+            intensity_at_324: (1.0 - self.intensity_at_324).abs(),
         }
     }
 }


### PR DESCRIPTION
## Introduced Changes

Implements discrete levels of ear temperature visualization for better differentiation

## How to Test

Let it walk and see how the ears fill. This should only be at 1/3, 2/3 and full.
If a whistle is detected, the ear lighting should be reversed.
