### PR TITLE
Change 2.0 * PI to TAU

### DIFF
--- a/crates/filtering/src/low_pass_filter.rs
+++ b/crates/filtering/src/low_pass_filter.rs
@@ -1,5 +1,5 @@
 use std::{
-    f32::consts::PI,
+    f32::consts::{PI, TAU},
     ops::{Add, Mul, Sub},
 };
 

--- a/crates/filtering/src/orientation_filtering.rs
+++ b/crates/filtering/src/orientation_filtering.rs
@@ -187,7 +187,7 @@ fn calculate_initial_orientation(linear_acceleration: Vector3<f32>) -> UnitQuate
 
 #[cfg(test)]
 mod test {
-    use std::f32::consts::PI;
+    use std::f32::consts::{PI, TAU};
 
     use approx::assert_relative_eq;
     use nalgebra::vector;

--- a/crates/geometry/src/arc.rs
+++ b/crates/geometry/src/arc.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use approx::{AbsDiffEq, RelativeEq};
 use nalgebra::Point2;

--- a/crates/geometry/src/circle.rs
+++ b/crates/geometry/src/circle.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use approx::{AbsDiffEq, RelativeEq};
 use nalgebra::{distance, vector, Point2};

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -1,4 +1,4 @@
-use std::f32::consts::PI;
+use std::f32::consts::TAU;
 
 use approx::{AbsDiffEq, RelativeEq};
 use nalgebra::{vector, Point2, Vector2};


### PR DESCRIPTION
## Introduced Changes

All the 2.0 * PI is substituted with TAU.

## How to Test

See if all 2.0 * PI  is replaced by TAU.
