### PR TITLE
Improve kick accuracy for PenaltyShootout

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -44,7 +44,7 @@ fn generate_module(cycler: &Cycler, cyclers: &Cyclers) -> TokenStream {
     let cycler_implementation = generate_implementation(cycler, cyclers);
 
     quote! {
-        #[allow(dead_code, unused_mut, unused_variables, clippy::too_many_arguments, clippy::needless_question_mark, clippy::borrow_deref_ref)]
+        #[allow(dead_code, unused_mut, unused_variables, clippy::too_many_arguments, clippy::needless_question_mark, clippy::borrow_deref_ref, clippy::explicit_auto_deref)]
         pub(crate) mod #module_name {
             use color_eyre::eyre::WrapErr;
             use crate::structs::#module_name::{MainOutputs, AdditionalOutputs};

--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -80,24 +80,16 @@ fn is_kick_pose_reached(
     kick_info: &InWalkKickInfoParameters,
     game_phase: &GamePhase,
 ) -> bool {
-    match game_phase {
-        GamePhase::PenaltyShootout { .. } => {
-            let is_x_reached = kick_pose_to_robot.position().x().abs()
-                < kick_info.penalty_shootout_reached_thresholds.x;
-            let is_y_reached = kick_pose_to_robot.position().y().abs()
-                < kick_info.penalty_shootout_reached_thresholds.y;
-            let is_orientation_reached = kick_pose_to_robot.orientation().angle().abs()
-                < kick_info.penalty_shootout_reached_thresholds.z;
-            is_x_reached && is_y_reached && is_orientation_reached
-        }
-        _ => {
-            let is_x_reached =
-                kick_pose_to_robot.position().x().abs() < kick_info.reached_thresholds.x;
-            let is_y_reached =
-                kick_pose_to_robot.position().y().abs() < kick_info.reached_thresholds.y;
-            let is_orientation_reached =
-                kick_pose_to_robot.orientation().angle().abs() < kick_info.reached_thresholds.z;
-            is_x_reached && is_y_reached && is_orientation_reached
-        }
-    }
+    let penalty_shootout = matches!(game_phase, GamePhase::PenaltyShootout { .. });
+    let thresholds = if penalty_shootout {
+        kick_info.penalty_shootout_reached_thresholds
+    } else {
+        kick_info.reached_thresholds
+    };
+
+    let is_x_reached = kick_pose_to_robot.position().x().abs() < thresholds.x;
+    let is_y_reached = kick_pose_to_robot.position().y().abs() < thresholds.y;
+    let is_orientation_reached = kick_pose_to_robot.orientation().angle().abs() < thresholds.z;
+
+    is_x_reached && is_y_reached && is_orientation_reached
 }

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -251,6 +251,11 @@ impl Behavior {
                         context.in_walk_kicks,
                         &context.parameters.dribbling,
                         dribble_path.clone(),
+                        world_state
+                            .filtered_game_controller_state
+                            .as_ref()
+                            .map(|state| &state.game_phase)
+                            .unwrap_or(&GamePhase::default()),
                     ),
                     Action::Jump => jump::execute(world_state),
                     Action::PrepareJump => prepare_jump::execute(world_state),

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -113,6 +113,7 @@ pub struct InWalkKickInfoParameters {
     pub position: nalgebra::Point2<f32>,
     pub orientation: f32,
     pub reached_thresholds: Vector3<f32>,
+    pub penalty_shootout_reached_thresholds: Vector3<f32>,
     pub shot_distance: f32,
     pub enabled: bool,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -809,7 +809,7 @@
       "position": [-0.23, 0.05],
       "orientation": 0.0,
       "reached_thresholds": [0.06, 0.03, 0.1],
-      "penalty_shootout_reached_thresholds": [0.03, 0.015, 0.05],
+      "penalty_shootout_reached_thresholds": [0.01, 0.015, 0.03],
       "shot_distance": 4.0,
       "enabled": true
     },

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -809,6 +809,7 @@
       "position": [-0.23, 0.05],
       "orientation": 0.0,
       "reached_thresholds": [0.06, 0.03, 0.1],
+      "penalty_shootout_reached_thresholds": [0.03, 0.015, 0.05],
       "shot_distance": 4.0,
       "enabled": true
     },
@@ -816,6 +817,7 @@
       "position": [-0.176, 0.09],
       "orientation": -1.0,
       "reached_thresholds": [0.04, 0.04, 0.1],
+      "penalty_shootout_reached_thresholds": [0.0, 0.0, 0.0],
       "shot_distance": 3.5,
       "enabled": true
     },
@@ -823,6 +825,7 @@
       "position": [-0.2, -0.02],
       "orientation": -1.57,
       "reached_thresholds": [0.05, 0.06, 0.1],
+      "penalty_shootout_reached_thresholds": [0.0, 0.0, 0.0],
       "shot_distance": 0.5,
       "enabled": true
     }

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -207,6 +207,11 @@ impl BehaviorCycler {
                             own_database.main_outputs.ground_to_field.as_ref().unwrap(),
                             own_database.main_outputs.ball_state.as_ref().unwrap(),
                             &own_database.main_outputs.obstacles,
+                            own_database
+                                .main_outputs
+                                .filtered_game_controller_state
+                                .as_ref()
+                                .map(|s| &s.game_phase),
                             &parameters.field_dimensions,
                             &parameters.in_walk_kicks,
                             &parameters.kick_selector.angle_distance_weight,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -211,7 +211,9 @@ impl BehaviorCycler {
                                 .main_outputs
                                 .filtered_game_controller_state
                                 .as_ref()
-                                .map(|s| &s.game_phase),
+                                .map(|filtered_game_controller_state| {
+                                    &filtered_game_controller_state.game_phase
+                                }),
                             &parameters.field_dimensions,
                             &parameters.in_walk_kicks,
                             &parameters.kick_selector.angle_distance_weight,


### PR DESCRIPTION
## Introduced Changes
- Disables `side` and `turn`-kicks during `PenaltyShootout`
- Introduces new `penalty_shootout_reached_thresholds` for `PenaltyShootout`

Based on #742 

## How to Test
- Check, if the penalty shootout is more accurate
