### PR TITLE
add remote compile documentation

### DIFF
--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -84,3 +84,18 @@ cargo install --path tools/pepsi
 ```
 
 and adding `~/.cargo/bin` to the `PATH`.
+
+## Remote Compile
+
+To use the remote compilation you need to create yourself an account on the rechenknecht. Therefore open an ssh connection to ```root@134.28.57.226```. There create a new account by ```adduser {name}``` and set a password with ```passwd {name}```, you will then be asked to type your password. 
+
+In the next step change to your user ssh connection ```{name}@134.28.57.226```. There clone the HULKs repository using https: ```https://github.com/HULKs/hulk.git```.
+
+Back on your local machine do ```ssh-copy-id {name}@134.28.57.226```.
+And add the compiler to your git remote: ```git remote add compiler {name}@134.28.57.226:{hulk}``` where ```{hulk}``` refers to the path where you cloned the repository.
+
+To use the remote compile with pepsi:
+
+```bash
+./pepsi build --remote
+```

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -87,11 +87,11 @@ and adding `~/.cargo/bin` to the `PATH`.
 
 ## Remote Compile
 
-To use the remote compilation you need to create yourself an account on the rechenknecht. Therefore open an ssh connection to ```root@134.28.57.226```. There create a new account by ```adduser {name}``` and set a password with ```passwd {name}```, you will then be asked to type your password. 
+To use the remote compilation you need to create yourself an account on the remote-compiler. Therefore open an ssh connection to ```root@134.28.57.226```. There create a new account by ```adduser {name}``` and set a password with ```passwd {name}```, you will then be asked to type your password. 
 
-In the next step change to your user ssh connection ```{name}@134.28.57.226```. There clone the HULKs repository using https: ```https://github.com/HULKs/hulk.git```.
+Terminate the root ssh session and change to your user ssh connection ```{name}@134.28.57.226```. There clone the HULKs repository using https: ```https://github.com/HULKs/hulk.git```.
 
-Back on your local machine do ```ssh-copy-id {name}@134.28.57.226```.
+Back on your local machine do ```ssh-copy-id {name}@134.28.57.226``` to copy your public ssh key to the remote-compiler.
 And add the compiler to your git remote: ```git remote add compiler {name}@134.28.57.226:{hulk}``` where ```{hulk}``` refers to the path where you cloned the repository.
 
 To use the remote compile with pepsi:

--- a/scripts/remote
+++ b/scripts/remote
@@ -81,8 +81,7 @@ git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --fil
 
 # invoke compile script remotely
 ssh $address "sh -c \" \
-    . '$HOME/.profile' \
-    && cd \"$remotePath\" \
+    cd \"$remotePath\" \
     && $@
 \""
 


### PR DESCRIPTION
## Introduced Changes

In this pull request the documentation is extended by remote compilation steps. 

Fixes #

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

You could try to set up remote compile for your machine. 
