### PR TITLE
remove visible check for kick targets

### DIFF
--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -29,8 +29,7 @@ pub fn execute(
         .iter()
         .chain(instant_kick_decisions.iter())
         .find(|decision| {
-            decision.visible
-                && is_kick_pose_reached(decision.kick_pose, &in_walk_kicks[decision.variant])
+            is_kick_pose_reached(decision.kick_pose, &in_walk_kicks[decision.variant])
         });
     if let Some(kick) = available_kick {
         let command = MotionCommand::InWalkKick {

--- a/crates/types/src/kick_decision.rs
+++ b/crates/types/src/kick_decision.rs
@@ -10,5 +10,4 @@ pub struct KickDecision {
     pub kicking_side: Side,
     pub kick_pose: Isometry2<f32>,
     pub strength: f32,
-    pub visible: bool,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -850,11 +850,7 @@
     },
     "goal_accuracy_margin": 0.25,
     "default_kick_strength": 1.0,
-    "corner_kick_strength": 0.25,
-    "invisible_ball_timeout": {
-      "nanos": 0,
-      "secs": 2
-    }
+    "corner_kick_strength": 0.25
   },
   "behavior": {
     "optional_roles": [

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -203,8 +203,6 @@ impl BehaviorCycler {
                 let main_outputs = {
                     self.kick_selector
                         .cycle(control::kick_selector::CycleContext::new(
-                            &own_database.main_outputs.cycle_time,
-                            &parameters.kick_selector.invisible_ball_timeout,
                             own_database.main_outputs.robot_to_field.as_ref().unwrap(),
                             own_database.main_outputs.ball_state.as_ref().unwrap(),
                             &own_database.main_outputs.obstacles,


### PR DESCRIPTION
## Introduced Changes

This PR removes the check for a *visible* ball. This visibility was determined by checking whether a ball was last seen in e.g. 2 seconds. If the robot has a 3 second old ball in the filter, it remains striker but does not have any kick pose. The fallback in dribbling without any kick pose is walking on the spot. This leads to a striker who has seen the ball 3 seconds ago to stop and not approach the ball anymore.

IMHO the visibility check was a *dirty* hack to fix the issue of a missing short term ball search.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Let the striker approach the ball, remove the ball, it should continue approaching the ball for 5 seconds
