### PR TITLE
Abort upload on remote error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "aliveness",
  "bat",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "2.7.0"
+version = "2.8.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -1,5 +1,8 @@
 use clap::Args;
-use color_eyre::{eyre::WrapErr, Result};
+use color_eyre::{
+    eyre::{bail, WrapErr},
+    Result,
+};
 use tokio::process::Command as TokioCommand;
 
 use repository::Repository;
@@ -117,10 +120,14 @@ pub async fn remote(arguments: Arguments, command: Command) -> Result<()> {
             command.arg("--");
             command.args(arguments.passthrough_arguments);
 
-            command
+            let status = command
                 .status()
                 .await
                 .wrap_err("failed to execute remote script")?;
+
+            if !status.success() {
+                bail!("remote script exited with code {}", status.code().unwrap())
+            }
 
             Ok(())
         }


### PR DESCRIPTION
## Introduced Changes

Previously, when remote compilation failed, `pepsi upload` would still proceed to upload whatever binary was build previously to the robots. Because while we checked whether there was an exit status from the remote script execution, we never checked whether that code was anything other than 0.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Change something that makes compilation fail, try to `pepsi upload --remote <nao>`.
On main, this will show a compilation error and then proceed to upload anyway.
On this branch it will show an error message instead of uploading.
