### PR TITLE
Highlight via aliveness reachable NAOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4527,7 +4527,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
- "tracing",
  "windows-sys 0.48.0",
 ]
 
@@ -4700,6 +4699,7 @@ dependencies = [
 name = "twix"
 version = "0.2.0"
 dependencies = [
+ "aliveness",
  "bincode",
  "color-eyre",
  "communication",
@@ -5481,7 +5481,6 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
- "tokio",
  "tracing",
  "uds_windows",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ v4l = { version = "0.12.1", git = "https://github.com/HULKs/libv4l-rs", rev = "b
 vision = { path = "crates/vision" }
 walkdir = "2.3.2"
 webots = { version = "0.8.0" }
-zbus = { version = "3.7.0", features = ["tokio"] }
+zbus = { version = "3.7.0" }
 
 [profile.incremental]
 inherits = "release"

--- a/crates/aliveness/src/lib.rs
+++ b/crates/aliveness/src/lib.rs
@@ -113,3 +113,16 @@ pub async fn query_aliveness(
         }
     }
 }
+
+pub fn query_aliveness_sync(
+    timeout: Duration,
+    ips: Option<Vec<Ipv4Addr>>,
+) -> Result<Vec<(IpAddr, AlivenessState)>, AlivenessError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+    let inner = rt.block_on(query_aliveness(timeout, ips));
+
+    return inner;
+}

--- a/crates/aliveness/src/lib.rs
+++ b/crates/aliveness/src/lib.rs
@@ -113,16 +113,3 @@ pub async fn query_aliveness(
         }
     }
 }
-
-pub fn query_aliveness_sync(
-    timeout: Duration,
-    ips: Option<Vec<Ipv4Addr>>,
-) -> Result<Vec<(IpAddr, AlivenessState)>, AlivenessError> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-    let inner = rt.block_on(query_aliveness(timeout, ips));
-
-    return inner;
-}

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
+aliveness = { workspace = true }
 bincode = { workspace = true }
 color-eyre = { workspace = true }
 communication = { workspace = true }

--- a/tools/twix/src/completion_edit.rs
+++ b/tools/twix/src/completion_edit.rs
@@ -71,7 +71,7 @@ impl<'key> CompletionEdit<'key> {
     pub fn addresses(
         key: &'key mut String,
         numbers: RangeInclusive<u8>,
-        highlighted_ips: &Vec<IpAddr>,
+        highlighted_ips: &[IpAddr],
     ) -> Self {
         let completion_items: Vec<_> = chain!(
             once(CompletionEntry::new("localhost".to_string(), true)),

--- a/tools/twix/src/completion_edit.rs
+++ b/tools/twix/src/completion_edit.rs
@@ -1,4 +1,4 @@
-use std::{iter::once, ops::RangeInclusive};
+use std::{iter::once, net::IpAddr, ops::RangeInclusive};
 
 use communication::messages::Fields;
 use eframe::egui::{
@@ -44,13 +44,28 @@ impl<'key> CompletionEdit<'key> {
         }
     }
 
-    pub fn addresses(key: &'key mut String, numbers: RangeInclusive<u8>) -> Self {
-        let completion_items = chain!(
+    pub fn addresses(
+        key: &'key mut String,
+        numbers: RangeInclusive<u8>,
+        highlight: Option<&Vec<IpAddr>>,
+    ) -> Self {
+        use color_eyre::owo_colors::OwoColorize;
+
+        let mut completion_items: Vec<_> = chain!(
             once("localhost".to_string()),
             numbers.clone().map(|number| format!("10.1.24.{number}")),
             numbers.map(|number| format!("10.0.24.{number}"))
         )
         .collect();
+
+        if let Some(highlighted_ips) = highlight {
+            let highlighted_ips: Vec<_> = highlighted_ips.into_iter().map(|ip| ip.to_string()).collect();
+            for ip in completion_items.iter_mut() {
+                if highlighted_ips.contains(ip) {
+                    *ip = format!("{ip} {}", "✅");
+                }
+            }
+        }
 
         Self {
             hint_text: "Address",

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -112,7 +112,7 @@ impl ReachableNaos {
         let tx = self.tx.clone();
         let _guard = self.runtime.enter();
         spawn(async move {
-            if let Ok(ips) = query_aliveness(Duration::from_millis(800), None).await {
+            if let Ok(ips) = query_aliveness(Duration::from_millis(200), None).await {
                 let ips = ips.into_iter().map(|(ip, _)| ip).collect();
                 let _ = tx.send(ips);
             }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -37,7 +37,6 @@ use serde_json::{from_str, to_string, Value};
 use tokio::{
     runtime::{Builder, Runtime},
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-    task::spawn,
 };
 use visuals::Visuals;
 
@@ -110,8 +109,7 @@ impl ReachableNaos {
 
     pub fn query_reachability(&self) {
         let tx = self.tx.clone();
-        let _guard = self.runtime.enter();
-        spawn(async move {
+        self.runtime.spawn(async move {
             if let Ok(ips) = query_aliveness(Duration::from_millis(200), None).await {
                 let ips = ips.into_iter().map(|(ip, _)| ip).collect();
                 let _ = tx.send(ips);

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::{self, Display, Formatter},
-    net::{IpAddr, Ipv4Addr},
+    net::IpAddr,
     str::FromStr,
     sync::Arc,
     time::{Duration, SystemTime},
@@ -177,7 +177,7 @@ impl App for TwixApp {
                     let address_input = CompletionEdit::addresses(
                         &mut self.ip_address,
                         21..=37,
-                        Some(&self.reachable_ips),
+                        &self.reachable_ips,
                     )
                     .ui(ui);
                     if address_input.gained_focus() {
@@ -223,7 +223,10 @@ impl App for TwixApp {
                     }
                     let panel_input = CompletionEdit::new(
                         &mut self.panel_selection,
-                        SelectablePanel::registered(),
+                        SelectablePanel::registered()
+                            .into_iter()
+                            .map(|registered| registered.into())
+                            .collect(),
                         "Panel",
                     )
                     .ui(ui);


### PR DESCRIPTION
## Introduced Changes

This PR highlights the reachable NAOs in the address selection field in twix. The aliveness service is used for querying the reachability.

## ToDo / Known Issues

~~If no GUI update is done after selecting the address field (e.g. with no mouse or keyboard interaction), the highlight will not be applied.~~ - Fixed.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Start twix and select the address field. Observe the NAOs reachable via aliveness being highlighted in the dropdown list.
