### PR TITLE
Add new motor_commands_optimizer node to set hand stiffness to zero

### DIFF
--- a/crates/control/src/motion/command_sender.rs
+++ b/crates/control/src/motion/command_sender.rs
@@ -13,7 +13,7 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
-    motor_commands: Input<MotorCommands<f32>, "motor_commands">,
+    optimized_motor_commands: Input<MotorCommands<f32>, "optimized_motor_commands">,
     leds: Input<Leds, "leds">,
 
     motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
@@ -38,7 +38,7 @@ impl CommandSender {
         &mut self,
         mut context: CycleContext<impl ActuatorInterface>,
     ) -> Result<MainOutputs> {
-        let motor_commands = context.motor_commands;
+        let motor_commands = context.optimized_motor_commands;
 
         context
             .hardware_interface

--- a/crates/control/src/motion/mod.rs
+++ b/crates/control/src/motion/mod.rs
@@ -11,6 +11,7 @@ pub mod look_around;
 pub mod look_at;
 pub mod motion_selector;
 pub mod motor_commands_collector;
+pub mod motor_commands_optimizer;
 pub mod sit_down;
 pub mod stand_up_back;
 pub mod stand_up_front;

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -26,7 +26,7 @@ impl MotorCommandsOptimizer {
         Ok(Self {})
     }
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let mut motor_commands = context.motor_commands.clone();
+        let mut motor_commands = *context.motor_commands;
         motor_commands.stiffnesses.left_arm.hand = 0.0;
         motor_commands.stiffnesses.right_arm.hand = 0.0;
         Ok(MainOutputs {

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -1,0 +1,36 @@
+use color_eyre::Result;
+use context_attribute::context;
+use framework::MainOutput;
+use serde::{Deserialize, Serialize};
+use types::motor_commands::MotorCommands;
+
+#[derive(Deserialize, Serialize)]
+pub struct MotorCommandsOptimizer {}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    motor_commands: Input<MotorCommands<f32>, "motor_commands">,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub optimized_motor_commands: MainOutput<MotorCommands<f32>>,
+}
+
+impl MotorCommandsOptimizer {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {})
+    }
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        let mut motor_commands = context.motor_commands.clone();
+        motor_commands.stiffnesses.left_arm.hand = 0.0;
+        motor_commands.stiffnesses.right_arm.hand = 0.0;
+        Ok(MainOutputs {
+            optimized_motor_commands: motor_commands.into(),
+        })
+    }
+}

--- a/crates/hulk/build.rs
+++ b/crates/hulk/build.rs
@@ -59,6 +59,7 @@ fn main() -> Result<()> {
                     "control::motion::fall_protector",
                     "control::motion::head_motion",
                     "control::motion::motor_commands_collector",
+                    "control::motion::motor_commands_optimizer",
                     "control::motion::command_sender",
                     "control::motion::jump_left",
                     "control::motion::jump_right",


### PR DESCRIPTION
## Introduced Changes

Creates a new node "motor_commands_optimizer" which sets the hand stiffness in the motor commands to zero.

Fixes #558

## ToDo / Known Issues

None. Has been tested on nao.

## How to Test

Test on nao and check that hands are never stiff.
