### PR TITLE
Only repaint Twix when new data is received

### DIFF
--- a/crates/communication/src/client/communication.rs
+++ b/crates/communication/src/client/communication.rs
@@ -97,6 +97,24 @@ impl Communication {
         subscriber_receiver
     }
 
+    pub async fn on_update(&self) -> mpsc::Receiver<()> {
+        let (notification_sender, notification_receiver) = mpsc::channel(10);
+        self.output_subscription_manager
+            .send(output_subscription_manager::Message::ListenToUpdates {
+                notification_sender: notification_sender.clone(),
+            })
+            .await
+            .unwrap();
+        self.parameter_subscription_manager
+            .send(parameter_subscription_manager::Message::ListenToUpdates {
+                notification_sender,
+            })
+            .await
+            .unwrap();
+
+        notification_receiver
+    }
+
     pub async fn subscribe_output(
         &self,
         output: CyclerOutput,

--- a/crates/communication/src/client/mod.rs
+++ b/crates/communication/src/client/mod.rs
@@ -1,6 +1,7 @@
 mod communication;
 mod connector;
 mod id_tracker;
+mod notify;
 mod output_subscription_manager;
 mod parameter_subscription_manager;
 mod receiver;

--- a/crates/communication/src/client/notify.rs
+++ b/crates/communication/src/client/notify.rs
@@ -1,0 +1,10 @@
+use log::error;
+use tokio::sync::mpsc;
+
+pub async fn notify_all(notification_senders: &[mpsc::Sender<()>]) {
+    for sender in notification_senders {
+        if let Err(error) = sender.send(()).await {
+            error!("{error:?}");
+        };
+    }
+}

--- a/crates/communication/src/client/output_subscription_manager.rs
+++ b/crates/communication/src/client/output_subscription_manager.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use crate::{
     client::{
         id_tracker::{self, get_message_id},
+        notify::notify_all,
         responder, Output, SubscriberMessage,
     },
     messages::{
@@ -205,19 +206,11 @@ pub async fn output_subscription_manager(
                         }
                     }
                 }
-                for sender in &notification_senders {
-                    if let Err(error) = sender.send(()).await {
-                        error!("{error:?}");
-                    };
-                }
+                notify_all(&notification_senders).await;
             }
             Message::UpdateFields { fields: new_fields } => {
                 fields = Some(new_fields);
-                for sender in &notification_senders {
-                    if let Err(error) = sender.send(()).await {
-                        error!("{error:?}");
-                    };
-                }
+                notify_all(&notification_senders).await;
             }
             Message::GetOutputFields { response_sender } => {
                 if let Err(error) = response_sender.send(fields.clone()) {
@@ -244,11 +237,7 @@ pub async fn output_subscription_manager(
                         binary_data_waiting_for_references.insert(reference_id, data);
                     }
                 }
-                for sender in &notification_senders {
-                    if let Err(error) = sender.send(()).await {
-                        error!("{error:?}");
-                    };
-                }
+                notify_all(&notification_senders).await;
             }
             Message::ListenToUpdates {
                 notification_sender: notify_sender,

--- a/crates/communication/src/client/output_subscription_manager.rs
+++ b/crates/communication/src/client/output_subscription_manager.rs
@@ -213,6 +213,11 @@ pub async fn output_subscription_manager(
             }
             Message::UpdateFields { fields: new_fields } => {
                 fields = Some(new_fields);
+                for sender in &notification_senders {
+                    if let Err(error) = sender.send(()).await {
+                        error!("{error:?}");
+                    };
+                }
             }
             Message::GetOutputFields { response_sender } => {
                 if let Err(error) = response_sender.send(fields.clone()) {
@@ -238,6 +243,11 @@ pub async fn output_subscription_manager(
                     } else {
                         binary_data_waiting_for_references.insert(reference_id, data);
                     }
+                }
+                for sender in &notification_senders {
+                    if let Err(error) = sender.send(()).await {
+                        error!("{error:?}");
+                    };
                 }
             }
             Message::ListenToUpdates {

--- a/crates/communication/src/client/parameter_subscription_manager.rs
+++ b/crates/communication/src/client/parameter_subscription_manager.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use crate::{
     client::{
         id_tracker::{self, get_message_id},
+        notify::notify_all,
         responder, SubscriberMessage,
     },
     messages::{ParametersRequest, Path, Request},
@@ -164,11 +165,7 @@ pub async fn parameter_subscription_manager(
                         error!("{error}");
                     }
                 }
-                for sender in &notification_senders {
-                    if let Err(error) = sender.send(()).await {
-                        error!("{error:?}");
-                    };
-                }
+                notify_all(&notification_senders).await;
             }
             Message::UpdateFields { fields: new_fields } => {
                 fields = Some(new_fields);

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -138,6 +138,10 @@ impl TwixApp {
             connect: false,
         };
         let connection_receiver = nao.subscribe_status_updates();
+        {
+            let context = creation_context.egui_ctx.clone();
+            nao.on_update(move || context.request_repaint());
+        }
 
         let visual = creation_context
             .storage
@@ -167,7 +171,6 @@ impl App for TwixApp {
             self.connection_status = status;
         }
 
-        context.request_repaint();
         TopBottomPanel::top("top_bar").show(context, |ui| {
             ui.horizontal(|ui| {
                 ui.with_layout(Layout::left_to_right(Align::Center), |ui| {

--- a/tools/twix/src/nao.rs
+++ b/tools/twix/src/nao.rs
@@ -9,7 +9,6 @@ use serde_json::Value;
 use tokio::{
     runtime::{Builder, Runtime},
     spawn,
-    sync::mpsc,
 };
 
 use crate::{image_buffer::ImageBuffer, value_buffer::ValueBuffer};

--- a/tools/twix/src/nao.rs
+++ b/tools/twix/src/nao.rs
@@ -92,7 +92,7 @@ impl Nao {
             .block_on(self.communication.update_parameter_value(path, value));
     }
 
-    pub fn on_update<F>(&self, f: F)
+    pub fn on_update<F>(&self, callback: F)
     where
         F: Fn() + Sync + Send + 'static,
     {
@@ -102,7 +102,7 @@ impl Nao {
         spawn(async move {
             let mut receiver = communication.on_update().await;
             while receiver.recv().await.is_some() {
-                f();
+                callback();
             }
         });
     }


### PR DESCRIPTION
## Introduced Changes

Instead of repainting twix with the monitor's refresh rate, only request a repaint when new data is received by the communication client.

This is implemented by introducing a general notification feature to the communication client which sends an empty mpsc message when new data arrives (from outputs or parameter changes).
The `Nao` type in twix then provides a way to register a callback executed on these channel messages.
The twix app then registers such a callback which requests a repaint with the egui context.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Compared to main, twix should use much less cpu/gpu when not receiving updates.
The greatest effect should be seen on devices like @h3ndrk's Gurke.