### PR TITLE
Human readable struct hierarchy error messages

### DIFF
--- a/crates/source_analyzer/src/struct_hierarchy.rs
+++ b/crates/source_analyzer/src/struct_hierarchy.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use quote::ToTokens;
 use syn::Type;
 use thiserror::Error;
 
@@ -42,7 +43,7 @@ pub enum HierarchyError {
     StructInOptional,
     #[error("failed to append data type in-place of optional")]
     TypeForOptional,
-    #[error("unmatching data types: previous data type {old} does not match data type {new} to be inserted")]
+    #[error("unmatching data types: previous data type\n\t{old}\ndoes not match data type\n\t{new}\nto be inserted")]
     MismatchingTypes { old: String, new: String },
 }
 
@@ -99,8 +100,8 @@ impl StructHierarchy {
                     data_type: data_type_to_be_inserted,
                 } if *data_type != data_type_to_be_inserted => {
                     return Err(HierarchyError::MismatchingTypes {
-                        old: format!("{data_type:?}"),
-                        new: format!("{data_type_to_be_inserted:?}"),
+                        old: format!("{}", data_type.to_token_stream()),
+                        new: format!("{}", data_type_to_be_inserted.to_token_stream()),
                     });
                 }
                 _ => (),

--- a/crates/source_analyzer/src/struct_hierarchy.rs
+++ b/crates/source_analyzer/src/struct_hierarchy.rs
@@ -55,7 +55,10 @@ pub enum HierarchyError {
 impl HierarchyError {
     fn wrap_in_field(self, field_name: String) -> HierarchyError {
         match self {
-            HierarchyError::ErrorInChild { path, source: error } => HierarchyError::ErrorInChild {
+            HierarchyError::ErrorInChild {
+                path,
+                source: error,
+            } => HierarchyError::ErrorInChild {
                 path: format!("{field_name}.{path}"),
                 source: error,
             },


### PR DESCRIPTION
## Introduced Changes

Old error message:
```
Error: cannot resolve struct hierarchy

Caused by:
    unmatching data types: previous data type Path(TypePath { qself: None, path: Path { leading_colon: None, segments: [PathSegment { ident: Ident { sym: bool, span: bytes(106673..106677) }, arguments: None }] } }) does not match data type Path(TypePath { qself: None, path: Path { leading_colon: None, segments: [PathSegment { ident: Ident { sym: types, span: bytes(1973..1978) }, arguments: None }, Colon2, PathSegment { ident: Ident { sym: parameters, span: bytes(2058..2068) }, arguments: None }, Colon2, PathSegment { ident: Ident { sym: BallDetectionParameters, span: bytes(2070..2093) }, arguments: None }] } }) to be inserted
```

New error message:
```
Error: cannot resolve struct hierarchy for BallDetection in Vision
Caused by:
   0: error in field ball_detection.vision_top
   1: previous data type
          bool
      does not match data type
          types :: parameters :: BallDetectionParameters 
      to be inserted
```
Fixes #pain

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

Ideally this mismatch error would show where the previous type came from as well (node and cycler), but since the error is generated on the first collision, we'd have to store that information for every type in the hierarchy just in case someone else tries to insert something different there later.

## How to Test

- Cause the error. For example by adding this to any node context in vision that isn't the ball detection.
```
parameters: Parameter<bool, "ball_detection.$cycler_instance">,
```
- Observe the error and bask in its readability.