### PR TITLE
Make timeout flag dependent on operating system

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -34,10 +34,15 @@ impl Nao {
         host: Ipv4Addr,
         timeout_seconds: u32,
     ) -> Result<Self> {
+        #[cfg(target_os = "macos")]
+        let timeout_flag = "-t";
+        #[cfg(not(target_os = "macos"))]
+        let timeout_flag = "-w";
+
         match Command::new("ping")
             .arg("-c")
             .arg("1")
-            .arg("-w")
+            .arg(timeout_flag)
             .arg(timeout_seconds.to_string())
             .arg(host.to_string())
             .output()

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -35,14 +35,14 @@ impl Nao {
         timeout_seconds: u32,
     ) -> Result<Self> {
         #[cfg(target_os = "macos")]
-        let timeout_flag = "-t";
+        const TIMEOUT_FLAG: &str = "-t";
         #[cfg(not(target_os = "macos"))]
-        let timeout_flag = "-w";
+        const TIMEOUT_FLAG: &str = "-w";
 
         match Command::new("ping")
             .arg("-c")
             .arg("1")
-            .arg(timeout_flag)
+            .arg(TIMEOUT_FLAG)
             .arg(timeout_seconds.to_string())
             .arg(host.to_string())
             .output()


### PR DESCRIPTION
## Introduced Changes

Timeout flag of ping is dependent on the os. Under MacOs ping doesn't have the -w flag, but has an equivalent -t flag. Changed this flag depending on the operating system.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

`./pepsi ping` on a linux and macos machine.
