### PR TITLE
Players iterator traits

### DIFF
--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -117,15 +117,7 @@ impl RoleAssignment {
                     player_roles[striker] = Role::Striker;
                 }
             }
-            role = match context.player_number {
-                PlayerNumber::One => player_roles.one,
-                PlayerNumber::Two => player_roles.two,
-                PlayerNumber::Three => player_roles.three,
-                PlayerNumber::Four => player_roles.four,
-                PlayerNumber::Five => player_roles.five,
-                PlayerNumber::Six => player_roles.six,
-                PlayerNumber::Seven => player_roles.seven,
-            };
+            role = player_roles[*context.player_number];
 
             self.role_initialized = true;
             self.last_received_spl_striker_message = Some(cycle_start_time);

--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -103,16 +103,27 @@ impl<'a, T> Iterator for PlayersIterator<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = match self.next_forward {
-            Some(PlayerNumber::One) => 7,
-            Some(PlayerNumber::Two) => 6,
-            Some(PlayerNumber::Three) => 5,
-            Some(PlayerNumber::Four) => 4,
-            Some(PlayerNumber::Five) => 3,
-            Some(PlayerNumber::Six) => 2,
-            Some(PlayerNumber::Seven) => 1,
-            None => 0,
+        let consumed_forward = match self.next_forward {
+            Some(PlayerNumber::One) => 0,
+            Some(PlayerNumber::Two) => 1,
+            Some(PlayerNumber::Three) => 2,
+            Some(PlayerNumber::Four) => 3,
+            Some(PlayerNumber::Five) => 4,
+            Some(PlayerNumber::Six) => 5,
+            Some(PlayerNumber::Seven) => 6,
+            None => 7,
         };
+        let consumed_back = match self.next_back {
+            Some(PlayerNumber::One) => 6,
+            Some(PlayerNumber::Two) => 5,
+            Some(PlayerNumber::Three) => 4,
+            Some(PlayerNumber::Four) => 3,
+            Some(PlayerNumber::Five) => 2,
+            Some(PlayerNumber::Six) => 1,
+            Some(PlayerNumber::Seven) => 0,
+            None => 7,
+        };
+        let remaining = 7usize.saturating_sub(consumed_forward + consumed_back);
         (remaining, Some(remaining))
     }
 }
@@ -374,16 +385,28 @@ mod test {
         };
         let mut iterator = players.iter();
 
+        assert_eq!(iterator.len(), 7);
         assert_eq!(iterator.next(), Some((PlayerNumber::One, &1)));
+        assert_eq!(iterator.len(), 6);
         assert_eq!(iterator.next(), Some((PlayerNumber::Two, &2)));
+        assert_eq!(iterator.len(), 5);
         assert_eq!(iterator.next_back(), Some((PlayerNumber::Seven, &7)));
+        assert_eq!(iterator.len(), 4);
         assert_eq!(iterator.next_back(), Some((PlayerNumber::Six, &6)));
+        assert_eq!(iterator.len(), 3);
         assert_eq!(iterator.next(), Some((PlayerNumber::Three, &3)));
+        assert_eq!(iterator.len(), 2);
         assert_eq!(iterator.next(), Some((PlayerNumber::Four, &4)));
+        assert_eq!(iterator.len(), 1);
         assert_eq!(iterator.next_back(), Some((PlayerNumber::Five, &5)));
+        assert_eq!(iterator.len(), 0);
         assert_eq!(iterator.next(), None);
+        assert_eq!(iterator.len(), 0);
         assert_eq!(iterator.next_back(), None);
+        assert_eq!(iterator.len(), 0);
         assert_eq!(iterator.next(), None);
+        assert_eq!(iterator.len(), 0);
         assert_eq!(iterator.next_back(), None);
+        assert_eq!(iterator.len(), 0);
     }
 }

--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -64,16 +64,19 @@ impl From<TeamState> for Players<Option<Penalty>> {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct PlayersIterator<'a, T> {
     data: &'a Players<T>,
-    player_number: Option<PlayerNumber>,
+    next_forward: Option<PlayerNumber>,
+    next_back: Option<PlayerNumber>,
 }
 
 impl<'a, T> PlayersIterator<'a, T> {
     fn new(data: &'a Players<T>) -> Self {
         Self {
             data,
-            player_number: Some(PlayerNumber::One),
+            next_forward: Some(PlayerNumber::One),
+            next_back: Some(PlayerNumber::Seven),
         }
     }
 }
@@ -81,16 +84,12 @@ impl<'a, T> PlayersIterator<'a, T> {
 impl<'a, T> Iterator for PlayersIterator<'a, T> {
     type Item = (PlayerNumber, &'a T);
     fn next(&mut self) -> Option<Self::Item> {
-        let result = self.player_number.map(|number| match number {
-            PlayerNumber::One => (PlayerNumber::One, &self.data.one),
-            PlayerNumber::Two => (PlayerNumber::Two, &self.data.two),
-            PlayerNumber::Three => (PlayerNumber::Three, &self.data.three),
-            PlayerNumber::Four => (PlayerNumber::Four, &self.data.four),
-            PlayerNumber::Five => (PlayerNumber::Five, &self.data.five),
-            PlayerNumber::Six => (PlayerNumber::Six, &self.data.six),
-            PlayerNumber::Seven => (PlayerNumber::Seven, &self.data.seven),
-        });
-        self.player_number = match self.player_number {
+        let result = self.next_forward.map(|number| (number, &self.data[number]));
+        if self.next_forward == self.next_back {
+            self.next_forward = None;
+            self.next_back = None;
+        }
+        self.next_forward = match self.next_forward {
             Some(PlayerNumber::One) => Some(PlayerNumber::Two),
             Some(PlayerNumber::Two) => Some(PlayerNumber::Three),
             Some(PlayerNumber::Three) => Some(PlayerNumber::Four),
@@ -104,7 +103,7 @@ impl<'a, T> Iterator for PlayersIterator<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = match self.player_number {
+        let remaining = match self.next_forward {
             Some(PlayerNumber::One) => 7,
             Some(PlayerNumber::Two) => 6,
             Some(PlayerNumber::Three) => 5,
@@ -118,8 +117,29 @@ impl<'a, T> Iterator for PlayersIterator<'a, T> {
     }
 }
 
+impl<'a, T> DoubleEndedIterator for PlayersIterator<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let result = self.next_back.map(|number| (number, &self.data[number]));
+        if self.next_forward == self.next_back {
+            self.next_forward = None;
+            self.next_back = None;
+        }
+        self.next_back = match self.next_back {
+            Some(PlayerNumber::One) => None,
+            Some(PlayerNumber::Two) => Some(PlayerNumber::One),
+            Some(PlayerNumber::Three) => Some(PlayerNumber::Two),
+            Some(PlayerNumber::Four) => Some(PlayerNumber::Three),
+            Some(PlayerNumber::Five) => Some(PlayerNumber::Four),
+            Some(PlayerNumber::Six) => Some(PlayerNumber::Five),
+            Some(PlayerNumber::Seven) => Some(PlayerNumber::Six),
+            None => None,
+        };
+        result
+    }
+}
+
 impl<'a, T> ExactSizeIterator for PlayersIterator<'a, T> {
-    // only requires `Iterator::size_hint()` to be exact
+    // The default implementation only requires `Iterator::size_hint()` to be exact
 }
 
 impl<T> Players<T> {
@@ -339,5 +359,31 @@ mod test {
         iterator.next();
         assert_eq!(iterator.len(), 0);
         iterator.next();
+    }
+
+    #[test]
+    fn double_ended() {
+        let players = Players {
+            one: 1,
+            two: 2,
+            three: 3,
+            four: 4,
+            five: 5,
+            six: 6,
+            seven: 7,
+        };
+        let mut iterator = players.iter();
+
+        assert_eq!(iterator.next(), Some((PlayerNumber::One, &1)));
+        assert_eq!(iterator.next(), Some((PlayerNumber::Two, &2)));
+        assert_eq!(iterator.next_back(), Some((PlayerNumber::Seven, &7)));
+        assert_eq!(iterator.next_back(), Some((PlayerNumber::Six, &6)));
+        assert_eq!(iterator.next(), Some((PlayerNumber::Three, &3)));
+        assert_eq!(iterator.next(), Some((PlayerNumber::Four, &4)));
+        assert_eq!(iterator.next_back(), Some((PlayerNumber::Five, &5)));
+        assert_eq!(iterator.next(), None);
+        assert_eq!(iterator.next_back(), None);
+        assert_eq!(iterator.next(), None);
+        assert_eq!(iterator.next_back(), None);
     }
 }

--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -102,6 +102,24 @@ impl<'a, T> Iterator for PlayersIterator<'a, T> {
         };
         result
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = match self.player_number {
+            Some(PlayerNumber::One) => 7,
+            Some(PlayerNumber::Two) => 6,
+            Some(PlayerNumber::Three) => 5,
+            Some(PlayerNumber::Four) => 4,
+            Some(PlayerNumber::Five) => 3,
+            Some(PlayerNumber::Six) => 2,
+            Some(PlayerNumber::Seven) => 1,
+            None => 0,
+        };
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a, T> ExactSizeIterator for PlayersIterator<'a, T> {
+    // only requires `Iterator::size_hint()` to be exact
 }
 
 impl<T> Players<T> {
@@ -291,5 +309,35 @@ where
                     .map(|name| format!("seven.{name}")),
             )
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn exact_size() {
+        let players = Players::<i32>::default();
+        let mut iterator = players.iter();
+
+        assert_eq!(iterator.len(), 7);
+        iterator.next();
+        assert_eq!(iterator.len(), 6);
+        iterator.next();
+        assert_eq!(iterator.len(), 5);
+        iterator.next();
+        assert_eq!(iterator.len(), 4);
+        iterator.next();
+        assert_eq!(iterator.len(), 3);
+        iterator.next();
+        assert_eq!(iterator.len(), 2);
+        iterator.next();
+        assert_eq!(iterator.len(), 1);
+        iterator.next();
+        assert_eq!(iterator.len(), 0);
+        iterator.next();
+        assert_eq!(iterator.len(), 0);
+        iterator.next();
     }
 }


### PR DESCRIPTION
## Introduced Changes

Implements [`DoubleEndedIterator`](https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) and [`ExactSizeIterator`](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html) for the `Players` container type.
Note that neither trait is currently used outside of tests.

Plus some cleanup by indexing into the Player struct more.

Fixes #415

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

There should be no functional change.