### PR TITLE
Add Intrisic Matrix

### DIFF
--- a/crates/control/src/camera_matrix_calculator.rs
+++ b/crates/control/src/camera_matrix_calculator.rs
@@ -106,7 +106,7 @@ pub fn camera_to_head(
     camera_position: CameraPosition,
     extrinsic_rotation: Vector3<f32>,
 ) -> Isometry3<f32> {
-    let extrinsic_angles_in_radians = extrinsic_rotation.map(|a: f32| a.to_radians());
+    let extrinsic_angles_in_radians = extrinsic_rotation.map(|degree: f32| degree.to_radians());
     let extrinsic_rotation = UnitQuaternion::from_euler_angles(
         extrinsic_angles_in_radians.x,
         extrinsic_angles_in_radians.y,


### PR DESCRIPTION
## Introduced Changes
Based on #727 

This PR will be required for the robot filtering.
It adds the intrinsic matrix to the `CameraMatrix` struct. Consequently, the `impl Projection` also uses the intrinsic matrix.
For now I've decided against flipping the extrinsic coordinate system of our matrix (we don't follow typical conventions of having z along the optical axis). Instead, the flipping now happens at the same position as previously, but now it is encoded in the intrinsic matrix.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* `cargo test` :)
