### PR TITLE
Distant rainbows

### DIFF
--- a/scripts/remoteWorkspace
+++ b/scripts/remoteWorkspace
@@ -69,8 +69,17 @@ remotePath="$(echo $remoteWorkspace | cut -d':' -f 2-)"
 # send local state to remote
 rsync -ah --info progress2 --exclude='.git' --filter="dir-merge,- .gitignore" --delete . "$remoteWorkspace"
 
+# if stdout is a tty/pty, make ssh behave as one as well
+SSH_FLAGS=""
+if [ -t 1 ]; then
+    SSH_FLAGS="-t"
+fi
+
 # invoke command remotely
-ssh $address "sh -c \" \
+ssh \
+    $SSH_FLAGS \
+    $address \
+    "sh -c \" \
     cd \"$remotePath\" \
     && $@
 \""


### PR DESCRIPTION
## Introduced Changes

Cargo as well as other programs detect whether their stdout is connected to a tty/pty or file/pipe/etc.
If stdout is a terminal session (tty/pty), programs often add colors and other visual niceties.

However, ssh does not allocate a pty on the target machine by default, which causes cargo commands to lose color as well as the progress indicator (X/Y jobs done, currently running jobs) during remote compilation.

This PR add detection for tty-ish-ness to the remoteWorkspace script and instructs ssh to allocate a pty.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- [Set up a remote workspace](https://hulks.de/hulk/tooling/pepsi/#remote-compile)
- Run
```sh
# should show colored cargo output
pepsi build --remote

# should show plain cargo output since stdout is not a tty
pepsi build --remote | cat
```