### PR TITLE
Framework Time Measurement

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -72,7 +72,7 @@ fn generate_cycler_instance(cycler: &Cycler) -> TokenStream {
 
 fn generate_database_struct(cycler: &Cycler) -> TokenStream {
     let cycler_name = format_ident!("{}", cycler.name.to_case(Case::Snake));
-    
+
     quote! {
         #[derive(Default, serde::Deserialize, serde::Serialize, serialize_hierarchy::SerializeHierarchy)]
         pub(crate) struct Database {

--- a/crates/code_generation/src/structs.rs
+++ b/crates/code_generation/src/structs.rs
@@ -36,12 +36,18 @@ pub fn generate_structs(structs: &Structs) -> TokenStream {
                 format_ident!("CyclerState"),
                 &derives,
             );
+            let cycle_times = hierarchy_to_token_stream(
+                &cycler_structs.cycle_times,
+                format_ident!("CycleTimings"),
+                &derives,
+            );
 
             quote! {
                 pub mod #cycler_module_identifier {
                     #main_outputs
                     #additional_outputs
                     #cycler_state
+                    #cycle_times
                 }
             }
         });


### PR DESCRIPTION
## Introduced Changes
Adds instrumental profiling for all framework nodes subscribable at a new `cycle_times` output.
Only works in twix when #709 is merged.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Check that cycle time outputs are generated and meaningful
