### PR TITLE
Hardcode cache in workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - gh-readonly-queue/main/**
   pull_request:
+env:
+  CARGO_HOME: /__w/hulk/cargo
+  CARGO_TARGET_DIR: /__w/hulk/target
 jobs:
   required_checks:
     name: Require all CI jobs

--- a/tools/ci/github-runners/v3/Dockerfile
+++ b/tools/ci/github-runners/v3/Dockerfile
@@ -30,3 +30,8 @@ RUN wget --no-verbose https://github.com/HULKs/meta-hulks/releases/download/${SD
   chmod +x HULKs-OS-toolchain-${SDK_VERSION}.sh && \
   ./HULKs-OS-toolchain-${SDK_VERSION}.sh -y -d /ci/.naosdk/${SDK_VERSION} && \
   rm HULKs-OS-toolchain-${SDK_VERSION}.sh
+
+COPY cargo.sh.patch /ci
+RUN cd /ci/.naosdk/${SDK_VERSION}/sysroots/x86_64-naosdk-linux/environment-setup.d && \
+  patch -i /ci/cargo.sh.patch && \
+  rm /ci/cargo.sh.patch

--- a/tools/ci/github-runners/v3/cargo.sh.patch
+++ b/tools/ci/github-runners/v3/cargo.sh.patch
@@ -1,0 +1,8 @@
+--- cargo.sh
++++ cargo.sh
+@@ -1,4 +1,4 @@
+-export CARGO_HOME="$OECORE_TARGET_SYSROOT/home/cargo"
++export CARGO_HOME="/__w/hulk/cargo.x86_64-aldebaran-linux-gnu"
+ mkdir -p "$CARGO_HOME"
+         # Init the default target once, it might be otherwise user modified.
+ if [ ! -f "$CARGO_HOME/config" ]; then


### PR DESCRIPTION
## Introduced Changes

It seems that environment variables configured in the runners `.env` are not forwarded to the Docker container, this PR adds the variables to our workflow. This is a little smelly, because the execution environment leaks into our workflow, but since we also configure the user to run the job steps with, it should be fine.

Fixes #527

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Check that everything compiles and the cache is picked up on later jobs.