### PR TITLE
Remove CyclerOutput from Communication Client and changes the communication protocol to only use the `String` type for paths

### DIFF
--- a/crates/communication/src/client/communication.rs
+++ b/crates/communication/src/client/communication.rs
@@ -24,7 +24,6 @@ use super::{
     id_tracker::id_tracker,
     output_subscription_manager::{self, output_subscription_manager},
     responder::responder,
-    CyclerOutput,
 };
 
 #[derive(Clone)]
@@ -113,14 +112,14 @@ impl Communication {
 
     pub async fn subscribe_output(
         &self,
-        output: CyclerOutput,
+        path: Path,
         format: Format,
     ) -> (Uuid, Receiver<SubscriberMessage>) {
         let (subscriber_sender, subscriber_receiver) = mpsc::channel(10);
         let (response_sender, response_receiver) = oneshot::channel();
         self.output_subscription_manager
             .send(output_subscription_manager::Message::Subscribe {
-                output,
+                path,
                 format,
                 subscriber: subscriber_sender,
                 response_sender,

--- a/crates/communication/src/client/mod.rs
+++ b/crates/communication/src/client/mod.rs
@@ -10,4 +10,4 @@ mod types;
 
 pub use crate::client::communication::Communication;
 pub use connector::ConnectionStatus;
-pub use types::{Cycler, CyclerOutput, HierarchyType, Output, OutputHierarchy, SubscriberMessage};
+pub use types::{HierarchyType, OutputHierarchy, SubscriberMessage};

--- a/crates/communication/src/messages.rs
+++ b/crates/communication/src/messages.rs
@@ -72,13 +72,11 @@ pub enum OutputsRequest {
     },
     GetNext {
         id: usize,
-        cycler_instance: CyclerInstance,
         path: Path,
         format: Format,
     },
     Subscribe {
         id: usize,
-        cycler_instance: CyclerInstance,
         path: Path,
         format: Format,
     },

--- a/crates/communication/src/server/outputs/provider.rs
+++ b/crates/communication/src/server/outputs/provider.rs
@@ -102,16 +102,16 @@ where
         }
         OutputsRequest::GetNext {
             id,
-            cycler_instance: received_cycler_instance,
-            path,
+            path: received_path,
             format,
         }
         | OutputsRequest::Subscribe {
             id,
-            cycler_instance: received_cycler_instance,
-            path,
+            path: received_path,
             format,
         } => {
+            let (received_cycler_instance, path) = received_path.split_once(".").expect("path does not contain cycler");
+
             assert_eq!(cycler_instance, received_cycler_instance);
             if Outputs::exists(&path) {
                 match subscriptions.entry((request.client.clone(), id)) {
@@ -139,7 +139,7 @@ where
                     }
                     Entry::Vacant(entry) => {
                         entry.insert(Subscription {
-                            path,
+                            path: path.to_string(),
                             format,
                             once: is_get_next,
                         });
@@ -533,8 +533,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: ID,
-                    cycler_instance: cycler_instance.clone(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format,
                 },
                 client: Client {
@@ -570,8 +569,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: ID,
-                    cycler_instance,
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format,
                 },
                 client: Client {
@@ -634,8 +632,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: ID,
-                    cycler_instance: cycler_instance.clone(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format,
                 },
                 client: Client {
@@ -671,8 +668,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: ID,
-                    cycler_instance,
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format,
                 },
                 client: Client {
@@ -735,8 +731,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: 42,
-                    cycler_instance: cycler_instance.clone(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format,
                 },
                 client: Client {
@@ -772,8 +767,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: 1337,
-                    cycler_instance,
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format,
                 },
                 client: Client {
@@ -889,8 +883,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Textual,
                 },
                 client: Client {
@@ -1013,8 +1006,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: 42,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Textual,
                 },
                 client: Client {
@@ -1129,8 +1121,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Textual,
                 },
                 client: Client {
@@ -1256,8 +1247,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Binary,
                 },
                 client: Client {
@@ -1391,8 +1381,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Textual,
                 },
                 client: Client {
@@ -1429,8 +1418,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::Subscribe {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Textual,
                 },
                 client: Client {
@@ -1613,8 +1601,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::GetNext {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Textual,
                 },
                 client: Client {
@@ -1691,8 +1678,7 @@ mod tests {
             .send(ClientRequest {
                 request: OutputsRequest::GetNext {
                     id: SUBSCRIPTION_ID,
-                    cycler_instance: cycler_instance.to_string(),
-                    path: path.clone(),
+                    path: format!("{cycler_instance}.{path}"),
                     format: Format::Binary,
                 },
                 client: Client {

--- a/crates/communication/src/server/outputs/provider.rs
+++ b/crates/communication/src/server/outputs/provider.rs
@@ -110,10 +110,12 @@ where
             path: received_path,
             format,
         } => {
-            let (received_cycler_instance, path) = received_path.split_once(".").expect("path does not contain cycler");
+            let (received_cycler_instance, path) = received_path
+                .split_once('.')
+                .expect("path does not contain cycler");
 
             assert_eq!(cycler_instance, received_cycler_instance);
-            if Outputs::exists(&path) {
+            if Outputs::exists(path) {
                 match subscriptions.entry((request.client.clone(), id)) {
                     Entry::Occupied(_) => {
                         let error_message = format!("already subscribed with id {id}");

--- a/crates/communication/src/server/outputs/router.rs
+++ b/crates/communication/src/server/outputs/router.rs
@@ -70,7 +70,7 @@ async fn handle_request(
                 .expect("receiver should always wait for all senders");
         }
         OutputsRequest::GetNext { id, path, .. } | OutputsRequest::Subscribe { id, path, .. } => {
-            let cycler_instance = match path.split_once(".") {
+            let cycler_instance = match path.split_once('.') {
                 Some((cycler_instance, _)) => cycler_instance,
                 None => {
                     let error_message = format!("cannot parse path {path}");

--- a/tools/fanta/src/main.rs
+++ b/tools/fanta/src/main.rs
@@ -1,9 +1,7 @@
-use std::str::FromStr;
-
 use clap::Parser;
 use color_eyre::{eyre::bail, Result};
 use communication::{
-    client::{Communication, CyclerOutput, SubscriberMessage},
+    client::{Communication, SubscriberMessage},
     messages::Format,
 };
 use log::{error, info};
@@ -25,7 +23,7 @@ async fn main() -> Result<()> {
     setup_logger()?;
 
     let arguments = CommandlineArguments::parse();
-    let output_to_subscribe = CyclerOutput::from_str(&arguments.path)?;
+    let output_to_subscribe = arguments.path;
     let communication = Communication::new(Some(format!("ws://{}:1337", arguments.address)), true);
     let (_uuid, mut receiver) = communication
         .subscribe_output(output_to_subscribe, Format::Textual)

--- a/tools/twix/src/image_buffer.rs
+++ b/tools/twix/src/image_buffer.rs
@@ -1,4 +1,4 @@
-use communication::client::{Communication, CyclerOutput, SubscriberMessage};
+use communication::client::{Communication, SubscriberMessage};
 use log::error;
 use tokio::{
     select, spawn,
@@ -23,7 +23,7 @@ pub struct ImageBuffer {
 }
 
 impl ImageBuffer {
-    pub fn new(communication: Communication, output: CyclerOutput) -> Self {
+    pub fn new(communication: Communication, output: String) -> Self {
         let (command_sender, command_receiver) = mpsc::channel(10);
         spawn(async move {
             let (uuid, receiver) = communication

--- a/tools/twix/src/nao.rs
+++ b/tools/twix/src/nao.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, sync::Mutex};
 
 use communication::{
-    client::{Communication, ConnectionStatus, CyclerOutput},
+    client::{Communication, ConnectionStatus},
     messages::{Fields, Path},
 };
 
@@ -57,17 +57,17 @@ impl Nao {
         );
     }
 
-    pub fn subscribe_output(&self, output: CyclerOutput) -> ValueBuffer {
+    pub fn subscribe_output(&self, output: impl ToString) -> ValueBuffer {
         let _guard = self.runtime.enter();
-        ValueBuffer::output(self.communication.clone(), output)
+        ValueBuffer::output(self.communication.clone(), output.to_string())
     }
 
-    pub fn subscribe_image(&self, output: CyclerOutput) -> ImageBuffer {
+    pub fn subscribe_image(&self, output: impl ToString) -> ImageBuffer {
         let _guard = self.runtime.enter();
-        ImageBuffer::new(self.communication.clone(), output)
+        ImageBuffer::new(self.communication.clone(), output.to_string())
     }
 
-    pub fn subscribe_parameter(&self, path: &str) -> ValueBuffer {
+    pub fn subscribe_parameter(&self, path: impl ToString) -> ValueBuffer {
         let _guard = self.runtime.enter();
         ValueBuffer::parameter(self.communication.clone(), path.to_string())
     }

--- a/tools/twix/src/panels/behavior_simulator.rs
+++ b/tools/twix/src/panels/behavior_simulator.rs
@@ -28,7 +28,7 @@ impl Panel for BehaviorSimulatorPanel {
         value_buffer.listen_to_updates(update_notify_sender);
 
         let frame_count = nao.subscribe_output("BehaviorSimulator.main_outputs.frame_count");
-        
+
         Self {
             nao,
             update_notify_receiver,

--- a/tools/twix/src/panels/behavior_simulator.rs
+++ b/tools/twix/src/panels/behavior_simulator.rs
@@ -1,6 +1,5 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
-use communication::client::CyclerOutput;
 use eframe::egui::{Response, Slider, Ui, Widget};
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -28,9 +27,8 @@ impl Panel for BehaviorSimulatorPanel {
         let (update_notify_sender, update_notify_receiver) = mpsc::channel(1);
         value_buffer.listen_to_updates(update_notify_sender);
 
-        let frame_count = nao.subscribe_output(
-            CyclerOutput::from_str("BehaviorSimulator.main_outputs.frame_count").unwrap(),
-        );
+        let frame_count = nao.subscribe_output("BehaviorSimulator.main_outputs.frame_count");
+        
         Self {
             nao,
             update_notify_receiver,

--- a/tools/twix/src/panels/image/cycler_selector.rs
+++ b/tools/twix/src/panels/image/cycler_selector.rs
@@ -1,13 +1,14 @@
-use communication::client::Cycler;
 use eframe::egui::{ComboBox, Response, Ui, Widget};
+
+use super::overlay::VisionCycler;
 
 #[derive(Debug)]
 pub struct VisionCyclerSelector {
-    cycler: Cycler,
+    cycler: VisionCycler,
 }
 
 impl VisionCyclerSelector {
-    pub fn selected_cycler(&self) -> Cycler {
+    pub fn selected_cycler(&self) -> VisionCycler {
         self.cycler
     }
 }
@@ -15,13 +16,13 @@ impl VisionCyclerSelector {
 impl Default for VisionCyclerSelector {
     fn default() -> Self {
         Self {
-            cycler: Cycler::VisionTop,
+            cycler: VisionCycler::VisionTop,
         }
     }
 }
 
 impl VisionCyclerSelector {
-    pub fn new(cycler: Cycler) -> Self {
+    pub fn new(cycler: VisionCycler) -> Self {
         Self { cycler }
     }
 }
@@ -33,13 +34,13 @@ impl Widget for &mut VisionCyclerSelector {
             .selected_text(format!("{:?}", self.cycler))
             .show_ui(ui, |ui| {
                 if ui
-                    .selectable_value(&mut self.cycler, Cycler::VisionTop, "VisionTop")
+                    .selectable_value(&mut self.cycler, VisionCycler::VisionTop, "VisionTop")
                     .clicked()
                 {
                     camera_selection_changed = true;
                 };
                 if ui
-                    .selectable_value(&mut self.cycler, Cycler::VisionBottom, "VisionBottom")
+                    .selectable_value(&mut self.cycler, VisionCycler::VisionBottom, "VisionBottom")
                     .clicked()
                 {
                     camera_selection_changed = true;

--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
-use color_eyre::Result;
-use communication::client::Cycler;
+use color_eyre::{Report, Result};
 use convert_case::Casing;
 use eframe::egui::Ui;
 use serde_json::{json, Value};
@@ -10,9 +9,37 @@ use crate::{nao::Nao, twix_painter::TwixPainter};
 
 use super::overlays::{BallDetection, FeetDetection, LineDetection, PenaltyBoxes};
 
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum VisionCycler {
+    VisionTop,
+    VisionBottom,
+}
+
+impl ToString for VisionCycler {
+    fn to_string(&self) -> String {
+        match self {
+            VisionCycler::VisionTop => "VisionTop",
+            VisionCycler::VisionBottom => "VisionBottom",
+        }
+        .to_string()
+    }
+}
+
+impl FromStr for VisionCycler {
+    type Err = Report;
+
+    fn from_str(cycler: &str) -> Result<Self, Self::Err> {
+        match cycler {
+            "VisionTop" => Ok(VisionCycler::VisionTop),
+            "VisionBottom" => Ok(VisionCycler::VisionBottom),
+            _ => Err(Report::msg(format!("Unknown vision cycler: {}", cycler))),
+        }
+    }
+}
+
 pub trait Overlay {
     const NAME: &'static str;
-    fn new(nao: Arc<Nao>, selected_cycler: Cycler) -> Self;
+    fn new(nao: Arc<Nao>, selected_cycler: VisionCycler) -> Self;
     fn paint(&self, painter: &TwixPainter) -> Result<()>;
 }
 
@@ -33,7 +60,7 @@ where
         nao: Arc<Nao>,
         value: Option<&Value>,
         active: bool,
-        selected_cycler: Cycler,
+        selected_cycler: VisionCycler,
     ) -> Self {
         let active = value
             .and_then(|value| value.get(T::NAME.to_case(convert_case::Case::Snake)))
@@ -48,13 +75,13 @@ where
         }
     }
 
-    pub fn update_cycler(&mut self, selected_cycler: Cycler) {
+    pub fn update_cycler(&mut self, selected_cycler: VisionCycler) {
         if let Some(overlay) = self.overlay.as_mut() {
             *overlay = T::new(self.nao.clone(), selected_cycler);
         }
     }
 
-    pub fn checkbox(&mut self, ui: &mut Ui, selected_cycler: Cycler) {
+    pub fn checkbox(&mut self, ui: &mut Ui, selected_cycler: VisionCycler) {
         if ui.checkbox(&mut self.active, T::NAME).changed() {
             match (self.active, self.overlay.is_some()) {
                 (true, false) => self.overlay = Some(T::new(self.nao.clone(), selected_cycler)),
@@ -84,7 +111,7 @@ pub struct Overlays {
 }
 
 impl Overlays {
-    pub fn new(nao: Arc<Nao>, storage: Option<&Value>, selected_cycler: Cycler) -> Self {
+    pub fn new(nao: Arc<Nao>, storage: Option<&Value>, selected_cycler: VisionCycler) -> Self {
         let line_detection = EnabledOverlay::new(nao.clone(), storage, true, selected_cycler);
         let ball_detection = EnabledOverlay::new(nao.clone(), storage, true, selected_cycler);
         let penalty_boxes = EnabledOverlay::new(nao.clone(), storage, true, selected_cycler);
@@ -97,14 +124,14 @@ impl Overlays {
         }
     }
 
-    pub fn update_cycler(&mut self, selected_cycler: Cycler) {
+    pub fn update_cycler(&mut self, selected_cycler: VisionCycler) {
         self.line_detection.update_cycler(selected_cycler);
         self.ball_detection.update_cycler(selected_cycler);
         self.penalty_boxes.update_cycler(selected_cycler);
         self.feet_detection.update_cycler(selected_cycler);
     }
 
-    pub fn combo_box(&mut self, ui: &mut Ui, selected_cycler: Cycler) {
+    pub fn combo_box(&mut self, ui: &mut Ui, selected_cycler: VisionCycler) {
         ui.menu_button("Overlays", |ui| {
             self.line_detection.checkbox(ui, selected_cycler);
             self.ball_detection.checkbox(ui, selected_cycler);

--- a/tools/twix/src/panels/image/overlays/ball_detection.rs
+++ b/tools/twix/src/panels/image/overlays/ball_detection.rs
@@ -23,7 +23,10 @@ impl Overlay for BallDetection {
             VisionCycler::VisionBottom => "bottom",
         };
         Self {
-            balls: nao.subscribe_output(format!("{}.main_outputs.balls", selected_cycler.to_string())),
+            balls: nao.subscribe_output(format!(
+                "{}.main_outputs.balls",
+                selected_cycler.to_string()
+            )),
             filtered_balls: nao.subscribe_output(format!(
                 "Control.additional.filtered_balls_in_image_{}",
                 camera_position,

--- a/tools/twix/src/panels/image/overlays/ball_detection.rs
+++ b/tools/twix/src/panels/image/overlays/ball_detection.rs
@@ -1,12 +1,12 @@
-use std::str::FromStr;
-
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput};
 use eframe::epaint::{Color32, Stroke};
 use geometry::circle::Circle;
 use types::ball::{Ball, CandidateEvaluation};
 
-use crate::{panels::image::overlay::Overlay, value_buffer::ValueBuffer};
+use crate::{
+    panels::image::overlay::{Overlay, VisionCycler},
+    value_buffer::ValueBuffer,
+};
 
 pub struct BallDetection {
     balls: ValueBuffer,
@@ -17,27 +17,21 @@ pub struct BallDetection {
 impl Overlay for BallDetection {
     const NAME: &'static str = "Ball Detection";
 
-    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
+    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: VisionCycler) -> Self {
         let camera_position = match selected_cycler {
-            Cycler::VisionTop => "top",
-            Cycler::VisionBottom => "bottom",
-            cycler => panic!("Invalid vision cycler: {cycler}"),
+            VisionCycler::VisionTop => "top",
+            VisionCycler::VisionBottom => "bottom",
         };
         Self {
-            balls: nao.subscribe_output(
-                CyclerOutput::from_str(&format!("{}.main.balls", selected_cycler)).unwrap(),
-            ),
-            filtered_balls: nao.subscribe_output(
-                CyclerOutput::from_str(&format!(
-                    "Control.additional.filtered_balls_in_image_{}",
-                    camera_position,
-                ))
-                .unwrap(),
-            ),
-            ball_candidates: nao.subscribe_output(
-                CyclerOutput::from_str(&format!("{}.additional.ball_candidates", selected_cycler))
-                    .unwrap(),
-            ),
+            balls: nao.subscribe_output(format!("{}.main_outputs.balls", selected_cycler.to_string())),
+            filtered_balls: nao.subscribe_output(format!(
+                "Control.additional.filtered_balls_in_image_{}",
+                camera_position,
+            )),
+            ball_candidates: nao.subscribe_output(format!(
+                "{}.additional_outputs.ball_candidates",
+                selected_cycler.to_string()
+            )),
         }
     }
 

--- a/tools/twix/src/panels/image/overlays/feet_detection.rs
+++ b/tools/twix/src/panels/image/overlays/feet_detection.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::Color32;
 use types::detected_feet::ClusterPoint;
 
 use crate::{
-    nao::Nao, panels::image::overlay::Overlay, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+    nao::Nao, panels::image::overlay::{Overlay, VisionCycler}, twix_painter::TwixPainter, value_buffer::ValueBuffer,
 };
 
 pub struct FeetDetection {
@@ -16,14 +15,12 @@ pub struct FeetDetection {
 impl Overlay for FeetDetection {
     const NAME: &'static str = "Feet Detection";
 
-    fn new(nao: Arc<Nao>, selected_cycler: Cycler) -> Self {
+    fn new(nao: Arc<Nao>, selected_cycler: VisionCycler) -> Self {
         Self {
-            cluster_points: nao.subscribe_output(CyclerOutput {
-                cycler: selected_cycler,
-                output: Output::Additional {
-                    path: "feet_detection.cluster_points".to_string(),
-                },
-            }),
+            cluster_points: nao.subscribe_output(format!(
+                "{}.additional_outputs.feet_detection.cluster_points",
+                selected_cycler.to_string()
+            )),
         }
     }
 

--- a/tools/twix/src/panels/image/overlays/feet_detection.rs
+++ b/tools/twix/src/panels/image/overlays/feet_detection.rs
@@ -5,7 +5,10 @@ use eframe::epaint::Color32;
 use types::detected_feet::ClusterPoint;
 
 use crate::{
-    nao::Nao, panels::image::overlay::{Overlay, VisionCycler}, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+    nao::Nao,
+    panels::image::overlay::{Overlay, VisionCycler},
+    twix_painter::TwixPainter,
+    value_buffer::ValueBuffer,
 };
 
 pub struct FeetDetection {

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -17,8 +17,10 @@ impl Overlay for LineDetection {
 
     fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: VisionCycler) -> Self {
         Self {
-            lines_in_image: nao
-                .subscribe_output(format!("{}.additional_outputs.lines_in_image", selected_cycler.to_string()))
+            lines_in_image: nao.subscribe_output(format!(
+                "{}.additional_outputs.lines_in_image",
+                selected_cycler.to_string()
+            )),
         }
     }
 

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -1,11 +1,9 @@
-use std::str::FromStr;
-
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput};
 use eframe::epaint::{Color32, Stroke};
 use types::line_data::ImageLines;
 use types::line_data::LineDiscardReason;
 
+use crate::panels::image::overlay::VisionCycler;
 use crate::{
     panels::image::overlay::Overlay, twix_painter::TwixPainter, value_buffer::ValueBuffer,
 };
@@ -17,12 +15,10 @@ pub struct LineDetection {
 impl Overlay for LineDetection {
     const NAME: &'static str = "Line Detection";
 
-    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
+    fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: VisionCycler) -> Self {
         Self {
-            lines_in_image: nao.subscribe_output(
-                CyclerOutput::from_str(&format!("{selected_cycler}.additional.lines_in_image"))
-                    .unwrap(),
-            ),
+            lines_in_image: nao
+                .subscribe_output(format!("{}.additional_outputs.lines_in_image", selected_cycler.to_string()))
         }
     }
 

--- a/tools/twix/src/panels/image/overlays/penalty_boxes.rs
+++ b/tools/twix/src/panels/image/overlays/penalty_boxes.rs
@@ -5,7 +5,9 @@ use eframe::epaint::{Color32, Stroke};
 use types::line::Line2;
 
 use crate::{
-    panels::image::overlay::{Overlay, VisionCycler}, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+    panels::image::overlay::{Overlay, VisionCycler},
+    twix_painter::TwixPainter,
+    value_buffer::ValueBuffer,
 };
 
 pub struct PenaltyBoxes {
@@ -21,8 +23,9 @@ impl Overlay for PenaltyBoxes {
             VisionCycler::VisionBottom => "bottom",
         };
         Self {
-            penalty_boxes: nao
-                .subscribe_output(format!("Control.additional_outputs.projected_field_lines.{top_or_bottom}")),
+            penalty_boxes: nao.subscribe_output(format!(
+                "Control.additional_outputs.projected_field_lines.{top_or_bottom}"
+            )),
         }
     }
 

--- a/tools/twix/src/panels/image/overlays/penalty_boxes.rs
+++ b/tools/twix/src/panels/image/overlays/penalty_boxes.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::{Color32, Stroke};
 use types::line::Line2;
 
 use crate::{
-    panels::image::overlay::Overlay, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+    panels::image::overlay::{Overlay, VisionCycler}, twix_painter::TwixPainter, value_buffer::ValueBuffer,
 };
 
 pub struct PenaltyBoxes {
@@ -16,19 +15,14 @@ pub struct PenaltyBoxes {
 impl Overlay for PenaltyBoxes {
     const NAME: &'static str = "Penalty Boxes";
 
-    fn new(nao: Arc<crate::nao::Nao>, selected_cycler: Cycler) -> Self {
+    fn new(nao: Arc<crate::nao::Nao>, selected_cycler: VisionCycler) -> Self {
         let top_or_bottom = match selected_cycler {
-            Cycler::VisionTop => "top",
-            Cycler::VisionBottom => "bottom",
-            cycler => panic!("Invalid vision cycler: {cycler}"),
+            VisionCycler::VisionTop => "top",
+            VisionCycler::VisionBottom => "bottom",
         };
         Self {
-            penalty_boxes: nao.subscribe_output(CyclerOutput {
-                cycler: Cycler::Control,
-                output: Output::Additional {
-                    path: format!("projected_field_lines.{top_or_bottom}"),
-                },
-            }),
+            penalty_boxes: nao
+                .subscribe_output(format!("Control.additional_outputs.projected_field_lines.{top_or_bottom}")),
         }
     }
 

--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -1,6 +1,5 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
-use communication::client::CyclerOutput;
 use eframe::{
     egui::{ComboBox, Response, Ui, Widget},
     epaint::{Color32, Stroke},
@@ -44,8 +43,8 @@ impl Panel for ImageSegmentsPanel {
     const NAME: &'static str = "Image Segments";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
-        let value_buffer =
-            nao.subscribe_output(CyclerOutput::from_str("VisionTop.main.image_segments").unwrap());
+        let value_buffer = nao.subscribe_output("VisionTop.main_outputs.image_segments");
+
         Self {
             nao,
             value_buffer,
@@ -84,18 +83,10 @@ impl Widget for &mut ImageSegmentsPanel {
                 ui.checkbox(&mut self.use_filtered_segments, "Filtered Segments");
             if camera_selection_changed || filtered_segments_checkbox.changed() {
                 let output = match (self.camera_position, self.use_filtered_segments) {
-                    (CameraPosition::Top, false) => {
-                        CyclerOutput::from_str("VisionTop.main.image_segments").unwrap()
-                    }
-                    (CameraPosition::Top, true) => {
-                        CyclerOutput::from_str("VisionTop.main.filtered_segments").unwrap()
-                    }
-                    (CameraPosition::Bottom, false) => {
-                        CyclerOutput::from_str("VisionBottom.main.image_segments").unwrap()
-                    }
-                    (CameraPosition::Bottom, true) => {
-                        CyclerOutput::from_str("VisionBottom.main.filtered_segments").unwrap()
-                    }
+                    (CameraPosition::Top, false) => "VisionTop.main_outputs.image_segments",
+                    (CameraPosition::Top, true) => "VisionTop.main_outputs.filtered_segments",
+                    (CameraPosition::Bottom, false) => "VisionBottom.main_outputs.image_segments",
+                    (CameraPosition::Bottom, true) => "VisionBottom.main_outputs.filtered_segments",
                 };
                 self.value_buffer = self.nao.subscribe_output(output);
             }

--- a/tools/twix/src/panels/look_at.rs
+++ b/tools/twix/src/panels/look_at.rs
@@ -1,12 +1,11 @@
 use crate::{nao::Nao, panel::Panel, value_buffer::ValueBuffer};
-use communication::client::CyclerOutput;
 use eframe::{
     egui::{Response, Slider, TextFormat, Ui, Widget},
     epaint::{text::LayoutJob, Color32, FontId},
 };
 use nalgebra::{point, Point2};
 use serde_json::Value;
-use std::{ops::RangeInclusive, str::FromStr, sync::Arc};
+use std::{ops::RangeInclusive, sync::Arc};
 use types::{
     camera_position::CameraPosition,
     field_dimensions::FieldDimensions,
@@ -38,10 +37,7 @@ impl Panel for LookAtPanel {
 
     fn new(nao: Arc<Nao>, _: Option<&Value>) -> Self {
         let field_dimensions_buffer = nao.subscribe_parameter("field_dimensions");
-        let motion_command_buffer = nao.subscribe_output(
-            CyclerOutput::from_str("Control.main_outputs.motion_command")
-                .expect("Failed to subscribe to main_outputs.motion_command"),
-        );
+        let motion_command_buffer = nao.subscribe_output("Control.main_outputs.motion_command");
 
         Self {
             nao,

--- a/tools/twix/src/panels/map/layers/ball_filter.rs
+++ b/tools/twix/src/panels/map/layers/ball_filter.rs
@@ -23,7 +23,7 @@ impl Layer for BallFilter {
     fn new(nao: Arc<Nao>) -> Self {
         let robot_to_field = nao.subscribe_output("Control.robot_to_field");
         let ball_hypotheses = nao.subscribe_output("Control.best_ball_state");
-        
+
         Self {
             robot_to_field,
             ball_state: ball_hypotheses,

--- a/tools/twix/src/panels/map/layers/ball_filter.rs
+++ b/tools/twix/src/panels/map/layers/ball_filter.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{Isometry2, Point2};
 use types::{
@@ -22,18 +21,9 @@ impl Layer for BallFilter {
     const NAME: &'static str = "Ball Filter";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Main {
-                path: "robot_to_field".to_string(),
-            },
-        });
-        let ball_hypotheses = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Additional {
-                path: "best_ball_state".to_string(),
-            },
-        });
+        let robot_to_field = nao.subscribe_output("Control.robot_to_field");
+        let ball_hypotheses = nao.subscribe_output("Control.best_ball_state");
+        
         Self {
             robot_to_field,
             ball_state: ball_hypotheses,

--- a/tools/twix/src/panels/map/layers/ball_position.rs
+++ b/tools/twix/src/panels/map/layers/ball_position.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::Color32;
 use nalgebra::Isometry2;
 use types::field_dimensions::FieldDimensions;
@@ -20,10 +19,10 @@ impl Layer for BallPosition {
 
     fn new(nao: Arc<Nao>) -> Self {
         let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
+            nao.subscribe_output("Control.main.robot_to_field");
         robot_to_field.reserve(100);
         let ball_position =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.ball_position").unwrap());
+            nao.subscribe_output("Control.main.ball_position");
         ball_position.reserve(100);
         Self {
             robot_to_field,

--- a/tools/twix/src/panels/map/layers/ball_position.rs
+++ b/tools/twix/src/panels/map/layers/ball_position.rs
@@ -18,11 +18,9 @@ impl Layer for BallPosition {
     const NAME: &'static str = "Ball Position";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output("Control.main.robot_to_field");
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
         robot_to_field.reserve(100);
-        let ball_position =
-            nao.subscribe_output("Control.main.ball_position");
+        let ball_position = nao.subscribe_output("Control.main.ball_position");
         ball_position.reserve(100);
         Self {
             robot_to_field,

--- a/tools/twix/src/panels/map/layers/behavior_simulator.rs
+++ b/tools/twix/src/panels/map/layers/behavior_simulator.rs
@@ -43,7 +43,7 @@ impl Layer for BehaviorSimulator {
         )
         .unwrap();
         let ball = nao.subscribe_output("BehaviorSimulator.main_outputs.ball.position");
-        
+
         Self {
             robot_to_field,
             motion_command,

--- a/tools/twix/src/panels/map/layers/behavior_simulator.rs
+++ b/tools/twix/src/panels/map/layers/behavior_simulator.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{point, Isometry2, Point2, UnitComplex};
 use types::{field_dimensions::FieldDimensions, motion_command::MotionCommand};
@@ -43,9 +42,8 @@ impl Layer for BehaviorSimulator {
             "main_outputs.sensor_data.positions.head.yaw",
         )
         .unwrap();
-        let ball = nao.subscribe_output(
-            CyclerOutput::from_str("BehaviorSimulator.main_outputs.ball.position").unwrap(),
-        );
+        let ball = nao.subscribe_output("BehaviorSimulator.main_outputs.ball.position");
+        
         Self {
             robot_to_field,
             motion_command,

--- a/tools/twix/src/panels/map/layers/feet_detection.rs
+++ b/tools/twix/src/panels/map/layers/feet_detection.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::Color32;
 use nalgebra::{Isometry2, Point2};
 
@@ -23,36 +22,12 @@ impl Layer for FeetDetection {
     const NAME: &'static str = "FeetDetection";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Main {
-                path: "robot_to_field".to_string(),
-            },
-        });
-        let cluster_bottom = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::VisionBottom,
-            output: Output::Additional {
-                path: "feet_detection.clusters_in_ground".to_string(),
-            },
-        });
-        let cluster_top = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::VisionTop,
-            output: Output::Additional {
-                path: "feet_detection.clusters_in_ground".to_string(),
-            },
-        });
-        let segments_bottom = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::VisionBottom,
-            output: Output::Additional {
-                path: "feet_detection.cluster_points".to_string(),
-            },
-        });
-        let segments_top = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::VisionTop,
-            output: Output::Additional {
-                path: "feet_detection.cluster_points".to_string(),
-            },
-        });
+        let robot_to_field = nao.subscribe_output("Control.robot_to_field");
+        let cluster_bottom = nao.subscribe_output("VisionBottom.feet_detection.clusters_in_ground");
+        let cluster_top = nao.subscribe_output("VisionTop.feet_detection.clusters_in_ground");
+        let segments_bottom = nao.subscribe_output("VisionBottom.feet_detection.cluster_points");
+        let segments_top = nao.subscribe_output("VisionTop.feet_detection.cluster_points");
+        
         Self {
             robot_to_field,
             cluster_bottom,

--- a/tools/twix/src/panels/map/layers/feet_detection.rs
+++ b/tools/twix/src/panels/map/layers/feet_detection.rs
@@ -27,7 +27,7 @@ impl Layer for FeetDetection {
         let cluster_top = nao.subscribe_output("VisionTop.feet_detection.clusters_in_ground");
         let segments_bottom = nao.subscribe_output("VisionBottom.feet_detection.cluster_points");
         let segments_top = nao.subscribe_output("VisionTop.feet_detection.cluster_points");
-        
+
         Self {
             robot_to_field,
             cluster_bottom,

--- a/tools/twix/src/panels/map/layers/image_segments.rs
+++ b/tools/twix/src/panels/map/layers/image_segments.rs
@@ -23,7 +23,7 @@ impl Layer for ImageSegments {
         let camera_matrix_bottom = nao.subscribe_output("VisionBottom.main.camera_matrix");
         let image_segments_top = nao.subscribe_output("VisionTop.main.image_segments");
         let camera_matrix_top = nao.subscribe_output("VisionTop.main.camera_matrix");
-        
+
         Self {
             robot_to_field,
             image_segments_bottom,

--- a/tools/twix/src/panels/map/layers/image_segments.rs
+++ b/tools/twix/src/panels/map/layers/image_segments.rs
@@ -1,7 +1,4 @@
-use std::str::FromStr;
-
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{point, vector, Isometry2, Point2};
 use projection::Projection;
@@ -21,16 +18,12 @@ impl Layer for ImageSegments {
     const NAME: &'static str = "Image Segments";
 
     fn new(nao: std::sync::Arc<crate::nao::Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
-        let image_segments_bottom = nao
-            .subscribe_output(CyclerOutput::from_str("VisionBottom.main.image_segments").unwrap());
-        let camera_matrix_bottom = nao
-            .subscribe_output(CyclerOutput::from_str("VisionBottom.main.camera_matrix").unwrap());
-        let image_segments_top =
-            nao.subscribe_output(CyclerOutput::from_str("VisionTop.main.image_segments").unwrap());
-        let camera_matrix_top =
-            nao.subscribe_output(CyclerOutput::from_str("VisionTop.main.camera_matrix").unwrap());
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
+        let image_segments_bottom = nao.subscribe_output("VisionBottom.main.image_segments");
+        let camera_matrix_bottom = nao.subscribe_output("VisionBottom.main.camera_matrix");
+        let image_segments_top = nao.subscribe_output("VisionTop.main.image_segments");
+        let camera_matrix_top = nao.subscribe_output("VisionTop.main.camera_matrix");
+        
         Self {
             robot_to_field,
             image_segments_bottom,

--- a/tools/twix/src/panels/map/layers/kick_decisions.rs
+++ b/tools/twix/src/panels/map/layers/kick_decisions.rs
@@ -26,7 +26,7 @@ impl Layer for KickDecisions {
         let instant_kick_decisions = nao.subscribe_output("Control.main.instant_kick_decisions");
         let kick_targets = nao.subscribe_output("Control.additional.kick_targets");
         let instant_kick_targets = nao.subscribe_output("Control.additional.instant_kick_targets");
-        
+
         Self {
             robot_to_field,
             kick_decisions,

--- a/tools/twix/src/panels/map/layers/kick_decisions.rs
+++ b/tools/twix/src/panels/map/layers/kick_decisions.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{Isometry2, Point2};
 use types::{field_dimensions::FieldDimensions, kick_decision::KickDecision};
@@ -22,18 +21,12 @@ impl Layer for KickDecisions {
     const NAME: &'static str = "Kick Decisions";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
-        let kick_decisions =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.kick_decisions").unwrap());
-        let instant_kick_decisions = nao.subscribe_output(
-            CyclerOutput::from_str("Control.main.instant_kick_decisions").unwrap(),
-        );
-        let kick_targets = nao
-            .subscribe_output(CyclerOutput::from_str("Control.additional.kick_targets").unwrap());
-        let instant_kick_targets = nao.subscribe_output(
-            CyclerOutput::from_str("Control.additional.instant_kick_targets").unwrap(),
-        );
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
+        let kick_decisions = nao.subscribe_output("Control.main.kick_decisions");
+        let instant_kick_decisions = nao.subscribe_output("Control.main.instant_kick_decisions");
+        let kick_targets = nao.subscribe_output("Control.additional.kick_targets");
+        let instant_kick_targets = nao.subscribe_output("Control.additional.instant_kick_targets");
+        
         Self {
             robot_to_field,
             kick_decisions,

--- a/tools/twix/src/panels/map/layers/line_correspondences.rs
+++ b/tools/twix/src/panels/map/layers/line_correspondences.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 
 use types::{field_dimensions::FieldDimensions, line::Line2};
@@ -19,14 +18,10 @@ impl Layer for LineCorrespondences {
     const NAME: &'static str = "Line Correspondences";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let lines_in_robot_bottom = nao.subscribe_output(
-            CyclerOutput::from_str("VisionBottom.additional.localization.correspondence_lines")
-                .unwrap(),
-        );
-        let lines_in_robot_top = nao.subscribe_output(
-            CyclerOutput::from_str("VisionTop.additional.localization.correspondence_lines")
-                .unwrap(),
-        );
+        let lines_in_robot_bottom =
+            nao.subscribe_output("VisionBottom.additional.localization.correspondence_lines");
+        let lines_in_robot_top =
+            nao.subscribe_output("VisionTop.additional.localization.correspondence_lines");
         Self {
             lines_in_robot_bottom,
             lines_in_robot_top,

--- a/tools/twix/src/panels/map/layers/lines.rs
+++ b/tools/twix/src/panels/map/layers/lines.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::Isometry2;
 
@@ -21,14 +20,11 @@ impl Layer for Lines {
     const NAME: &'static str = "Lines";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
-        let lines_in_robot_bottom = nao.subscribe_output(
-            CyclerOutput::from_str("VisionBottom.main.line_data.lines_in_robot").unwrap(),
-        );
-        let lines_in_robot_top = nao.subscribe_output(
-            CyclerOutput::from_str("VisionTop.main.line_data.lines_in_robot").unwrap(),
-        );
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
+        let lines_in_robot_bottom =
+            nao.subscribe_output("VisionBottom.main.line_data.lines_in_robot");
+        let lines_in_robot_top = nao.subscribe_output("VisionTop.main.line_data.lines_in_robot");
+        
         Self {
             robot_to_field,
             lines_in_robot_bottom,

--- a/tools/twix/src/panels/map/layers/lines.rs
+++ b/tools/twix/src/panels/map/layers/lines.rs
@@ -24,7 +24,7 @@ impl Layer for Lines {
         let lines_in_robot_bottom =
             nao.subscribe_output("VisionBottom.main.line_data.lines_in_robot");
         let lines_in_robot_top = nao.subscribe_output("VisionTop.main.line_data.lines_in_robot");
-        
+
         Self {
             robot_to_field,
             lines_in_robot_bottom,

--- a/tools/twix/src/panels/map/layers/obstacle_filter.rs
+++ b/tools/twix/src/panels/map/layers/obstacle_filter.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::{Cycler, CyclerOutput, Output};
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::{Isometry2, Point2};
 use types::{field_dimensions::FieldDimensions, obstacle_filter::Hypothesis};
@@ -19,18 +18,9 @@ impl Layer for ObstacleFilter {
     const NAME: &'static str = "Obstacle Filter";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Main {
-                path: "robot_to_field".to_string(),
-            },
-        });
-        let hypotheses = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Additional {
-                path: "obstacle_filter_hypotheses".to_string(),
-            },
-        });
+        let robot_to_field = nao.subscribe_output("Control.main_outputs.robot_to_field");
+        let hypotheses = nao.subscribe_output("Control.main_outputs.obstacle_filter_hypotheses");
+
         Self {
             robot_to_field,
             hypotheses,

--- a/tools/twix/src/panels/map/layers/obstacles.rs
+++ b/tools/twix/src/panels/map/layers/obstacles.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::Isometry2;
 use types::{field_dimensions::FieldDimensions, obstacles::Obstacle};
@@ -20,9 +19,9 @@ impl Layer for Obstacles {
 
     fn new(nao: Arc<Nao>) -> Self {
         let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
+            nao.subscribe_output("Control.main.robot_to_field");
         let obstacles =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.obstacles").unwrap());
+            nao.subscribe_output("Control.main.obstacles");
         Self {
             robot_to_field,
             obstacles,

--- a/tools/twix/src/panels/map/layers/obstacles.rs
+++ b/tools/twix/src/panels/map/layers/obstacles.rs
@@ -18,10 +18,8 @@ impl Layer for Obstacles {
     const NAME: &'static str = "Obstacles";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output("Control.main.robot_to_field");
-        let obstacles =
-            nao.subscribe_output("Control.main.obstacles");
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
+        let obstacles = nao.subscribe_output("Control.main.obstacles");
         Self {
             robot_to_field,
             obstacles,

--- a/tools/twix/src/panels/map/layers/path.rs
+++ b/tools/twix/src/panels/map/layers/path.rs
@@ -18,10 +18,8 @@ impl Layer for Path {
     const NAME: &'static str = "Path";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output("Control.main.robot_to_field");
-        let motion_command =
-            nao.subscribe_output("Control.main.motion_command");
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
+        let motion_command = nao.subscribe_output("Control.main.motion_command");
         Self {
             robot_to_field,
             motion_command,

--- a/tools/twix/src/panels/map/layers/path.rs
+++ b/tools/twix/src/panels/map/layers/path.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::Color32;
 use nalgebra::Isometry2;
 use types::{field_dimensions::FieldDimensions, motion_command::MotionCommand};
@@ -20,9 +19,9 @@ impl Layer for Path {
 
     fn new(nao: Arc<Nao>) -> Self {
         let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
+            nao.subscribe_output("Control.main.robot_to_field");
         let motion_command =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.motion_command").unwrap());
+            nao.subscribe_output("Control.main.motion_command");
         Self {
             robot_to_field,
             motion_command,

--- a/tools/twix/src/panels/map/layers/path_obstacles.rs
+++ b/tools/twix/src/panels/map/layers/path_obstacles.rs
@@ -18,10 +18,8 @@ impl Layer for PathObstacles {
     const NAME: &'static str = "Path Obstacles";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output("Control.main.robot_to_field");
-        let path_obstacles = nao
-            .subscribe_output("Control.additional.path_obstacles");
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
+        let path_obstacles = nao.subscribe_output("Control.additional.path_obstacles");
         Self {
             robot_to_field,
             path_obstacles,

--- a/tools/twix/src/panels/map/layers/path_obstacles.rs
+++ b/tools/twix/src/panels/map/layers/path_obstacles.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::Isometry2;
 use types::{field_dimensions::FieldDimensions, path_obstacles::PathObstacle};
@@ -20,9 +19,9 @@ impl Layer for PathObstacles {
 
     fn new(nao: Arc<Nao>) -> Self {
         let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
+            nao.subscribe_output("Control.main.robot_to_field");
         let path_obstacles = nao
-            .subscribe_output(CyclerOutput::from_str("Control.additional.path_obstacles").unwrap());
+            .subscribe_output("Control.additional.path_obstacles");
         Self {
             robot_to_field,
             path_obstacles,

--- a/tools/twix/src/panels/map/layers/robot_pose.rs
+++ b/tools/twix/src/panels/map/layers/robot_pose.rs
@@ -17,8 +17,7 @@ impl Layer for RobotPose {
     const NAME: &'static str = "Robot Pose";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let robot_to_field =
-            nao.subscribe_output("Control.main.robot_to_field");
+        let robot_to_field = nao.subscribe_output("Control.main.robot_to_field");
         Self { robot_to_field }
     }
 

--- a/tools/twix/src/panels/map/layers/robot_pose.rs
+++ b/tools/twix/src/panels/map/layers/robot_pose.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
-use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 use nalgebra::Isometry2;
 use types::field_dimensions::FieldDimensions;
@@ -19,7 +18,7 @@ impl Layer for RobotPose {
 
     fn new(nao: Arc<Nao>) -> Self {
         let robot_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.robot_to_field").unwrap());
+            nao.subscribe_output("Control.main.robot_to_field");
         Self { robot_to_field }
     }
 

--- a/tools/twix/src/panels/plot.rs
+++ b/tools/twix/src/panels/plot.rs
@@ -1,7 +1,6 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::eyre::{eyre, Result, WrapErr};
-use communication::client::CyclerOutput;
 use eframe::{
     egui::{
         Button, CollapsingHeader, DragValue, Response, RichText, TextEdit, TextStyle, Ui, Widget,
@@ -9,7 +8,7 @@ use eframe::{
     epaint::Color32,
 };
 use egui_plot::{Line, Plot as EguiPlot, PlotPoints};
-use log::{error, info};
+use log::info;
 use mlua::{Function, Lua, LuaSerdeExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_string_pretty, Value};
@@ -171,16 +170,10 @@ impl LineData {
     }
 
     fn subscribe_key(&mut self, nao: Arc<Nao>, buffer_size: usize) {
-        self.value_buffer = match CyclerOutput::from_str(&self.output_key) {
-            Ok(output) => {
-                let buffer = nao.subscribe_output(output);
-                buffer.reserve(buffer_size);
-                Some(buffer)
-            }
-            Err(error) => {
-                error!("Failed to subscribe: {:#}", error);
-                None
-            }
+        self.value_buffer = {
+            let buffer = nao.subscribe_output(&self.output_key);
+            buffer.reserve(buffer_size);
+            Some(buffer)
         };
     }
 }

--- a/tools/twix/src/panels/text.rs
+++ b/tools/twix/src/panels/text.rs
@@ -1,15 +1,13 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
-use communication::client::CyclerOutput;
 use eframe::egui::{Label, ScrollArea, Sense, Widget};
-use log::error;
 use serde_json::{json, Value};
 
 use crate::{completion_edit::CompletionEdit, nao::Nao, panel::Panel, value_buffer::ValueBuffer};
 
 pub struct TextPanel {
     nao: Arc<Nao>,
-    output: String,
+    path: String,
     values: Option<ValueBuffer>,
 }
 
@@ -17,49 +15,33 @@ impl Panel for TextPanel {
     const NAME: &'static str = "Text";
 
     fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
-        let output = match value.and_then(|value| value.get("subscribe_key")) {
+        let path = match value.and_then(|value| value.get("subscribe_key")) {
             Some(Value::String(string)) => string.to_string(),
             _ => String::new(),
         };
-        let values = if !output.is_empty() {
-            let output = CyclerOutput::from_str(&output);
-            match output {
-                Ok(output) => Some(nao.subscribe_output(output)),
-                Err(error) => {
-                    error!("Failed to subscribe: {error:?}");
-                    None
-                }
-            }
+        let values = if !path.is_empty() {
+            Some(nao.subscribe_output(&path))
         } else {
             None
         };
-        Self {
-            nao,
-            output,
-            values,
-        }
+
+        Self { nao, path, values }
     }
 
     fn save(&self) -> Value {
         json!({
-            "subscribe_key": self.output.clone()
+            "subscribe_key": self.path.clone()
         })
     }
 }
 
 impl Widget for &mut TextPanel {
     fn ui(self, ui: &mut eframe::egui::Ui) -> eframe::egui::Response {
-        let edit_response = ui.add(CompletionEdit::outputs(&mut self.output, self.nao.as_ref()));
+        let edit_response = ui.add(CompletionEdit::outputs(&mut self.path, self.nao.as_ref()));
         if edit_response.changed() {
-            match CyclerOutput::from_str(&self.output) {
-                Ok(output) => {
-                    self.values = Some(self.nao.subscribe_output(output));
-                }
-                Err(error) => {
-                    error!("Failed to subscribe: {error:#?}");
-                }
-            }
+            self.values = Some(self.nao.subscribe_output(&self.path));
         }
+
         let scroll_area = ScrollArea::vertical()
             .auto_shrink([false, false])
             .show(ui, |ui| {

--- a/tools/twix/src/players_value_buffer.rs
+++ b/tools/twix/src/players_value_buffer.rs
@@ -1,8 +1,7 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
 
-use communication::client::CyclerOutput;
 use types::players::Players;
 
 use crate::{nao::Nao, value_buffer::ValueBuffer};
@@ -12,15 +11,13 @@ pub struct PlayersValueBuffer(pub Players<ValueBuffer>);
 impl PlayersValueBuffer {
     pub fn try_new(nao: Arc<Nao>, prefix: &str, output: &str) -> Result<Self> {
         let buffers = Players {
-            one: nao.subscribe_output(CyclerOutput::from_str(&format!("{prefix}.one.{output}"))?),
-            two: nao.subscribe_output(CyclerOutput::from_str(&format!("{prefix}.two.{output}"))?),
-            three: nao
-                .subscribe_output(CyclerOutput::from_str(&format!("{prefix}.three.{output}"))?),
-            four: nao.subscribe_output(CyclerOutput::from_str(&format!("{prefix}.four.{output}"))?),
-            five: nao.subscribe_output(CyclerOutput::from_str(&format!("{prefix}.five.{output}"))?),
-            six: nao.subscribe_output(CyclerOutput::from_str(&format!("{prefix}.six.{output}"))?),
-            seven: nao
-                .subscribe_output(CyclerOutput::from_str(&format!("{prefix}.seven.{output}"))?),
+            one: nao.subscribe_output(format!("{prefix}.one.{output}")),
+            two: nao.subscribe_output(format!("{prefix}.two.{output}")),
+            three: nao.subscribe_output(format!("{prefix}.three.{output}")),
+            four: nao.subscribe_output(format!("{prefix}.four.{output}")),
+            five: nao.subscribe_output(format!("{prefix}.five.{output}")),
+            six: nao.subscribe_output(format!("{prefix}.six.{output}")),
+            seven: nao.subscribe_output(format!("{prefix}.seven.{output}")),
         };
 
         Ok(Self(buffers))

--- a/tools/twix/src/value_buffer.rs
+++ b/tools/twix/src/value_buffer.rs
@@ -5,8 +5,8 @@ use color_eyre::{
     Result,
 };
 use communication::{
-    client::{Communication, CyclerOutput, SubscriberMessage},
-    messages::Format,
+    client::{Communication, SubscriberMessage},
+    messages::{Format, Path},
 };
 use log::error;
 use serde::Deserialize;
@@ -46,11 +46,11 @@ pub struct ValueBuffer {
 }
 
 impl ValueBuffer {
-    pub fn output(communication: Communication, output: CyclerOutput) -> Self {
+    pub fn output(communication: Communication, path: Path) -> Self {
         let (command_sender, command_receiver) = mpsc::channel(10);
         spawn(async move {
             let (uuid, receiver) = communication
-                .subscribe_output(output.clone(), Format::Textual)
+                .subscribe_output(path.clone(), Format::Textual)
                 .await;
             value_buffer(receiver, command_receiver, communication.clone(), None).await;
             communication.unsubscribe_output(uuid).await;


### PR DESCRIPTION
## Introduced Changes

Removes the `CyclerOutput` from the communication client. This means we can add features on the server side without modifying the client.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Check that all twix panels and overlays still work ;)
