### PR TITLE
[NIX] Split dev shells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,46 +11,70 @@
     flake-utils.lib.eachDefaultSystem
       (system:
         let
-          pkgs = import nixpkgs { 
-            inherit system; 
+          pkgs = import nixpkgs {
+            inherit system;
             overlays = [ nixgl.overlay ];
           };
+
+          nao_sdk_version = "5.9.0";
+          nao_sdk_environment_path = "$HOME/.naosdk/${nao_sdk_version}/environment-setup-corei7-64-aldebaran-linux";
         in
         {
-          devShells.default = pkgs.mkShell
-            rec {
-              buildInputs = with pkgs;[
-                # Tools
-                cargo
-                rustc
-                rustfmt
-                cmake
-                pkg-config
-                llvmPackages.clang
-                python312
-                rsync
+          devShells = {
+            tools = pkgs.mkShell
+              rec {
+                buildInputs = with pkgs;[
+                  # Tools
+                  cargo
+                  rustc
+                  rustfmt
+                  cmake
+                  pkg-config
+                  llvmPackages.clang
+                  python312
+                  rsync
 
-                # Libs
-                luajit
-                systemdLibs
-                hdf5
-                alsa-lib
-                opusfile
-                libogg
-                libGL
-                libxkbcommon
-                wayland
-                xorg.libX11
-                xorg.libXcursor
-                xorg.libXi
-                xorg.libXrandr
-                pkgs.nixgl.auto.nixGLDefault
-              ];
-              env = {
-                LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
-                LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+                  # Libs
+                  luajit
+                  systemdLibs
+                  hdf5
+                  alsa-lib
+                  opusfile
+                  libogg
+                  libGL
+                  libxkbcommon
+                  wayland
+                  xorg.libX11
+                  xorg.libXcursor
+                  xorg.libXi
+                  xorg.libXrandr
+                  pkgs.nixgl.auto.nixGLDefault
+                  rustPlatform.bindgenHook
+                ];
+                env = {
+                  LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
+                  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+                };
               };
-            };
+
+
+            robot = (pkgs.buildFHSUserEnv {
+              name = "hulk-robot-dev-env";
+              targetPkgs = pkgs: ([]);
+              extraOutputsToInstall = [ "dev" ];
+              runScript = "bash";
+              profile = ''
+                if [[ ! -f "${nao_sdk_environment_path}" ]]; then
+                  echo "WARNING: nao sdk v${nao_sdk_version} not found! Please install it."
+                  exit 1
+                fi
+                echo "Unsetting LD_LIBRARY_PATH..."
+                unset LD_LIBRARY_PATH
+                echo "Sourcing nao sdk v${nao_sdk_version}..."
+                source ${nao_sdk_environment_path}
+              '';
+            }).env;
+          };
         }
       );
 }


### PR DESCRIPTION
## Introduced Changes
Splits dev shells into `tools` and `robot` allowing better dependency management.
Further, the naosdk will be sourced automatically when entering `robot` dev 

## ToDo / Known Issues
~~Maybe check if the nao sdk is already installed and print a warning if not.~~ Done.


## Ideas for Next Iterations (Not This PR)
Since the dev shells are completed the next step should be to build the tools and robot packages by nix command instead of using cargo directly. Something like `nix build twix` should be implemented.

## How to Test
For tools dev shell:
1. Enter shell by executing `nix develop .#tools --impure`
2. Build a tool like twix: `cargo b -p twix`
3. sit back and enjoy
4. execute twix. Use nixGl when on non-nixos setup

For robot dev shell:
1. Be sure the nao sdk is already installed
2. Enter shell by executing `nix develop .#robot`
3. Build a package that should run on the nao: `cargo b -p breeze`
4. Patch the binary to allow it ro run on the nao: `patchelf --set-interpreter /lib/ld-linux-x86-64.so.2 <path_to_binary>`
5. Copy the patched binary to the nao and execute it
6. profit
