### PR TITLE
Make pepsi logs delete arguments compatible with busy box

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,7 +3836,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "aliveness",
  "bat",

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -151,8 +151,8 @@ impl Nao {
         let status = self
             .ssh_to_nao()
             .arg("rm")
-            .arg("--recursive")
-            .arg("--force")
+            .arg("-r")
+            .arg("-f")
             .arg("/home/nao/hulk/logs/*")
             .status()
             .await

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Introduced Changes

BusyBox 1.35 which implements the shell ```rm``` command on the NAO does not support ```--recursive``` and ```--force``` as arguments. This fixes it as per the BusyBox manpage https://www.commandlinux.com/man-page/man1/busybox.1.html

Fixes #701 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

1. Turn on robot
2. Check that some logs exist in /home/nao/hulk/logs/ folder either through pepsi shell or through pepsi logs show
3. Our current main outputs an error and does not delete the logs (see #701)
4. This one does
5. Profit
