### PR TITLE
Improved ball search

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+zu schnell hin und her
+points of interest in active vision
+positions für die leuchttürme timeouten
+penalties beachten, playernumber
+search positions können immer weiter von den aktuellen positionen vergrößert werden
+looser schon sinnvoll

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-zu schnell hin und her
-points of interest in active vision
-positions für die leuchttürme timeouten
-penalties beachten, playernumber
-search positions können immer weiter von den aktuellen positionen vergrößert werden
-looser schon sinnvoll

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -61,6 +61,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub ball_position: MainOutput<Option<BallPosition<Ground>>>,
+    pub removed_ball_positions: MainOutput<Vec<Point2<f32>>>,
     pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition>>,
 }
 
@@ -95,7 +96,7 @@ impl BallFilter {
         &mut self,
         measurements: Vec<(&SystemTime, Vec<&Ball>)>,
         context: &CycleContext,
-    ) {
+    ) -> Vec<Hypothesis> {
         for (detection_time, balls) in measurements {
             let current_odometry_to_last_odometry = context
                 .current_odometry_to_last_odometry
@@ -130,16 +131,17 @@ impl BallFilter {
             }
         }
 
-        self.remove_hypotheses(
+        let removed_hypotheses = self.remove_hypotheses(
             context.cycle_time.start_time,
             context.ball_filter_configuration,
             context.field_dimensions,
         );
+        removed_hypotheses
     }
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let persistent_updates = Self::persistent_balls_in_control_cycle(&context);
-        self.advance_all_hypotheses(persistent_updates, &context);
+        let removed_hypotheses = self.advance_all_hypotheses(persistent_updates, &context);
 
         context
             .ball_filter_hypotheses
@@ -164,42 +166,56 @@ impl BallFilter {
                 )
             });
 
-        context
-            .best_ball_hypothesis
-            .fill_if_subscribed(|| self.find_best_hypothesis().cloned());
+        context.best_ball_hypothesis.fill_if_subscribed(|| {
+            self.find_best_hypothesis(context.ball_filter_configuration)
+                .cloned()
+        });
 
         context.best_ball_state.fill_if_subscribed(|| {
-            self.find_best_hypothesis()
+            self.find_best_hypothesis(context.ball_filter_configuration)
                 .map(|hypothesis| hypothesis.selected_state(context.ball_filter_configuration))
         });
 
         let ball_position = self
-            .find_best_hypothesis()
-            .filter(|hypothesis| {
-                hypothesis.validity >= context.ball_filter_configuration.validity_output_threshold
-            })
+            .find_best_hypothesis(context.ball_filter_configuration)
             .map(|hypothesis| {
                 context.chooses_resting_model.fill_if_subscribed(|| {
                     hypothesis.is_resting(context.ball_filter_configuration)
                 });
                 hypothesis.selected_ball_position(context.ball_filter_configuration)
             });
+        let removed_ball_positions = removed_hypotheses
+            .into_iter()
+            .filter(|hypothesis| {
+                hypothesis.validity >= context.ball_filter_configuration.validity_output_threshold
+            })
+            .map(|hypothesis| {
+                hypothesis
+                    .selected_ball_position(context.ball_filter_configuration)
+                    .position
+            })
+            .collect::<Vec<_>>();
         let invalid_ball_positions = self
             .hypotheses
             .iter()
-            .filter(|hypothesis| {
-                hypothesis.validity < context.ball_filter_configuration.validity_output_threshold
-            })
-            .map(|hypothesis| HypotheticalBallPosition {
-                position: hypothesis
-                    .selected_ball_position(context.ball_filter_configuration)
-                    .position,
-                validity: hypothesis.validity,
+            .filter_map(|hypothesis| {
+                if hypothesis.validity < context.ball_filter_configuration.validity_output_threshold
+                {
+                    Some(HypotheticalBallPosition {
+                        position: hypothesis
+                            .selected_ball_position(context.ball_filter_configuration)
+                            .position,
+                        validity: hypothesis.validity,
+                    })
+                } else {
+                    None
+                }
             })
             .collect::<Vec<_>>();
 
         Ok(MainOutputs {
             ball_position: ball_position.into(),
+            removed_ball_positions: removed_ball_positions.into(),
             invalid_ball_positions: invalid_ball_positions.into(),
         })
     }
@@ -338,10 +354,11 @@ impl BallFilter {
         });
     }
 
-    fn find_best_hypothesis(&self) -> Option<&Hypothesis> {
+    fn find_best_hypothesis(&self, configuration: &BallFilterConfiguration) -> Option<&Hypothesis> {
         self.hypotheses
             .iter()
-            .max_by(|a, b| a.validity.total_cmp(&b.validity))
+            .filter(|hypothesis| hypothesis.validity > configuration.validity_output_threshold)
+            .max_by(|left, right| left.validity.total_cmp(&right.validity))
     }
 
     fn spawn_hypothesis(
@@ -372,23 +389,27 @@ impl BallFilter {
         now: SystemTime,
         configuration: &BallFilterParameters,
         field_dimensions: &FieldDimensions,
-    ) {
-        self.hypotheses.retain(|hypothesis| {
-            let selected_position = hypothesis.selected_ball_position(configuration).position;
-            let is_inside_field = {
-                selected_position.x().abs()
-                    < field_dimensions.length / 2.0 + field_dimensions.border_strip_width
-                    && selected_position.y().abs()
-                        < field_dimensions.width / 2.0 + field_dimensions.border_strip_width
-            };
-            now.duration_since(hypothesis.last_update)
-                .expect("Time has run backwards")
-                < configuration.hypothesis_timeout
-                && hypothesis.validity > configuration.validity_discard_threshold
-                && is_inside_field
-        });
+    ) -> Vec<Hypothesis> {
+        let (retained_hypotheses, removed_hypotheses) = self
+            .hypotheses
+            .drain(..)
+            .into_iter()
+            .partition::<Vec<_>, _>(|hypothesis| {
+                let selected_position = hypothesis.selected_ball_position(configuration).position;
+                let is_inside_field = {
+                    selected_position.coords.x.abs()
+                        < field_dimensions.length / 2.0 + field_dimensions.border_strip_width
+                        && selected_position.y.abs()
+                            < field_dimensions.width / 2.0 + field_dimensions.border_strip_width
+                };
+                now.duration_since(hypothesis.last_update)
+                    .expect("Time has run backwards")
+                    < configuration.hypothesis_timeout
+                    && hypothesis.validity > configuration.validity_discard_threshold
+                    && is_inside_field
+            });
         let mut deduplicated_hypotheses = Vec::<Hypothesis>::new();
-        for hypothesis in self.hypotheses.drain(..) {
+        for hypothesis in retained_hypotheses {
             let hypothesis_in_merge_distance =
                 deduplicated_hypotheses
                     .iter_mut()
@@ -418,6 +439,7 @@ impl BallFilter {
             }
         }
         self.hypotheses = deduplicated_hypotheses;
+        removed_hypotheses
     }
 }
 

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -14,7 +14,8 @@ use projection::{camera_matrices::CameraMatrices, camera_matrix::CameraMatrix, P
 use types::{
     ball::Ball,
     ball_filter::Hypothesis,
-    ball_position::BallPosition,
+    ball_position::{BallPosition, HypotheticalBallPosition},
+    camera_matrix::{CameraMatrices, CameraMatrix},
     cycle_time::CycleTime,
     field_dimensions::FieldDimensions,
     limb::{is_above_limbs, Limb, ProjectedLimbs},
@@ -60,6 +61,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub ball_position: MainOutput<Option<BallPosition<Ground>>>,
+    pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition>>,
 }
 
 impl BallFilter {
@@ -182,9 +184,23 @@ impl BallFilter {
                 });
                 hypothesis.selected_ball_position(context.ball_filter_configuration)
             });
+        let invalid_ball_positions = self
+            .hypotheses
+            .iter()
+            .filter(|hypothesis| {
+                hypothesis.validity < context.ball_filter_configuration.validity_output_threshold
+            })
+            .map(|hypothesis| HypotheticalBallPosition {
+                position: hypothesis
+                    .selected_ball_position(context.ball_filter_configuration)
+                    .position,
+                validity: hypothesis.validity,
+            })
+            .collect::<Vec<_>>();
 
         Ok(MainOutputs {
             ball_position: ball_position.into(),
+            invalid_ball_positions: invalid_ball_positions.into(),
         })
     }
 

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -61,8 +61,8 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub ball_position: MainOutput<Option<BallPosition<Ground>>>,
-    pub removed_ball_positions: MainOutput<Vec<Point2<f32>>>,
-    pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition>>,
+    pub removed_ball_positions: MainOutput<Vec<Point2<Ground>>>,
+    pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition<Ground>>>,
 }
 
 impl BallFilter {
@@ -395,9 +395,9 @@ impl BallFilter {
             .partition::<Vec<_>, _>(|hypothesis| {
                 let selected_position = hypothesis.selected_ball_position(configuration).position;
                 let is_inside_field = {
-                    selected_position.coords.x.abs()
+                    selected_position.coords().x().abs()
                         < field_dimensions.length / 2.0 + field_dimensions.border_strip_width
-                        && selected_position.y.abs()
+                        && selected_position.y().abs()
                             < field_dimensions.width / 2.0 + field_dimensions.border_strip_width
                 };
                 now.duration_since(hypothesis.last_update)

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -354,7 +354,7 @@ impl BallFilter {
         });
     }
 
-    fn find_best_hypothesis(&self, configuration: &BallFilterConfiguration) -> Option<&Hypothesis> {
+    fn find_best_hypothesis(&self, configuration: &BallFilterParameters) -> Option<&Hypothesis> {
         self.hypotheses
             .iter()
             .filter(|hypothesis| hypothesis.validity > configuration.validity_output_threshold)

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -15,7 +15,6 @@ use types::{
     ball::Ball,
     ball_filter::Hypothesis,
     ball_position::{BallPosition, HypotheticalBallPosition},
-    camera_matrix::{CameraMatrices, CameraMatrix},
     cycle_time::CycleTime,
     field_dimensions::FieldDimensions,
     limb::{is_above_limbs, Limb, ProjectedLimbs},

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -171,12 +171,17 @@ impl BallFilter {
                 .map(|hypothesis| hypothesis.selected_state(context.ball_filter_configuration))
         });
 
-        let ball_position = self.find_best_hypothesis().map(|hypothesis| {
-            context
-                .chooses_resting_model
-                .fill_if_subscribed(|| hypothesis.is_resting(context.ball_filter_configuration));
-            hypothesis.selected_ball_position(context.ball_filter_configuration)
-        });
+        let ball_position = self
+            .find_best_hypothesis()
+            .filter(|hypothesis| {
+                hypothesis.validity >= context.ball_filter_configuration.validity_output_threshold
+            })
+            .map(|hypothesis| {
+                context.chooses_resting_model.fill_if_subscribed(|| {
+                    hypothesis.is_resting(context.ball_filter_configuration)
+                });
+                hypothesis.selected_ball_position(context.ball_filter_configuration)
+            });
 
         Ok(MainOutputs {
             ball_position: ball_position.into(),

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -131,12 +131,11 @@ impl BallFilter {
             }
         }
 
-        let removed_hypotheses = self.remove_hypotheses(
+        self.remove_hypotheses(
             context.cycle_time.start_time,
             context.ball_filter_configuration,
             context.field_dimensions,
-        );
-        removed_hypotheses
+        )
     }
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
@@ -393,7 +392,6 @@ impl BallFilter {
         let (retained_hypotheses, removed_hypotheses) = self
             .hypotheses
             .drain(..)
-            .into_iter()
             .partition::<Vec<_>, _>(|hypothesis| {
                 let selected_position = hypothesis.selected_ball_position(configuration).position;
                 let is_inside_field = {

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -62,9 +62,13 @@ pub fn execute(
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let search_role = assign_search_role(world_state);
-    let search_position = search_role
-        .map(|role| role.to_position(ground_to_field, field_dimensions))
-        .unwrap_or(point![0.0, 0.0]);
+    let search_position = match world_state.suggested_search_position {
+        Some(_) => world_state.suggested_search_position.unwrap(),
+        None => search_role
+            .map(|role| role.to_position(robot_to_field, field_dimensions))
+            .unwrap_or(point![0.0, 0.0]),
+    };
+    // ;
     let head = HeadMotion::SearchForLostBall;
     if let Some(SearchRole::Goal) = search_role {
         let goal_pose = Pose2::from(search_position);

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -37,12 +37,18 @@ impl SearchRole {
             -field_dimensions.goal_inner_width / 4.0
         ];
         let center = point![0.0, 0.0];
+        let supporting_left = point![
+            field_dimensions.length / 2.0 + field_dimensions.goal_box_area_length + 0.2,
+            field_dimensions.goal_inner_width / 4.0
+        ];
+        let supporting_right = point![
+            field_dimensions.length / 2.0 + field_dimensions.penalty_area_length + 0.2,
+            -field_dimensions.goal_inner_width / 4.0
+        ];
         let aggressive = point![
             field_dimensions.length / 2.0 - field_dimensions.penalty_area_length,
             0.0
         ];
-        let supporting_left = point![0.0, 0.0];
-        let supporting_right = point![0.0, 0.0];
 
         ground_to_field.inverse()
             * match self {

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -75,10 +75,10 @@ pub fn execute(
     let search_role = assign_search_role(world_state);
     let search_position = match (world_state.suggested_search_position, search_role) {
         (Some(_), Some(SearchRole::Aggressive) | Some(SearchRole::Support { side: _ })) => {
-            robot_to_field.inverse() * world_state.suggested_search_position.unwrap()
+            ground_to_field.inverse() * world_state.suggested_search_position.unwrap()
         }
         _ => search_role
-            .map(|role| role.to_position(robot_to_field, field_dimensions))
+            .map(|role| role.to_position(ground_to_field, field_dimensions))
             .unwrap_or(point![0.0, 0.0]),
     };
     let head = HeadMotion::SearchForLostBall;

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -17,6 +17,7 @@ enum SearchRole {
     Goal,
     Defend { side: Side },
     Center,
+    Support { side: Side },
     Aggressive,
 }
 
@@ -40,6 +41,8 @@ impl SearchRole {
             field_dimensions.length / 2.0 - field_dimensions.penalty_area_length,
             0.0
         ];
+        let supporting_left = point![0.0, 0.0];
+        let supporting_right = point![0.0, 0.0];
 
         ground_to_field.inverse()
             * match self {
@@ -47,6 +50,8 @@ impl SearchRole {
                 SearchRole::Defend { side: Side::Left } => defending_left,
                 SearchRole::Defend { side: Side::Right } => defending_right,
                 SearchRole::Center => center,
+                SearchRole::Support { side: Side::Left } => supporting_left,
+                SearchRole::Support { side: Side::Right } => supporting_right,
                 SearchRole::Aggressive => aggressive,
             }
     }
@@ -63,7 +68,7 @@ pub fn execute(
     let ground_to_field = world_state.robot.ground_to_field?;
     let search_role = assign_search_role(world_state);
     let search_position = match (world_state.suggested_search_position, search_role) {
-        (Some(_), Some(SearchRole::Aggressive) | Some(SearchRole::Center)) => {
+        (Some(_), Some(SearchRole::Aggressive) | Some(SearchRole::Support { side: _ })) => {
             robot_to_field.inverse() * world_state.suggested_search_position.unwrap()
         }
         _ => search_role
@@ -101,6 +106,8 @@ fn assign_search_role(world_state: &WorldState) -> Option<SearchRole> {
         SearchRole::Defend { side: Side::Left },
         SearchRole::Defend { side: Side::Right },
         SearchRole::Center,
+        SearchRole::Support { side: Side::Left },
+        SearchRole::Support { side: Side::Right },
         SearchRole::Aggressive,
     ]
     .into_iter();

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -62,9 +62,11 @@ pub fn execute(
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let search_role = assign_search_role(world_state);
-    let search_position = match world_state.suggested_search_position {
-        Some(_) => robot_to_field.inverse() * world_state.suggested_search_position.unwrap(),
-        None => search_role
+    let search_position = match (world_state.suggested_search_position, search_role) {
+        (Some(_), Some(SearchRole::Aggressive) | Some(SearchRole::Center)) => {
+            robot_to_field.inverse() * world_state.suggested_search_position.unwrap()
+        }
+        _ => search_role
             .map(|role| role.to_position(robot_to_field, field_dimensions))
             .unwrap_or(point![0.0, 0.0]),
     };

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -63,7 +63,7 @@ pub fn execute(
     let ground_to_field = world_state.robot.ground_to_field?;
     let search_role = assign_search_role(world_state);
     let search_position = match world_state.suggested_search_position {
-        Some(_) => world_state.suggested_search_position.unwrap(),
+        Some(_) => robot_to_field.inverse() * world_state.suggested_search_position.unwrap(),
         None => search_role
             .map(|role| role.to_position(robot_to_field, field_dimensions))
             .unwrap_or(point![0.0, 0.0]),

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -6,6 +6,7 @@ use types::{
     motion_command::{HeadMotion, MotionCommand, OrientationMode},
     parameters::SearchParameters,
     path_obstacles::PathObstacle,
+    roles::Role,
     support_foot::Side,
     world_state::WorldState,
 };
@@ -70,11 +71,12 @@ pub fn execute(
     field_dimensions: &FieldDimensions,
     parameters: &SearchParameters,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
+    previous_role: Role,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let search_role = assign_search_role(world_state);
-    let search_position = match (world_state.suggested_search_position, search_role) {
-        (Some(_), Some(SearchRole::Aggressive) | Some(SearchRole::Support { side: _ })) => {
+    let search_position = match (world_state.suggested_search_position, previous_role) {
+        (Some(_), Role::Striker | Role::StrikerSupporter) => {
             ground_to_field.inverse() * world_state.suggested_search_position.unwrap()
         }
         _ => search_role

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -38,11 +38,11 @@ impl SearchRole {
         ];
         let center = point![0.0, 0.0];
         let supporting_left = point![
-            field_dimensions.length / 2.0 + field_dimensions.goal_box_area_length + 0.2,
+            field_dimensions.goal_box_area_length + 0.2,
             field_dimensions.goal_inner_width / 4.0
         ];
         let supporting_right = point![
-            field_dimensions.length / 2.0 + field_dimensions.penalty_area_length + 0.2,
+            field_dimensions.penalty_area_length + 0.2,
             -field_dimensions.goal_inner_width / 4.0
         ];
         let aggressive = point![

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -68,7 +68,6 @@ pub fn execute(
             .map(|role| role.to_position(robot_to_field, field_dimensions))
             .unwrap_or(point![0.0, 0.0]),
     };
-    // ;
     let head = HeadMotion::SearchForLostBall;
     if let Some(SearchRole::Goal) = search_role {
         let goal_pose = Pose2::from(search_position);

--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -9,7 +9,7 @@ use coordinate_systems::{Field, Ground};
 use framework::MainOutput;
 use spl_network_messages::HulkMessage;
 use types::{
-    ball_position::BallPosition,
+    ball_position::{BallPosition, HypotheticalBallPosition},
     cycle_time::CycleTime,
     fall_state::FallState,
     filtered_whistle::FilteredWhistle,
@@ -50,6 +50,7 @@ pub struct MainOutputs {
     pub game_controller_state: MainOutput<Option<GameControllerState>>,
     pub has_ground_contact: MainOutput<bool>,
     pub hulk_messages: MainOutput<Vec<HulkMessage>>,
+    pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition>>,
     pub obstacles: MainOutput<Vec<Obstacle>>,
     pub penalty_shot_direction: MainOutput<Option<PenaltyShotDirection>>,
     pub primary_state: MainOutput<PrimaryState>,

--- a/crates/control/src/fake_data.rs
+++ b/crates/control/src/fake_data.rs
@@ -50,7 +50,7 @@ pub struct MainOutputs {
     pub game_controller_state: MainOutput<Option<GameControllerState>>,
     pub has_ground_contact: MainOutput<bool>,
     pub hulk_messages: MainOutput<Vec<HulkMessage>>,
-    pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition>>,
+    pub invalid_ball_positions: MainOutput<Vec<HypotheticalBallPosition<Ground>>>,
     pub obstacles: MainOutput<Vec<Obstacle>>,
     pub penalty_shot_direction: MainOutput<Option<PenaltyShotDirection>>,
     pub primary_state: MainOutput<PrimaryState>,

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -27,6 +27,7 @@ pub mod penalty_shot_direction_estimation;
 pub mod primary_state_filter;
 pub mod role_assignment;
 pub mod rule_obstacle_composer;
+pub mod search_suggestor;
 pub mod sensor_data_receiver;
 pub mod sole_pressure_filter;
 pub mod sonar_filter;

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -1,10 +1,10 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
-use nalgebra::{DMatrix, DimNameSub, Point2};
+use nalgebra::{DMatrix, Isometry2, Point2};
 use types::{
     ball_position::{BallPosition, HypotheticalBallPosition},
-    field_dimensions::{self, FieldDimensions},
+    field_dimensions::FieldDimensions,
     parameters::SearchSuggestorParameters,
 };
 
@@ -24,6 +24,7 @@ pub struct CycleContext {
     search_suggestor_configuration: Parameter<SearchSuggestorParameters, "search_suggestor">,
     ball_position: Input<Option<BallPosition>, "ball_position?">,
     invalid_ball_positions: Input<Vec<HypotheticalBallPosition>, "invalid_ball_positions">,
+    robot_to_field: Input<Option<Isometry2<f32>>, "robot_to_field?">,
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
 }
 
@@ -50,13 +51,14 @@ impl SearchSuggestor {
         self.update_heatmap(
             context.ball_position,
             context.invalid_ball_positions,
+            context.robot_to_field.copied(),
             context.search_suggestor_configuration.cells_per_meter,
             context.field_dimensions,
             context.search_suggestor_configuration.heatmap_decay_factor,
         );
         let maximum_heat_heatmap_position = self.heatmap.iamax_full();
         let mut suggested_search_position: Option<Point2<f32>> = None;
-        if self.heatmap[maximum_heat_heatmap_position] > 0.001 {
+        if self.heatmap[maximum_heat_heatmap_position] > 0.0001 {
             let mut search_suggestion = Point2::new(
                 maximum_heat_heatmap_position.0 as f32
                     / context.search_suggestor_configuration.cells_per_meter as f32,
@@ -74,7 +76,7 @@ impl SearchSuggestor {
             if search_suggestion.y >= width_half {
                 search_suggestion.y -= width_half;
             } else {
-                search_suggestion.y = width_half - search_suggestion.x
+                search_suggestion.y = width_half - search_suggestion.y
             }
             suggested_search_position = Some(search_suggestion);
         }
@@ -88,17 +90,20 @@ impl SearchSuggestor {
         &mut self,
         ball_position: Option<&BallPosition>,
         invalid_ball_positions: &Vec<HypotheticalBallPosition>,
+        robot_to_field: Option<Isometry2<f32>>,
         cells_per_meter: usize,
         field_dimensions: &FieldDimensions,
         heatmap_decay_factor: f32,
     ) {
-        if ball_position.is_some() {
-            let ball_heatmap_position = self.calculate_heatmap_position(
-                ball_position.unwrap().position,
-                cells_per_meter,
-                field_dimensions,
-            );
-            self.heatmap[ball_heatmap_position] = 1.0;
+        if let Some(ball_position) = ball_position {
+            if let Some(robot_to_field) = robot_to_field {
+                let ball_heatmap_position = self.calculate_heatmap_position(
+                    robot_to_field * ball_position.position,
+                    cells_per_meter,
+                    field_dimensions,
+                );
+                self.heatmap[ball_heatmap_position] = 1.0;
+            }
         }
         for ball_hypothesis in invalid_ball_positions {
             let heatmap_position = self.calculate_heatmap_position(
@@ -118,8 +123,8 @@ impl SearchSuggestor {
         cells_per_meter: usize,
         field_dimensions: &FieldDimensions,
     ) -> (usize, usize) {
-        let row_count = field_dimensions.length as usize * cells_per_meter;
-        let collum_count = field_dimensions.width as usize * cells_per_meter;
+        let row_count = field_dimensions.length.round() as usize * cells_per_meter;
+        let collum_count = field_dimensions.width.round() as usize * cells_per_meter;
         let mut x_position: usize = 0;
         let mut y_position: usize = 0;
         if hypothesis_position.x > 0.0 {
@@ -136,12 +141,12 @@ impl SearchSuggestor {
             y_position = (collum_count / 2)
                 - (hypothesis_position.y.abs() * cells_per_meter as f32).round() as usize;
         }
-        if 0 >= x_position || row_count < x_position{
+        if 0 >= x_position || row_count < x_position {
             x_position = row_count;
-        } 
-        if 0 >= y_position || collum_count < y_position{
+        }
+        if 0 >= y_position || collum_count < y_position {
             y_position = collum_count;
-        } 
+        }
         x_position -= 1;
         y_position -= 1;
         return (x_position, y_position);

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -1,0 +1,64 @@
+use color_eyre::Result;
+use context_attribute::context;
+use framework::MainOutput;
+use nalgebra::Point2;
+use types::{
+    ball_position::HypotheticalBallPosition,
+    field_dimensions::FieldDimensions,
+};
+
+pub struct SearchSuggestor {
+    heatmap: Vec<Vec<ProbCell>>,
+}
+
+#[context]
+pub struct CreationContext {
+    field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
+}
+
+#[context]
+pub struct CycleContext {
+    removed_ball_positions: Input<Vec<Point2<f32>>, "removed_ball_positions">,
+    invalid_ball_positions: Input<Vec<HypotheticalBallPosition>, "invalid_ball_positions">,
+}
+
+#[derive(Clone, Copy)]
+pub struct ProbCell {
+    weight: f64,
+    age: f64,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub suggestest_search_position: MainOutput<Point2<f64>>,
+}
+
+impl SearchSuggestor {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        let dpi:usize = 5;
+        Ok(Self {
+            heatmap: vec![
+                vec![
+                    ProbCell {
+                        weight: 0.0,
+                        age: 0.0
+                    };
+                    _context.field_dimensions.length as usize * dpi
+                ];
+                _context.field_dimensions.width as usize * dpi
+            ],
+        })
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+
+
+        
+
+        Ok(MainOutputs{
+            suggestest_search_position: ,
+        }
+        )
+    }
+}

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -2,7 +2,10 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use nalgebra::{DMatrix, Point2};
-use types::{ball_position::HypotheticalBallPosition, field_dimensions::FieldDimensions};
+use types::{
+    ball_position::HypotheticalBallPosition, field_dimensions::FieldDimensions,
+    parameters::SearchSuggestorParameters,
+};
 
 pub struct SearchSuggestor {
     heatmap: DMatrix<f32>,
@@ -11,11 +14,13 @@ pub struct SearchSuggestor {
 #[context]
 pub struct CreationContext {
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
+    search_suggestor_configuration: Parameter<SearchSuggestorParameters, "search_suggestor">,
 }
 
 #[context]
 pub struct CycleContext {
-    removed_ball_positions: Input<Vec<Point2<f32>>, "removed_ball_positions">,
+    //removed_ball_positions: Input<Vec<Point2<f32>>, "removed_ball_positions">,
+    search_suggestor_configuration: Parameter<SearchSuggestorParameters, "search_suggestor">,
     invalid_ball_positions: Input<Vec<HypotheticalBallPosition>, "invalid_ball_positions">,
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
 }
@@ -28,23 +33,30 @@ pub struct MainOutputs {
 
 impl SearchSuggestor {
     pub fn new(_context: CreationContext) -> Result<Self> {
-        let dpi: usize = 5;
         Ok(Self {
             heatmap: DMatrix::from_element(
-                _context.field_dimensions.length as usize * dpi,
-                _context.field_dimensions.width as usize * dpi,
+                _context.field_dimensions.length as usize
+                    * _context.search_suggestor_configuration.cells_per_meter,
+                _context.field_dimensions.width as usize
+                    * _context.search_suggestor_configuration.cells_per_meter,
                 0.0,
             ),
         })
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let dpi = 5;
-        self.update_heatmap(context.invalid_ball_positions, context.field_dimensions);
+        self.update_heatmap(
+            context.invalid_ball_positions,
+            context.search_suggestor_configuration.cells_per_meter,
+            context.field_dimensions,
+            context.search_suggestor_configuration.heatmap_decay_factor,
+        );
         let maximum_heat_heatmap_position = self.heatmap.iamax_full();
         let suggestest_search_position = Point2::new(
-            maximum_heat_heatmap_position.0 as f32 / dpi as f32,
-            maximum_heat_heatmap_position.1 as f32 / dpi as f32,
+            maximum_heat_heatmap_position.0 as f32
+                / context.search_suggestor_configuration.cells_per_meter as f32,
+            maximum_heat_heatmap_position.1 as f32
+                / context.search_suggestor_configuration.cells_per_meter as f32,
         );
 
         Ok(MainOutputs {
@@ -55,14 +67,17 @@ impl SearchSuggestor {
     fn update_heatmap(
         &mut self,
         invalid_ball_positions: &Vec<HypotheticalBallPosition>,
+        cells_per_meter: usize,
         field_dimensions: &FieldDimensions,
+        heatmap_decay_factor: f32,
     ) {
-        let dpi: usize = 5;
-        let heatmap_decay_factor = 0.99;
         for ball_hypothesis in invalid_ball_positions {
-            let heatmap_position =
-                self.calculate_heatmap_position(ball_hypothesis.position, dpi, field_dimensions);
-            self.heatmap[heatmap_position] = ball_hypothesis.validity;
+            let heatmap_position = self.calculate_heatmap_position(
+                ball_hypothesis.position,
+                cells_per_meter,
+                field_dimensions,
+            );
+            self.heatmap[heatmap_position] += ball_hypothesis.validity;
         }
         self.heatmap = self.heatmap.clone() * heatmap_decay_factor;
     }
@@ -70,24 +85,26 @@ impl SearchSuggestor {
     fn calculate_heatmap_position(
         &mut self,
         hypothesis_position: Point2<f32>,
-        dpi: usize,
+        cells_per_meter: usize,
         field_dimensions: &FieldDimensions,
     ) -> (usize, usize) {
-        let row_count = field_dimensions.length as usize * dpi;
-        let collum_count = field_dimensions.width as usize * dpi;
+        let row_count = field_dimensions.length as usize * cells_per_meter;
+        let collum_count = field_dimensions.width as usize * cells_per_meter;
         let mut x_position: usize = 0;
         let mut y_position: usize = 0;
         if hypothesis_position.x > 0.0 {
-            x_position = (row_count / 2) + (hypothesis_position.x * dpi as f32).round() as usize;
-        } else if hypothesis_position.x < 0.0 {
             x_position =
-                (row_count / 2) - (hypothesis_position.x.abs() * dpi as f32).round() as usize;
+                (row_count / 2) + (hypothesis_position.x * cells_per_meter as f32).round() as usize;
+        } else if hypothesis_position.x < 0.0 {
+            x_position = (row_count / 2)
+                - (hypothesis_position.x.abs() * cells_per_meter as f32).round() as usize;
         }
         if hypothesis_position.y > 0.0 {
-            y_position = (collum_count / 2) + (hypothesis_position.y * dpi as f32).round() as usize;
+            y_position = (collum_count / 2)
+                + (hypothesis_position.y * cells_per_meter as f32).round() as usize;
         } else if hypothesis_position.y < 0.0 {
-            y_position =
-                (collum_count / 2) - (hypothesis_position.y.abs() * dpi as f32).round() as usize;
+            y_position = (collum_count / 2)
+                - (hypothesis_position.y.abs() * cells_per_meter as f32).round() as usize;
         }
         return (x_position, y_position);
     }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -114,7 +114,6 @@ impl SearchSuggestor {
                     self.heatmap[ball_heatmap_position] = 1.0;
                 } else {
                     println!("Invalid ball heatmap position");
-                    println!("{}, {}", ball_heatmap_position.0, ball_heatmap_position.1);
                 }
             }
         }
@@ -129,7 +128,6 @@ impl SearchSuggestor {
                         (self.heatmap[heatmap_position] + ball_hypothesis.validity) / 2.0;
                 } else {
                     println!("Invalid hypothesis heatmap position");
-                    println!("{}, {}", heatmap_position.0, heatmap_position.1);
                 }
             }
         }
@@ -157,18 +155,11 @@ impl SearchSuggestor {
             y_position = (self.heatmap_dimensions.1 / 2)
                 - (hypothesis_position.y.abs() * cells_per_meter as f32).round() as usize;
         }
-        if self.heatmap_dimensions.0 < x_position {
-            x_position = self.heatmap_dimensions.0;
-        }
-        if self.heatmap_dimensions.1 < y_position {
-            y_position = self.heatmap_dimensions.1;
-        }
-        if x_position >= 1 {
-            x_position -= 1;
-        }
-        if y_position >= 1 {
-            y_position -= 1;
-        }
+        x_position = x_position.clamp(0, self.heatmap_dimensions.0);
+        y_position = y_position.clamp(0, self.heatmap_dimensions.1);
+        x_position -= 1;
+        x_position -= 1;
+
         (x_position, y_position)
     }
 }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -1,11 +1,8 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
-use nalgebra::{Point2, DMatrix,};
-use types::{
-    ball_position::HypotheticalBallPosition,
-    field_dimensions::FieldDimensions, ball,
-};
+use nalgebra::{DMatrix, Point2};
+use types::{ball_position::HypotheticalBallPosition, field_dimensions::FieldDimensions};
 
 pub struct SearchSuggestor {
     heatmap: DMatrix<f32>,
@@ -26,50 +23,72 @@ pub struct CycleContext {
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
-    pub suggestest_search_position: MainOutput<Point2<f64>>,
+    pub suggestest_search_position: MainOutput<Point2<f32>>,
 }
 
 impl SearchSuggestor {
     pub fn new(_context: CreationContext) -> Result<Self> {
-        let dpi:usize = 5;
+        let dpi: usize = 5;
         Ok(Self {
-            heatmap: DMatrix::from_element(_context.field_dimensions.length as usize * dpi,  _context.field_dimensions.width as usize * dpi, 0.0),
+            heatmap: DMatrix::from_element(
+                _context.field_dimensions.length as usize * dpi,
+                _context.field_dimensions.width as usize * dpi,
+                0.0,
+            ),
         })
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-
+        let dpi = 5;
         self.update_heatmap(context.invalid_ball_positions, context.field_dimensions);
-        
+        let maximum_heat_heatmap_position = self.heatmap.iamax_full();
+        let suggestest_search_position = Point2::new(
+            maximum_heat_heatmap_position.0 as f32 / dpi as f32,
+            maximum_heat_heatmap_position.1 as f32 / dpi as f32,
+        );
 
-        Ok(MainOutputs{
-            suggestest_search_position: ,
-        }
-        )
+        Ok(MainOutputs {
+            suggestest_search_position: suggestest_search_position.into(),
+        })
     }
 
-    fn update_heatmap(&mut self, invalid_ball_positions: &Vec<HypotheticalBallPosition>, field_dimensions: &FieldDimensions,){
-        let dpi:usize = 5;
-        for ball_hypothesis in invalid_ball_positions{
-            self.heatmap[self.calculate_heatmap_position(ball_hypothesis.position, dpi, field_dimensions)] = ball_hypothesis.validity;
+    fn update_heatmap(
+        &mut self,
+        invalid_ball_positions: &Vec<HypotheticalBallPosition>,
+        field_dimensions: &FieldDimensions,
+    ) {
+        let dpi: usize = 5;
+        let heatmap_decay_factor = 0.99;
+        for ball_hypothesis in invalid_ball_positions {
+            let heatmap_position =
+                self.calculate_heatmap_position(ball_hypothesis.position, dpi, field_dimensions);
+            self.heatmap[heatmap_position] = ball_hypothesis.validity;
         }
+        self.heatmap = self.heatmap.clone() * heatmap_decay_factor;
     }
-    
-    fn calculate_heatmap_position(&mut self, hypothesis_position: Point2<f32>, dpi: usize, field_dimensions: &FieldDimensions)-> (usize, usize){
+
+    fn calculate_heatmap_position(
+        &mut self,
+        hypothesis_position: Point2<f32>,
+        dpi: usize,
+        field_dimensions: &FieldDimensions,
+    ) -> (usize, usize) {
         let row_count = field_dimensions.length as usize * dpi;
         let collum_count = field_dimensions.width as usize * dpi;
         let mut x_position: usize = 0;
         let mut y_position: usize = 0;
         if hypothesis_position.x > 0.0 {
-            x_position = (row_count/2)  + (hypothesis_position.x * dpi as f32).round() as usize;
+            x_position = (row_count / 2) + (hypothesis_position.x * dpi as f32).round() as usize;
         } else if hypothesis_position.x < 0.0 {
-            x_position = (hypothesis_position.x.abs() * dpi as f32).round() as usize;     
+            x_position =
+                (row_count / 2) - (hypothesis_position.x.abs() * dpi as f32).round() as usize;
         }
         if hypothesis_position.y > 0.0 {
-            y_position = (row_count/2)  + (hypothesis_position.y * dpi as f32).round() as usize;
+            y_position = (collum_count / 2) + (hypothesis_position.y * dpi as f32).round() as usize;
         } else if hypothesis_position.y < 0.0 {
-            y_position = (hypothesis_position.y.abs() * dpi as f32).round() as usize;     
+            y_position =
+                (collum_count / 2) - (hypothesis_position.y.abs() * dpi as f32).round() as usize;
         }
-        return(x_position, y_position);
+        return (x_position, y_position);
     }
 }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -20,7 +20,6 @@ pub struct CreationContext {
 
 #[context]
 pub struct CycleContext {
-    //removed_ball_positions: Input<Vec<Point2<f32>>, "removed_ball_positions">,
     search_suggestor_configuration: Parameter<SearchSuggestorParameters, "search_suggestor">,
     ball_position: Input<Option<BallPosition>, "ball_position?">,
     invalid_ball_positions: Input<Vec<HypotheticalBallPosition>, "invalid_ball_positions">,
@@ -149,8 +148,12 @@ impl SearchSuggestor {
         if collum_count < y_position {
             y_position = collum_count;
         }
-        x_position -= 1;
-        y_position -= 1;
+        if x_position >= 1 {
+            x_position -= 1;
+        }
+        if y_position >= 1 {
+            y_position -= 1;
+        }
         (x_position, y_position)
     }
 }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -155,10 +155,14 @@ impl SearchSuggestor {
             y_position = (self.heatmap_dimensions.1 / 2)
                 - (hypothesis_position.y.abs() * cells_per_meter as f32).round() as usize;
         }
-        x_position = x_position.clamp(0, self.heatmap_dimensions.0);
-        y_position = y_position.clamp(0, self.heatmap_dimensions.1);
-        x_position -= 1;
-        x_position -= 1;
+        if x_position >= 1 {
+            x_position -= 1;
+        }
+        if y_position >= 1 {
+            y_position -= 1;
+        }
+        x_position = x_position.clamp(0, self.heatmap_dimensions.0 - 1);
+        y_position = y_position.clamp(0, self.heatmap_dimensions.1 - 1);
 
         (x_position, y_position)
     }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -56,7 +56,7 @@ impl SearchSuggestor {
         );
         let maximum_heat_heatmap_position = self.heatmap.iamax_full();
         let mut suggested_search_position: Option<Point2<f32>> = None;
-        if self.heatmap[maximum_heat_heatmap_position] > 0.1 {
+        if self.heatmap[maximum_heat_heatmap_position] > 0.001 {
             let mut search_suggestion = Point2::new(
                 maximum_heat_heatmap_position.0 as f32
                     / context.search_suggestor_configuration.cells_per_meter as f32,
@@ -136,6 +136,14 @@ impl SearchSuggestor {
             y_position = (collum_count / 2)
                 - (hypothesis_position.y.abs() * cells_per_meter as f32).round() as usize;
         }
+        if 0 >= x_position || row_count < x_position{
+            x_position = row_count;
+        } 
+        if 0 >= y_position || collum_count < y_position{
+            y_position = collum_count;
+        } 
+        x_position -= 1;
+        y_position -= 1;
         return (x_position, y_position);
     }
 }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -28,7 +28,7 @@ pub struct CycleContext {
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
-    pub suggestest_search_position: MainOutput<Point2<f32>>,
+    pub suggested_search_position: MainOutput<Point2<f32>>,
 }
 
 impl SearchSuggestor {
@@ -52,7 +52,7 @@ impl SearchSuggestor {
             context.search_suggestor_configuration.heatmap_decay_factor,
         );
         let maximum_heat_heatmap_position = self.heatmap.iamax_full();
-        let suggestest_search_position = Point2::new(
+        let suggested_search_position = Point2::new(
             maximum_heat_heatmap_position.0 as f32
                 / context.search_suggestor_configuration.cells_per_meter as f32,
             maximum_heat_heatmap_position.1 as f32
@@ -60,7 +60,7 @@ impl SearchSuggestor {
         );
 
         Ok(MainOutputs {
-            suggestest_search_position: suggestest_search_position.into(),
+            suggested_search_position: suggested_search_position.into(),
         })
     }
 

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -58,7 +58,9 @@ impl SearchSuggestor {
         );
         let maximum_heat_heatmap_position = self.heatmap.iamax_full();
         let mut suggested_search_position: Option<Point2<f32>> = None;
-        if self.heatmap[maximum_heat_heatmap_position] > 0.0001 {
+        if self.heatmap[maximum_heat_heatmap_position]
+            > context.search_suggestor_configuration.minimum_validity
+        {
             let mut search_suggestion = Point2::new(
                 maximum_heat_heatmap_position.0 as f32
                     / context.search_suggestor_configuration.cells_per_meter as f32,
@@ -141,14 +143,14 @@ impl SearchSuggestor {
             y_position = (collum_count / 2)
                 - (hypothesis_position.y.abs() * cells_per_meter as f32).round() as usize;
         }
-        if 0 >= x_position || row_count < x_position {
+        if row_count < x_position {
             x_position = row_count;
         }
-        if 0 >= y_position || collum_count < y_position {
+        if collum_count < y_position {
             y_position = collum_count;
         }
         x_position -= 1;
         y_position -= 1;
-        return (x_position, y_position);
+        (x_position, y_position)
     }
 }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -86,7 +86,7 @@ impl SearchSuggestor {
                 suggested_search_position = Some(search_suggestion);
             }
         } else {
-            println!("Invalid maximum heatmap position")
+            println!("Invalid maximum heatmap position");
         }
         context.heatmap.fill_if_subscribed(|| self.heatmap.clone());
 
@@ -114,7 +114,8 @@ impl SearchSuggestor {
                 if self.heatmap.get(ball_heatmap_position).is_some() {
                     self.heatmap[ball_heatmap_position] = 1.0;
                 } else {
-                    println!("Invalid ball heatmap position")
+                    println!("Invalid ball heatmap position");
+                    println!("{}, {}", ball_heatmap_position.0, ball_heatmap_position.1);
                 }
             }
         }
@@ -129,6 +130,7 @@ impl SearchSuggestor {
                     (self.heatmap[heatmap_position] + ball_hypothesis.validity) / 2.0;
             } else {
                 println!("Invalid hypothesis heatmap position");
+                println!("{}, {}", heatmap_position.0, heatmap_position.1);
             }
         }
         self.heatmap = self.heatmap.clone() * heatmap_decay_factor;

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -84,6 +84,12 @@ impl SearchSuggestor {
                 } else {
                     search_suggestion.y = width_half - search_suggestion.y
                 }
+
+                search_suggestion.x +=
+                    context.search_suggestor_configuration.cells_per_meter as f32 / 2.0;
+                search_suggestion.y -=
+                    context.search_suggestor_configuration.cells_per_meter as f32 / 2.0;
+
                 suggested_search_position = Some(search_suggestion);
             }
         } else {
@@ -131,7 +137,7 @@ impl SearchSuggestor {
                 }
             }
         }
-        self.heatmap = self.heatmap.clone() * heatmap_decay_factor;
+        self.heatmap = self.heatmap.clone() * (1.0 - heatmap_decay_factor);
     }
 
     fn calculate_heatmap_position(

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -86,9 +86,9 @@ impl SearchSuggestor {
                 }
 
                 search_suggestion.x +=
-                    context.search_suggestor_configuration.cells_per_meter as f32 / 2.0;
-                search_suggestion.y -=
-                    context.search_suggestor_configuration.cells_per_meter as f32 / 2.0;
+                    1.0 / context.search_suggestor_configuration.cells_per_meter as f32 / 2.0;
+                search_suggestion.y +=
+                    1.0 / context.search_suggestor_configuration.cells_per_meter as f32 / 2.0;
 
                 suggested_search_position = Some(search_suggestion);
             }

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -29,8 +29,7 @@ pub struct CycleContext {
     filtered_game_controller_state:
         Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
-    suggested_search_position: Input<Option<Point2<f32>>, "suggested_search_position?">,
-    robot_to_field: Input<Option<Isometry2<f32>>, "robot_to_field?">,
+    suggested_search_position: Input<Option<Point2<Field>>, "suggested_search_position?">,
     kick_decisions: Input<Option<Vec<KickDecision>>, "kick_decisions?">,
     instant_kick_decisions: Input<Option<Vec<KickDecision>>, "instant_kick_decisions?">,
 

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -29,6 +29,9 @@ pub struct CycleContext {
     filtered_game_controller_state:
         Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
+    suggested_search_position: Input<Option<Point2<f32>>, "suggested_search_position?">,
+    filtered_game_state: Input<Option<FilteredGameState>, "filtered_game_state?">,
+    robot_to_field: Input<Option<Isometry2<f32>>, "robot_to_field?">,
     kick_decisions: Input<Option<Vec<KickDecision>>, "kick_decisions?">,
     instant_kick_decisions: Input<Option<Vec<KickDecision>>, "instant_kick_decisions?">,
 
@@ -68,10 +71,10 @@ impl WorldStateComposer {
         let world_state = WorldState {
             ball: context.ball.copied(),
             rule_ball: context.rule_ball.copied(),
+            suggested_search_position: context.suggested_search_position.copied(),
             obstacles: context.obstacles.clone(),
             rule_obstacles: context.rule_obstacles.clone(),
             position_of_interest: *context.position_of_interest,
-            suggested_search_position: *context.suggested_search_position,
             robot,
             kick_decisions: context.kick_decisions.cloned(),
             instant_kick_decisions: context.instant_kick_decisions.cloned(),

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -41,6 +41,7 @@ pub struct CycleContext {
     primary_state: Input<PrimaryState, "primary_state">,
     role: Input<Role, "role">,
     position_of_interest: Input<Point2<Ground>, "position_of_interest">,
+    suggested_search_position: Input<Point2<f32>, "suggested_search_position">,
 }
 
 #[context]
@@ -70,6 +71,7 @@ impl WorldStateComposer {
             obstacles: context.obstacles.clone(),
             rule_obstacles: context.rule_obstacles.clone(),
             position_of_interest: *context.position_of_interest,
+            suggested_search_position: *context.suggested_search_position,
             robot,
             kick_decisions: context.kick_decisions.cloned(),
             instant_kick_decisions: context.instant_kick_decisions.cloned(),

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -30,7 +30,6 @@ pub struct CycleContext {
         Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
     suggested_search_position: Input<Option<Point2<f32>>, "suggested_search_position?">,
-    filtered_game_state: Input<Option<FilteredGameState>, "filtered_game_state?">,
     robot_to_field: Input<Option<Isometry2<f32>>, "robot_to_field?">,
     kick_decisions: Input<Option<Vec<KickDecision>>, "kick_decisions?">,
     instant_kick_decisions: Input<Option<Vec<KickDecision>>, "instant_kick_decisions?">,
@@ -44,7 +43,6 @@ pub struct CycleContext {
     primary_state: Input<PrimaryState, "primary_state">,
     role: Input<Role, "role">,
     position_of_interest: Input<Point2<Ground>, "position_of_interest">,
-    suggested_search_position: Input<Point2<f32>, "suggested_search_position">,
 }
 
 #[context]

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -74,6 +74,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "control::primary_state_filter",
                     "control::role_assignment",
                     "control::rule_obstacle_composer",
+                    "control::search_suggestor",
                     "control::sole_pressure_filter",
                     "control::sonar_filter",
                     "control::support_foot_estimation",

--- a/crates/serialize_hierarchy/src/not_supported.rs
+++ b/crates/serialize_hierarchy/src/not_supported.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use nalgebra::{Isometry2, Isometry3, Rotation3, SMatrix, UnitComplex, UnitQuaternion, DMatrix};
+use nalgebra::{DMatrix, Isometry2, Isometry3, Rotation3, SMatrix, UnitComplex, UnitQuaternion};
 use serde::{Deserializer, Serializer};
 
 use crate::{error::Error, SerializeHierarchy};

--- a/crates/serialize_hierarchy/src/not_supported.rs
+++ b/crates/serialize_hierarchy/src/not_supported.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use nalgebra::{Isometry2, Isometry3, Rotation3, SMatrix, UnitComplex, UnitQuaternion};
+use nalgebra::{Isometry2, Isometry3, Rotation3, SMatrix, UnitComplex, UnitQuaternion, DMatrix};
 use serde::{Deserializer, Serializer};
 
 use crate::{error::Error, SerializeHierarchy};
@@ -97,6 +97,7 @@ implement_as_not_supported!(u32);
 implement_as_not_supported!(u64);
 implement_as_not_supported!(usize);
 // nalgebra
+implement_as_not_supported!(DMatrix<f32>);
 implement_as_not_supported!(SMatrix<f32, 3, 3>);
 implement_as_not_supported!(SMatrix<f32, 3, 4>);
 implement_as_not_supported!(Isometry2<f32>);

--- a/crates/types/src/ball_position.rs
+++ b/crates/types/src/ball_position.rs
@@ -23,7 +23,7 @@ impl<Frame> Default for BallPosition<Frame> {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, SerializeHierarchy)]
-pub struct HypotheticalBallPosition {
-    pub position: Point2<f32>,
+pub struct HypotheticalBallPosition<Frame> {
+    pub position: Point2<Frame>,
     pub validity: f32,
 }

--- a/crates/types/src/ball_position.rs
+++ b/crates/types/src/ball_position.rs
@@ -21,3 +21,9 @@ impl<Frame> Default for BallPosition<Frame> {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, SerializeHierarchy)]
+pub struct HypotheticalBallPosition {
+    pub position: Point2<f32>,
+    pub validity: f32,
+}

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -371,36 +371,6 @@ pub struct FallProtectionParameters {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
-pub struct ProjectedLimbsParameters {
-    pub torso_bounding_polygon: Vec<Point3<f32>>,
-    pub lower_arm_bounding_polygon: Vec<Point3<f32>>,
-    pub upper_arm_bounding_polygon: Vec<Point3<f32>>,
-    pub knee_bounding_polygon: Vec<Point3<f32>>,
-    pub foot_bounding_polygon: Vec<Point3<f32>>,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
-pub struct RobotDetectionParameters {
-    pub enable: bool,
-    pub amount_of_segments_factor: f32,
-    pub amount_score_exponent: f32,
-    pub cluster_cone_radius: f32,
-    pub cluster_distance_score_range: Range<f32>,
-    pub detection_box_width: f32,
-    pub ignore_ball_segments: bool,
-    pub ignore_line_segments: bool,
-    pub luminance_score_exponent: f32,
-    pub maximum_cluster_distance: f32,
-    pub minimum_cluster_score: f32,
-    pub minimum_consecutive_segments: usize,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
-pub struct PenaltyShotDirectionEstimationParameters {
-    pub moving_distance_threshold: f32,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
 pub struct SearchSuggestorParameters {
     pub cells_per_meter: usize,
     pub heatmap_decay_factor: f32,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -308,6 +308,7 @@ pub struct BallFilterParameters {
     pub initial_covariance: Vector4<f32>,
     pub visible_validity_exponential_decay_factor: f32,
     pub hidden_validity_exponential_decay_factor: f32,
+    pub validity_output_threshold: f32,
     pub validity_discard_threshold: f32,
     pub velocity_decay_factor: f32,
     pub resting_ball_velocity_threshold: f32,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -372,7 +372,7 @@ pub struct FallProtectionParameters {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
 pub struct SearchSuggestorParameters {
-    pub cells_per_meter: usize,
+    pub cells_per_meter: f32,
     pub heatmap_decay_factor: f32,
     pub minimum_validity: f32,
 }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -404,4 +404,5 @@ pub struct PenaltyShotDirectionEstimationParameters {
 pub struct SearchSuggestorParameters {
     pub cells_per_meter: usize,
     pub heatmap_decay_factor: f32,
+    pub minimum_validity: f32,
 }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, time::Duration};
 
 use coordinate_systems::{Field, Ground};
 use linear_algebra::{Point2, Vector2};
-use nalgebra::{Vector3, Vector4};
+use nalgebra::{Point3, Vector3, Vector4};
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 
@@ -368,4 +368,40 @@ pub struct FallProtectionParameters {
     pub right_arm_positions: ArmJoints<f32>,
     pub arm_stiffness: f32,
     pub leg_stiffness: f32,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
+pub struct ProjectedLimbsParameters {
+    pub torso_bounding_polygon: Vec<Point3<f32>>,
+    pub lower_arm_bounding_polygon: Vec<Point3<f32>>,
+    pub upper_arm_bounding_polygon: Vec<Point3<f32>>,
+    pub knee_bounding_polygon: Vec<Point3<f32>>,
+    pub foot_bounding_polygon: Vec<Point3<f32>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
+pub struct RobotDetectionParameters {
+    pub enable: bool,
+    pub amount_of_segments_factor: f32,
+    pub amount_score_exponent: f32,
+    pub cluster_cone_radius: f32,
+    pub cluster_distance_score_range: Range<f32>,
+    pub detection_box_width: f32,
+    pub ignore_ball_segments: bool,
+    pub ignore_line_segments: bool,
+    pub luminance_score_exponent: f32,
+    pub maximum_cluster_distance: f32,
+    pub minimum_cluster_score: f32,
+    pub minimum_consecutive_segments: usize,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
+pub struct PenaltyShotDirectionEstimationParameters {
+    pub moving_distance_threshold: f32,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
+pub struct SearchSuggestorParameters {
+    pub cells_per_meter: usize,
+    pub heatmap_decay_factor: f32,
 }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, time::Duration};
 
 use coordinate_systems::{Field, Ground};
 use linear_algebra::{Point2, Vector2};
-use nalgebra::{Point3, Vector3, Vector4};
+use nalgebra::{Vector3, Vector4};
 use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 

--- a/crates/types/src/world_state.rs
+++ b/crates/types/src/world_state.rs
@@ -21,7 +21,7 @@ pub struct WorldState {
     pub obstacles: Vec<Obstacle>,
     pub rule_obstacles: Vec<RuleObstacle>,
     pub position_of_interest: Point2<Ground>,
-    pub suggested_search_position: Point2<f32>,
+    pub suggested_search_position: Option<Point2<f32>>,
     pub kick_decisions: Option<Vec<KickDecision>>,
     pub instant_kick_decisions: Option<Vec<KickDecision>>,
     pub robot: RobotState,

--- a/crates/types/src/world_state.rs
+++ b/crates/types/src/world_state.rs
@@ -21,6 +21,7 @@ pub struct WorldState {
     pub obstacles: Vec<Obstacle>,
     pub rule_obstacles: Vec<RuleObstacle>,
     pub position_of_interest: Point2<Ground>,
+    pub suggested_search_position: Point2<f32>,
     pub kick_decisions: Option<Vec<KickDecision>>,
     pub instant_kick_decisions: Option<Vec<KickDecision>>,
     pub robot: RobotState,

--- a/crates/types/src/world_state.rs
+++ b/crates/types/src/world_state.rs
@@ -21,7 +21,7 @@ pub struct WorldState {
     pub obstacles: Vec<Obstacle>,
     pub rule_obstacles: Vec<RuleObstacle>,
     pub position_of_interest: Point2<Ground>,
-    pub suggested_search_position: Option<Point2<f32>>,
+    pub suggested_search_position: Option<Point2<Field>>,
     pub kick_decisions: Option<Vec<KickDecision>>,
     pub instant_kick_decisions: Option<Vec<KickDecision>>,
     pub robot: RobotState,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1172,7 +1172,7 @@
   },
   "search_suggestor":{
     "cells_per_meter": 2,
-    "heatmap_decay_factor": 0.001,
-    "minimum_validity": 0.0001
+    "heatmap_decay_factor": 0.002,
+    "minimum_validity": 0.01
   }
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1171,8 +1171,8 @@
     "penaltykick_box_extension": 0.2
   },
   "search_suggestor":{
-    "cells_per_meter": 10,
-    "heatmap_decay_factor": 0.99,
+    "cells_per_meter": 1,
+    "heatmap_decay_factor": 0.01,
     "minimum_validity": 0.0001
   }
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1,5 +1,5 @@
 {
-  "whistle_detection": {
+    "whistle_detection": {
     "detection_band": {
       "start": 2000,
       "end": 4000
@@ -1169,5 +1169,9 @@
     "center_circle_obstacle_increase": 1.2,
     "free_kick_obstacle_radius": 0.75,
     "penaltykick_box_extension": 0.2
+  },
+  "search_suggestor":{
+    "cells_per_meter": 10,
+    "heatmap_decay_factor": 0.99
   }
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1171,7 +1171,7 @@
     "penaltykick_box_extension": 0.2
   },
   "search_suggestor":{
-    "cells_per_meter": 2,
+    "cells_per_meter": 2.0,
     "heatmap_decay_factor": 0.002,
     "minimum_validity": 0.01
   }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -328,7 +328,7 @@
   "ball_filter": {
     "hypothesis_timeout": {
       "nanos": 0,
-      "secs": 5
+      "secs": 20
     },
     "measurement_matching_distance": 1.0,
     "hypothesis_merge_distance": 1.0,
@@ -339,7 +339,8 @@
     "resting_ball_velocity_threshold": 0.25,
     "visible_validity_exponential_decay_factor": 0.96,
     "hidden_validity_exponential_decay_factor": 0.999,
-    "validity_discard_threshold": 0.5,
+    "validity_output_threshold": 1.0,
+    "validity_discard_threshold": 1.0e-7,
     "velocity_decay_factor": 0.99
   },
   "button_filter": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1,5 +1,5 @@
 {
-    "whistle_detection": {
+  "whistle_detection": {
     "detection_band": {
       "start": 2000,
       "end": 4000

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -339,8 +339,8 @@
     "resting_ball_velocity_threshold": 0.25,
     "visible_validity_exponential_decay_factor": 0.96,
     "hidden_validity_exponential_decay_factor": 0.999,
-    "validity_output_threshold": 1.0,
-    "validity_discard_threshold": 1.0e-7,
+    "validity_output_threshold": 10.0,
+    "validity_discard_threshold": 0.5,
     "velocity_decay_factor": 0.99
   },
   "button_filter": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1171,8 +1171,8 @@
     "penaltykick_box_extension": 0.2
   },
   "search_suggestor":{
-    "cells_per_meter": 1,
-    "heatmap_decay_factor": 0.01,
+    "cells_per_meter": 2,
+    "heatmap_decay_factor": 0.001,
     "minimum_validity": 0.0001
   }
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1172,6 +1172,7 @@
   },
   "search_suggestor":{
     "cells_per_meter": 10,
-    "heatmap_decay_factor": 0.99
+    "heatmap_decay_factor": 0.99,
+    "minimum_validity": 0.0001
   }
 }

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -1,0 +1,75 @@
+local inspect = require 'inspect'
+print("Hello world from lua!")
+
+function spawn_robot(number)
+    table.insert(state.robots, create_robot(number))
+end
+
+-- spawn_robot(1)
+-- spawn_robot(2)
+-- spawn_robot(3)
+-- spawn_robot(4)
+-- spawn_robot(5)
+-- spawn_robot(6)
+spawn_robot(7)
+
+local game_end_time = -1.0
+
+function on_goal()
+    print("Goal scored, resetting ball!")
+    print("Ball: " .. inspect(state.ball))
+    print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
+    state.ball = nil
+    game_end_time = state.cycle_count + 200
+end
+
+state.ball = {
+    position = { 0.0, 0.0 },
+    velocity = { 0.0, 0.0 },
+}
+
+function on_cycle()
+    if state.cycle_count % 1000 == 0 then
+        print(inspect(state))
+    end
+
+    if state.cycle_count == 100 then
+        state.game_controller_state.game_state = "Ready"
+        state.filtered_game_state = {
+            Ready = {
+                kicking_team = "Hulks"
+            }
+        }
+    end
+
+    if state.cycle_count == 1600 then
+        state.filtered_game_state.game_state = "Set"
+        state.filtered_game_state = "Set"
+    end
+
+    if state.cycle_count == 1700 then
+        state.filtered_game_state = {
+            Playing = {
+                ball_is_free = true
+            }
+        }
+    end
+
+    if state.cycle_count == 1900 then
+        state.ball = None
+    end
+
+    if state.cycle_count == 2500 then
+        state.ball = {
+            position = { -3.0, -2.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 6000 then
+        state.finished = true
+    end
+    if state.cycle_count == game_end_time then
+        state.finished = true
+    end
+end

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -33,6 +33,7 @@ function on_cycle()
         print(inspect(state))
     end
 
+    print(state.cycle_count)
     if state.cycle_count == 100 then
         state.game_controller_state.game_state = "Ready"
         state.filtered_game_state = {
@@ -56,15 +57,23 @@ function on_cycle()
     end
 
     if state.cycle_count == 1900 then
+        set_robot_pose(7, { -3, 0 }, 0)
+        state.ball = {
+            position = { -2.0, 0.0 },
+            velocity = { 9.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 2000 then
         state.ball = None
     end
 
-    if state.cycle_count == 2500 then
-        state.ball = {
-            position = { -3.0, -2.0 },
-            velocity = { 0.0, 0.0 },
-        }
-    end
+    -- if state.cycle_count == 2100 then
+    --     state.ball = {
+    --         position = { 3.0, 0.0 },
+    --         velocity = { 0.0, 0.0 },
+    --     }
+    -- end
 
     if state.cycle_count == 6000 then
         state.finished = true

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -33,7 +33,6 @@ function on_cycle()
         print(inspect(state))
     end
 
-    print(state.cycle_count)
     if state.cycle_count == 100 then
         state.game_controller_state.game_state = "Ready"
         state.filtered_game_state = {
@@ -67,13 +66,6 @@ function on_cycle()
     if state.cycle_count == 2000 then
         state.ball = None
     end
-
-    -- if state.cycle_count == 2100 then
-    --     state.ball = {
-    --         position = { 3.0, 0.0 },
-    --         velocity = { 0.0, 0.0 },
-    --     }
-    -- end
 
     if state.cycle_count == 6000 then
         state.finished = true

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -34,8 +34,7 @@ function on_cycle()
     end
 
     if state.cycle_count == 100 then
-        state.game_controller_state.game_state = "Ready"
-        state.filtered_game_state = {
+        state.filtered_game_controller_state.game_state = {
             Ready = {
                 kicking_team = "Hulks"
             }
@@ -43,14 +42,14 @@ function on_cycle()
     end
 
     if state.cycle_count == 1600 then
-        state.filtered_game_state.game_state = "Set"
-        state.filtered_game_state = "Set"
+        state.filtered_game_controller_state.game_state = "Set"
     end
 
     if state.cycle_count == 1700 then
-        state.filtered_game_state = {
+        state.filtered_game_controller_state.game_state = {
             Playing = {
-                ball_is_free = true
+                ball_is_free = true,
+                kick_off = true
             }
         }
     end

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -59,7 +59,7 @@ function on_cycle()
         set_robot_pose(7, { -3, 0 }, 0)
         state.ball = {
             position = { -2.0, 0.0 },
-            velocity = { 9.0, 0.0 },
+            velocity = { 9.0, 2.0 },
         }
     end
 

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -5,12 +5,6 @@ function spawn_robot(number)
     table.insert(state.robots, create_robot(number))
 end
 
--- spawn_robot(1)
--- spawn_robot(2)
--- spawn_robot(3)
--- spawn_robot(4)
--- spawn_robot(5)
--- spawn_robot(6)
 spawn_robot(7)
 
 local game_end_time = -1.0

--- a/tools/behavior_simulator/build.rs
+++ b/tools/behavior_simulator/build.rs
@@ -24,6 +24,7 @@ fn main() -> Result<()> {
                     "control::motion::look_around",
                     "control::role_assignment",
                     "control::rule_obstacle_composer",
+                    "control::search_suggestor",
                     "control::time_to_reach_kick_position",
                     "control::world_state_composer",
                 ],

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -116,9 +116,9 @@ impl BehaviorCycler {
             self.search_suggestor
                 .cycle(control::search_suggestor::CycleContext::new(
                     &parameters.search_suggestor,
-                    (|| Some(own_database.main_outputs.ball_position.as_ref()?))(),
+                    own_database.main_outputs.ball_position.as_ref(),
                     &own_database.main_outputs.invalid_ball_positions,
-                    (|| Some(own_database.main_outputs.robot_to_field.as_ref()?))(),
+                    own_database.main_outputs.robot_to_field.as_ref(),
                     &parameters.field_dimensions,
                     framework::AdditionalOutput::new(
                         true,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -123,6 +123,7 @@ impl BehaviorCycler {
                         true,
                         &mut own_database.additional_outputs.ball_search_heatmap,
                     ),
+                    &parameters.field_dimensions,
                 ))
                 .wrap_err("failed to execute cycle of `SearchSuggestor`")?
         };

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -119,7 +119,6 @@ impl BehaviorCycler {
                     own_database.main_outputs.ball_position.as_ref(),
                     &own_database.main_outputs.invalid_ball_positions,
                     own_database.main_outputs.ground_to_field.as_ref(),
-                    &parameters.field_dimensions,
                     framework::AdditionalOutput::new(
                         true,
                         &mut own_database.additional_outputs.ball_search_heatmap,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -120,6 +120,10 @@ impl BehaviorCycler {
                     &own_database.main_outputs.invalid_ball_positions,
                     (|| Some(own_database.main_outputs.robot_to_field.as_ref()?))(),
                     &parameters.field_dimensions,
+                    framework::AdditionalOutput::new(
+                        true,
+                        &mut own_database.additional_outputs.ball_search_heatmap,
+                    ),
                 ))
                 .wrap_err("failed to execute cycle of `SearchSuggestor`")?
         };

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -123,7 +123,6 @@ impl BehaviorCycler {
                         true,
                         &mut own_database.additional_outputs.ball_search_heatmap,
                     ),
-                    &parameters.field_dimensions,
                 ))
                 .wrap_err("failed to execute cycle of `SearchSuggestor`")?
         };

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -118,7 +118,7 @@ impl BehaviorCycler {
                     &parameters.search_suggestor,
                     own_database.main_outputs.ball_position.as_ref(),
                     &own_database.main_outputs.invalid_ball_positions,
-                    own_database.main_outputs.robot_to_field.as_ref(),
+                    own_database.main_outputs.ground_to_field.as_ref(),
                     &parameters.field_dimensions,
                     framework::AdditionalOutput::new(
                         true,
@@ -281,7 +281,6 @@ impl BehaviorCycler {
                         .as_ref(),
                     own_database.main_outputs.ground_to_field.as_ref(),
                     own_database.main_outputs.suggested_search_position.as_ref(),
-                    own_database.main_outputs.robot_to_field.as_ref(),
                     own_database.main_outputs.kick_decisions.as_ref(),
                     own_database.main_outputs.instant_kick_decisions.as_ref(),
                     &parameters.player_number,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -262,6 +262,7 @@ impl BehaviorCycler {
                     &own_database.main_outputs.primary_state,
                     &own_database.main_outputs.role,
                     &own_database.main_outputs.position_of_interest,
+                    &own_database.main_outputs.suggested_search_position,
                 ))
                 .wrap_err("failed to execute cycle of node `WorldStateComposer`")?;
             own_database.main_outputs.world_state = main_outputs.world_state.value;

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -9,6 +9,7 @@ use control::{
     motion::look_around::LookAround,
     role_assignment::{self, RoleAssignment},
     rule_obstacle_composer::RuleObstacleComposer,
+    search_suggestor::SearchSuggestor,
     time_to_reach_kick_position::{self, TimeToReachKickPosition},
     world_state_composer::{self, WorldStateComposer},
 };
@@ -36,6 +37,7 @@ pub struct Database {
 pub struct BehaviorCycler {
     hardware_interface: Arc<Interfake>,
     own_changed: Arc<Notify>,
+    search_suggestor: SearchSuggestor,
     active_vision: ActiveVision,
     ball_state_composer: BallStateComposer,
     behavior: Behavior,
@@ -53,6 +55,13 @@ impl BehaviorCycler {
         own_changed: Arc<Notify>,
         parameters: &Parameters,
     ) -> Result<Self> {
+        let search_suggestor = control::search_suggestor::SearchSuggestor::new(
+            control::search_suggestor::CreationContext::new(
+                &parameters.field_dimensions,
+                &parameters.search_suggestor,
+            ),
+        )
+        .wrap_err("failed to create node `SearchSuggestor`")?;
         let time_to_reach_kick_position =
             TimeToReachKickPosition::new(time_to_reach_kick_position::CreationContext {})
                 .wrap_err("failed to create node `TimeToReachKickPosition`")?;
@@ -83,6 +92,7 @@ impl BehaviorCycler {
         Ok(Self {
             hardware_interface,
             own_changed,
+            search_suggestor,
             active_vision,
             time_to_reach_kick_position,
             ball_state_composer,
@@ -102,6 +112,19 @@ impl BehaviorCycler {
         parameters: &Parameters,
         incoming_messages: BTreeMap<SystemTime, Vec<Option<&IncomingMessage>>>,
     ) -> Result<()> {
+        let main_outputs = {
+            self.search_suggestor
+                .cycle(control::search_suggestor::CycleContext::new(
+                    &parameters.search_suggestor,
+                    (|| Some(own_database.main_outputs.ball_position.as_ref()?))(),
+                    &own_database.main_outputs.invalid_ball_positions,
+                    &parameters.field_dimensions,
+                ))
+                .wrap_err("failed to execute cycle of `SearchSuggestor`")?
+        };
+        own_database.main_outputs.suggested_search_position =
+            main_outputs.suggested_search_position.value;
+
         if own_database
             .main_outputs
             .filtered_game_controller_state
@@ -252,6 +275,8 @@ impl BehaviorCycler {
                         .filtered_game_controller_state
                         .as_ref(),
                     own_database.main_outputs.ground_to_field.as_ref(),
+                    own_database.main_outputs.suggested_search_position.as_ref(),
+                    own_database.main_outputs.robot_to_field.as_ref(),
                     own_database.main_outputs.kick_decisions.as_ref(),
                     own_database.main_outputs.instant_kick_decisions.as_ref(),
                     &parameters.player_number,
@@ -262,7 +287,6 @@ impl BehaviorCycler {
                     &own_database.main_outputs.primary_state,
                     &own_database.main_outputs.role,
                     &own_database.main_outputs.position_of_interest,
-                    &own_database.main_outputs.suggested_search_position,
                 ))
                 .wrap_err("failed to execute cycle of node `WorldStateComposer`")?;
             own_database.main_outputs.world_state = main_outputs.world_state.value;

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -118,6 +118,7 @@ impl BehaviorCycler {
                     &parameters.search_suggestor,
                     (|| Some(own_database.main_outputs.ball_position.as_ref()?))(),
                     &own_database.main_outputs.invalid_ball_positions,
+                    (|| Some(own_database.main_outputs.robot_to_field.as_ref()?))(),
                     &parameters.field_dimensions,
                 ))
                 .wrap_err("failed to execute cycle of `SearchSuggestor`")?

--- a/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
+++ b/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
@@ -1,0 +1,55 @@
+use color_eyre::Result;
+use communication::client::{Cycler, CyclerOutput, Output};
+use eframe::epaint::Color32;
+use nalgebra::{DMatrix, Point2};
+use std::{str::FromStr, sync::Arc};
+use types::field_dimensions::FieldDimensions;
+
+use crate::{
+    nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+};
+
+pub struct BallSearchHeatmap {
+    ball_search_heatmap: ValueBuffer,
+}
+
+impl Layer for BallSearchHeatmap {
+    const NAME: &'static str = "Ball Search Heatmap";
+
+    fn new(nao: Arc<Nao>) -> Self {
+        let ball_search_heatmap = nao.subscribe_output(CyclerOutput {
+            cycler: Cycler::Control,
+            output: Output::Additional {
+                path: "ball_search_heatmap".to_string(),
+            },
+        });
+        Self {
+            ball_search_heatmap,
+        }
+    }
+
+    fn paint(&self, painter: &TwixPainter, field_dimensions: &FieldDimensions) -> Result<()> {
+        let heatmap: DMatrix<f32> = self.ball_search_heatmap.parse_latest()?;
+        let heatmap_dimensions = (heatmap.ncols(), heatmap.nrows());
+        let offset = (field_dimensions.length / 2.0, field_dimensions.width / 2.0);
+        let cell_width = field_dimensions.width / heatmap_dimensions.0 as f32;
+        let cell_length = field_dimensions.length / heatmap_dimensions.1 as f32;
+        for (x, row) in heatmap.row_iter().enumerate() {
+            for (y, value) in row.iter().enumerate() {
+                painter.rect_filled(
+                    Point2::new(
+                        x as f32 * cell_length - offset.0,
+                        y as f32 * cell_width - offset.1,
+                    ),
+                    Point2::new(
+                        (x + 1) as f32 * cell_length - offset.0,
+                        (y + 1) as f32 * cell_width - offset.1,
+                    ),
+                    Color32::from_rgba_unmultiplied(0, 0, 255, (value * 255.0) as u8),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
+++ b/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
@@ -1,7 +1,9 @@
 use color_eyre::Result;
 use communication::client::{Cycler, CyclerOutput, Output};
+use coordinate_systems::Field;
 use eframe::epaint::Color32;
-use nalgebra::{DMatrix, Point2};
+use linear_algebra::point;
+use nalgebra::DMatrix;
 use std::sync::Arc;
 use types::field_dimensions::FieldDimensions;
 
@@ -28,7 +30,11 @@ impl Layer for BallSearchHeatmap {
         }
     }
 
-    fn paint(&self, painter: &TwixPainter, field_dimensions: &FieldDimensions) -> Result<()> {
+    fn paint(
+        &self,
+        painter: &TwixPainter<Field>,
+        field_dimensions: &FieldDimensions,
+    ) -> Result<()> {
         let heatmap: DMatrix<f32> = self.ball_search_heatmap.parse_latest()?;
         let heatmap_dimensions = (heatmap.ncols(), heatmap.nrows());
         let offset = (field_dimensions.length / 2.0, field_dimensions.width / 2.0);
@@ -36,15 +42,17 @@ impl Layer for BallSearchHeatmap {
         let cell_length = field_dimensions.length / heatmap_dimensions.1 as f32;
         for (x, row) in heatmap.row_iter().enumerate() {
             for (y, value) in row.iter().enumerate() {
+                let first_point = point![
+                    x as f32 * cell_length - offset.0,
+                    y as f32 * cell_width - offset.1,
+                ];
+                let secound_point = point![
+                    (x + 1) as f32 * cell_length - offset.0,
+                    (y + 1) as f32 * cell_width - offset.1,
+                ];
                 painter.rect_filled(
-                    Point2::new(
-                        x as f32 * cell_length - offset.0,
-                        y as f32 * cell_width - offset.1,
-                    ),
-                    Point2::new(
-                        (x + 1) as f32 * cell_length - offset.0,
-                        (y + 1) as f32 * cell_width - offset.1,
-                    ),
+                    first_point,
+                    secound_point,
                     Color32::from_rgba_unmultiplied(0, 0, 255, ((value * 255.0) / 2.0) as u8),
                 );
             }

--- a/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
+++ b/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::Color32;
 use nalgebra::{DMatrix, Point2};
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 use types::field_dimensions::FieldDimensions;
 
 use crate::{

--- a/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
+++ b/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
@@ -15,7 +15,7 @@ pub struct BallSearchHeatmap {
     ball_search_heatmap: ValueBuffer,
 }
 
-impl Layer for BallSearchHeatmap {
+impl Layer<Field> for BallSearchHeatmap {
     const NAME: &'static str = "Ball Search Heatmap";
 
     fn new(nao: Arc<Nao>) -> Self {

--- a/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
+++ b/tools/twix/src/panels/map/layers/ball_search_heatmap.rs
@@ -45,7 +45,7 @@ impl Layer for BallSearchHeatmap {
                         (x + 1) as f32 * cell_length - offset.0,
                         (y + 1) as f32 * cell_width - offset.1,
                     ),
-                    Color32::from_rgba_unmultiplied(0, 0, 255, (value * 255.0) as u8),
+                    Color32::from_rgba_unmultiplied(0, 0, 255, ((value * 255.0) / 2.0) as u8),
                 );
             }
         }

--- a/tools/twix/src/panels/map/layers/mod.rs
+++ b/tools/twix/src/panels/map/layers/mod.rs
@@ -1,5 +1,6 @@
 mod ball_filter;
 mod ball_position;
+mod ball_search_heatmap;
 mod behavior_simulator;
 mod feet_detection;
 mod field;
@@ -16,6 +17,7 @@ mod robot_pose;
 pub use self::behavior_simulator::BehaviorSimulator;
 pub use ball_filter::BallFilter;
 pub use ball_position::BallPosition;
+pub use ball_search_heatmap::BallSearchHeatmap;
 pub use feet_detection::FeetDetection;
 pub use field::Field;
 pub use image_segments::ImageSegments;

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -78,6 +78,7 @@ pub struct MapPanel {
     feet_detection: EnabledLayer<layers::FeetDetection, Ground>,
     ball_filter: EnabledLayer<layers::BallFilter, Ground>,
     obstacle_filter: EnabledLayer<layers::ObstacleFilter, Ground>,
+    ball_search_heatmap: EnabledLayer<layers::BallSearchHeatmap, Field>,
 }
 
 impl Panel for MapPanel {
@@ -98,6 +99,7 @@ impl Panel for MapPanel {
         let feet_detection = EnabledLayer::new(nao.clone(), value, false);
         let ball_filter = EnabledLayer::new(nao.clone(), value, false);
         let obstacle_filter = EnabledLayer::new(nao.clone(), value, false);
+        let ball_search_heatmap = EnabledLayer::new(nao.clone(), value, false);
 
         let field_dimensions = nao.subscribe_parameter("field_dimensions");
         let ground_to_field =
@@ -123,6 +125,7 @@ impl Panel for MapPanel {
             feet_detection,
             ball_filter,
             obstacle_filter,
+            ball_search_heatmap,
         }
     }
 
@@ -143,6 +146,7 @@ impl Panel for MapPanel {
             "feet_detection": self.feet_detection.save(),
             "ball_filter": self.ball_filter.save(),
             "obstacle_filter": self.obstacle_filter.save(),
+            "ball_search_heatmap": self.obstacle_filter.save(),
         })
     }
 }
@@ -165,6 +169,7 @@ impl Widget for &mut MapPanel {
                 self.feet_detection.checkbox(ui);
                 self.ball_filter.checkbox(ui);
                 self.obstacle_filter.checkbox(ui);
+                self.ball_search_heatmap.checkbox(ui);
             });
             ComboBox::from_id_source("plot_type_selector")
                 .selected_text(format!("{:?}", self.current_plot_type))
@@ -240,7 +245,9 @@ impl Widget for &mut MapPanel {
         let _ = self
             .obstacle_filter
             .generic_paint(&painter, ground_to_field, &field_dimensions);
-
+        let _ =
+            self.ball_search_heatmap
+                .generic_paint(&painter, ground_to_field, &field_dimensions);
         self.apply_zoom_and_pan(ui, &mut painter, &response);
         if response.double_clicked() {
             self.transformation = Similarity2::identity();

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -67,6 +67,7 @@ pub struct MapPanel {
     field: EnabledLayer<layers::Field, Field>,
     image_segments: EnabledLayer<layers::ImageSegments, Ground>,
     lines: EnabledLayer<layers::Lines, Ground>,
+    ball_search_heatmap: EnabledLayer<layers::BallSearchHeatmap, Field>,
     line_correspondences: EnabledLayer<layers::LineCorrespondences, Field>,
     path_obstacles: EnabledLayer<layers::PathObstacles, Ground>,
     obstacles: EnabledLayer<layers::Obstacles, Ground>,
@@ -78,7 +79,6 @@ pub struct MapPanel {
     feet_detection: EnabledLayer<layers::FeetDetection, Ground>,
     ball_filter: EnabledLayer<layers::BallFilter, Ground>,
     obstacle_filter: EnabledLayer<layers::ObstacleFilter, Ground>,
-    ball_search_heatmap: EnabledLayer<layers::BallSearchHeatmap, Field>,
 }
 
 impl Panel for MapPanel {
@@ -89,6 +89,7 @@ impl Panel for MapPanel {
         let image_segments = EnabledLayer::new(nao.clone(), value, false);
         let line_correspondences = EnabledLayer::new(nao.clone(), value, false);
         let lines = EnabledLayer::new(nao.clone(), value, true);
+        let ball_search_heatmap = EnabledLayer::new(nao.clone(), value, false);
         let path_obstacles = EnabledLayer::new(nao.clone(), value, false);
         let obstacles = EnabledLayer::new(nao.clone(), value, false);
         let path = EnabledLayer::new(nao.clone(), value, false);
@@ -99,7 +100,6 @@ impl Panel for MapPanel {
         let feet_detection = EnabledLayer::new(nao.clone(), value, false);
         let ball_filter = EnabledLayer::new(nao.clone(), value, false);
         let obstacle_filter = EnabledLayer::new(nao.clone(), value, false);
-        let ball_search_heatmap = EnabledLayer::new(nao.clone(), value, false);
 
         let field_dimensions = nao.subscribe_parameter("field_dimensions");
         let ground_to_field =
@@ -115,6 +115,7 @@ impl Panel for MapPanel {
             image_segments,
             line_correspondences,
             lines,
+            ball_search_heatmap,
             path_obstacles,
             obstacles,
             path,
@@ -125,7 +126,6 @@ impl Panel for MapPanel {
             feet_detection,
             ball_filter,
             obstacle_filter,
-            ball_search_heatmap,
         }
     }
 
@@ -136,6 +136,7 @@ impl Panel for MapPanel {
             "image_segments": self.image_segments.save(),
             "line_correspondences": self.line_correspondences.save(),
             "lines": self.lines.save(),
+            "ball_search_heatmap": self.obstacle_filter.save(),
             "path_obstacles": self.path_obstacles.save(),
             "obstacles": self.obstacles.save(),
             "path": self.path.save(),
@@ -146,7 +147,6 @@ impl Panel for MapPanel {
             "feet_detection": self.feet_detection.save(),
             "ball_filter": self.ball_filter.save(),
             "obstacle_filter": self.obstacle_filter.save(),
-            "ball_search_heatmap": self.obstacle_filter.save(),
         })
     }
 }
@@ -159,6 +159,7 @@ impl Widget for &mut MapPanel {
                 self.image_segments.checkbox(ui);
                 self.line_correspondences.checkbox(ui);
                 self.lines.checkbox(ui);
+                self.ball_search_heatmap.checkbox(ui);
                 self.path_obstacles.checkbox(ui);
                 self.obstacles.checkbox(ui);
                 self.path.checkbox(ui);
@@ -169,7 +170,6 @@ impl Widget for &mut MapPanel {
                 self.feet_detection.checkbox(ui);
                 self.ball_filter.checkbox(ui);
                 self.obstacle_filter.checkbox(ui);
-                self.ball_search_heatmap.checkbox(ui);
             });
             ComboBox::from_id_source("plot_type_selector")
                 .selected_text(format!("{:?}", self.current_plot_type))
@@ -215,6 +215,9 @@ impl Widget for &mut MapPanel {
         let _ = self
             .lines
             .generic_paint(&painter, ground_to_field, &field_dimensions);
+        let _ =
+            self.ball_search_heatmap
+                .generic_paint(&painter, ground_to_field, &field_dimensions);
         let _ = self
             .path_obstacles
             .generic_paint(&painter, ground_to_field, &field_dimensions);
@@ -245,9 +248,6 @@ impl Widget for &mut MapPanel {
         let _ = self
             .obstacle_filter
             .generic_paint(&painter, ground_to_field, &field_dimensions);
-        let _ =
-            self.ball_search_heatmap
-                .generic_paint(&painter, ground_to_field, &field_dimensions);
         self.apply_zoom_and_pan(ui, &mut painter, &response);
         if response.double_clicked() {
             self.transformation = Similarity2::identity();


### PR DESCRIPTION
## Introduced Changes

Add a new note that outputs the most likely ball_position (suggested_ball_position) from a heat map, if the suggested_ball_position has a high enough validity
Change search behavior 
- After loosing the ball the offensive robots will now walk to the suggested_ball_position
- If there is no suggested_ball_position the robot will go back to the old search behavior
Add a heatmap layer in Twix 

## ToDo / Known Issues

- Testing of robot behavior with real robots in a test game
- Maybe some parameter changes

## Ideas for Next Iterations (Not This PR)

- Improve twix heatmap visual design
- Implement more changes to search behavior
- Lower heatmap validity for checked areas
- Set hypothesis for corner kicks, kick ins, etc.
- Better fake data for behavior-simulator

## How to Test

Run ball search Lua test files to see the implemented behavior
Let the Robot kick the ball across the field than hide it to see if he still walks to the last seen ball position
