### PR TITLE
1.72 delinting

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -462,6 +462,7 @@ fn generate_node_execution(node: &Node, cycler: &Cycler) -> TokenStream {
     let database_updates_from_defaults = generate_database_updates_from_defaults(node);
     quote! {
         {
+            #[allow(clippy::needless_else)]
             if #are_required_inputs_some {
                 let main_outputs = {
                     let _task = ittapi::Task::begin(&itt_domain, #node_name);

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -1455,7 +1455,7 @@ mod tests {
     fn median_of_five_calculates_median() {
         for (first, second, third, fourth, fifth) in iproduct!(0..5, 0..5, 0..5, 0..5, 0..5) {
             let calculated_median = median_of_five(first, second, third, fourth, fifth);
-            let mut numbers = vec![first, second, third, fourth, fifth];
+            let mut numbers = [first, second, third, fourth, fifth];
             numbers.sort();
             let real_median = numbers[2];
             assert_eq!(calculated_median,real_median, "test_case: {first} {second} {third} {fourth} {fifth}, median_of_five: {calculated_median}");

--- a/crates/vision/src/perspective_grid_candidates_provider.rs
+++ b/crates/vision/src/perspective_grid_candidates_provider.rs
@@ -314,16 +314,13 @@ mod tests {
                 segments,
             },
         ];
-        let skip_segments = HashSet::from_iter(
-            vec![
-                point![0, 18],
-                point![42, 5],
-                point![42, 45],
-                point![110, 5],
-                point![110, 18],
-            ]
-            .into_iter(),
-        );
+        let skip_segments = HashSet::from_iter([
+            point![0, 18],
+            point![42, 5],
+            point![42, 45],
+            point![110, 5],
+            point![110, 18],
+        ]);
         let candidates = generate_candidates(&vertical_scan_lines, &skip_segments, &rows);
         assert_relative_eq!(
             candidates,


### PR DESCRIPTION
## Introduced Changes

Fixes lints newly added to clippy in [Rust 1.72.0](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html).

Fixes #

## ToDo / Known Issues

Not sure about the change to the code generation, hence the extra commit. I'm in favor of ignoring the lint instead of adding more logic to the code generation but I'm unsure where to place the `#[allow(...)]` exactly.
For now I have placed it directly on the if statement in question, which is the one wrapping the cycle call for each node.
In the true case, the node is executed and in the else case the respective main outputs in the database are set to default.
However, there are some nodes that don't have main outputs, leaving the else branch empty.
@h3ndrk Opinions?

## Ideas for Next Iterations (Not This PR)

## How to Test

Try to build/clippy with latest Rust release. There should be no more warnings.
