### PR TITLE
Pepsi rsync progress

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -357,8 +357,7 @@ impl Nao {
 
         monitor_rsync_progress_with(rsync, progress_callback).await?;
 
-        // self.reboot().await
-        Ok(())
+        self.reboot().await
     }
 }
 

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -87,6 +87,7 @@ impl Nao {
             .arg("--recursive")
             .arg("--times")
             .arg("--no-inc-recursive")
+            .arg("--human-readable")
             .arg(format!("--rsh=ssh {ssh_flags}"));
         if mkpath {
             command.arg("--mkpath");

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -30,7 +30,7 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
     };
     let image_path = image_path.as_path();
 
-    ProgressIndicator::map_tasks_with_progress(
+    ProgressIndicator::map_tasks(
         arguments.naos,
         "Uploading image ...",
         |nao_address, progress_bar| async move {

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -30,14 +30,16 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
     };
     let image_path = image_path.as_path();
 
-    ProgressIndicator::map_tasks(
+    ProgressIndicator::map_tasks_with_progress(
         arguments.naos,
-        "Uploading image...",
-        |nao_address| async move {
+        "Uploading image ...",
+        |nao_address, progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
-            nao.flash_image(image_path)
-                .await
-                .wrap_err_with(|| format!("failed to flash image to {nao_address}"))
+            nao.flash_image(image_path, |msg| {
+                progress_bar.set_message(format!("Uploading image: {}", msg.trim()))
+            })
+            .await
+            .wrap_err_with(|| format!("failed to flash image to {nao_address}"))
         },
     )
     .await;

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -36,7 +36,7 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
         |nao_address, progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.flash_image(image_path, |msg| {
-                progress_bar.set_message(format!("Uploading image: {}", msg.trim()))
+                progress_bar.set_message(format!("Uploading image: {}", msg))
             })
             .await
             .wrap_err_with(|| format!("failed to flash image to {nao_address}"))

--- a/tools/pepsi/src/hulk.rs
+++ b/tools/pepsi/src/hulk.rs
@@ -28,7 +28,7 @@ pub async fn hulk(arguments: Arguments) -> Result<()> {
     ProgressIndicator::map_tasks(
         arguments.naos,
         "Executing systemctl hulk...",
-        |nao_address| async move {
+        |nao_address, _progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.execute_systemctl(arguments.action, "hulk")
                 .await

--- a/tools/pepsi/src/logs.rs
+++ b/tools/pepsi/src/logs.rs
@@ -1,4 +1,4 @@
-use std::{fmt::format, path::PathBuf};
+use std::path::PathBuf;
 
 use clap::Subcommand;
 use color_eyre::{eyre::WrapErr, Result};

--- a/tools/pepsi/src/logs.rs
+++ b/tools/pepsi/src/logs.rs
@@ -34,42 +34,46 @@ pub enum Arguments {
 pub async fn logs(arguments: Arguments) -> Result<()> {
     match arguments {
         Arguments::Delete { naos } => {
-            ProgressIndicator::map_tasks(naos, "Deleting logs...", |nao_address| async move {
-                let nao = Nao::try_new_with_ping(nao_address.ip).await?;
-                nao.delete_logs()
-                    .await
-                    .wrap_err_with(|| format!("failed to delete logs on {nao_address}"))
-            })
+            ProgressIndicator::map_tasks(
+                naos,
+                "Deleting logs...",
+                |nao_address, _progress_bar| async move {
+                    let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+                    nao.delete_logs()
+                        .await
+                        .wrap_err_with(|| format!("failed to delete logs on {nao_address}"))
+                },
+            )
             .await
         }
         Arguments::Download {
             log_directory,
             naos,
         } => {
-            ProgressIndicator::map_tasks_with_progress(
-                naos,
-                "Downloading logs: ...",
-                |nao_address, progress| {
-                    let log_directory = log_directory.join(nao_address.to_string());
-                    async move {
-                        let nao = Nao::try_new_with_ping(nao_address.ip).await?;
-                        nao.download_logs(log_directory, |status| {
-                            progress.set_message(format!("Downloading logs: {status}"))
-                        })
-                        .await
-                        .wrap_err_with(|| format!("failed to download logs from {nao_address}"))
-                    }
-                },
-            )
+            ProgressIndicator::map_tasks(naos, "Downloading logs: ...", |nao_address, progress| {
+                let log_directory = log_directory.join(nao_address.to_string());
+                async move {
+                    let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+                    nao.download_logs(log_directory, |status| {
+                        progress.set_message(format!("Downloading logs: {status}"))
+                    })
+                    .await
+                    .wrap_err_with(|| format!("failed to download logs from {nao_address}"))
+                }
+            })
             .await
         }
         Arguments::Show { naos } => {
-            ProgressIndicator::map_tasks(naos, "Retrieving logs...", |nao_address| async move {
-                let nao = Nao::try_new_with_ping(nao_address.ip).await?;
-                nao.retrieve_logs()
-                    .await
-                    .wrap_err("failed to retrieve logs")
-            })
+            ProgressIndicator::map_tasks(
+                naos,
+                "Retrieving logs...",
+                |nao_address, _progress_bar| async move {
+                    let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+                    nao.retrieve_logs()
+                        .await
+                        .wrap_err("failed to retrieve logs")
+                },
+            )
             .await
         }
     }

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -14,10 +14,14 @@ pub struct Arguments {
 }
 
 pub async fn ping(arguments: Arguments) {
-    ProgressIndicator::map_tasks(arguments.naos, "Pinging NAO...", |nao_address| async move {
-        Nao::try_new_with_ping_and_arguments(nao_address.ip, arguments.timeout_seconds)
-            .await
-            .map(|_| ())
-    })
+    ProgressIndicator::map_tasks(
+        arguments.naos,
+        "Pinging NAO...",
+        |nao_address, _progress_bar| async move {
+            Nao::try_new_with_ping_and_arguments(nao_address.ip, arguments.timeout_seconds)
+                .await
+                .map(|_| ())
+        },
+    )
     .await;
 }

--- a/tools/pepsi/src/player_number.rs
+++ b/tools/pepsi/src/player_number.rs
@@ -43,7 +43,7 @@ pub async fn player_number(arguments: Arguments, repository: &Repository) -> Res
     ProgressIndicator::map_tasks(
         arguments.assignments,
         "Setting player number...",
-        |assignment| {
+        |assignment, _progress_bar| {
             let head_id = &hardware_ids[&assignment.nao_number.number].head_id;
             async move {
                 repository

--- a/tools/pepsi/src/power_off.rs
+++ b/tools/pepsi/src/power_off.rs
@@ -16,7 +16,7 @@ pub async fn power_off(arguments: Arguments) -> Result<()> {
     ProgressIndicator::map_tasks(
         arguments.naos,
         "Powering off...",
-        |nao_address| async move {
+        |nao_address, _progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.power_off()
                 .await

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -39,29 +39,6 @@ impl ProgressIndicator {
     pub async fn map_tasks<T, F, M>(
         items: impl IntoIterator<Item = T>,
         message: &'static str,
-        task: impl Fn(T) -> F + Copy,
-    ) where
-        T: ToString,
-        F: Future<Output = Result<M>>,
-        M: Into<TaskMessage>,
-    {
-        let multi_progress = Self::new();
-        items
-            .into_iter()
-            .map(|item| (multi_progress.task(item.to_string()), item))
-            .map(|(progress, item)| {
-                progress.enable_steady_tick();
-                progress.set_message(message);
-                async move { progress.finish_with(task(item).await) }
-            })
-            .collect::<FuturesUnordered<_>>()
-            .collect::<Vec<_>>()
-            .await;
-    }
-
-    pub async fn map_tasks_with_progress<T, F, M>(
-        items: impl IntoIterator<Item = T>,
-        message: &'static str,
         task: impl Fn(T, ProgressBar) -> F + Copy,
     ) where
         T: ToString,

--- a/tools/pepsi/src/reboot.rs
+++ b/tools/pepsi/src/reboot.rs
@@ -13,12 +13,16 @@ pub struct Arguments {
 }
 
 pub async fn reboot(arguments: Arguments) -> Result<()> {
-    ProgressIndicator::map_tasks(arguments.naos, "Rebooting...", |nao_address| async move {
-        let nao = Nao::try_new_with_ping(nao_address.ip).await?;
-        nao.reboot()
-            .await
-            .wrap_err_with(|| format!("failed to reboot {nao_address}"))
-    })
+    ProgressIndicator::map_tasks(
+        arguments.naos,
+        "Rebooting...",
+        |nao_address, _progress_bar| async move {
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+            nao.reboot()
+                .await
+                .wrap_err_with(|| format!("failed to reboot {nao_address}"))
+        },
+    )
     .await;
 
     Ok(())

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -73,10 +73,12 @@ async fn upload_with_progress(
         .await
         .wrap_err_with(|| format!("failed to stop HULK service on {nao_address}"))?;
 
-    progress.set_message("Uploading...");
-    nao.upload(hulk_directory, !arguments.no_clean)
-        .await
-        .wrap_err_with(|| format!("failed to upload binary to {nao_address}"))?;
+    progress.set_message("Uploading: ...");
+    nao.upload(hulk_directory, !arguments.no_clean, |status| {
+        progress.set_message(format!("Uploading: {}", status.trim()))
+    })
+    .await
+    .wrap_err_with(|| format!("failed to upload binary to {nao_address}"))?;
 
     if !arguments.no_restart {
         progress.set_message("Restarting HULK...");

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -75,7 +75,7 @@ async fn upload_with_progress(
 
     progress.set_message("Uploading: ...");
     nao.upload(hulk_directory, !arguments.no_clean, |status| {
-        progress.set_message(format!("Uploading: {}", status.trim()))
+        progress.set_message(format!("Uploading: {}", status))
     })
     .await
     .wrap_err_with(|| format!("failed to upload binary to {nao_address}"))?;

--- a/tools/pepsi/src/wireless.rs
+++ b/tools/pepsi/src/wireless.rs
@@ -53,7 +53,7 @@ async fn status(naos: Vec<NaoAddress>) {
     ProgressIndicator::map_tasks(
         naos,
         "Retrieving network status...",
-        |nao_address| async move {
+        |nao_address, _progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.get_network_status()
                 .await
@@ -67,7 +67,7 @@ async fn available_networks(naos: Vec<NaoAddress>) {
     ProgressIndicator::map_tasks(
         naos,
         "Retrieving available networks...",
-        |nao_address| async move {
+        |nao_address, _progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.get_available_networks()
                 .await
@@ -78,11 +78,15 @@ async fn available_networks(naos: Vec<NaoAddress>) {
 }
 
 async fn set(naos: Vec<NaoAddress>, network: Network) {
-    ProgressIndicator::map_tasks(naos, "Setting network...", |nao_address| async move {
-        let nao = Nao::try_new_with_ping(nao_address.ip).await?;
-        nao.set_network(network)
-            .await
-            .wrap_err_with(|| format!("failed to set network on {nao_address}"))
-    })
+    ProgressIndicator::map_tasks(
+        naos,
+        "Setting network...",
+        |nao_address, _progress_bar| async move {
+            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+            nao.set_network(network)
+                .await
+                .wrap_err_with(|| format!("failed to set network on {nao_address}"))
+        },
+    )
     .await;
 }


### PR DESCRIPTION
## Introduced Changes

Adds the progress output from rsync to pepsi-`upload`, -`pregame`, -`logs`, and -`gammaray`.

```
$ pepsi gammaray 31 32 35 37
[10.1.24.31] ⣄ Uploading image: 162,004,992  58%    1.39MB/s    0:01:22
[10.1.24.32] ⢸ Uploading image: 248,283,136  89%    1.25MB/s    0:00:23
[10.1.24.35] ⣰ Uploading image: 278,892,544 100%    1.56MB/s    0:02:50
[10.1.24.37] ⢸ Uploading image: 257,916,928  92%    1.29MB/s    0:00:15
```

While this may not be necessary in most cases, when working over a wifi or vpn connection, being able to quickly see whether anything is transferred at all, at which bitrate, and whether the transfer got stuck for some reason is very useful.
Until now I had to rely on looking at the overall bandwidth of my network connection to confirm activity, which isn't ideal.

Fixes #

## ToDo / Known Issues



## Ideas for Next Iterations (Not This PR)

Use the `progress_bar`s that are now passed to tasks for the other pepsi commands.

## How to Test

Run any of the pepsi commands mentioned above.
For added effect, do so via a low-bandwidth connection such as wifi, vpn, or an [artificially limited](https://linux.die.net/man/8/tc) wired connection.