### PR TITLE
specify workspace.package information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ members = [
 # HuLA and Aliveness are built independently by yocto
 exclude = ["tools/aliveness", "tools/hula"]
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+homepage = "https://github.com/hulks/hulk"
+
 [workspace.dependencies]
 aliveness = { path = "crates/aliveness" }
 alsa = "0.7.0"

--- a/crates/aliveness/Cargo.toml
+++ b/crates/aliveness/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aliveness"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 futures-util = { workspace = true }

--- a/crates/approx_derive/Cargo.toml
+++ b/crates/approx_derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "approx_derive"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 proc-macro-error = { workspace = true }

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "audio"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/crates/calibration/Cargo.toml
+++ b/crates/calibration/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "calibration"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 levenberg-marquardt = { workspace = true }

--- a/crates/code_generation/Cargo.toml
+++ b/crates/code_generation/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "code_generation"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/communication/Cargo.toml
+++ b/crates/communication/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "communication"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 bincode = { workspace = true }

--- a/crates/constants/Cargo.toml
+++ b/crates/constants/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "constants"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]

--- a/crates/context_attribute/Cargo.toml
+++ b/crates/context_attribute/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "context_attribute"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 proc-macro-error = { workspace = true }

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "control"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 approx = { workspace = true }

--- a/crates/filtering/Cargo.toml
+++ b/crates/filtering/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "filtering"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 nalgebra = { workspace = true }

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "framework"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 parking_lot = { workspace = true }

--- a/crates/geometry/Cargo.toml
+++ b/crates/geometry/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "geometry"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 approx = { workspace = true }

--- a/crates/hardware/Cargo.toml
+++ b/crates/hardware/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hardware"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hulk"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 audio = { workspace = true }

--- a/crates/hulk_nao/Cargo.toml
+++ b/crates/hulk_nao/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hulk_nao"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 alsa = { workspace = true }

--- a/crates/hulk_webots/Cargo.toml
+++ b/crates/hulk_webots/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hulk_webots"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 chrono = { workspace = true }

--- a/crates/kinematics/Cargo.toml
+++ b/crates/kinematics/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "kinematics"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 nalgebra = { workspace = true }

--- a/crates/motionfile/Cargo.toml
+++ b/crates/motionfile/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "motionfile"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/crates/nao/Cargo.toml
+++ b/crates/nao/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nao"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/crates/nao_camera/Cargo.toml
+++ b/crates/nao_camera/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nao_camera"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 i2cdev = { workspace = true }

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "parameters"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/projection/Cargo.toml
+++ b/crates/projection/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "projection"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 nalgebra = { workspace = true }

--- a/crates/repository/Cargo.toml
+++ b/crates/repository/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "repository"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/crates/serialize_hierarchy/Cargo.toml
+++ b/crates/serialize_hierarchy/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serialize_hierarchy"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 bincode = { workspace = true }

--- a/crates/serialize_hierarchy_derive/Cargo.toml
+++ b/crates/serialize_hierarchy_derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serialize_hierarchy_derive"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 proc-macro-error = { workspace = true }

--- a/crates/source_analyzer/Cargo.toml
+++ b/crates/source_analyzer/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "source_analyzer"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 convert_case = { workspace = true }

--- a/crates/spl_network/Cargo.toml
+++ b/crates/spl_network/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "spl_network"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 bincode = { workspace = true }

--- a/crates/spl_network_messages/Cargo.toml
+++ b/crates/spl_network_messages/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "spl_network_messages"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [build-dependencies]
 bindgen = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "types"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 approx = { workspace = true }

--- a/crates/vision/Cargo.toml
+++ b/crates/vision/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "vision"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 approx = { workspace = true }

--- a/tools/aliveness/Cargo.toml
+++ b/tools/aliveness/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aliveness-service"
 version = "0.2.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 aliveness = { path = "../../crates/aliveness" }

--- a/tools/aliveness/Cargo.toml
+++ b/tools/aliveness/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aliveness-service"
 version = "0.2.0"
-edition.workspace = true
-license.workspace = true
-homepage.workspace = true
+edition = "2021"
+license = "GPL-3.0-only"
+homepage = "https://github.com/hulks/hulk"
 
 [dependencies]
 aliveness = { path = "../../crates/aliveness" }

--- a/tools/behavior_simulator/Cargo.toml
+++ b/tools/behavior_simulator/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-edition = "2021"
-license = "GPL-3.0-only"
 name = "behavior_simulator"
 version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [[bin]]
 name = "behavior_simulator"

--- a/tools/camera_matrix_extractor/Cargo.toml
+++ b/tools/camera_matrix_extractor/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "camera_matrix_extractor"
 version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/tools/depp/Cargo.toml
+++ b/tools/depp/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "depp"
 version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/tools/fanta/Cargo.toml
+++ b/tools/fanta/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "fanta"
 version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 clap = { workspace = true }

--- a/tools/localizer/Cargo.toml
+++ b/tools/localizer/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "localizer"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pepsi"
 version = "2.5.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 aliveness = { workspace = true }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "twix"
 version = "0.3.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 aliveness = { workspace = true }


### PR DESCRIPTION
## Introduced Changes

Replaces the package information of all crates in `/crates` with a central specification in the workspace.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

compile
