### PR TITLE
Serialize hierarchy speedup

### DIFF
--- a/crates/communication/src/server/outputs/provider.rs
+++ b/crates/communication/src/server/outputs/provider.rs
@@ -408,8 +408,10 @@ mod tests {
             field_path == "a.b.c"
         }
 
-        fn get_fields() -> BTreeSet<String> {
-            ["a".to_string(), "a.b".to_string(), "a.b.c".to_string()].into()
+        fn fill_fields(fields: &mut BTreeSet<String>, _prefix: &str) {
+            fields.insert("a".to_string());
+            fields.insert("a.b".to_string());
+            fields.insert("a.b.c".to_string());
         }
     }
 

--- a/crates/communication/src/server/parameters/storage.rs
+++ b/crates/communication/src/server/parameters/storage.rs
@@ -240,8 +240,10 @@ mod tests {
             field_path == "a.b.c"
         }
 
-        fn get_fields() -> BTreeSet<String> {
-            ["a".to_string(), "a.b".to_string(), "a.b.c".to_string()].into()
+        fn fill_fields(fields: &mut BTreeSet<String>, _prefix: &str) {
+            fields.insert("a".to_string());
+            fields.insert("a.b".to_string());
+            fields.insert("a.b.c".to_string());
         }
     }
 

--- a/crates/communication/src/server/parameters/subscriptions.rs
+++ b/crates/communication/src/server/parameters/subscriptions.rs
@@ -391,8 +391,10 @@ mod tests {
             field_path == "a.b.c"
         }
 
-        fn get_fields() -> BTreeSet<String> {
-            ["a".to_string(), "a.b".to_string(), "a.b.c".to_string()].into()
+        fn fill_fields(fields: &mut BTreeSet<String>, _prefix: &str) {
+            fields.insert("a".to_string());
+            fields.insert("a.b".to_string());
+            fields.insert("a.b.c".to_string());
         }
     }
 

--- a/crates/geometry/src/two_line_segments.rs
+++ b/crates/geometry/src/two_line_segments.rs
@@ -38,7 +38,7 @@ impl SerializeHierarchy for TwoLineSegments {
     }
 
     fn get_fields() -> BTreeSet<String> {
-        [String::new()].into()
+        Default::default()
     }
 
     fn fill_fields(_fields: &mut BTreeSet<String>, _prefix: &str) {}

--- a/crates/geometry/src/two_line_segments.rs
+++ b/crates/geometry/src/two_line_segments.rs
@@ -40,4 +40,6 @@ impl SerializeHierarchy for TwoLineSegments {
     fn get_fields() -> BTreeSet<String> {
         [String::new()].into()
     }
+
+    fn fill_fields(_fields: &mut BTreeSet<String>, _prefix: &str) {}
 }

--- a/crates/serialize_hierarchy/src/implementation.rs
+++ b/crates/serialize_hierarchy/src/implementation.rs
@@ -34,10 +34,6 @@ where
         T::exists(path)
     }
 
-    fn get_fields() -> BTreeSet<String> {
-        T::get_fields()
-    }
-
     fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
         T::fill_fields(fields, prefix)
     }
@@ -71,10 +67,6 @@ where
 
     fn exists(path: &str) -> bool {
         T::exists(path)
-    }
-
-    fn get_fields() -> BTreeSet<String> {
-        T::get_fields()
     }
 
     fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
@@ -144,12 +136,6 @@ where
         }
     }
 
-    fn get_fields() -> BTreeSet<String> {
-        ["start".to_string(), "end".to_string()]
-            .into_iter()
-            .collect()
-    }
-
     fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
         fields.insert(format!("{prefix}start"));
         fields.insert(format!("{prefix}end"));
@@ -204,13 +190,6 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
         Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::get_fields().contains(path)
     }
 
-    fn get_fields() -> BTreeSet<String> {
-        ["x", "y", "z", "w", "v", "u"][0..N]
-            .iter()
-            .map(|path| String::from(*path))
-            .collect()
-    }
-
     fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
         for field in &["x", "y", "z", "w", "v", "u"][0..N] {
             fields.insert(format!("{prefix}{field}"));
@@ -241,10 +220,6 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar, const N: usize> Serialize
 
     fn exists(path: &str) -> bool {
         Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::exists(path)
-    }
-
-    fn get_fields() -> BTreeSet<String> {
-        Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::get_fields()
     }
 
     fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {

--- a/crates/serialize_hierarchy/src/implementation.rs
+++ b/crates/serialize_hierarchy/src/implementation.rs
@@ -37,6 +37,10 @@ where
     fn get_fields() -> BTreeSet<String> {
         T::get_fields()
     }
+
+    fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
+        T::fill_fields(fields, prefix)
+    }
 }
 
 impl<T> SerializeHierarchy for Option<T>
@@ -71,6 +75,10 @@ where
 
     fn get_fields() -> BTreeSet<String> {
         T::get_fields()
+    }
+
+    fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
+        T::fill_fields(fields, prefix)
     }
 }
 
@@ -141,6 +149,11 @@ where
             .into_iter()
             .collect()
     }
+
+    fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
+        fields.insert(format!("{prefix}start"));
+        fields.insert(format!("{prefix}end"));
+    }
 }
 
 impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
@@ -197,6 +210,12 @@ impl<T: Serialize + DeserializeOwned, const N: usize> SerializeHierarchy
             .map(|path| String::from(*path))
             .collect()
     }
+
+    fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
+        for field in &["x", "y", "z", "w", "v", "u"][0..N] {
+            fields.insert(format!("{prefix}{field}"));
+        }
+    }
 }
 
 impl<T: Serialize + DeserializeOwned + Clone + Scalar, const N: usize> SerializeHierarchy
@@ -226,5 +245,9 @@ impl<T: Serialize + DeserializeOwned + Clone + Scalar, const N: usize> Serialize
 
     fn get_fields() -> BTreeSet<String> {
         Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::get_fields()
+    }
+
+    fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str) {
+        Matrix::<T, Const<N>, U1, ArrayStorage<T, N, 1>>::fill_fields(fields, prefix)
     }
 }

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -28,7 +28,11 @@ pub trait SerializeHierarchy {
 
     fn exists(path: &str) -> bool;
 
-    fn get_fields() -> BTreeSet<String>;
+    fn get_fields() -> BTreeSet<String> {
+        let mut fields = BTreeSet::default();
+        Self::fill_fields(&mut fields, "");
+        fields
+    }
 
     fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str);
 }

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -29,6 +29,8 @@ pub trait SerializeHierarchy {
     fn exists(path: &str) -> bool;
 
     fn get_fields() -> BTreeSet<String>;
+
+    fn fill_fields(fields: &mut BTreeSet<String>, prefix: &str);
 }
 
 #[cfg(test)]

--- a/crates/serialize_hierarchy/src/not_supported.rs
+++ b/crates/serialize_hierarchy/src/not_supported.rs
@@ -47,6 +47,8 @@ macro_rules! implement_as_not_supported {
             fn get_fields() -> BTreeSet<String> {
                 Default::default()
             }
+
+            fn fill_fields(_fields: &mut BTreeSet<String>, _prefix: &str) {}
         }
     };
     ($type:ty, $generic:tt) => {
@@ -86,6 +88,8 @@ macro_rules! implement_as_not_supported {
             fn get_fields() -> BTreeSet<String> {
                 Default::default()
             }
+
+            fn fill_fields(_fields: &mut BTreeSet<String>, _prefix: &str) {}
         }
     };
 }

--- a/crates/serialize_hierarchy/src/not_supported.rs
+++ b/crates/serialize_hierarchy/src/not_supported.rs
@@ -44,10 +44,6 @@ macro_rules! implement_as_not_supported {
                 false
             }
 
-            fn get_fields() -> BTreeSet<String> {
-                Default::default()
-            }
-
             fn fill_fields(_fields: &mut BTreeSet<String>, _prefix: &str) {}
         }
     };
@@ -83,10 +79,6 @@ macro_rules! implement_as_not_supported {
 
             fn exists(_path: &str) -> bool {
                 false
-            }
-
-            fn get_fields() -> BTreeSet<String> {
-                Default::default()
             }
 
             fn fill_fields(_fields: &mut BTreeSet<String>, _prefix: &str) {}

--- a/crates/serialize_hierarchy_derive/src/lib.rs
+++ b/crates/serialize_hierarchy_derive/src/lib.rs
@@ -135,12 +135,6 @@ fn process_input(mut input: DeriveInput) -> TokenStream {
                 }
             }
 
-            fn get_fields() -> std::collections::BTreeSet<String> {
-                let mut fields = Default::default();
-                Self::fill_fields(&mut fields, "");
-                fields
-            }
-
             fn fill_fields(fields: &mut std::collections::BTreeSet<String>, prefix: &str)  {
                 #(#field_chains)*
                 #(#path_field_chains)*


### PR DESCRIPTION
## Introduced Changes

Improves compilation time of the types crate by ~30% by changing the way the field list for SerializeHierarchy is generated.

Also fixes a bug in the SerializeHierarchy implementation similar to #621 where a trailing `.` would have been generated.
However, this type currently does not show up in our generated hierarchy and thus doesn't change anything for now.

Fixes #

## Compilation Time Improvements

Compilation times of the `types` crate on my desktop PC in seconds.

| Branch                  | hot build | cold build | hot, T=8 | cold T=8 |
| ------------------------ | ------------- | -------------- |-------------| ------------- |
| main                      | 1.15         |  4.75          | 1.16       | 3.10         |
| PR                          | 0.85         |  3.05           | 1.02       | 1.85         |
| PR vs. main          | -26%        | -35%          | -12%      | -40%        |
| noop                     | 0.80         |  2.78           | 0.97       | 1.73         |
| theoretical limit  | 0.68         |  2.23           | 0.83       | 1.40         |

- main and PR should be self explanatory
- noop: replaced the generated function body of `fill_fields` with and empty one
- theoretical limit: removed all serialize hierarchy derives from the types crate

The `T=8` columns use 8 threads for compilation as described [here](https://blog.rust-lang.org/2023/11/09/parallel-rustc.html).

## Correctness

As we don't have testcases for this, I validated that the set of field paths generated is exactly the same as on main.
```sh
pepsi run &!
echo '{ "Parameters": { "GetFields": { "id": 0 } } }' | websocat ws://127.0.0.1:1337/ws | jq > $(git rev-parse --abbrev-ref HEAD).json
```

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)


## How to Test

I used these commands for my "hot" and "cold" build times:
For `T=8` I set `RUSTFLAGS="-Z threads=8"`

Run once to make sure all dependencies are built, then run n more times to measure results, I used n=5.

#### Hot

```sh
touch crates/types/src/lib.rs
cargo +nightly build -p types
```
It does not seem to matter which file is `touch`ed, the recompilation times stay the same.

#### Cold

```sh
cargo +nightly clean -p types
cargo +nightly build -p types
```
