### PR TITLE
Add zstd to requirements for Fedora

### DIFF
--- a/docs/setup/main_setup.md
+++ b/docs/setup/main_setup.md
@@ -48,7 +48,7 @@ Use your distribution's package manager to install the following dependencies:
     1. Install dependencies
 
         ```sh
-        sudo dnf install git git-lfs hdf5-devel clang-devel rsync cmake python luajit-devel libudev-devel opusfile-devel
+        sudo dnf install git git-lfs hdf5-devel clang-devel rsync cmake python luajit-devel libudev-devel opusfile-devel zstd
         ```
 
     1. Install Webots


### PR DESCRIPTION
## Introduced Changes

Adds installation of zstd to setup instructions for Fedora
