### PR TITLE
Igittigitt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ default.nix
 target/
 
 .nao_cargo_home
+.remote-url
 
 rust-toolchain.toml
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ default.nix
 target/
 
 .nao_cargo_home
-.remote-url
+.REMOTE_WORKSPACE
 
 rust-toolchain.toml
 

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -92,7 +92,7 @@ Open an ssh connection to ```root@134.28.57.226```.
 There create a new account by ```adduser {name}``` and set a password with ```passwd {name}```.
 
 Terminate the root ssh session and log in with your new user ```{name}@134.28.57.226```.
-There create the folder you want to use for remote compilation, e.g. `mkdir ~/hulk`.
+There clone the HULKs repository using https: ```https://github.com/HULKs/hulk.git```
 
 Back on your local machine do ```ssh-copy-id {name}@134.28.57.226``` to allow passwordless login.
 In the hulk repo, create a `.REMOTE_WORKSPACE` file containing the username, IP, and path, e.g. `{name}@134.28.57.226:hulk`.

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -87,18 +87,24 @@ and adding `~/.cargo/bin` to the `PATH`.
 
 ## Remote Compile
 
-To use the remote compilation you need to create yourself an account on the remote-compiler. Therefore open an ssh connection to ```root@134.28.57.226```. There create a new account by ```adduser {name}``` and set a password with ```passwd {name}```, you will then be asked to type your password. 
+To use the remote compilation you need to create an account on the remote-compiler.
+Open an ssh connection to ```root@134.28.57.226```.
+There create a new account by ```adduser {name}``` and set a password with ```passwd {name}```.
 
-Terminate the root ssh session and change to your user ssh connection ```{name}@134.28.57.226```. There clone the HULKs repository using https: ```https://github.com/HULKs/hulk.git```.
+Terminate the root ssh session and log in with your new user ```{name}@134.28.57.226```.
+There create the folder you want to use for remote compilation, e.g. `mkdir ~/hulk`.
 
-Back on your local machine do ```ssh-copy-id {name}@134.28.57.226``` to copy your public ssh key to the remote-compiler.
-And add the compiler to your git remote: ```git remote add compiler {name}@134.28.57.226:{hulk}``` where ```{hulk}``` refers to the path where you cloned the repository.
+Back on your local machine do ```ssh-copy-id {name}@134.28.57.226``` to allow passwordless login.
+In the hulk repo, create a `.remote-url` file containing the username, IP, and path, e.g. `{name}@134.28.57.226:hulk`.
 
-To use the remote compile with pepsi:
+Now you can use the pepsi remote features:
 
 ```bash
 ./pepsi build --remote
 ```
+
+This will sync your local files to the remote, run the build command there, and then return the final binary to you.
+Other pepsi commands such as `run`, `upload`, or `pregame` also have a `--remote` option.
 
 To use the remote compile functionality from outside the lab, you need a VPN connection.
 Ask one of the older team members to provide you a `.ovpn` file. Create a new VPN client with this configuration file.

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -95,7 +95,7 @@ Terminate the root ssh session and log in with your new user ```{name}@134.28.57
 There create the folder you want to use for remote compilation, e.g. `mkdir ~/hulk`.
 
 Back on your local machine do ```ssh-copy-id {name}@134.28.57.226``` to allow passwordless login.
-In the hulk repo, create a `.remote-url` file containing the username, IP, and path, e.g. `{name}@134.28.57.226:hulk`.
+In the hulk repo, create a `.REMOTE_WORKSPACE` file containing the username, IP, and path, e.g. `{name}@134.28.57.226:hulk`.
 
 Now you can use the pepsi remote features:
 

--- a/scripts/remote
+++ b/scripts/remote
@@ -8,12 +8,11 @@ BASEDIR=`cd $(dirname $0); pwd -P`
 BASEDIR=${BASEDIR%/*}
 cd "$BASEDIR"
 
-# print help
 print_help() {
     cat <<-__helpText__
 Usage: $0 [OPTIONS] <Command>
 
-Send local changes to a remote repository and execute a command there.
+Send local changes to an ssh remote and execute a command there.
 Optionally, files can be rsync'ed back after.
 
 command: Command to execute on the remote machine
@@ -21,14 +20,15 @@ command: Command to execute on the remote machine
 
 Options:
 
-  --remote <remote>     The git remote to use. Defaults to \`compiler\`
+  --remote <remoteURL>  Override remote url
   --return-file <file>  Path of file to be returned.
                         The file path must be relative to the repository.
                         Can be repeated to return multiple files.
 
-This script expects a git remote with an url similar to this:
+If no --remote is given, the url loaded from `.remote-url`
+The remote url should follow this format:
 
-    \`user@host:path/to/hulks/repo\`
+    \`user@host:path/to/remote/repo\`
 
 It is recommended to use a dedicated remote worktree for this since
 it will be cleaned and synchronized with the local changes without
@@ -36,7 +36,7 @@ regard for possible unsaved changes on the remote.
 __helpText__
 }
 
-remote="${COMPILER_REMOTE:-compiler}"
+remoteURL="${COMPILER_REMOTE:-$(cat .remote-url)}"
 files=()
 while true; do
     case "$1" in
@@ -46,7 +46,7 @@ while true; do
             ;;
         --remote)
             shift
-            remote=$1
+            remoteURL=$1
             ;;
         --return-file)
             shift
@@ -59,27 +59,17 @@ while true; do
     esac
     shift
 done
-echo Using remote $(tput setaf 6)$remote$(tput sgr 0)
+echo Using remote $(tput setaf 6)$remoteURL$(tput sgr 0)
 
-# extract login information and remote path from git remote
+# extract login information and remote path from url
 # assumes remote url of this format: `user@domain:path/to/hulk/repo`
-remoteURL="$(git remote get-url $remote)"
 address="$(echo $remoteURL | cut -d':' -f 1)"
 remotePath="$(echo $remoteURL | cut -d':' -f 2-)"
 
-# push HEAD to compiler remote
-branch=remoteCompile
-git push $remote HEAD:$branch --force --no-verify
-# check out pushed branch on the remote
-ssh $address "sh -c \" \
-    cd "$remotePath" \
-    && git checkout --force \\\$(git rev-parse $branch) \
-    && git clean -d --force \
-\""
-# send all changes that aren't uncommitted yet
-git status -s | cut -c 4- | rsync -a --info=progress --delete-missing-args --files-from=- . "$remoteURL"
+# send local state to remote
+rsync -ah --info progress2 --exclude='.git' --filter="dir-merge,- .gitignore" --delete . "$remoteURL"
 
-# invoke compile script remotely
+# invoke command remotely
 ssh $address "sh -c \" \
     cd \"$remotePath\" \
     && $@
@@ -88,5 +78,5 @@ ssh $address "sh -c \" \
 # fetch results
 echo Returning files
 printf '  %s\n' "${files[@]}"
-printf '%s\n' "${files[@]}" | rsync -a --info=progress --files-from=- "$remoteURL" .
+printf '%s\n' "${files[@]}" | rsync -ah --info=progress --files-from=- "$remoteURL" .
 

--- a/scripts/remoteWorkspace
+++ b/scripts/remoteWorkspace
@@ -20,13 +20,13 @@ command: Command to execute on the remote machine
 
 Options:
 
-  --remote <remoteURL>  Override remote url
+  --remote <path>  Override remote workspace path
   --return-file <file>  Path of file to be returned.
                         The file path must be relative to the repository.
                         Can be repeated to return multiple files.
 
-If no --remote is given, the url loaded from `.remote-url`
-The remote url should follow this format:
+If no --remote is given, the path loaded from `.REMOTE_WORKSPACE`
+The remote workspace path should follow this format:
 
     \`user@host:path/to/remote/repo\`
 
@@ -36,7 +36,7 @@ regard for possible unsaved changes on the remote.
 __helpText__
 }
 
-remoteURL="${COMPILER_REMOTE:-$(cat .remote-url)}"
+remoteWorkspace="${REMOTE_WORKSPACE:-$(cat .REMOTE_WORKSPACE)}"
 files=()
 while true; do
     case "$1" in
@@ -46,7 +46,7 @@ while true; do
             ;;
         --remote)
             shift
-            remoteURL=$1
+            remoteWorkspace=$1
             ;;
         --return-file)
             shift
@@ -59,15 +59,15 @@ while true; do
     esac
     shift
 done
-echo Using remote $(tput setaf 6)$remoteURL$(tput sgr 0)
+echo Using remote $(tput setaf 6)$remoteWorkspace$(tput sgr 0)
 
-# extract login information and remote path from url
-# assumes remote url of this format: `user@domain:path/to/hulk/repo`
-address="$(echo $remoteURL | cut -d':' -f 1)"
-remotePath="$(echo $remoteURL | cut -d':' -f 2-)"
+# extract login information and remote path from workspace
+# assumes workspace path of this format: `user@domain:path/to/hulk/repo`
+address="$(echo $remoteWorkspace | cut -d':' -f 1)"
+remotePath="$(echo $remoteWorkspace | cut -d':' -f 2-)"
 
 # send local state to remote
-rsync -ah --info progress2 --exclude='.git' --filter="dir-merge,- .gitignore" --delete . "$remoteURL"
+rsync -ah --info progress2 --exclude='.git' --filter="dir-merge,- .gitignore" --delete . "$remoteWorkspace"
 
 # invoke command remotely
 ssh $address "sh -c \" \
@@ -78,5 +78,5 @@ ssh $address "sh -c \" \
 # fetch results
 echo Returning files
 printf '  %s\n' "${files[@]}"
-printf '%s\n' "${files[@]}" | rsync -ah --info=progress --files-from=- "$remoteURL" .
+printf '%s\n' "${files[@]}" | rsync -ah --info=progress --files-from=- "$remoteWorkspace" .
 

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -82,7 +82,7 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
 pub async fn remote(arguments: Arguments, command: Command) -> Result<()> {
     match command {
         Command::Build => {
-            let mut command = TokioCommand::new("./scripts/remote");
+            let mut command = TokioCommand::new("./scripts/remoteWorkspace");
 
             let profile_name = match arguments.profile.as_str() {
                 "dev" => "debug",


### PR DESCRIPTION
## Introduced Changes

Removes git from the remote script.
It now exclusively uses `rsync` to copy sources to the remote and return build artifacts.
Previous remote-compile setups should:tm: require no changes on the remote, only local configuration has to be adjusted.

Fixes #

## Migration

If you already have a remote compilation setup, you can use the following command to migrate your configuration.
```sh
git remote get-url compiler > .REMOTE_WORKSPACE
```
The `compiler` remote can safely be removed after.
```sh
git remote remove compiler
```

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- If you haven't already, set up a remote machine as described in the documentation.
- If you already have a setup, migrate it as described above.
```sh
pepsi build --remote
```