### PR TITLE
Make the CI green again

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_HOME: /__w/hulk/cargo
   CARGO_TARGET_DIR: /__w/hulk/target
+  CARGO_TERM_COLOR: always
 jobs:
   required_checks:
     name: Require all CI jobs


### PR DESCRIPTION
## Introduced Changes

While working on another project, I noticed that github has support for color text in the CI logs.
The [template for rust workflows](https://github.com/actions/starter-workflows/blob/main/ci/rust.yml) includes an environment variable which forces cargo to output colors even when not running in a terminal.

This PR adds said environment variable to our Rust CI workflow.

Fixes #sad black and white colors :(

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Look at [CI logs for this PR](https://github.com/HULKs/hulk/actions/runs/8057569396/job/22008907904?pr=730) and compare to [those from another PR](https://github.com/HULKs/hulk/actions/runs/8051021798/job/21987974268).
