### PR TITLE
Sorting stars

### DIFF
--- a/crates/communication/src/server/outputs/provider.rs
+++ b/crates/communication/src/server/outputs/provider.rs
@@ -314,12 +314,7 @@ async fn handle_notified_output(
                 (
                     client.response_sender,
                     Response::Textual(TextualResponse::Outputs(
-                        TextualOutputsResponse::SubscribedData {
-                            items: items
-                                .into_iter()
-                                .map(|(subscription_id, data)| (subscription_id, data))
-                                .collect(),
-                        },
+                        TextualOutputsResponse::SubscribedData { items },
                     )),
                 )
             }))

--- a/crates/control/src/a_star.rs
+++ b/crates/control/src/a_star.rs
@@ -76,7 +76,7 @@ impl Ord for Node {
 
 impl PartialOrd for Node {
     fn partial_cmp(&self, b: &Self) -> Option<Ordering> {
-        b.f.partial_cmp(&self.f)
+        Some(self.cmp(b))
     }
 }
 

--- a/crates/control/src/a_star.rs
+++ b/crates/control/src/a_star.rs
@@ -1,6 +1,6 @@
 // Modified version of https://github.com/amethyst/bracket-lib
 
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashMap};
 use std::convert::TryInto;
 
@@ -70,7 +70,7 @@ impl Eq for Node {}
 
 impl Ord for Node {
     fn cmp(&self, b: &Self) -> Ordering {
-        b.f.partial_cmp(&self.f).unwrap()
+        self.f.partial_cmp(&b.f).unwrap()
     }
 }
 
@@ -95,7 +95,7 @@ impl NavigationPath {
 struct AStar {
     start: usize,
     end: usize,
-    open_list: BinaryHeap<Node>,
+    open_list: BinaryHeap<Reverse<Node>>,
     closed_list: HashMap<usize, f32>,
     parents: HashMap<usize, (usize, f32)>, // (index, cost)
     step_counter: usize,
@@ -104,12 +104,12 @@ struct AStar {
 impl AStar {
     /// Creates a new path, with specified starting and ending indices.
     fn new(start: usize, end: usize) -> AStar {
-        let mut open_list: BinaryHeap<Node> = BinaryHeap::new();
-        open_list.push(Node {
+        let mut open_list = BinaryHeap::new();
+        open_list.push(Reverse(Node {
             idx: start,
             f: 0.0,
             g: 0.0,
-        });
+        }));
 
         AStar {
             start,
@@ -149,7 +149,7 @@ impl AStar {
         }
 
         if should_add {
-            self.open_list.push(s);
+            self.open_list.push(Reverse(s));
             self.parents.insert(idx, (q.idx, s.g));
         }
     }
@@ -178,7 +178,7 @@ impl AStar {
             self.step_counter += 1;
 
             // Pop Q off of the list
-            let q = self.open_list.pop().unwrap();
+            let q = self.open_list.pop().unwrap().0;
             if q.idx == self.end {
                 let success = self.found_it();
                 return success;

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -103,6 +103,7 @@ impl RoleAssignment {
             || primary_state == PrimaryState::Ready
             || primary_state == PrimaryState::Set
         {
+            #[allow(clippy::get_first)]
             let mut player_roles = Players {
                 one: Role::Keeper,
                 two: context.optional_roles.get(0).copied().unwrap_or_default(),

--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -401,7 +401,7 @@ impl TryFrom<RobotInfo> for Player {
     type Error = Report;
 
     fn try_from(player: RobotInfo) -> Result<Self> {
-        let remaining = Duration::from_secs(player.secsTillUnpenalised.try_into()?);
+        let remaining = Duration::from_secs(player.secsTillUnpenalised.into());
         Ok(Self {
             penalty: Penalty::try_from(remaining, player.penalty)?,
         })


### PR DESCRIPTION
## Introduced Changes

Replaces reversed `Ord` implemenation with a `Reverse` wrapper type in A* implementation.
The sorting has to be reversed such that the `BinaryHeap::pop()` always returns the node with the lowest cost value.

I accidentally fixed one of the lints in #631 incorrectly by inverting the result of the inverted `Ord` implementation again, resulting in an inconsistency between the `Ord` and `PartialOrd` implementations.
The [documentation for `BinaryHeap`](https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#min-heap) suggest either modifying the `Ord` implementation or using a `Reverse` wrapper. I'd argue the latter method leads to less confusion when trying to understand the code.

Fixes #
Based on #631

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

There should be no change, if this implementation is incorrect testcases for A* and pathplanning [fail](https://github.com/HULKs/hulk/actions/runs/6830353009/job/18578133174).
