### PR TITLE
Pepsi poweroff all improvements

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     net::Ipv4Addr,
     path::Path,
     process::Stdio,
@@ -379,6 +379,12 @@ impl Nao {
         monitor_rsync_progress_with(rsync, progress_callback).await?;
 
         self.reboot().await
+    }
+}
+
+impl Display for Nao {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.host, formatter)
     }
 }
 

--- a/tools/pepsi/src/power_off.rs
+++ b/tools/pepsi/src/power_off.rs
@@ -84,11 +84,11 @@ pub enum AddressOrAll {
 impl FromStr for AddressOrAll {
     type Err = Report;
 
-    fn from_str(s: &str) -> Result<Self> {
-        if s == "all" {
+    fn from_str(string: &str) -> Result<Self> {
+        if string == "all" {
             Ok(Self::All)
         } else {
-            Ok(Self::Address(NaoAddress::from_str(s)?))
+            Ok(Self::Address(NaoAddress::from_str(string)?))
         }
     }
 }

--- a/tools/pepsi/src/power_off.rs
+++ b/tools/pepsi/src/power_off.rs
@@ -41,7 +41,6 @@ pub async fn power_off(arguments: Arguments) -> Result<()> {
             addresses.into_iter().filter_map(|nao| nao.ok()),
             "Powering off...",
             |nao, _progress_bar| async move {
-                let nao = Nao::try_new_with_ping(nao.host).await?;
                 nao.power_off()
                     .await
                     .wrap_err_with(|| format!("failed to power {nao} off"))


### PR DESCRIPTION
## Introduced Changes

This PR introduces various improvements to `pepsi poweroff`. The proposed semantic is the following:

```sh
# Power off specified NAOs
pepsi poweroff 32 33 34

# Power off all NAOs
pepsi poweroff all

# Note that specifying any numbers besides all are ignored
pepsi poweroff 32 33 all 34 # equivalent to the command above
```

Fixes #704.

Additionally, a progress indicator for all NAOs powered off via `poweroff all` is added.

## ToDo / Known Issues

~Testing in the lab.~ Done.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
pepsi poweroff
```
