### PR TITLE
Use Footbumpers to spawn unseen obstacles

### DIFF
--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -91,9 +91,8 @@ impl FootBumperFilter {
             return Ok(MainOutputs::default());
         }
 
-        if context.sensor_data.touch_sensors.left_foot_left
-            || context.sensor_data.touch_sensors.left_foot_right
-        {
+        let touch_sensors = context.sensor_data.touch_sensors;
+        if touch_sensors.left_foot_left || touch_sensors.left_foot_right {
             if !self.left_pressed_last_cycle {
                 self.left_count += 1;
                 self.left_pressed_last_cycle = true;
@@ -103,9 +102,7 @@ impl FootBumperFilter {
             self.left_pressed_last_cycle = false;
         }
 
-        if context.sensor_data.touch_sensors.right_foot_left
-            || context.sensor_data.touch_sensors.right_foot_right
-        {
+        if touch_sensors.right_foot_left || touch_sensors.right_foot_right {
             if !self.right_pressed_last_cycle {
                 self.right_count += 1;
                 self.right_pressed_last_cycle = true;

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -6,7 +6,7 @@ use framework::{AdditionalOutput, MainOutput};
 use nalgebra::point;
 use types::{
     foot_bumper_obstacle::FootBumperObstacle, foot_bumper_values::FootBumperValues, CycleTime,
-    FallState, SensorData,
+    FallState, SensorData
 };
 
 pub struct FootBumperFilter {
@@ -54,10 +54,9 @@ impl FootBumperFilter {
     }
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
-        let foot_bumper_sensors = &context.sensor_data.force_sensitive_resistors;
         let fall_state = context.fall_state;
 
-        if foot_bumper_sensors.left.sum() > 1.0 {
+        if context.sensor_data.touch_sensors.left_foot_left || context.sensor_data.touch_sensors.left_foot_right {
             if !self.left_foot_bumper_pressed_last_cycle {
                 self.left_foot_bumper_count += 1;
                 self.left_foot_bumper_pressed_last_cycle = true;
@@ -67,7 +66,7 @@ impl FootBumperFilter {
             self.left_foot_bumper_pressed_last_cycle = false;
         }
 
-        if foot_bumper_sensors.right.sum() > 1.0 {
+        if context.sensor_data.touch_sensors.right_foot_left || context.sensor_data.touch_sensors.right_foot_right {
             if !self.right_foot_bumper_pressed_last_cycle {
                 self.right_foot_bumper_count += 1;
                 self.right_foot_bumper_pressed_last_cycle = true;

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -116,7 +116,11 @@ impl FootBumperFilter {
         }
 
         if let Some(last_left_foot_bumper_time) = self.last_left_time {
-            if last_left_foot_bumper_time.elapsed().expect("Time ran backwards") > *context.acceptance_duration {
+            if last_left_foot_bumper_time
+                .elapsed()
+                .expect("Time ran backwards")
+                > *context.acceptance_duration
+            {
                     self.last_left_time = None;
                     self.left_count = 0;
                     self.left_pressed_last_cycle = false;
@@ -124,7 +128,11 @@ impl FootBumperFilter {
         }
 
         if let Some(last_right_foot_bumper_time) = self.last_right_time {
-            if last_right_foot_bumper_time.elapsed().expect("Time ran backwards") > *context.acceptance_duration {
+            if last_right_foot_bumper_time
+                .elapsed()
+                .expect("Time ran backwards")
+                > *context.acceptance_duration
+            {
                     self.last_right_time = None;
                     self.right_count = 0;
                     self.right_pressed_last_cycle = false;

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -4,11 +4,13 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::point;
+use serde::{Deserialize, Serialize};
 use types::{
-    foot_bumper_obstacle::FootBumperObstacle, foot_bumper_values::FootBumperValues, CycleTime,
-    FallState, SensorData
+    cycle_time::CycleTime, fall_state::FallState, foot_bumper_obstacle::FootBumperObstacle,
+    foot_bumper_values::FootBumperValues, sensor_data::SensorData,
 };
 
+#[derive(Deserialize, Serialize)]
 pub struct FootBumperFilter {
     left_foot_bumper_count: i32,
     right_foot_bumper_count: i32,
@@ -56,7 +58,9 @@ impl FootBumperFilter {
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let fall_state = context.fall_state;
 
-        if context.sensor_data.touch_sensors.left_foot_left || context.sensor_data.touch_sensors.left_foot_right {
+        if context.sensor_data.touch_sensors.left_foot_left
+            || context.sensor_data.touch_sensors.left_foot_right
+        {
             if !self.left_foot_bumper_pressed_last_cycle {
                 self.left_foot_bumper_count += 1;
                 self.left_foot_bumper_pressed_last_cycle = true;
@@ -66,7 +70,9 @@ impl FootBumperFilter {
             self.left_foot_bumper_pressed_last_cycle = false;
         }
 
-        if context.sensor_data.touch_sensors.right_foot_left || context.sensor_data.touch_sensors.right_foot_right {
+        if context.sensor_data.touch_sensors.right_foot_left
+            || context.sensor_data.touch_sensors.right_foot_right
+        {
             if !self.right_foot_bumper_pressed_last_cycle {
                 self.right_foot_bumper_count += 1;
                 self.right_foot_bumper_pressed_last_cycle = true;

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -1,0 +1,159 @@
+use std::time::{Duration, SystemTime};
+
+use color_eyre::Result;
+use context_attribute::context;
+use framework::{AdditionalOutput, MainOutput};
+use nalgebra::point;
+use types::{
+    foot_bumper_obstacle::FootBumperObstacle, foot_bumper_values::FootBumperValues, CycleTime,
+    FallState, SensorData,
+};
+
+pub struct FootBumperFilter {
+    left_foot_bumper_count: i32,
+    right_foot_bumper_count: i32,
+    last_left_foot_bumper_time: Option<SystemTime>,
+    last_right_foot_bumper_time: Option<SystemTime>,
+    left_foot_bumper_pressed_last_cycle: bool,
+    right_foot_bumper_pressed_last_cycle: bool,
+}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    pub foot_bumper_values: AdditionalOutput<FootBumperValues, "foot_bumper_values">,
+    pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
+    pub acceptance_duration: Parameter<Duration, "foot_bumper_filter.acceptance_duration">,
+    pub activations_needed: Parameter<i32, "foot_bumper_filter.activations_needed">,
+    pub obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
+
+    pub cycle_time: Input<CycleTime, "cycle_time">,
+    pub fall_state: Input<FallState, "fall_state">,
+    pub sensor_data: Input<SensorData, "sensor_data">,
+    // Maybe consider kicks
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub foot_bumper_obstacle: MainOutput<Vec<FootBumperObstacle>>,
+}
+
+impl FootBumperFilter {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            left_foot_bumper_count: 0,
+            right_foot_bumper_count: 0,
+            last_left_foot_bumper_time: None,
+            last_right_foot_bumper_time: None,
+            left_foot_bumper_pressed_last_cycle: false,
+            right_foot_bumper_pressed_last_cycle: false,
+        })
+    }
+
+    pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
+        let foot_bumper_sensors = &context.sensor_data.force_sensitive_resistors;
+        let fall_state = context.fall_state;
+
+        if foot_bumper_sensors.left.sum() > 1.0 {
+            if !self.left_foot_bumper_pressed_last_cycle {
+                self.left_foot_bumper_count += 1;
+                self.left_foot_bumper_pressed_last_cycle = true;
+                self.last_left_foot_bumper_time = Some(SystemTime::now())
+            }
+        } else {
+            self.left_foot_bumper_pressed_last_cycle = false;
+        }
+
+        if foot_bumper_sensors.right.sum() > 1.0 {
+            if !self.right_foot_bumper_pressed_last_cycle {
+                self.right_foot_bumper_count += 1;
+                self.right_foot_bumper_pressed_last_cycle = true;
+                self.last_right_foot_bumper_time = Some(SystemTime::now())
+            }
+        } else {
+            self.right_foot_bumper_pressed_last_cycle = false;
+        }
+
+        if let Some(last_left_foot_bumper_time) = self.last_left_foot_bumper_time {
+            match last_left_foot_bumper_time.elapsed() {
+                Ok(last_left_foot_bumper_duration) => {
+                    if last_left_foot_bumper_duration > *context.acceptance_duration {
+                        self.last_left_foot_bumper_time = None;
+                        self.left_foot_bumper_count = 0;
+                        self.left_foot_bumper_pressed_last_cycle = false;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Duration elapsed failed: {e:?}");
+                    self.last_left_foot_bumper_time = None;
+                    self.left_foot_bumper_count = 0;
+                    self.left_foot_bumper_pressed_last_cycle = false;
+                }
+            }
+        }
+        if let Some(last_right_foot_bumper_time) = self.last_right_foot_bumper_time {
+            match last_right_foot_bumper_time.elapsed() {
+                Ok(last_right_foot_bumper_duration) => {
+                    if last_right_foot_bumper_duration > *context.acceptance_duration {
+                        self.last_right_foot_bumper_time = None;
+                        self.right_foot_bumper_count = 0;
+                        self.right_foot_bumper_pressed_last_cycle = false;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Duration elapsed failed: {e:?}");
+                    self.last_right_foot_bumper_time = None;
+                    self.right_foot_bumper_count = 0;
+                    self.right_foot_bumper_pressed_last_cycle = false;
+                }
+            }
+        }
+
+        let obstacle_detected_on_left = self.left_foot_bumper_count >= *context.activations_needed;
+        let obstacle_detected_on_right =
+            self.right_foot_bumper_count >= *context.activations_needed;
+
+        let left_point = point![
+            context.sensor_angle.cos() * *context.obstacle_distance,
+            context.sensor_angle.sin() * *context.obstacle_distance
+        ];
+        let right_point = point![
+            context.sensor_angle.cos() * *context.obstacle_distance,
+            -context.sensor_angle.sin() * *context.obstacle_distance
+        ];
+        let middle_point = point![*context.obstacle_distance, 0.0];
+
+        let obstacle_positions = match (
+            fall_state,
+            obstacle_detected_on_left,
+            obstacle_detected_on_right,
+        ) {
+            (FallState::Upright, true, true) => vec![middle_point],
+            (FallState::Upright, true, false) => vec![left_point],
+            (FallState::Upright, false, true) => vec![right_point],
+            _ => vec![],
+        };
+        let foot_bumper_obstacles: Vec<_> = obstacle_positions
+            .iter()
+            .map(|position_in_robot| FootBumperObstacle {
+                position_in_robot: *position_in_robot,
+            })
+            .collect();
+
+        context
+            .foot_bumper_values
+            .fill_if_subscribed(|| FootBumperValues {
+                left_foot_bumper_count: self.left_foot_bumper_count,
+                right_foot_bumper_count: self.right_foot_bumper_count,
+                obstacle_deteced_on_left: obstacle_detected_on_left,
+                obstacle_deteced_on_right: obstacle_detected_on_right,
+            });
+
+        Ok(MainOutputs {
+            foot_bumper_obstacle: foot_bumper_obstacles.into(),
+        })
+    }
+}

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -38,7 +38,7 @@ pub struct CycleContext {
     pub acceptance_duration: Parameter<Duration, "foot_bumper_filter.acceptance_duration">,
     pub activations_needed: Parameter<i32, "foot_bumper_filter.activations_needed">,
     pub buffer_size: Parameter<i32, "foot_bumper_filter.buffer_size">,
-    pub enabled: Parameter<bool, "foot_bumper_filter.enabled">,
+    pub enabled: Parameter<bool, "obstacle_filter.use_foot_bumper_measurements">,
     pub number_of_detections_in_buffer_for_defective_declaration: Parameter<
         i32,
         "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
@@ -146,7 +146,7 @@ impl FootBumperFilter {
         self.right_detection_buffer
             .push_back(obstacle_detected_on_right);
 
-        self.check_for_bumper_errors(&context);
+        // self.check_for_bumper_errors(&context);
 
         let obstacle_positions = match (
             fall_state,
@@ -189,6 +189,8 @@ impl FootBumperFilter {
             .count()
             .try_into()
             .unwrap();
+
+        dbg!(left_count);
         if left_count >= *context.number_of_detections_in_buffer_for_defective_declaration {
             self.left_in_use = false;
         }

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -10,18 +10,18 @@ use types::{
     foot_bumper_values::FootBumperValues, sensor_data::SensorData,
 };
 
-#[derive(Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct FootBumperFilter {
+    left_in_use: bool,
+    right_in_use: bool,
+    left_detection_buffer: VecDeque<bool>,
+    right_detection_buffer: VecDeque<bool>,
     left_count: i32,
     right_count: i32,
     last_left_time: Option<SystemTime>,
     last_right_time: Option<SystemTime>,
     left_pressed_last_cycle: bool,
     right_pressed_last_cycle: bool,
-    left_in_use: bool,
-    right_in_use: bool,
-    left_detection_buffer: VecDeque<bool>,
-    right_detection_buffer: VecDeque<bool>,
 }
 
 #[context]
@@ -29,23 +29,24 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
-    pub foot_bumper_values: AdditionalOutput<FootBumperValues, "foot_bumper_values">,
     pub acceptance_duration: Parameter<Duration, "foot_bumper_filter.acceptance_duration">,
     pub activations_needed: Parameter<i32, "foot_bumper_filter.activations_needed">,
     pub buffer_size: Parameter<i32, "foot_bumper_filter.buffer_size">,
     pub enabled: Parameter<bool, "foot_bumper_filter.enabled">,
     pub number_of_detections_in_buffer_for_defective_declaration: Parameter<
-        i32,
-        "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
+    i32,
+    "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
     >,
     pub number_of_detections_in_buffer_to_reset_in_use:
-        Parameter<i32, "foot_bumper_filter.number_of_detections_in_buffer_to_reset_in_use">,
+    Parameter<i32, "foot_bumper_filter.number_of_detections_in_buffer_to_reset_in_use">,
     pub obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
     pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
-
+    
     pub cycle_time: Input<CycleTime, "cycle_time">,
     pub fall_state: Input<FallState, "fall_state">,
     pub sensor_data: Input<SensorData, "sensor_data">,
+
+    pub foot_bumper_values: AdditionalOutput<FootBumperValues, "foot_bumper_values">,
 }
 
 #[context]
@@ -57,16 +58,11 @@ pub struct MainOutputs {
 impl FootBumperFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
-            left_count: 0,
-            right_count: 0,
-            last_left_time: None,
-            last_right_time: None,
-            left_pressed_last_cycle: false,
-            right_pressed_last_cycle: false,
             left_in_use: true,
             right_in_use: true,
             left_detection_buffer: VecDeque::with_capacity(15),
             right_detection_buffer: VecDeque::with_capacity(15),
+            ..Default::default()
         })
     }
 

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -1,10 +1,10 @@
-use std::time::{Duration, SystemTime};
-
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 use nalgebra::point;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::time::{Duration, SystemTime};
 use types::{
     cycle_time::CycleTime, fall_state::FallState, foot_bumper_obstacle::FootBumperObstacle,
     foot_bumper_values::FootBumperValues, sensor_data::SensorData,
@@ -12,12 +12,16 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct FootBumperFilter {
-    left_foot_bumper_count: i32,
-    right_foot_bumper_count: i32,
-    last_left_foot_bumper_time: Option<SystemTime>,
-    last_right_foot_bumper_time: Option<SystemTime>,
-    left_foot_bumper_pressed_last_cycle: bool,
-    right_foot_bumper_pressed_last_cycle: bool,
+    left_count: i32,
+    right_count: i32,
+    last_left_time: Option<SystemTime>,
+    last_right_time: Option<SystemTime>,
+    left_pressed_last_cycle: bool,
+    right_pressed_last_cycle: bool,
+    left_in_use: bool,
+    right_in_use: bool,
+    left_detection_buffer: VecDeque<bool>,
+    right_detection_buffer: VecDeque<bool>,
 }
 
 #[context]
@@ -26,15 +30,22 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     pub foot_bumper_values: AdditionalOutput<FootBumperValues, "foot_bumper_values">,
-    pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
     pub acceptance_duration: Parameter<Duration, "foot_bumper_filter.acceptance_duration">,
     pub activations_needed: Parameter<i32, "foot_bumper_filter.activations_needed">,
+    pub buffer_size: Parameter<i32, "foot_bumper_filter.buffer_size">,
+    pub enabled: Parameter<bool, "foot_bumper_filter.enabled">,
+    pub number_of_true_elements_in_buffer_for_defective_declaration: Parameter<
+        i32,
+        "foot_bumper_filter.number_of_true_elements_in_buffer_for_defective_declaration",
+    >,
+    pub number_of_true_elements_in_buffer_to_reset_in_use:
+        Parameter<i32, "foot_bumper_filter.number_of_true_elements_in_buffer_to_reset_in_use">,
     pub obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
+    pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
 
     pub cycle_time: Input<CycleTime, "cycle_time">,
     pub fall_state: Input<FallState, "fall_state">,
     pub sensor_data: Input<SensorData, "sensor_data">,
-    // Maybe consider kicks
 }
 
 #[context]
@@ -46,81 +57,119 @@ pub struct MainOutputs {
 impl FootBumperFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
-            left_foot_bumper_count: 0,
-            right_foot_bumper_count: 0,
-            last_left_foot_bumper_time: None,
-            last_right_foot_bumper_time: None,
-            left_foot_bumper_pressed_last_cycle: false,
-            right_foot_bumper_pressed_last_cycle: false,
+            left_count: 0,
+            right_count: 0,
+            last_left_time: None,
+            last_right_time: None,
+            left_pressed_last_cycle: false,
+            right_pressed_last_cycle: false,
+            left_in_use: true,
+            right_in_use: true,
+            left_detection_buffer: VecDeque::with_capacity(15),
+            right_detection_buffer: VecDeque::with_capacity(15),
         })
     }
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let fall_state = context.fall_state;
 
+        if !context.enabled {
+            return Ok(MainOutputs::default());
+        }
+
         if context.sensor_data.touch_sensors.left_foot_left
             || context.sensor_data.touch_sensors.left_foot_right
         {
-            if !self.left_foot_bumper_pressed_last_cycle {
-                self.left_foot_bumper_count += 1;
-                self.left_foot_bumper_pressed_last_cycle = true;
-                self.last_left_foot_bumper_time = Some(SystemTime::now())
+            if !self.left_pressed_last_cycle {
+                self.left_count += 1;
+                self.left_pressed_last_cycle = true;
+                self.last_left_time = Some(SystemTime::now());
             }
         } else {
-            self.left_foot_bumper_pressed_last_cycle = false;
+            self.left_pressed_last_cycle = false;
         }
 
         if context.sensor_data.touch_sensors.right_foot_left
             || context.sensor_data.touch_sensors.right_foot_right
         {
-            if !self.right_foot_bumper_pressed_last_cycle {
-                self.right_foot_bumper_count += 1;
-                self.right_foot_bumper_pressed_last_cycle = true;
-                self.last_right_foot_bumper_time = Some(SystemTime::now())
+            if !self.right_pressed_last_cycle {
+                self.right_count += 1;
+                self.right_pressed_last_cycle = true;
+                self.last_right_time = Some(SystemTime::now());
             }
         } else {
-            self.right_foot_bumper_pressed_last_cycle = false;
+            self.right_pressed_last_cycle = false;
         }
 
-        if let Some(last_left_foot_bumper_time) = self.last_left_foot_bumper_time {
+        if let Some(last_left_foot_bumper_time) = self.last_left_time {
             match last_left_foot_bumper_time.elapsed() {
                 Ok(last_left_foot_bumper_duration) => {
                     if last_left_foot_bumper_duration > *context.acceptance_duration {
-                        self.last_left_foot_bumper_time = None;
-                        self.left_foot_bumper_count = 0;
-                        self.left_foot_bumper_pressed_last_cycle = false;
+                        self.last_left_time = None;
+                        self.left_count = 0;
+                        self.left_pressed_last_cycle = false;
                     }
                 }
                 Err(e) => {
                     eprintln!("Duration elapsed failed: {e:?}");
-                    self.last_left_foot_bumper_time = None;
-                    self.left_foot_bumper_count = 0;
-                    self.left_foot_bumper_pressed_last_cycle = false;
+                    self.last_left_time = None;
+                    self.left_count = 0;
+                    self.left_pressed_last_cycle = false;
                 }
             }
         }
-        if let Some(last_right_foot_bumper_time) = self.last_right_foot_bumper_time {
+        if let Some(last_right_foot_bumper_time) = self.last_right_time {
             match last_right_foot_bumper_time.elapsed() {
                 Ok(last_right_foot_bumper_duration) => {
                     if last_right_foot_bumper_duration > *context.acceptance_duration {
-                        self.last_right_foot_bumper_time = None;
-                        self.right_foot_bumper_count = 0;
-                        self.right_foot_bumper_pressed_last_cycle = false;
+                        self.last_right_time = None;
+                        self.right_count = 0;
+                        self.right_pressed_last_cycle = false;
                     }
                 }
                 Err(e) => {
                     eprintln!("Duration elapsed failed: {e:?}");
-                    self.last_right_foot_bumper_time = None;
-                    self.right_foot_bumper_count = 0;
-                    self.right_foot_bumper_pressed_last_cycle = false;
+                    self.last_right_time = None;
+                    self.right_count = 0;
+                    self.right_pressed_last_cycle = false;
                 }
             }
         }
 
-        let obstacle_detected_on_left = self.left_foot_bumper_count >= *context.activations_needed;
-        let obstacle_detected_on_right =
-            self.right_foot_bumper_count >= *context.activations_needed;
+        let obstacle_detected_on_left = self.left_count >= *context.activations_needed;
+        let obstacle_detected_on_right = self.right_count >= *context.activations_needed;
+        self.left_detection_buffer
+            .push_back(obstacle_detected_on_left);
+        self.right_detection_buffer
+            .push_back(obstacle_detected_on_right);
 
+        let left_count: i32 = self
+            .left_detection_buffer
+            .iter()
+            .filter(|x| **x)
+            .count()
+            .try_into()
+            .unwrap();
+        if left_count >= *context.number_of_true_elements_in_buffer_for_defective_declaration {
+            self.left_in_use = false;
+        }
+        let right_count: i32 = self
+            .left_detection_buffer
+            .iter()
+            .filter(|x| **x)
+            .count()
+            .try_into()
+            .unwrap();
+        if right_count >= *context.number_of_true_elements_in_buffer_for_defective_declaration {
+            self.right_in_use = false;
+        }
+        if self.left_in_use == false && left_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use {
+            self.left_in_use = true;
+        }
+        if self.right_in_use == false && right_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use {
+            self.right_in_use = true;
+        }
+        
         let left_point = point![
             context.sensor_angle.cos() * *context.obstacle_distance,
             context.sensor_angle.sin() * *context.obstacle_distance
@@ -135,10 +184,12 @@ impl FootBumperFilter {
             fall_state,
             obstacle_detected_on_left,
             obstacle_detected_on_right,
+            self.left_in_use,
+            self.right_in_use,
         ) {
-            (FallState::Upright, true, true) => vec![middle_point],
-            (FallState::Upright, true, false) => vec![left_point],
-            (FallState::Upright, false, true) => vec![right_point],
+            (FallState::Upright, true, true, true, true) => vec![middle_point],
+            (FallState::Upright, true, false, true, _) => vec![left_point],
+            (FallState::Upright, false, true, _, true) => vec![right_point],
             _ => vec![],
         };
         let foot_bumper_obstacles: Vec<_> = obstacle_positions
@@ -151,8 +202,8 @@ impl FootBumperFilter {
         context
             .foot_bumper_values
             .fill_if_subscribed(|| FootBumperValues {
-                left_foot_bumper_count: self.left_foot_bumper_count,
-                right_foot_bumper_count: self.right_foot_bumper_count,
+                left_foot_bumper_count: self.left_count,
+                right_foot_bumper_count: self.right_count,
                 obstacle_deteced_on_left: obstacle_detected_on_left,
                 obstacle_deteced_on_right: obstacle_detected_on_right,
             });

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -34,12 +34,12 @@ pub struct CycleContext {
     pub activations_needed: Parameter<i32, "foot_bumper_filter.activations_needed">,
     pub buffer_size: Parameter<i32, "foot_bumper_filter.buffer_size">,
     pub enabled: Parameter<bool, "foot_bumper_filter.enabled">,
-    pub number_of_true_elements_in_buffer_for_defective_declaration: Parameter<
+    pub number_of_detections_in_buffer_for_defective_declaration: Parameter<
         i32,
-        "foot_bumper_filter.number_of_true_elements_in_buffer_for_defective_declaration",
+        "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
     >,
-    pub number_of_true_elements_in_buffer_to_reset_in_use:
-        Parameter<i32, "foot_bumper_filter.number_of_true_elements_in_buffer_to_reset_in_use">,
+    pub number_of_detections_in_buffer_to_reset_in_use:
+        Parameter<i32, "foot_bumper_filter.number_of_detections_in_buffer_to_reset_in_use">,
     pub obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
     pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
 
@@ -150,7 +150,7 @@ impl FootBumperFilter {
             .count()
             .try_into()
             .unwrap();
-        if left_count >= *context.number_of_true_elements_in_buffer_for_defective_declaration {
+        if left_count >= *context.number_of_detections_in_buffer_for_defective_declaration {
             self.left_in_use = false;
         }
         let right_count: i32 = self
@@ -160,16 +160,16 @@ impl FootBumperFilter {
             .count()
             .try_into()
             .unwrap();
-        if right_count >= *context.number_of_true_elements_in_buffer_for_defective_declaration {
+        if right_count >= *context.number_of_detections_in_buffer_for_defective_declaration {
             self.right_in_use = false;
         }
         if !self.left_in_use
-            && left_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use
+            && left_count <= *context.number_of_detections_in_buffer_to_reset_in_use
         {
             self.left_in_use = true;
         }
         if !self.right_in_use
-            && right_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use
+            && right_count <= *context.number_of_detections_in_buffer_to_reset_in_use
         {
             self.right_in_use = true;
         }

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -40,14 +40,14 @@ pub struct CycleContext {
     pub buffer_size: Parameter<i32, "foot_bumper_filter.buffer_size">,
     pub enabled: Parameter<bool, "foot_bumper_filter.enabled">,
     pub number_of_detections_in_buffer_for_defective_declaration: Parameter<
-    i32,
-    "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
+        i32,
+        "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
     >,
     pub number_of_detections_in_buffer_to_reset_in_use:
-    Parameter<i32, "foot_bumper_filter.number_of_detections_in_buffer_to_reset_in_use">,
+        Parameter<i32, "foot_bumper_filter.number_of_detections_in_buffer_to_reset_in_use">,
     pub obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
     pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
-    
+
     pub cycle_time: Input<CycleTime, "cycle_time">,
     pub fall_state: Input<FallState, "fall_state">,
     pub sensor_data: Input<SensorData, "sensor_data">,
@@ -121,9 +121,9 @@ impl FootBumperFilter {
                 .expect("Time ran backwards")
                 > *context.acceptance_duration
             {
-                    self.last_left_time = None;
-                    self.left_count = 0;
-                    self.left_pressed_last_cycle = false;
+                self.last_left_time = None;
+                self.left_count = 0;
+                self.left_pressed_last_cycle = false;
             }
         }
 
@@ -133,9 +133,9 @@ impl FootBumperFilter {
                 .expect("Time ran backwards")
                 > *context.acceptance_duration
             {
-                    self.last_right_time = None;
-                    self.right_count = 0;
-                    self.right_pressed_last_cycle = false;
+                self.last_right_time = None;
+                self.right_count = 0;
+                self.right_pressed_last_cycle = false;
             }
         }
 
@@ -146,6 +146,42 @@ impl FootBumperFilter {
         self.right_detection_buffer
             .push_back(obstacle_detected_on_right);
 
+        self.check_for_bumper_errors(&context);
+
+        let obstacle_positions = match (
+            fall_state,
+            obstacle_detected_on_left,
+            obstacle_detected_on_right,
+            self.left_in_use,
+            self.right_in_use,
+        ) {
+            (FallState::Upright, true, true, true, true) => vec![self.middle_point],
+            (FallState::Upright, true, false, true, _) => vec![self.left_point],
+            (FallState::Upright, false, true, _, true) => vec![self.right_point],
+            _ => vec![],
+        };
+        let foot_bumper_obstacles: Vec<_> = obstacle_positions
+            .iter()
+            .map(|position_in_robot| FootBumperObstacle {
+                position_in_robot: *position_in_robot,
+            })
+            .collect();
+
+        context
+            .foot_bumper_values
+            .fill_if_subscribed(|| FootBumperValues {
+                left_foot_bumper_count: self.left_count,
+                right_foot_bumper_count: self.right_count,
+                obstacle_deteced_on_left: obstacle_detected_on_left,
+                obstacle_deteced_on_right: obstacle_detected_on_right,
+            });
+
+        Ok(MainOutputs {
+            foot_bumper_obstacle: foot_bumper_obstacles.into(),
+        })
+    }
+
+    fn check_for_bumper_errors(&mut self, context: &CycleContext) {
         let left_count: i32 = self
             .left_detection_buffer
             .iter()
@@ -176,47 +212,5 @@ impl FootBumperFilter {
         {
             self.right_in_use = true;
         }
-
-        let left_point = point![
-            context.sensor_angle.cos() * *context.obstacle_distance,
-            context.sensor_angle.sin() * *context.obstacle_distance
-        ];
-        let right_point = point![
-            context.sensor_angle.cos() * *context.obstacle_distance,
-            -context.sensor_angle.sin() * *context.obstacle_distance
-        ];
-        let middle_point = point![*context.obstacle_distance, 0.0];
-
-        let obstacle_positions = match (
-            fall_state,
-            obstacle_detected_on_left,
-            obstacle_detected_on_right,
-            self.left_in_use,
-            self.right_in_use,
-        ) {
-            (FallState::Upright, true, true, true, true) => vec![middle_point],
-            (FallState::Upright, true, false, true, _) => vec![left_point],
-            (FallState::Upright, false, true, _, true) => vec![right_point],
-            _ => vec![],
-        };
-        let foot_bumper_obstacles: Vec<_> = obstacle_positions
-            .iter()
-            .map(|position_in_robot| FootBumperObstacle {
-                position_in_robot: *position_in_robot,
-            })
-            .collect();
-
-        context
-            .foot_bumper_values
-            .fill_if_subscribed(|| FootBumperValues {
-                left_foot_bumper_count: self.left_count,
-                right_foot_bumper_count: self.right_count,
-                obstacle_deteced_on_left: obstacle_detected_on_left,
-                obstacle_deteced_on_right: obstacle_detected_on_right,
-            });
-
-        Ok(MainOutputs {
-            foot_bumper_obstacle: foot_bumper_obstacles.into(),
-        })
     }
 }

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -97,38 +97,22 @@ impl FootBumperFilter {
             self.right_pressed_last_cycle = false;
         }
 
+
+        
+
         if let Some(last_left_foot_bumper_time) = self.last_left_time {
-            match last_left_foot_bumper_time.elapsed() {
-                Ok(last_left_foot_bumper_duration) => {
-                    if last_left_foot_bumper_duration > *context.acceptance_duration {
-                        self.last_left_time = None;
-                        self.left_count = 0;
-                        self.left_pressed_last_cycle = false;
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Duration elapsed failed: {e:?}");
+            if last_left_foot_bumper_time.elapsed().expect("Time ran backwards") > *context.acceptance_duration {
                     self.last_left_time = None;
                     self.left_count = 0;
                     self.left_pressed_last_cycle = false;
-                }
             }
         }
+
         if let Some(last_right_foot_bumper_time) = self.last_right_time {
-            match last_right_foot_bumper_time.elapsed() {
-                Ok(last_right_foot_bumper_duration) => {
-                    if last_right_foot_bumper_duration > *context.acceptance_duration {
-                        self.last_right_time = None;
-                        self.right_count = 0;
-                        self.right_pressed_last_cycle = false;
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Duration elapsed failed: {e:?}");
+            if last_right_foot_bumper_time.elapsed().expect("Time ran backwards") > *context.acceptance_duration {
                     self.last_right_time = None;
                     self.right_count = 0;
                     self.right_pressed_last_cycle = false;
-                }
             }
         }
 

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -191,8 +191,6 @@ impl FootBumperFilter {
         }
         let right_count: usize = self.right_detection_buffer.iter().filter(|x| **x).count();
 
-        dbg!(right_count);
-
         if right_count >= *context.number_of_detections_in_buffer_for_defective_declaration {
             self.right_in_use = false;
         }
@@ -206,6 +204,5 @@ impl FootBumperFilter {
         {
             self.right_in_use = true;
         }
-        dbg!(self.right_in_use);
     }
 }

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -163,13 +163,17 @@ impl FootBumperFilter {
         if right_count >= *context.number_of_true_elements_in_buffer_for_defective_declaration {
             self.right_in_use = false;
         }
-        if self.left_in_use == false && left_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use {
+        if !self.left_in_use
+            && left_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use
+        {
             self.left_in_use = true;
         }
-        if self.right_in_use == false && right_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use {
+        if !self.right_in_use
+            && right_count <= *context.number_of_true_elements_in_buffer_to_reset_in_use
+        {
             self.right_in_use = true;
         }
-        
+
         let left_point = point![
             context.sensor_angle.cos() * *context.obstacle_distance,
             context.sensor_angle.sin() * *context.obstacle_distance

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -91,7 +91,7 @@ impl FootBumperFilter {
             return Ok(MainOutputs::default());
         }
 
-        let touch_sensors = context.sensor_data.touch_sensors;
+        let touch_sensors = &context.sensor_data.touch_sensors;
         if touch_sensors.left_foot_left || touch_sensors.left_foot_right {
             if !self.left_pressed_last_cycle {
                 self.left_count += 1;

--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -73,9 +73,9 @@ impl FootBumperFilter {
         ];
         let middle_point = point![*_context.obstacle_distance, 0.0];
         Ok(Self {
-            left_point: left_point,
-            right_point: right_point,
-            middle_point: middle_point,
+            left_point,
+            right_point,
+            middle_point,
             left_in_use: true,
             right_in_use: true,
             left_detection_buffer: VecDeque::with_capacity(15),

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -9,6 +9,7 @@ pub mod center_of_mass_provider;
 pub mod dribble_path_planner;
 pub mod fake_data;
 pub mod fall_state_estimation;
+pub mod foot_bumper_filter;
 pub mod game_controller_filter;
 pub mod game_controller_state_filter;
 pub mod ground_contact_detector;

--- a/crates/hulk/build.rs
+++ b/crates/hulk/build.rs
@@ -42,6 +42,7 @@ fn main() -> Result<()> {
                     "control::camera_matrix_calculator",
                     "control::center_of_mass_provider",
                     "control::fall_state_estimation",
+                    "control::foot_bumper_filter",
                     "control::game_controller_filter",
                     "control::game_controller_state_filter",
                     "control::ground_contact_detector",

--- a/crates/types/src/foot_bumper_obstacle.rs
+++ b/crates/types/src/foot_bumper_obstacle.rs
@@ -1,0 +1,8 @@
+use nalgebra::Point2;
+use serde::{Deserialize, Serialize};
+use serialize_hierarchy::SerializeHierarchy;
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]
+pub struct FootBumperObstacle {
+    pub position_in_robot: Point2<f32>,
+}

--- a/crates/types/src/foot_bumper_values.rs
+++ b/crates/types/src/foot_bumper_values.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+use serialize_hierarchy::SerializeHierarchy;
+
+#[derive(Default, Debug, Clone, SerializeHierarchy, Serialize, Deserialize)]
+pub struct FootBumperValues {
+    pub left_foot_bumper_count: i32,
+    pub right_foot_bumper_count: i32,
+    pub obstacle_deteced_on_left: bool,
+    pub obstacle_deteced_on_right: bool,
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -20,6 +20,8 @@ pub mod filtered_game_controller_state;
 pub mod filtered_game_state;
 pub mod filtered_segments;
 pub mod filtered_whistle;
+pub mod foot_bumper_obstacle;
+pub mod foot_bumper_values;
 pub mod game_controller_state;
 pub mod grayscale_image;
 pub mod hardware;

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -327,6 +327,7 @@ pub struct ObstacleFilterParameters {
     pub measurement_count_threshold: usize,
     pub use_feet_detection_measurements: bool,
     pub use_sonar_measurements: bool,
+    pub use_foot_bumper_measurements: bool,
     pub robot_obstacle_radius_at_hip_height: f32,
     pub robot_obstacle_radius_at_foot_height: f32,
     pub unknown_obstacle_radius: f32,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -53,10 +53,10 @@
   "foot_bumper_filter": {
     "activations_needed": 2,
     "acceptance_duration": { "nanos": 0, "secs": 1 },
-    "buffer_size": 15,
-    "number_of_detections_in_buffer_for_defective_declaration": 13,
+    "buffer_size": 25,
+    "number_of_detections_in_buffer_for_defective_declaration": 22,
     "number_of_detections_in_buffer_to_reset_in_use": 2,
-    "obstacle_distance": 0.15,
+    "obstacle_distance": 0.18,
     "sensor_angle": 0.3
   },
   "image_receiver": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -57,7 +57,7 @@
     "enabled": false,
     "number_of_detections_in_buffer_for_defective_declaration": 13,
     "number_of_detections_in_buffer_to_reset_in_use": 2,
-    "obstacle_distance": 0.02,
+    "obstacle_distance": 0.1,
     "sensor_angle": 0.1
   },
   "image_receiver": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -50,6 +50,12 @@
       "cc_optical_center": [0.5, 0.5]
     }
   },
+  "foot_bumper_filter": {
+    "activations_needed": 2,
+    "acceptance_duration": { "nanos": 0, "secs": 1 },
+    "obstacle_distance": 0.02,
+    "sensor_angle": 0.1
+  },
   "image_receiver": {
     "vision_top": {
       "resolution": 42,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -55,8 +55,8 @@
     "acceptance_duration": { "nanos": 0, "secs": 1 },
     "buffer_size": 15,
     "enabled": false,
-    "number_of_true_elements_in_buffer_for_defective_declaration": 13,
-    "number_of_true_elements_in_buffer_to_reset_in_use": 2,
+    "number_of_detections_in_buffer_for_defective_declaration": 13,
+    "number_of_detections_in_buffer_to_reset_in_use": 2,
     "obstacle_distance": 0.02,
     "sensor_angle": 0.1
   },

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -54,11 +54,10 @@
     "activations_needed": 2,
     "acceptance_duration": { "nanos": 0, "secs": 1 },
     "buffer_size": 15,
-    "enabled": false,
     "number_of_detections_in_buffer_for_defective_declaration": 13,
     "number_of_detections_in_buffer_to_reset_in_use": 2,
-    "obstacle_distance": 0.1,
-    "sensor_angle": 0.1
+    "obstacle_distance": 0.15,
+    "sensor_angle": 0.3
   },
   "image_receiver": {
     "vision_top": {
@@ -378,7 +377,7 @@
     "use_foot_bumper_measurements": true,
     "robot_obstacle_radius_at_hip_height": 0.2,
     "robot_obstacle_radius_at_foot_height": 0.2,
-    "unknown_obstacle_radius": 0.15,
+    "unknown_obstacle_radius": 0.125,
     "goal_post_obstacle_radius": 0.2
   },
   "role_assignment": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -371,6 +371,7 @@
     "measurement_count_threshold": 10,
     "use_feet_detection_measurements": true,
     "use_sonar_measurements": true,
+    "use_foot_bumper_measurements": true,
     "robot_obstacle_radius_at_hip_height": 0.2,
     "robot_obstacle_radius_at_foot_height": 0.2,
     "unknown_obstacle_radius": 0.15,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -53,6 +53,10 @@
   "foot_bumper_filter": {
     "activations_needed": 2,
     "acceptance_duration": { "nanos": 0, "secs": 1 },
+    "buffer_size": 15,
+    "enabled": false,
+    "number_of_true_elements_in_buffer_for_defective_declaration": 13,
+    "number_of_true_elements_in_buffer_to_reset_in_use": 2,
     "obstacle_distance": 0.02,
     "sensor_angle": 0.1
   },


### PR DESCRIPTION
## Introduced Changes

The robot makes use of the foot bumper to spawn obstacles it recognizes by stepping into it.

Fixes #502 , #510 

## ToDo / Known Issues

Needs to be tested in test games, to see potential issues

## Ideas for Next Iterations (Not This PR)
- Think about having different life times for sonar obstacles and footbumper obstacles
- Merge counter for center obstacles

## How to Test

Has to be enabled in config
Needs to be tested when you let a robot walk and observe in twix if it spawns no existing obstacles.
Tape one fottbumper to force constant triggering, and see if it does not spawn obstacles in that case.
