### PR TITLE
Recording error handling

### DIFF
--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -137,7 +137,7 @@ fn generate_recording_thread(cyclers: &Cyclers) -> TokenStream {
             std::thread::Builder::new()
                 .name("Recording".to_string())
                 .spawn(move || -> color_eyre::Result<()> {
-                    fn recording_loop(recording_receiver: std::sync::mpsc::Receiver<crate::cyclers::RecordingFrame>) -> color_eyre::Result<()> {
+                    let result = (|| {
                         use std::io::Write;
                         let seconds = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap().as_secs();
                         #(#file_creations)*
@@ -147,9 +147,8 @@ fn generate_recording_thread(cyclers: &Cyclers) -> TokenStream {
                             }
                         }
                         Ok(())
-                    }
+                    })();
 
-                    let result = recording_loop(recording_receiver);
                     keep_running.cancel();
                     result
                 })

--- a/crates/code_generation/src/run.rs
+++ b/crates/code_generation/src/run.rs
@@ -40,6 +40,9 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
             let recording_thread = #recording_thread;
 
             #construct_cyclers
+            // Drop sender to cause channel to close once all cyclers exit,
+            // otherwise the recording thread waits forever
+            drop(recording_sender);
 
             #start_cyclers
 


### PR DESCRIPTION
## Introduced Changes

This PR addresses two problems.
1. If there was an error in the recording thread, it never cancelled the `keep_running` token, causing it to fail silently.
1. The recording thread never properly exited because the channel was never closed.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

Rethink error handling in thread cleanup.

## How to Test

Causing an error in the recording thread (e.g. by deleting the logs folder, see #581) should now cause the hulk process to exit.
