### PR TITLE
Bump OS to 5.9.1

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -3,5 +3,5 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "5.9.0";
+pub const OS_VERSION: &str = "5.9.1";
 pub const SDK_VERSION: &str = "5.9.0";


### PR DESCRIPTION

## Introduced Changes

Update to 5.9.1 which replaces the NAO fan controller with breeze, our Rust implementation.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Flash a NAO