### PR TITLE
Increase resting ball threshold

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -343,7 +343,7 @@
     "measurement_noise_moving": [0.5, 2.0],
     "measurement_noise_resting": [300.0, 500.0],
     "initial_covariance": [0.5, 0.5, 0.5, 0.5],
-    "resting_ball_velocity_threshold": 0.12,
+    "resting_ball_velocity_threshold": 0.25,
     "visible_validity_exponential_decay_factor": 0.96,
     "hidden_validity_exponential_decay_factor": 0.999,
     "validity_discard_threshold": 0.5,


### PR DESCRIPTION
## Introduced Changes

Increase the resting ball velocity threshold. This mitigates the issue of strikers doing side steps when going to the ball.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

Maybe we should make this parameter adaptive to the robot role or speed or fix the issue in the kinematic chain.

## How to Test

Check if striker doesn't do intercepting steps anymore when heading to the ball.
