### PR TITLE
Git-ignore logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ target/
 rust-toolchain.toml
 
 site/
+
+logs/


### PR DESCRIPTION
## Introduced Changes

This ignores the `logs/` directory that is created when starting webots

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

...