### PR TITLE
Penalized pose arm spacing

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -718,17 +718,17 @@
     },
     "left_arm": {
       "shoulder_pitch": 1.57,
-      "shoulder_roll": 0.0,
+      "shoulder_roll": 0.2,
       "elbow_yaw": 0.0,
-      "elbow_roll": 0.0,
+      "elbow_roll": -0.008,
       "wrist_yaw": -1.57,
       "hand": 0.0
     },
     "right_arm": {
       "shoulder_pitch": 1.57,
-      "shoulder_roll": 0.0,
+      "shoulder_roll": -0.2,
       "elbow_yaw": 0.0,
-      "elbow_roll": 0.0,
+      "elbow_roll": 0.008,
       "wrist_yaw": 1.57,
       "hand": 0.0
     },


### PR DESCRIPTION
## Introduced Changes

The arms in the `penalized_pose` are know (again) the same as in the `initial_pose` and therefore not as tight to the torso as before.

Fixes #

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Bring robot in `penalized_pose` by pressing the chest button twice.
