### PR TITLE
Twix slider UX

### DIFF
--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -41,10 +41,10 @@ mod panel;
 mod panels;
 mod players_value_buffer;
 mod repository_parameters;
-pub mod selectable_panel_macro;
+mod selectable_panel_macro;
 mod twix_painter;
 mod value_buffer;
-pub mod visuals;
+mod visuals;
 
 fn setup_logger() -> Result<(), InitError> {
     Dispatch::new()

--- a/tools/twix/src/panels/vision_tuner.rs
+++ b/tools/twix/src/panels/vision_tuner.rs
@@ -116,10 +116,9 @@ impl Widget for &mut VisionTunerPanel {
                 )
                 .changed()
             {
-                self.nao.update_parameter_value(
-                    get_vertical_edge_threshold_path(self.cycler),
-                    to_value(vertical_edge_threshold).unwrap(),
-                );
+                self.buffers
+                    .vertical_edge_threshold_buffer
+                    .update_parameter_value(to_value(vertical_edge_threshold).unwrap());
             }
 
             let value = get_value_from_interpolated(self.position, &mut red_chromaticity_threshold);
@@ -131,10 +130,9 @@ impl Widget for &mut VisionTunerPanel {
                 )
                 .changed()
             {
-                self.nao.update_parameter_value(
-                    get_red_chromaticity_threshold_path(self.cycler),
-                    to_value(red_chromaticity_threshold).unwrap(),
-                );
+                self.buffers
+                    .red_chromaticity_threshold_buffer
+                    .update_parameter_value(to_value(red_chromaticity_threshold).unwrap());
             }
 
             let value =
@@ -147,10 +145,9 @@ impl Widget for &mut VisionTunerPanel {
                 )
                 .changed()
             {
-                self.nao.update_parameter_value(
-                    get_blue_chromaticity_threshold_path(self.cycler),
-                    to_value(blue_chromaticity_threshold).unwrap(),
-                );
+                self.buffers
+                    .blue_chromaticity_threshold_buffer
+                    .update_parameter_value(to_value(blue_chromaticity_threshold).unwrap());
             }
             let value =
                 get_value_from_interpolated(self.position, &mut lower_green_chromaticity_threshold);
@@ -162,10 +159,9 @@ impl Widget for &mut VisionTunerPanel {
                 )
                 .changed()
             {
-                self.nao.update_parameter_value(
-                    get_lower_green_chromaticity_threshold_path(self.cycler),
-                    to_value(lower_green_chromaticity_threshold).unwrap(),
-                );
+                self.buffers
+                    .lower_green_chromaticity_threshold_buffer
+                    .update_parameter_value(to_value(lower_green_chromaticity_threshold).unwrap());
             }
             let value =
                 get_value_from_interpolated(self.position, &mut upper_green_chromaticity_threshold);
@@ -177,10 +173,9 @@ impl Widget for &mut VisionTunerPanel {
                 )
                 .changed()
             {
-                self.nao.update_parameter_value(
-                    get_upper_green_chromaticity_threshold_path(self.cycler),
-                    to_value(upper_green_chromaticity_threshold).unwrap(),
-                );
+                self.buffers
+                    .upper_green_chromaticity_threshold_buffer
+                    .update_parameter_value(to_value(upper_green_chromaticity_threshold).unwrap());
             }
             let value = get_value_from_interpolated(self.position, &mut green_luminance_threshold);
             if ui
@@ -191,10 +186,9 @@ impl Widget for &mut VisionTunerPanel {
                 )
                 .changed()
             {
-                self.nao.update_parameter_value(
-                    get_green_luminance_threshold_path(self.cycler),
-                    to_value(green_luminance_threshold).unwrap(),
-                );
+                self.buffers
+                    .green_luminance_threshold_buffer
+                    .update_parameter_value(to_value(green_luminance_threshold).unwrap());
             }
         })
         .response

--- a/tools/twix/src/value_buffer.rs
+++ b/tools/twix/src/value_buffer.rs
@@ -233,7 +233,7 @@ async fn value_buffer(
                             add_element(&mut values, buffer_capacity, value.clone());
                             communication.update_parameter_value(
                                 parameter_path.as_ref().expect(
-                                    "Tried updating parameter on output value buffer"
+                                    "tried updating parameter on output value buffer"
                                 ),
                                 value,
                             ).await;

--- a/tools/twix/src/value_buffer.rs
+++ b/tools/twix/src/value_buffer.rs
@@ -169,11 +169,9 @@ async fn value_buffer(
                             SubscriberMessage::Update{value} => {
                                 if skip_updates > 0 {
                                     skip_updates -= 1;
-                                    println!("Skipping update");
                                     continue;
                                 }
                                 if parameter_path.is_some() {
-                                    println!("Updating");
                                 }
                                 add_element(&mut values, buffer_capacity, value);
                                 update_listeners.retain(|listener| {
@@ -232,7 +230,6 @@ async fn value_buffer(
                         },
                         Message::UpdateParameterValue{value} => {
                             skip_updates += 1;
-                            println!("Sending update");
                             add_element(&mut values, buffer_capacity, value.clone());
                             communication.update_parameter_value(
                                 parameter_path.as_ref().expect(

--- a/tools/twix/src/value_buffer.rs
+++ b/tools/twix/src/value_buffer.rs
@@ -171,8 +171,6 @@ async fn value_buffer(
                                     skip_updates -= 1;
                                     continue;
                                 }
-                                if parameter_path.is_some() {
-                                }
                                 add_element(&mut values, buffer_capacity, value);
                                 update_listeners.retain(|listener| {
                                     if let Err(TrySendError::Closed(_)) = listener.try_send(()) {


### PR DESCRIPTION
## Introduced Changes

Previously, a changed parameter slider value would have to be sent to the server and the updated slider value sent back before the new value was reflected in the slider position.
This is especially an issue if there is more than one update "in flight" as it would cause the slider to "replay" the movement over some period of time.

This PR changes the behavior by moving the parameter setting feature to the value buffers, where the new value is applied immediately. For each change request sent to the nao, one update is ignored to prevent overwriting newly requested values with old responses.

Fixes #534 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- Open twix
- Connect to nao
- For added effect, open image panel
- Open a panel with sliders (manual calibration, vision tuner)
- Drag a slider around

Compared to current master, the slider should not jump around anymore.