### PR TITLE
Trust but verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "opn"
+version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "color-eyre",
+ "sha2",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3947,6 +3956,7 @@ dependencies = [
  "futures-util",
  "indicatif",
  "nao",
+ "opn",
  "regex",
  "repository",
  "serde_json",
@@ -4655,6 +4665,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,7 +3945,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "aliveness",
  "bat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ members = [
   "crates/constants",
   "crates/context_attribute",
   "crates/control",
-  "crates/linear_algebra",
-  "crates/filtering",
+  "crates/coordinate_systems",
   "crates/energy_optimization",
+  "crates/filtering",
   "crates/framework",
   "crates/geometry",
   "crates/hardware",
@@ -20,9 +20,11 @@ members = [
   "crates/hulk_nao",
   "crates/hulk_webots",
   "crates/kinematics",
+  "crates/linear_algebra",
   "crates/motionfile",
   "crates/nao",
   "crates/nao_camera",
+  "crates/opn",
   "crates/parameters",
   "crates/projection",
   "crates/repository",
@@ -42,8 +44,6 @@ members = [
   "tools/localizer",
   "tools/pepsi",
   "tools/twix",
-  "crates/energy_optimization",
-  "crates/coordinate_systems",
 ]
 # HuLA and Aliveness are built independently by yocto
 exclude = ["tools/aliveness", "tools/breeze", "tools/hula"]
@@ -124,6 +124,7 @@ nix = { version = "0.28", features = ["ioctl"] }
 num-derive = "0.3"
 num-traits = "0.2"
 once_cell = "1.19.0"
+opn = { path = "crates/opn" }
 opusfile-ng = "0.1.0"
 ordered-float = "3.1.0"
 parameters = { path = "crates/parameters" }
@@ -148,6 +149,7 @@ serde_json = "1.0.91"
 serde_test = "1.0.152"
 serialize_hierarchy = { path = "crates/serialize_hierarchy" }
 serialize_hierarchy_derive = { path = "crates/serialize_hierarchy_derive" }
+sha2 = "0.10.8"
 smallvec = "1.9.0"
 source_analyzer = { path = "crates/source_analyzer" }
 spl_network = { path = "crates/spl_network" }

--- a/crates/opn/Cargo.toml
+++ b/crates/opn/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "opn"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+color-eyre = { workspace = true }
+byteorder = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/opn/Cargo.toml
+++ b/crates/opn/Cargo.toml
@@ -5,8 +5,6 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 color-eyre = { workspace = true }
 byteorder = { workspace = true }

--- a/crates/opn/src/lib.rs
+++ b/crates/opn/src/lib.rs
@@ -1,0 +1,88 @@
+use std::{
+    fs::File,
+    io::{Read, Seek},
+    path::Path,
+};
+
+use byteorder::{BigEndian, ByteOrder};
+use color_eyre::{
+    eyre::{bail, Context, OptionExt},
+    Result,
+};
+use sha2::{Digest, Sha256};
+
+// #[repr(packed)]
+// pub struct OpnHeader {
+//     magic: [u8; 8],
+//     flags: u8,
+//     zero_a: [u8; 86],
+//     unknown_a: u8,
+//     installer_size_raw: u64,
+//     zero_b: [u8; 64],
+//     unknown_b: u8,
+//     robot_kind: u8,
+//     unknown_c: u8,
+//     version: u64,
+//     zero_c: [u8; 3896],
+// }
+
+pub fn verify_image(image_path: impl AsRef<Path>) -> Result<()> {
+    let mut file = File::open(&image_path)
+        .wrap_err_with(|| format!("failed to open {}", image_path.as_ref().display()))?;
+
+    let mut buffer = [0; 8];
+    file.read_exact(&mut buffer)
+        .wrap_err("failed to read magic from header")?;
+    println!("Magic: {}", String::from_utf8_lossy(&buffer));
+    (buffer == b"ALDIMAGE"[..])
+        .then_some(())
+        .ok_or_eyre("magic doesn't match")?;
+
+    let header_data = read_exact_at(&mut file, 56, 4040).wrap_err("failed to read header data")?;
+    let header_checksum = read_u64(&mut file, 24).wrap_err("failed to read header checksum")?;
+    verify_checksum(&header_data, header_checksum).wrap_err("header checksum does not match")?;
+
+    let installer_size = read_u64(&mut file, 96)?;
+    let installer_data =
+        read_exact_at(&mut file, 4096, installer_size).wrap_err("failed to read intaller data")?;
+    let installer_checksum =
+        read_u64(&mut file, 104).wrap_err("failed to read installer checksum")?;
+    verify_checksum(&installer_data, installer_checksum)
+        .wrap_err("installer checksum does not match")?;
+
+    let image_start = 4096 + installer_size;
+    let image_size = file.metadata().wrap_err("failed to read metadata")?.len() - image_start;
+    let image_data =
+        read_exact_at(&mut file, image_start, image_size).wrap_err("failed to read image data")?;
+    let image_checksum = read_u64(&mut file, 136).wrap_err("failed to read image checksum")?;
+    verify_checksum(&image_data, image_checksum).wrap_err("image checksum does not match")?;
+
+    Ok(())
+}
+
+fn verify_checksum(data: &[u8], expected_checksum: u64) -> Result<()> {
+    let calulated_checksum = Sha256::digest(data);
+    let calulated_checksum = BigEndian::read_u64(&calulated_checksum);
+    if calulated_checksum != expected_checksum {
+        bail!("expected: {expected_checksum}, actual: {calulated_checksum}");
+    }
+
+    Ok(())
+}
+
+fn read_exact_at(file: &mut File, data_position: u64, size: u64) -> Result<Vec<u8>> {
+    let mut data = vec![0; size as usize];
+    file.seek(std::io::SeekFrom::Start(data_position))?;
+    file.read_exact(&mut data)?;
+
+    Ok(data)
+}
+
+fn read_u64(file: &mut File, position: u64) -> Result<u64> {
+    let mut buffer = [0; 8];
+    file.seek(std::io::SeekFrom::Start(position))?;
+    file.read_exact(&mut buffer)?;
+    let size = BigEndian::read_u64(&buffer);
+
+    Ok(size)
+}

--- a/crates/opn/src/lib.rs
+++ b/crates/opn/src/lib.rs
@@ -11,21 +11,6 @@ use color_eyre::{
 };
 use sha2::{Digest, Sha256};
 
-// #[repr(packed)]
-// pub struct OpnHeader {
-//     magic: [u8; 8],
-//     flags: u8,
-//     zero_a: [u8; 86],
-//     unknown_a: u8,
-//     installer_size_raw: u64,
-//     zero_b: [u8; 64],
-//     unknown_b: u8,
-//     robot_kind: u8,
-//     unknown_c: u8,
-//     version: u64,
-//     zero_c: [u8; 3896],
-// }
-
 pub fn verify_image(image_path: impl AsRef<Path>) -> Result<()> {
     let mut file = File::open(&image_path)
         .wrap_err_with(|| format!("failed to open {}", image_path.as_ref().display()))?;
@@ -64,7 +49,7 @@ fn verify_checksum(data: &[u8], expected_checksum: u64) -> Result<()> {
     let calulated_checksum = Sha256::digest(data);
     let calulated_checksum = BigEndian::read_u64(&calulated_checksum);
     if calulated_checksum != expected_checksum {
-        bail!("expected: {expected_checksum}, actual: {calulated_checksum}");
+        bail!("expected: {expected_checksum}\n  actual: {calulated_checksum}");
     }
 
     Ok(())

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.0.0"
+version = "3.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -15,6 +15,7 @@ constants = { workspace = true }
 futures-util = { workspace = true }
 indicatif = { workspace = true }
 nao = { workspace = true }
+opn = { workspace = true }
 regex = { workspace = true }
 repository = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -5,6 +5,7 @@ use color_eyre::{eyre::WrapErr, Result};
 
 use constants::OS_VERSION;
 use nao::Nao;
+use opn::verify_image;
 use repository::get_image_path;
 
 use crate::{parsers::NaoAddress, progress_indicator::ProgressIndicator};
@@ -29,6 +30,8 @@ pub async fn gammaray(arguments: Arguments) -> Result<()> {
         None => get_image_path(version).await?,
     };
     let image_path = image_path.as_path();
+
+    verify_image(image_path).wrap_err("image verification failed")?;
 
     ProgressIndicator::map_tasks(
         arguments.naos,


### PR DESCRIPTION
## Introduced Changes

Based on #748 

Adds an image verification step in `pepsi gammaray`.
Before an image is sent of to the robot for flashing, the internal checksums of the opn file format are used to verify integrity.

Note that our images between and including 5.7.0 and 5.9.1 are considered invalid by this check, since we reused one of the checksum fields for other data when optimizing the installer script last year.

To fix this, I have reverted this change in https://github.com/HULKs/opn-tools/commit/630d559f74b92c118209afc1f39c2d7b1fe6bc66.
However, this PR should not be merged until we have a new new image with this fix released and deployed, which @schmidma is currently working on.

This would also mean that we won't be able to use gammaray to flash these older, invalid but functional images, however, this is rarely a usecase and we can still use the old USB stick method.

Example error message:

```
Error: 
   0: failed to execute gammaray command
   1: image verification failed
   2: rootfs verification failed
   3: checksum verification failed
   4: found   : 15126611277323492171
      expected: 4327915211679979315
```

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

gammaray should work as normal when using an image with valid checksums like the official robocupper image or our own pre 5.7.0 ones.
When using an invalid image like 5.9.1 or a [truncated](https://man.archlinux.org/man/truncate.1) one, an error message should appear and the gammaray process should abort.