### PR TITLE
Context Privacy 2

### DIFF
--- a/crates/control/src/foot_bumper_filter.rs
+++ b/crates/control/src/foot_bumper_filter.rs
@@ -10,7 +10,7 @@ use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput};
 
 use types::{
-    cycle_time::CycleTime, fall_state::FallState, foot_bumper_obstacle::FootBumperObstacle,
+    fall_state::FallState, foot_bumper_obstacle::FootBumperObstacle,
     foot_bumper_values::FootBumperValues, sensor_data::SensorData,
 };
 
@@ -30,7 +30,7 @@ pub struct FootBumperFilter {
 
 #[context]
 pub struct CreationContext {
-    pub buffer_size: Parameter<usize, "foot_bumper_filter.buffer_size">,
+    buffer_size: Parameter<usize, "foot_bumper_filter.buffer_size">,
 }
 
 #[context]
@@ -42,16 +42,15 @@ pub struct CycleContext {
         usize,
         "foot_bumper_filter.number_of_detections_in_buffer_for_defective_declaration",
     >,
-    pub number_of_detections_in_buffer_to_reset_in_use:
+    number_of_detections_in_buffer_to_reset_in_use:
         Parameter<usize, "foot_bumper_filter.number_of_detections_in_buffer_to_reset_in_use">,
-    pub obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
-    pub sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
+    obstacle_distance: Parameter<f32, "foot_bumper_filter.obstacle_distance">,
+    sensor_angle: Parameter<f32, "foot_bumper_filter.sensor_angle">,
 
-    pub cycle_time: Input<CycleTime, "cycle_time">,
-    pub fall_state: Input<FallState, "fall_state">,
-    pub sensor_data: Input<SensorData, "sensor_data">,
+    fall_state: Input<FallState, "fall_state">,
+    sensor_data: Input<SensorData, "sensor_data">,
 
-    pub foot_bumper_values: AdditionalOutput<FootBumperValues, "foot_bumper_values">,
+    foot_bumper_values: AdditionalOutput<FootBumperValues, "foot_bumper_values">,
 }
 
 #[context]

--- a/crates/control/src/visual_referee_filter.rs
+++ b/crates/control/src/visual_referee_filter.rs
@@ -25,7 +25,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     primary_state: Input<PrimaryState, "primary_state">,
-    pub game_controller_state: RequiredInput<Option<GameControllerState>, "game_controller_state?">,
+    game_controller_state: RequiredInput<Option<GameControllerState>, "game_controller_state?">,
     cycle_time: Input<CycleTime, "cycle_time">,
     filtered_whistle: Input<FilteredWhistle, "filtered_whistle">,
     player_number: Parameter<PlayerNumber, "player_number">,

--- a/crates/control/src/whistle_filter.rs
+++ b/crates/control/src/whistle_filter.rs
@@ -8,9 +8,9 @@ use types::{cycle_time::CycleTime, filtered_whistle::FilteredWhistle, whistle::W
 
 #[derive(Deserialize, Serialize)]
 pub struct WhistleFilter {
-    pub detection_buffer: VecDeque<bool>,
-    pub was_detected_last_cycle: bool,
-    pub last_detection: Option<SystemTime>,
+    detection_buffer: VecDeque<bool>,
+    was_detected_last_cycle: bool,
+    last_detection: Option<SystemTime>,
 }
 
 #[context]


### PR DESCRIPTION
## Introduced Changes

Context (heh): #535 

Removes `pub` tags from all `CreationContext` and `CycleContext` struct members since they are unnecessary and prevent detection of unused fields.

~~Also adds a check to our source analyzer which makes `pub` fields in contexts a compilation error with the exception of `MainOutput` fields.
I had wanted to make this a warning, but it appears that [warnings from proc macros are only emitted on nightly](https://docs.rs/proc-macro-error/latest/proc_macro_error/index.html#limitations).
There exists a [proc-macro-warning](https://crates.io/crates/proc-macro-warning) crate, but that only supports deprecation warnings via a hack.~~

~~An alternative approach I considered is be to have the context macro strip the pub tag. This would allow detecting unused fields but also allows inconsistency and at least in my editor screws with the syntax highlighting.~~

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Find a way to emit warnings

## How to Test

~~Making any context field `pub` should result in a an error.~~