### PR TITLE
Players serialize hierarchy fix

### DIFF
--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -125,10 +125,7 @@ impl<'a, T> Iterator for PlayersIterator<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for PlayersIterator<'a, T>
-where
-    T: SerializeHierarchy,
-{
+impl<'a, T> DoubleEndedIterator for PlayersIterator<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let result = self.next_back.map(|number| (number, &self.data[number]));
         if self.next_forward == self.next_back {
@@ -149,17 +146,11 @@ where
     }
 }
 
-impl<'a, T> ExactSizeIterator for PlayersIterator<'a, T>
-where
-    T: SerializeHierarchy,
-{
+impl<'a, T> ExactSizeIterator for PlayersIterator<'a, T> {
     // The default implementation only requires `Iterator::size_hint()` to be exact
 }
 
-impl<T> Players<T>
-where
-    T: SerializeHierarchy,
-{
+impl<T> Players<T> {
     pub fn iter(&self) -> PlayersIterator<'_, T> {
         PlayersIterator::new(self)
     }

--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeSet,
-    iter::once,
+    iter::empty,
     ops::{Index, IndexMut},
 };
 
@@ -303,7 +303,7 @@ where
     }
 
     fn get_fields() -> BTreeSet<String> {
-        once(String::new())
+        empty()
             .chain(
                 T::get_fields()
                     .into_iter()


### PR DESCRIPTION
## Introduced Changes

The output paths generated from `get_fields` on player structs would previously return one additional entry that has a trailing period, which isn't a valid path.
Now it doesn't.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
