### PR TITLE
Update to nix 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -3333,7 +3333,7 @@ dependencies = [
  "bindgen 0.65.1",
  "i2cdev",
  "libc",
- "nix 0.26.1",
+ "nix 0.28.0",
  "serde",
  "thiserror",
  "types",
@@ -3426,19 +3426,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
-source = "git+https://github.com/nix-rust/nix.git?rev=89b4976#89b4976fddf713ca54834612e351ae35d86c430a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.9.0",
- "pin-utils",
- "static_assertions",
-]
-
-[[package]]
-name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
@@ -3457,6 +3444,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,7 @@ motionfile = { path = "crates/motionfile" }
 nalgebra = { version = "0.32.2", features = ["serde", "serde-serialize"] }
 nao = { path = "crates/nao" }
 nao_camera = { path = "crates/nao_camera" }
-# Pinned git version since the latest release does not contained https://github.com/nix-rust/nix/pull/2022 yet
-nix = { git = "https://github.com/nix-rust/nix.git", version = "0.26.1", rev = "89b4976" }
+nix = { version = "0.28", features = ["ioctl"] }
 num-derive = "0.3"
 num-traits = "0.2"
 once_cell = "1.19.0"


### PR DESCRIPTION
## Introduced Changes

https://github.com/nix-rust/nix/pull/2022 is landed in the latest release of `nix`. We can thus update to the latest release...