### PR TITLE
Add approx_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "arboard"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4736,6 +4746,7 @@ name = "types"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "approx_derive",
  "color-eyre",
  "enum-iterator",
  "geometry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/aliveness",
+  "crates/approx_derive",
   "crates/audio",
   "crates/calibration",
   "crates/code_generation",
@@ -46,6 +47,7 @@ exclude = ["tools/aliveness", "tools/hula"]
 aliveness = { path = "crates/aliveness" }
 alsa = "0.7.0"
 approx = "0.5.1"
+approx_derive = { path = "crates/approx_derive" }
 audio = { path = "crates/audio" }
 awaitgroup = "0.6.0"
 base64 = "0.21.0"

--- a/crates/approx_derive/Cargo.toml
+++ b/crates/approx_derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "approx_derive"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+homepage = "https://github.com/hulks/hulk"
+
+[dependencies]
+proc-macro-error = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[lib]
+proc-macro = true

--- a/crates/approx_derive/src/lib.rs
+++ b/crates/approx_derive/src/lib.rs
@@ -1,0 +1,136 @@
+use proc_macro2::TokenStream;
+use proc_macro_error::{abort, proc_macro_error, OptionExt, ResultExt};
+use quote::quote;
+use syn::{
+    parse_macro_input,
+    punctuated::{self},
+    Attribute, Data, DeriveInput, Lit, Meta, MetaNameValue, NestedMeta, Type,
+};
+
+#[proc_macro_derive(AbsDiffEq, attributes(abs_diff_eq))]
+#[proc_macro_error]
+pub fn abs_diff_eq(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    generate_abs_diff_eq(input).into()
+}
+
+fn generate_abs_diff_eq(input: DeriveInput) -> TokenStream {
+    let fields = match input.data {
+        Data::Struct(data) => data.fields,
+        Data::Enum(data) => abort!(
+            data.enum_token,
+            "`AbsDiffEq` can only be derived for `struct`",
+        ),
+        Data::Union(data) => abort!(
+            data.union_token,
+            "`AbsDiffEq` can only be derived for `struct`",
+        ),
+    };
+    let epsilon = extract_epsilon(&input.attrs).expect_or_abort("`epsilon` not specified");
+    let name = input.ident;
+
+    let conditions = fields.into_iter().map(|field| {
+        let identifier = field
+            .ident
+            .clone()
+            .unwrap_or_else(|| abort!(field, "field has to be named"));
+        quote! {
+            self.#identifier.abs_diff_eq(&other.#identifier, epsilon)
+        }
+    });
+
+    quote! {
+        impl approx::AbsDiffEq for #name {
+            type Epsilon = #epsilon;
+
+            fn default_epsilon() -> Self::Epsilon {
+                Self::Epsilon::default_epsilon()
+            }
+
+            fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+                #(#conditions)&&*
+            }
+        }
+    }
+}
+
+fn extract_epsilon(attrs: &[Attribute]) -> Option<Type> {
+    attrs
+        .iter()
+        .filter_map(parse_meta_items)
+        .flatten()
+        .find_map(|meta| match meta {
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. }))
+                if path.is_ident("epsilon") =>
+            {
+                let string = match lit {
+                    Lit::Str(string) => string,
+                    _ => abort!(lit, "expected string literal"),
+                };
+                let epsilon = string
+                    .parse()
+                    .expect_or_abort("failed to parse epsilon type");
+                Some(epsilon)
+            }
+            _ => None,
+        })
+}
+
+fn parse_meta_items(attribute: &Attribute) -> Option<punctuated::IntoIter<NestedMeta>> {
+    if !attribute.path.is_ident("abs_diff_eq") {
+        return None;
+    }
+    match attribute.parse_meta() {
+        Ok(Meta::List(meta)) => Some(meta.nested.into_iter()),
+        Ok(other) => abort!(other, "expected `#[abs_diff_eq(...)]`",),
+        Err(error) => abort!(error.span(), error.to_string()),
+    }
+}
+
+#[proc_macro_derive(RelativeEq)]
+#[proc_macro_error]
+pub fn relative_eq(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    generate_relative_eq(input).into()
+}
+
+fn generate_relative_eq(input: DeriveInput) -> TokenStream {
+    let fields = match input.data {
+        Data::Struct(data) => data.fields,
+        Data::Enum(data) => abort!(
+            data.enum_token,
+            "`RelativeEq` can only be derived for `struct`",
+        ),
+        Data::Union(data) => abort!(
+            data.union_token,
+            "`RelativeEq` can only be derived for `struct`",
+        ),
+    };
+    let name = input.ident;
+    let conditions = fields.into_iter().map(|field| {
+        let identifier = field
+            .ident
+            .clone()
+            .unwrap_or_else(|| abort!(field, "field has to be named"));
+        quote! {
+            self.#identifier.relative_eq(&other.#identifier, epsilon, max_relative)
+        }
+    });
+
+    quote! {
+        impl approx::RelativeEq for #name {
+            fn default_max_relative() -> Self::Epsilon {
+                Self::Epsilon::default_max_relative()
+            }
+
+            fn relative_eq(
+                &self,
+                other: &Self,
+                epsilon: Self::Epsilon,
+                max_relative: Self::Epsilon,
+            ) -> bool {
+                #(#conditions)&&*
+            }
+        }
+    }
+}

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 approx = { workspace = true }
+approx_derive = { workspace = true }
 color-eyre = { workspace = true }
 enum-iterator = { workspace = true }
 geometry = { workspace = true }

--- a/crates/types/src/ball.rs
+++ b/crates/types/src/ball.rs
@@ -1,4 +1,4 @@
-use approx::{AbsDiffEq, RelativeEq};
+use approx_derive::{AbsDiffEq, RelativeEq};
 use geometry::circle::Circle;
 use nalgebra::Point2;
 use serde::{Deserialize, Serialize};
@@ -13,42 +13,11 @@ pub struct CandidateEvaluation {
     pub merge_weight: Option<f32>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, SerializeHierarchy)]
+#[derive(
+    Clone, Debug, Deserialize, PartialEq, Serialize, SerializeHierarchy, AbsDiffEq, RelativeEq,
+)]
+#[abs_diff_eq(epsilon = "f32")]
 pub struct Ball {
     pub position: Point2<f32>,
     pub image_location: Circle,
-}
-
-impl AbsDiffEq for Ball {
-    type Epsilon = f32;
-
-    fn default_epsilon() -> Self::Epsilon {
-        Self::Epsilon::default_epsilon()
-    }
-
-    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.position.abs_diff_eq(&other.position, epsilon)
-            && self
-                .image_location
-                .abs_diff_eq(&other.image_location, epsilon)
-    }
-}
-
-impl RelativeEq for Ball {
-    fn default_max_relative() -> Self::Epsilon {
-        Self::Epsilon::default_max_relative()
-    }
-
-    fn relative_eq(
-        &self,
-        other: &Self,
-        epsilon: Self::Epsilon,
-        max_relative: Self::Epsilon,
-    ) -> bool {
-        self.position
-            .relative_eq(&other.position, epsilon, max_relative)
-            && self
-                .image_location
-                .relative_eq(&other.image_location, epsilon, max_relative)
-    }
 }


### PR DESCRIPTION
## Introduced Changes

Implement a new `approx_derive` crate to derive `AbsDiffEq` und `RelativeEq` of the `approx` crate.

I'm open to discussion whether this change is actually useful...

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

compile?
