### PR TITLE
fix torso_to_robot confusion

### DIFF
--- a/crates/control/src/kinematics_provider.rs
+++ b/crates/control/src/kinematics_provider.rs
@@ -45,7 +45,7 @@ impl KinematicsProvider {
         let neck_to_robot = neck_to_robot(&joints.head);
         let head_to_robot = neck_to_robot * head_to_neck(&joints.head);
         // torso
-        let torso_to_robot = Isometry3::from(RobotDimensions::TORSO_TO_ROBOT);
+        let torso_to_robot = Isometry3::from(RobotDimensions::ROBOT_TO_TORSO);
         // left arm
         let left_shoulder_to_robot = left_shoulder_to_robot(&joints.left_arm);
         let left_upper_arm_to_robot =

--- a/crates/types/src/robot_dimensions.rs
+++ b/crates/types/src/robot_dimensions.rs
@@ -4,7 +4,7 @@ use nalgebra::{vector, Vector3};
 pub struct RobotDimensions {}
 
 impl RobotDimensions {
-    pub const TORSO_TO_ROBOT: Vector3<f32> = vector![-0.0413, 0.0, -0.12842];
+    pub const ROBOT_TO_TORSO: Vector3<f32> = vector![0.0413, 0.0, 0.12842];
     pub const ROBOT_TO_NECK: Vector3<f32> = vector![0.0, 0.0, 0.2115];
     pub const ROBOT_TO_LEFT_PELVIS: Vector3<f32> = vector![0.0, 0.05, 0.0];
     pub const ROBOT_TO_RIGHT_PELVIS: Vector3<f32> = vector![0.0, -0.05, 0.0];


### PR DESCRIPTION
## Introduced Changes

Fixes a bug in the transformation from torso coordinate frame to robot coordinate frame. This bug is caused by the misconception of vectors versus transformations and their respective naming scheme.

A vector pointing from the robot to the torso (`RobotDimensions::ROBOT_TO_TORSO`) is pointing upwards and is thus positive in the *z* component.

A transformation called `robot_to_torso` on the other hand is transforming a point from robot coordinate frame to torso coordinate frame. The translation component in *z* direction is thus **negative**.
The transformation `torso_to_robot` is thus composed of the inverse (negative) `TORSO_TO_ROBOT` vector. Or alternatively the `ROBOT_TO_TORSO` vector.

This PR changes the direction the `TORSO_TO_ROBOT` vector is pointing, and thus calls it `ROBOT_TO_TORSO` to use the correct transformation direction in the resulting `Isometry3` for the `torso_to_robot` transformation.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Only the COM computation uses this transformation. You can check for the correct COM in twix.