### PR TITLE
Add margin to goal line to determine whether a kick scores a goal

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -848,6 +848,7 @@
       "max_kick_around_obstacle_angle": 1.0,
       "ball_radius_for_kick_target_selection": 0.15
     },
+    "goal_accuracy_margin": 0.25,
     "default_kick_strength": 1.0,
     "corner_kick_strength": 0.25,
     "invisible_ball_timeout": {


### PR DESCRIPTION
## Introduced Changes

The instant kick decisions check whether a kick scores a goal. Currently, this check estimates if the ball kick line intersects with the goal line (the line connecting the goal posts). This results in a kick being valid if the kick line is ever so slightly in the goal.

This PR adds a margin such that the line to be a valid goal is shorter (more towards the center of the goal).

![image](https://github.com/HULKs/hulk/assets/7946935/a8d76a0e-93c0-45cf-9a5d-eec22d589323)


## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

let the robot do instant kicks in situations in which the shot accuracy matters, observe the accuracy