### PR TITLE
Horizontal median for segmentation

### DIFF
--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -132,7 +132,7 @@ impl YCbCr422Image {
     pub fn zero(width: u32, height: u32) -> Self {
         assert!(
             width % 2 == 0,
-            "the Image type does not support odd widths. Dimensions were {width}x{height}",
+            "YCbCr422Image does not support odd widths because pixels are stored in pairs. Dimensions were {width}x{height}",
         );
         Self::from_ycbcr_buffer(
             width / 2,
@@ -142,6 +142,7 @@ impl YCbCr422Image {
     }
 
     pub fn from_ycbcr_buffer(width_422: u32, height: u32, buffer: Vec<YCbCr422>) -> Self {
+        assert_eq!(buffer.len() as u32, width_422 * height);
         Self {
             width_422,
             height,

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -752,7 +752,7 @@ mod tests {
                 row(2), // skipped
                 row(3),
                 row(3), // skipped
-                         // segment boundary will be here
+                        // segment boundary will be here
             ]
             .into_iter()
             .flatten()
@@ -906,7 +906,7 @@ mod tests {
                 row(0),
                 row(0), // skipped
 
-                         // segment boundary will be here
+                        // segment boundary will be here
             ]
             .into_iter()
             .flatten()
@@ -1165,7 +1165,7 @@ mod tests {
                 row(0),
                 row(0), // skipped
 
-                         // segment boundary will be here
+                        // segment boundary will be here
             ]
             .into_iter()
             .flatten()
@@ -1395,7 +1395,7 @@ mod tests {
                 row(15), // skipped
                 row(21),
                 row(21), // skipped
-                          // segment boundary will be here
+                         // segment boundary will be here
             ]
             .into_iter()
             .flatten()

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -124,7 +124,7 @@ fn new_grid(
         .clamp(0.0, image.height() as f32);
 
     ScanGrid {
-        vertical_scan_lines: (0..image.width())
+        vertical_scan_lines: (2..image.width() - 2)
             .step_by(horizontal_stride)
             .map(|x| {
                 new_vertical_scan_line(
@@ -225,8 +225,8 @@ fn new_vertical_scan_line(
     let luminance_value_of_first_pixel = match median_mode {
         MedianModeParameters::Disabled => first_pixel,
         MedianModeParameters::ThreePixels => {
-            let previous_pixel = image.at(position, start_y - 1);
-            let next_pixel = image.at(position, start_y + 1);
+            let previous_pixel = image.at(position - 1, start_y);
+            let next_pixel = image.at(position + 1, start_y);
             median_of_three(
                 pixel_to_edge_detection_value(previous_pixel, edge_detection_source),
                 first_pixel,
@@ -234,10 +234,10 @@ fn new_vertical_scan_line(
             )
         }
         MedianModeParameters::FivePixels => {
-            let second_previous_pixel = image.at(position, start_y - 2);
-            let previous_pixel = image.at(position, start_y - 1);
-            let next_pixel = image.at(position, start_y + 1);
-            let second_next_pixel = image.at(position, start_y + 2);
+            let second_previous_pixel = image.at(position - 2, start_y);
+            let previous_pixel = image.at(position - 1, start_y);
+            let next_pixel = image.at(position + 1, start_y);
+            let second_next_pixel = image.at(position + 2, start_y);
             median_of_five(
                 pixel_to_edge_detection_value(second_previous_pixel, edge_detection_source),
                 pixel_to_edge_detection_value(previous_pixel, edge_detection_source),
@@ -259,8 +259,8 @@ fn new_vertical_scan_line(
         let luminance_value = match median_mode {
             MedianModeParameters::Disabled => pixel,
             MedianModeParameters::ThreePixels => {
-                let previous_pixel = image.at(position, y - 1);
-                let next_pixel = image.at(position, y + 1);
+                let previous_pixel = image.at(position - 1, y);
+                let next_pixel = image.at(position + 1, y);
                 median_of_three(
                     pixel_to_edge_detection_value(previous_pixel, edge_detection_source),
                     pixel,
@@ -268,10 +268,10 @@ fn new_vertical_scan_line(
                 )
             }
             MedianModeParameters::FivePixels => {
-                let second_previous_pixel = image.at(position, y - 2);
-                let previous_pixel = image.at(position, y - 1);
-                let next_pixel = image.at(position, y + 1);
-                let second_next_pixel = image.at(position, y + 2);
+                let second_previous_pixel = image.at(position - 2, y);
+                let previous_pixel = image.at(position - 1, y);
+                let next_pixel = image.at(position + 1, y);
+                let second_next_pixel = image.at(position + 2, y);
                 median_of_five(
                     pixel_to_edge_detection_value(second_previous_pixel, edge_detection_source),
                     pixel_to_edge_detection_value(previous_pixel, edge_detection_source),

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -192,7 +192,6 @@ fn median_of_three(values: [u8; 3]) -> u8 {
 }
 
 fn median_of_five(mut values: [u8; 5]) -> u8 {
-    // let mut values = [first, second, third, fourth, fifth];
     let (_, median, _) = values.select_nth_unstable(2);
     *median
 }

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -563,7 +563,7 @@ mod tests {
         let scan_line = new_vertical_scan_line(
             &image,
             &field_color,
-            0,
+            1,
             2,
             EdgeDetectionSourceParameters::Luminance,
             1,
@@ -571,7 +571,7 @@ mod tests {
             0.0,
             &[],
         );
-        assert_eq!(scan_line.position, 0);
+        assert_eq!(scan_line.position, 1);
         assert_eq!(scan_line.segments.len(), 1);
         assert_eq!(scan_line.segments[0].start, 0);
         assert_eq!(scan_line.segments[0].end, 3);
@@ -726,27 +726,37 @@ mod tests {
 
     #[test]
     fn image_with_three_vertical_increasing_segments_with_median() {
+        let row = |y| {
+            [
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+            ]
+        };
         let image = YCbCr422Image::from_ycbcr_buffer(
-            1,
+            3,
             12,
-            vec![
+            [
                 // only evaluating every second pixel
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
+                row(0),
+                row(0), // skipped
+                row(1),
                 // segment boundary will be here
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(2, 0, 0, 0),
+                row(1), // skipped
+                row(1),
+                row(1), // skipped
+                row(2),
                 // segment boundary will be here
-                YCbCr422::new(2, 0, 0, 0), // skipped
-                YCbCr422::new(2, 0, 0, 0),
-                YCbCr422::new(2, 0, 0, 0), // skipped
-                YCbCr422::new(3, 0, 0, 0),
-                YCbCr422::new(3, 0, 0, 0), // skipped
-                                           // segment boundary will be here
-            ],
+                row(2), // skipped
+                row(2),
+                row(2), // skipped
+                row(3),
+                row(3), // skipped
+                         // segment boundary will be here
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -774,7 +784,7 @@ mod tests {
         let scan_line = new_vertical_scan_line(
             &image,
             &field_color,
-            0,
+            1,
             2,
             EdgeDetectionSourceParameters::Luminance,
             1,
@@ -782,7 +792,7 @@ mod tests {
             0.0,
             &[],
         );
-        assert_eq!(scan_line.position, 0);
+        assert_eq!(scan_line.position, 1);
         assert_eq!(scan_line.segments.len(), 3);
         assert_eq!(scan_line.segments[0].start, 0);
         assert_eq!(scan_line.segments[0].end, 3);
@@ -869,28 +879,38 @@ mod tests {
 
     #[test]
     fn image_with_three_vertical_decreasing_segments_with_median() {
+        let row = |y| {
+            [
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+            ]
+        };
         let image = YCbCr422Image::from_ycbcr_buffer(
-            1,
+            3,
             12,
-            vec![
+            [
                 // only evaluating every secondth 422 pixel
-                YCbCr422::new(3, 0, 0, 0),
-                YCbCr422::new(3, 0, 0, 0), // skipped
-                YCbCr422::new(2, 0, 0, 0),
+                row(3),
+                row(3), // skipped
+                row(2),
                 // segment boundary will be here
-                YCbCr422::new(2, 0, 0, 0), // skipped
-                YCbCr422::new(2, 0, 0, 0),
-                YCbCr422::new(2, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
+                row(2), // skipped
+                row(2),
+                row(2), // skipped
+                row(1),
                 // segment boundary will be here
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
+                row(1), // skipped
+                row(1),
+                row(1), // skipped
+                row(0),
+                row(0), // skipped
 
-                                           // segment boundary will be here
-            ],
+                         // segment boundary will be here
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -918,7 +938,7 @@ mod tests {
         let scan_line = new_vertical_scan_line(
             &image,
             &field_color,
-            0,
+            1,
             2,
             EdgeDetectionSourceParameters::Luminance,
             1,
@@ -926,7 +946,7 @@ mod tests {
             0.0,
             &[],
         );
-        assert_eq!(scan_line.position, 0);
+        assert_eq!(scan_line.position, 1);
         assert_eq!(scan_line.segments.len(), 3);
         assert_eq!(scan_line.segments[0].start, 0);
         assert_eq!(scan_line.segments[0].end, 3);
@@ -1086,60 +1106,70 @@ mod tests {
 
     #[test]
     fn image_with_three_vertical_segments_with_higher_differences_with_median() {
+        let row = |y| {
+            [
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+            ]
+        };
         let image = YCbCr422Image::from_ycbcr_buffer(
-            1,
+            3,
             44,
-            vec![
+            [
                 // only evaluating every secondth 422 pixel
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(2, 0, 0, 0),
-                YCbCr422::new(2, 0, 0, 0), // skipped
-                YCbCr422::new(3, 0, 0, 0),
-                YCbCr422::new(3, 0, 0, 0), // skipped
-                YCbCr422::new(4, 0, 0, 0),
-                YCbCr422::new(4, 0, 0, 0), // skipped
-                YCbCr422::new(5, 0, 0, 0),
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(1),
+                row(1), // skipped
+                row(2),
+                row(2), // skipped
+                row(3),
+                row(3), // skipped
+                row(4),
+                row(4), // skipped
+                row(5),
                 // segment boundary will be here
-                YCbCr422::new(5, 0, 0, 0), // skipped
-                YCbCr422::new(4, 0, 0, 0),
-                YCbCr422::new(4, 0, 0, 0), // skipped
-                YCbCr422::new(3, 0, 0, 0),
-                YCbCr422::new(3, 0, 0, 0), // skipped
-                YCbCr422::new(2, 0, 0, 0),
-                YCbCr422::new(2, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
+                row(5), // skipped
+                row(4),
+                row(4), // skipped
+                row(3),
+                row(3), // skipped
+                row(2),
+                row(2), // skipped
+                row(1),
+                row(1), // skipped
+                row(0),
                 // segment boundary will be here
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
 
-                                           // segment boundary will be here
-            ],
+                         // segment boundary will be here
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -1246,7 +1276,7 @@ mod tests {
         let scan_line = new_vertical_scan_line(
             &image,
             &field_color,
-            0,
+            1,
             2,
             EdgeDetectionSourceParameters::Luminance,
             1,
@@ -1254,7 +1284,7 @@ mod tests {
             0.0,
             &[],
         );
-        assert_eq!(scan_line.position, 0);
+        assert_eq!(scan_line.position, 1);
         assert_eq!(scan_line.segments.len(), 3);
         assert_eq!(scan_line.segments[0].start, 0);
         assert_eq!(scan_line.segments[0].end, 17);
@@ -1337,30 +1367,39 @@ mod tests {
 
     #[test]
     fn image_with_one_vertical_segment_with_increasing_differences_with_median() {
+        let row = |y| {
+            [
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+                YCbCr422::new(y, 0, 0, 0),
+            ]
+        };
         let image = YCbCr422Image::from_ycbcr_buffer(
-            1,
+            3,
             16,
-            vec![
+            [
                 // only evaluating every secondth 422 pixel
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(0, 0, 0, 0),
-                YCbCr422::new(0, 0, 0, 0), // skipped
-                YCbCr422::new(1, 0, 0, 0),
-                YCbCr422::new(1, 0, 0, 0), // skipped
-                YCbCr422::new(3, 0, 0, 0),
-                YCbCr422::new(3, 0, 0, 0), // skipped
-                YCbCr422::new(6, 0, 0, 0),
-                YCbCr422::new(6, 0, 0, 0), // skipped
-                YCbCr422::new(10, 0, 0, 0),
-                YCbCr422::new(10, 0, 0, 0), // skipped
-                YCbCr422::new(15, 0, 0, 0),
-                YCbCr422::new(15, 0, 0, 0), // skipped
-                YCbCr422::new(21, 0, 0, 0),
-                YCbCr422::new(21, 0, 0, 0), // skipped
-
-                                            // segment boundary will be here
-            ],
+                row(0),
+                row(0), // skipped
+                row(0),
+                row(0), // skipped
+                row(1),
+                row(1), // skipped
+                row(3),
+                row(3), // skipped
+                row(6),
+                row(6), // skipped
+                row(10),
+                row(10), // skipped
+                row(15),
+                row(15), // skipped
+                row(21),
+                row(21), // skipped
+                          // segment boundary will be here
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -1392,7 +1431,7 @@ mod tests {
         let scan_line = new_vertical_scan_line(
             &image,
             &field_color,
-            0,
+            1,
             2,
             EdgeDetectionSourceParameters::Luminance,
             1,
@@ -1400,7 +1439,7 @@ mod tests {
             0.0,
             &[],
         );
-        assert_eq!(scan_line.position, 0);
+        assert_eq!(scan_line.position, 1);
         assert_eq!(scan_line.segments.len(), 1);
         assert_eq!(scan_line.segments[0].start, 0);
         assert_eq!(scan_line.segments[0].end, 16);


### PR DESCRIPTION
## Introduced Changes

Instead of using a vertical moving median for segmenting vertical scan lines, the median is calculated by looking left and right of the considered pixels.
Since we have a horizontal stride of 4 anyways, we simply ignored most pixels.

This PR is part of a set:
- #683
- #684
- #686
- #687

 ~~Collect them all for a chance to win a golden PR! Buy now and win!~~
If you wish to test them all together, use this branch: [fliewatüüt](https://github.com/knoellle/hulk/tree/fliewat%C3%BC%C3%BCt)


Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

Investigate also using horizontal median for calculating the color

## How to Test

Stare at segments, pray for salvation.