### PR TITLE
Fix illegal kick-off position

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -884,7 +884,7 @@
       "nanos": 0,
       "secs": 4
     },
-    "distance_to_consider_ball_moved_in_kick_off": 0.2,
+    "distance_to_consider_ball_moved_in_kick_off": 0.3,
     "whistle_acceptance_goal_distance": [0.5, 0.5]
   },
   "ground_contact_detector": {


### PR DESCRIPTION
Increases the `distance_to_consider_ball_moved_in_kick_off`, since this sometimes triggered a false `free_ball`.

Closes #513 