### PR TITLE
Fix Two Replacementkeeper

### DIFF
--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -289,7 +289,7 @@ impl RoleAssignment {
                         }
                     }
                     _ => {
-                        let previous_player = match context.player_number{
+                        let previous_player = match context.player_number {
                             PlayerNumber::Three => PlayerNumber::Two,
                             PlayerNumber::Four => PlayerNumber::Three,
                             PlayerNumber::Five => PlayerNumber::Four,

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -277,38 +277,23 @@ impl RoleAssignment {
             }
         }
         if self.role == Role::ReplacementKeeper {
-            if let Some(last_time_keeper_penalized) = self.last_time_player_was_penalized.one {
-                match context.player_number {
-                    PlayerNumber::Two => {
-                        let deny_replacement_keeper_switch = cycle_start_time
-                            .duration_since(last_time_keeper_penalized)
-                            .expect("Keeper/Replacmentkeeper was penalized in the Future")
-                            < *context.keeper_replacementkeeper_switch_time;
-                        if !send_spl_striker_message && deny_replacement_keeper_switch {
-                            new_role = Role::ReplacementKeeper;
-                        }
-                    }
-                    _ => {
-                        let previous_player = match context.player_number {
-                            PlayerNumber::Three => PlayerNumber::Two,
-                            PlayerNumber::Four => PlayerNumber::Three,
-                            PlayerNumber::Five => PlayerNumber::Four,
-                            PlayerNumber::Six => PlayerNumber::Five,
-                            PlayerNumber::Seven => PlayerNumber::Six,
-                            _ => PlayerNumber::One,
-                        };
-                        if let Some(last_time_player_penalized) =
-                            self.last_time_player_was_penalized[previous_player]
-                        {
-                            let deny_replacement_keeper_switch = cycle_start_time
-                                .duration_since(last_time_player_penalized)
-                                .expect("Keeper/Replacmentkeeper was penalized in the Future")
-                                < *context.keeper_replacementkeeper_switch_time;
-                            if !send_spl_striker_message && deny_replacement_keeper_switch {
-                                new_role = Role::ReplacementKeeper;
-                            }
-                        }
-                    }
+            let previous_player = match context.player_number {
+                PlayerNumber::Three => PlayerNumber::Two,
+                PlayerNumber::Four => PlayerNumber::Three,
+                PlayerNumber::Five => PlayerNumber::Four,
+                PlayerNumber::Six => PlayerNumber::Five,
+                PlayerNumber::Seven => PlayerNumber::Six,
+                _ => PlayerNumber::One,
+            };
+            if let Some(last_time_player_penalized) =
+                self.last_time_player_was_penalized[previous_player]
+            {
+                let deny_replacement_keeper_switch = cycle_start_time
+                    .duration_since(last_time_player_penalized)
+                    .expect("Keeper/Replacmentkeeper was penalized in the future")
+                    < *context.keeper_replacementkeeper_switch_time;
+                if !send_spl_striker_message && deny_replacement_keeper_switch {
+                    new_role = Role::ReplacementKeeper;
                 }
             }
         }
@@ -359,7 +344,7 @@ impl RoleAssignment {
                 .last_time_player_was_penalized
                 .clone()
                 .iter()
-                .map(|(playernumber, _systemtime)| playernumber)
+                .map(|(playernumber, ..)| playernumber)
             {
                 if game_controller_state.penalties[player].is_some() {
                     self.last_time_player_was_penalized[player] = Some(cycle_start_time);

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -280,9 +280,6 @@ impl RoleAssignment {
                             role = Role::ReplacementKeeper;
                         }
                     }
-                    PlayerNumber::One => {
-                        println!("Keeper is Replacmentkeeper")
-                    }
                     _ => {
                         if let Some(last_time_player_penalized) = self
                             .last_time_player_was_penalized[context.player_number.to_number() - 2]

--- a/crates/spl_network_messages/src/lib.rs
+++ b/crates/spl_network_messages/src/lib.rs
@@ -72,6 +72,35 @@ pub enum PlayerNumber {
     Seven,
 }
 
+impl PlayerNumber {
+    pub fn to_number(&self) -> usize {
+        match self {
+            PlayerNumber::One => 1,
+            PlayerNumber::Two => 2,
+            PlayerNumber::Three => 3,
+            PlayerNumber::Four => 4,
+            PlayerNumber::Five => 5,
+            PlayerNumber::Six => 6,
+            PlayerNumber::Seven => 7,
+        }
+    }
+    pub fn to_player_number(number: usize) -> Self {
+        match number {
+            1 => PlayerNumber::One,
+            2 => PlayerNumber::Two,
+            3 => PlayerNumber::Three,
+            4 => PlayerNumber::Four,
+            5 => PlayerNumber::Five,
+            6 => PlayerNumber::Six,
+            7 => PlayerNumber::Seven,
+            _ => {
+                println!("No valid Playernumber, corrected to 7");
+                PlayerNumber::Seven
+            }
+        }
+    }
+}
+
 impl Display for PlayerNumber {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         let number = match self {

--- a/crates/spl_network_messages/src/lib.rs
+++ b/crates/spl_network_messages/src/lib.rs
@@ -72,35 +72,6 @@ pub enum PlayerNumber {
     Seven,
 }
 
-impl PlayerNumber {
-    pub fn to_number(&self) -> usize {
-        match self {
-            PlayerNumber::One => 1,
-            PlayerNumber::Two => 2,
-            PlayerNumber::Three => 3,
-            PlayerNumber::Four => 4,
-            PlayerNumber::Five => 5,
-            PlayerNumber::Six => 6,
-            PlayerNumber::Seven => 7,
-        }
-    }
-    pub fn to_player_number(number: usize) -> Self {
-        match number {
-            1 => PlayerNumber::One,
-            2 => PlayerNumber::Two,
-            3 => PlayerNumber::Three,
-            4 => PlayerNumber::Four,
-            5 => PlayerNumber::Five,
-            6 => PlayerNumber::Six,
-            7 => PlayerNumber::Seven,
-            _ => {
-                println!("No valid Playernumber, corrected to 7");
-                PlayerNumber::Seven
-            }
-        }
-    }
-}
-
 impl Display for PlayerNumber {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         let number = match self {

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -13,7 +13,7 @@ spawn_robot(5)
 spawn_robot(6)
 spawn_robot(7)
 
-local game_end_time = -1.0
+local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -89,19 +89,19 @@ function on_cycle()
 
     if state.cycle_count == 3500 then
         unpenalize(2);
-        state.game_controller_state.penalties.one = nil;
+        state.game_controller_state.penalties.two = nil;
     end
 
 
 
-    if state.cycle_count == 4550 then
+    if state.cycle_count == 2550 then
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },
         }
     end
 
-    if state.cycle_count == game_end_time then
+    if state.cycle_count == 6000 then
         state.finished = true
     end
 end

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -33,30 +33,29 @@ function on_cycle()
     end
 
     if state.cycle_count == 100 then
-        state.game_controller_state.game_state = "Ready"
-        state.filtered_game_state = {
+        state.filtered_game_controller_state.game_state = {
             Ready = {
-                kicking_team = "Hulks"
+                kicking_team = "Hulks",
             }
         }
     end
 
     if state.cycle_count == 1600 then
-        state.filtered_game_state.game_state = "Set"
-        state.filtered_game_state = "Set"
+        state.filtered_game_controller_state.game_state = "Set"
     end
 
     if state.cycle_count == 1700 then
-        state.filtered_game_state = {
+        state.filtered_game_controller_state.game_state = {
             Playing = {
-                ball_is_free = true
+                ball_is_free = true,
+                kick_off = true
             }
         }
     end
 
     if state.cycle_count == 1750 then
         penalize(1);
-        state.game_controller_state.penalties.one = {
+        state.filtered_game_controller_state.penalties.one = {
             Manual = {
                 remaining = {
                     nanos = 0,
@@ -69,7 +68,7 @@ function on_cycle()
 
     if state.cycle_count == 2000 then
         penalize(2);
-        state.game_controller_state.penalties.two = {
+        state.filtered_game_controller_state.penalties.two = {
             Manual = {
                 remaining = {
                     nanos = 0,
@@ -89,7 +88,7 @@ function on_cycle()
 
     if state.cycle_count == 3500 then
         unpenalize(2);
-        state.game_controller_state.penalties.two = nil;
+        state.filtered_game_controller_state.penalties.two = nil;
     end
 
 

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -1,0 +1,107 @@
+local inspect = require 'inspect'
+print("Hello world from lua!")
+
+function spawn_robot(number)
+    table.insert(state.robots, create_robot(number))
+end
+
+spawn_robot(1)
+spawn_robot(2)
+spawn_robot(3)
+spawn_robot(4)
+spawn_robot(5)
+spawn_robot(6)
+spawn_robot(7)
+
+local game_end_time = -1.0
+
+function on_goal()
+    print("Goal scored, resetting ball!")
+    print("Ball: " .. inspect(state.ball))
+    print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
+    state.ball = nil
+    game_end_time = state.cycle_count + 200
+end
+
+function on_cycle()
+    if state.ball == nil and state.cycle_count % 1000 == 0 then
+        print(inspect(state))
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 100 then
+        state.game_controller_state.game_state = "Ready"
+        state.filtered_game_state = {
+            Ready = {
+                kicking_team = "Hulks"
+            }
+        }
+    end
+
+    if state.cycle_count == 1600 then
+        state.filtered_game_state.game_state = "Set"
+        state.filtered_game_state = "Set"
+    end
+
+    if state.cycle_count == 1700 then
+        state.filtered_game_state = {
+            Playing = {
+                ball_is_free = true
+            }
+        }
+    end
+
+    if state.cycle_count == 1750 then
+        penalize(1);
+        state.game_controller_state.penalties.one = {
+            Manual = {
+                remaining = {
+                    nanos = 0,
+                    secs = 50
+                },
+            }
+        };
+        set_robot_pose(1, { -3.2, 3 }, -1.5707963267948966);
+    end
+
+    if state.cycle_count == 2000 then
+        penalize(2);
+        state.game_controller_state.penalties.two = {
+            Manual = {
+                remaining = {
+                    nanos = 0,
+                    secs = 5
+                },
+            }
+        };
+        set_robot_pose(2, { -3.2, 3 }, -1.5707963267948966);
+    end
+
+    if state.cycle_count == 3550 then
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 3500 then
+        unpenalize(2);
+        state.game_controller_state.penalties.one = nil;
+    end
+
+
+
+    if state.cycle_count == 4550 then
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == game_end_time then
+        state.finished = true
+    end
+end

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -33,29 +33,21 @@ function on_cycle()
     end
 
     if state.cycle_count == 100 then
-        state.filtered_game_controller_state.game_state = {
-            Ready = {
-                kicking_team = "Hulks",
-            }
-        }
+        state.game_controller_state.game_state = "Ready"
+        state.game_controller_state.kicking_team = "Hulks"
     end
 
     if state.cycle_count == 1600 then
-        state.filtered_game_controller_state.game_state = "Set"
+        state.game_controller_state.game_state = "Set"
     end
 
     if state.cycle_count == 1700 then
-        state.filtered_game_controller_state.game_state = {
-            Playing = {
-                ball_is_free = true,
-                kick_off = true
-            }
-        }
+        state.game_controller_state.game_state = "Playing"
     end
 
     if state.cycle_count == 1750 then
         penalize(1);
-        state.filtered_game_controller_state.penalties.one = {
+        state.game_controller_state.penalties.one = {
             Manual = {
                 remaining = {
                     nanos = 0,
@@ -68,7 +60,7 @@ function on_cycle()
 
     if state.cycle_count == 2000 then
         penalize(2);
-        state.filtered_game_controller_state.penalties.two = {
+        state.game_controller_state.penalties.two = {
             Manual = {
                 remaining = {
                     nanos = 0,
@@ -85,7 +77,7 @@ function on_cycle()
             velocity = { 0.0, 0.0 },
         }
     end
-
+    
     if state.cycle_count == 2550 then
         state.ball = {
             position = { 0.0, 0.0 },
@@ -95,12 +87,12 @@ function on_cycle()
 
     if state.cycle_count == 3500 then
         unpenalize(2);
-        state.filtered_game_controller_state.penalties.two = nil;
+        state.game_controller_state.penalties.two = nil;
     end
 
     if state.cycle_count == 4500 then
         unpenalize(1);
-        state.filtered_game_controller_state.penalties.one = nil;
+        state.game_controller_state.penalties.one = nil;
     end
 
 

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -86,18 +86,16 @@ function on_cycle()
         }
     end
 
-    if state.cycle_count == 3500 then
-        unpenalize(2);
-        state.filtered_game_controller_state.penalties.two = nil;
-    end
-
-
-
     if state.cycle_count == 2550 then
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },
         }
+    end
+
+    if state.cycle_count == 3500 then
+        unpenalize(2);
+        state.filtered_game_controller_state.penalties.two = nil;
     end
 
     if state.cycle_count == 6000 then

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -72,7 +72,7 @@ function on_cycle()
             Manual = {
                 remaining = {
                     nanos = 0,
-                    secs = 5
+                    secs = 50
                 },
             }
         };
@@ -98,7 +98,13 @@ function on_cycle()
         state.filtered_game_controller_state.penalties.two = nil;
     end
 
-    if state.cycle_count == 6000 then
+    if state.cycle_count == 4500 then
+        unpenalize(1);
+        state.filtered_game_controller_state.penalties.one = nil;
+    end
+
+
+    if state.cycle_count == 8000 then
         state.finished = true
     end
 end


### PR DESCRIPTION
## Introduced Changes

Prevent two Replacmentkeepers at once
-Now the lowest number that is currently not penalized will claim replacement keeper
-Switch delay is now also implemented for Replacementkeeper to Replacementkeeper switching

Fixes #455 

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Check if you can still get two replacement keeper (Check out Issue #455, to see how this bug happens)
There is also a behaviortestfile in this pr in which this scenario is executed