### PR TITLE
Twix ground panel

### DIFF
--- a/crates/linear_algebra/src/pose.rs
+++ b/crates/linear_algebra/src/pose.rs
@@ -21,6 +21,10 @@ where
         ))
     }
 
+    pub fn zero() -> Self {
+        Default::default()
+    }
+
     pub fn as_transform<From>(&self) -> Isometry2<From, Frame, T> {
         Isometry2::wrap(self.inner)
     }

--- a/tools/twix/src/panels/map/layers/ball_filter.rs
+++ b/tools/twix/src/panels/map/layers/ball_filter.rs
@@ -4,8 +4,8 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use communication::client::{Cycler, CyclerOutput, Output};
-use coordinate_systems::{Field, Ground};
-use linear_algebra::{Isometry2, Point};
+use coordinate_systems::Ground;
+use linear_algebra::Point;
 use types::{
     field_dimensions::FieldDimensions,
     multivariate_normal_distribution::MultivariateNormalDistribution,
@@ -16,44 +16,32 @@ use crate::{
 };
 
 pub struct BallFilter {
-    ground_to_field: ValueBuffer,
     ball_state: ValueBuffer,
 }
 
-impl Layer for BallFilter {
+impl Layer<Ground> for BallFilter {
     const NAME: &'static str = "Ball Filter";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let ground_to_field = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Main {
-                path: "ground_to_field".to_string(),
-            },
-        });
         let ball_state = nao.subscribe_output(CyclerOutput {
             cycler: Cycler::Control,
             output: Output::Additional {
                 path: "best_ball_state".to_string(),
             },
         });
-        Self {
-            ground_to_field,
-            ball_state,
-        }
+        Self { ball_state }
     }
 
     fn paint(
         &self,
-        painter: &TwixPainter<Field>,
+        painter: &TwixPainter<Ground>,
         _field_dimensions: &FieldDimensions,
     ) -> Result<()> {
-        let ground_to_field: Option<Isometry2<Ground, Field>> =
-            self.ground_to_field.parse_latest()?;
         let ball_state: Option<MultivariateNormalDistribution<4>> =
             self.ball_state.parse_latest()?;
 
         if let Some(state) = ball_state {
-            let position = ground_to_field.unwrap_or_default() * Point::from(state.mean.xy());
+            let position = Point::from(state.mean.xy());
             let covariance = state.covariance.fixed_view::<2, 2>(0, 0).into_owned();
             let stroke = Stroke::new(0.01, Color32::BLACK);
             let fill_color = Color32::from_rgba_unmultiplied(255, 255, 0, 100);

--- a/tools/twix/src/panels/map/layers/ball_position.rs
+++ b/tools/twix/src/panels/map/layers/ball_position.rs
@@ -17,7 +17,7 @@ pub struct BallPosition {
     ball_position: ValueBuffer,
 }
 
-impl Layer for BallPosition {
+impl Layer<Field> for BallPosition {
     const NAME: &'static str = "Ball Position";
 
     fn new(nao: Arc<Nao>) -> Self {

--- a/tools/twix/src/panels/map/layers/behavior_simulator.rs
+++ b/tools/twix/src/panels/map/layers/behavior_simulator.rs
@@ -23,7 +23,7 @@ pub struct BehaviorSimulator {
     ball: ValueBuffer,
 }
 
-impl Layer for BehaviorSimulator {
+impl Layer<Field> for BehaviorSimulator {
     const NAME: &'static str = "Behavior Simulator";
 
     fn new(nao: Arc<Nao>) -> Self {
@@ -76,8 +76,8 @@ impl Layer for BehaviorSimulator {
             if let Ok(MotionCommand::Walk { path, .. }) =
                 self.motion_command.0[player_number].parse_latest()
             {
-                painter.path(
-                    ground_to_field,
+                let ground_painter = painter.transform_painter(ground_to_field.inverse());
+                ground_painter.path(
                     path,
                     TRANSPARENT_BLUE,
                     TRANSPARENT_LIGHT_BLUE,

--- a/tools/twix/src/panels/map/layers/behavior_simulator.rs
+++ b/tools/twix/src/panels/map/layers/behavior_simulator.rs
@@ -77,12 +77,7 @@ impl Layer<Field> for BehaviorSimulator {
                 self.motion_command.0[player_number].parse_latest()
             {
                 let ground_painter = painter.transform_painter(ground_to_field.inverse());
-                ground_painter.path(
-                    path,
-                    TRANSPARENT_BLUE,
-                    TRANSPARENT_LIGHT_BLUE,
-                    0.025,
-                );
+                ground_painter.path(path, TRANSPARENT_BLUE, TRANSPARENT_LIGHT_BLUE, 0.025);
             }
 
             if let Ok(head_yaw) = self.head_yaw.0[player_number].parse_latest::<f32>() {

--- a/tools/twix/src/panels/map/layers/field.rs
+++ b/tools/twix/src/panels/map/layers/field.rs
@@ -7,7 +7,7 @@ use crate::{nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter};
 
 pub struct Field {}
 
-impl Layer for Field {
+impl Layer<coordinate_systems::Field> for Field {
     const NAME: &'static str = "Field";
 
     fn new(_nao: Arc<Nao>) -> Self {

--- a/tools/twix/src/panels/map/layers/image_segments.rs
+++ b/tools/twix/src/panels/map/layers/image_segments.rs
@@ -4,27 +4,24 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use communication::client::CyclerOutput;
-use coordinate_systems::{Field, Ground};
-use linear_algebra::{center, point, Isometry2, Point2};
+use coordinate_systems::Ground;
+use linear_algebra::{center, point, Point2};
 use projection::Projection;
 use types::{camera_matrix::CameraMatrix, color::Rgb, field_dimensions::FieldDimensions};
 
 use crate::{panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer};
 
 pub struct ImageSegments {
-    ground_to_field: ValueBuffer,
     image_segments_bottom: ValueBuffer,
     camera_matrix_bottom: ValueBuffer,
     image_segments_top: ValueBuffer,
     camera_matrix_top: ValueBuffer,
 }
 
-impl Layer for ImageSegments {
+impl Layer<Ground> for ImageSegments {
     const NAME: &'static str = "Image Segments";
 
     fn new(nao: std::sync::Arc<crate::nao::Nao>) -> Self {
-        let ground_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.ground_to_field").unwrap());
         let image_segments_bottom = nao
             .subscribe_output(CyclerOutput::from_str("VisionBottom.main.image_segments").unwrap());
         let camera_matrix_bottom = nao
@@ -34,7 +31,6 @@ impl Layer for ImageSegments {
         let camera_matrix_top =
             nao.subscribe_output(CyclerOutput::from_str("VisionTop.main.camera_matrix").unwrap());
         Self {
-            ground_to_field,
             image_segments_bottom,
             camera_matrix_bottom,
             image_segments_top,
@@ -44,20 +40,16 @@ impl Layer for ImageSegments {
 
     fn paint(
         &self,
-        painter: &TwixPainter<Field>,
+        painter: &TwixPainter<Ground>,
         _field_dimensions: &FieldDimensions,
     ) -> Result<()> {
-        let ground_to_field: Isometry2<Ground, Field> =
-            self.ground_to_field.parse_latest().unwrap_or_default();
         paint_segments(
             painter,
-            ground_to_field,
             &self.camera_matrix_bottom.require_latest()?,
             &self.image_segments_bottom.require_latest()?,
         )?;
         paint_segments(
             painter,
-            ground_to_field,
             &self.camera_matrix_top.require_latest()?,
             &self.image_segments_top.require_latest()?,
         )?;
@@ -66,8 +58,7 @@ impl Layer for ImageSegments {
 }
 
 fn paint_segments(
-    painter: &TwixPainter<Field>,
-    ground_to_field: Isometry2<Ground, Field>,
+    painter: &TwixPainter<Ground>,
     camera_matrix: &CameraMatrix,
     segments: &types::image_segments::ImageSegments,
 ) -> Result<()> {
@@ -78,11 +69,10 @@ fn paint_segments(
             let rgb_color = Rgb::from(ycbcr_color);
             let original_color = Color32::from_rgb(rgb_color.r, rgb_color.g, rgb_color.b);
 
-            let segment_in_field =
-                match project_segment_to_field(x, segment, camera_matrix, ground_to_field) {
-                    Ok(result) => result,
-                    Err(_error) => break,
-                };
+            let segment_in_field = match project_segment_to_ground(x, segment, camera_matrix) {
+                Ok(result) => result,
+                Err(_error) => break,
+            };
 
             painter.line_segment(
                 segment_in_field.start,
@@ -97,33 +87,30 @@ fn paint_segments(
     Ok(())
 }
 
-struct SegmentInField {
-    start: Point2<Field>,
-    end: Point2<Field>,
+struct SegmentInGround {
+    start: Point2<Ground>,
+    end: Point2<Ground>,
     line_width: f32,
 }
 
-fn project_segment_to_field(
+fn project_segment_to_ground(
     x: f32,
     segment: &types::image_segments::Segment,
     camera_matrix: &CameraMatrix,
-    ground_to_field: Isometry2<Ground, Field>,
-) -> Result<SegmentInField> {
+) -> Result<SegmentInGround> {
     let start = point![x, segment.start as f32];
     let end = point![x, segment.end as f32];
 
     let start_in_ground = camera_matrix.pixel_to_ground(start)?;
     let end_in_ground = camera_matrix.pixel_to_ground(end)?;
-    let start_in_field = ground_to_field * start_in_ground;
-    let end_in_field = ground_to_field * end_in_ground;
 
     let midpoint = center(start, end);
     let pixel_radius = 100.0 * camera_matrix.get_pixel_radius(0.01, midpoint, point![640, 480])?;
     let line_width = 3.0 / pixel_radius;
 
-    Ok(SegmentInField {
-        start: start_in_field,
-        end: end_in_field,
+    Ok(SegmentInGround {
+        start: start_in_ground,
+        end: end_in_ground,
         line_width,
     })
 }

--- a/tools/twix/src/panels/map/layers/line_correspondences.rs
+++ b/tools/twix/src/panels/map/layers/line_correspondences.rs
@@ -16,7 +16,7 @@ pub struct LineCorrespondences {
     correspondence_lines: ValueBuffer,
 }
 
-impl Layer for LineCorrespondences {
+impl Layer<Field> for LineCorrespondences {
     const NAME: &'static str = "Line Correspondences";
 
     fn new(nao: Arc<Nao>) -> Self {

--- a/tools/twix/src/panels/map/layers/lines.rs
+++ b/tools/twix/src/panels/map/layers/lines.rs
@@ -4,9 +4,8 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use communication::client::CyclerOutput;
-use coordinate_systems::{Field, Ground};
+use coordinate_systems::Ground;
 use geometry::line::Line2;
-use linear_algebra::Isometry2;
 use types::field_dimensions::FieldDimensions;
 
 use crate::{

--- a/tools/twix/src/panels/map/layers/obstacle_filter.rs
+++ b/tools/twix/src/panels/map/layers/obstacle_filter.rs
@@ -4,8 +4,8 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use communication::client::{Cycler, CyclerOutput, Output};
-use coordinate_systems::{Field, Ground};
-use linear_algebra::{Isometry2, Point2};
+use coordinate_systems::Ground;
+use linear_algebra::Point2;
 use types::{field_dimensions::FieldDimensions, obstacle_filter::Hypothesis};
 
 use crate::{
@@ -13,44 +13,31 @@ use crate::{
 };
 
 pub struct ObstacleFilter {
-    ground_to_field: ValueBuffer,
     hypotheses: ValueBuffer,
 }
 
-impl Layer for ObstacleFilter {
+impl Layer<Ground> for ObstacleFilter {
     const NAME: &'static str = "Obstacle Filter";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let ground_to_field = nao.subscribe_output(CyclerOutput {
-            cycler: Cycler::Control,
-            output: Output::Main {
-                path: "ground_to_field".to_string(),
-            },
-        });
         let hypotheses = nao.subscribe_output(CyclerOutput {
             cycler: Cycler::Control,
             output: Output::Additional {
                 path: "obstacle_filter_hypotheses".to_string(),
             },
         });
-        Self {
-            ground_to_field,
-            hypotheses,
-        }
+        Self { hypotheses }
     }
 
     fn paint(
         &self,
-        painter: &TwixPainter<Field>,
+        painter: &TwixPainter<Ground>,
         _field_dimensions: &FieldDimensions,
     ) -> Result<()> {
-        let ground_to_field: Option<Isometry2<Ground, Field>> =
-            self.ground_to_field.parse_latest()?;
         let hypotheses: Vec<Hypothesis> = self.hypotheses.parse_latest()?;
 
         for hypothesis in hypotheses.iter() {
-            let position =
-                ground_to_field.unwrap_or_default() * Point2::from(hypothesis.state.mean);
+            let position = Point2::from(hypothesis.state.mean);
             let covariance = hypothesis.state.covariance;
             let stroke = Stroke::new(0.01, Color32::BLACK);
             let fill_color = Color32::from_rgba_unmultiplied(255, 255, 0, 20);

--- a/tools/twix/src/panels/map/layers/path.rs
+++ b/tools/twix/src/panels/map/layers/path.rs
@@ -4,8 +4,8 @@ use color_eyre::Result;
 use eframe::epaint::Color32;
 
 use communication::client::CyclerOutput;
-use coordinate_systems::{Field, Ground};
-use linear_algebra::Isometry2;
+use coordinate_systems::Ground;
+
 use types::{field_dimensions::FieldDimensions, motion_command::MotionCommand};
 
 use crate::{
@@ -13,40 +13,27 @@ use crate::{
 };
 
 pub struct Path {
-    ground_to_field: ValueBuffer,
     motion_command: ValueBuffer,
 }
 
-impl Layer for Path {
+impl Layer<Ground> for Path {
     const NAME: &'static str = "Path";
 
     fn new(nao: Arc<Nao>) -> Self {
-        let ground_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.ground_to_field").unwrap());
         let motion_command =
             nao.subscribe_output(CyclerOutput::from_str("Control.main.motion_command").unwrap());
-        Self {
-            ground_to_field,
-            motion_command,
-        }
+        Self { motion_command }
     }
 
     fn paint(
         &self,
-        painter: &TwixPainter<Field>,
+        painter: &TwixPainter<Ground>,
         _field_dimensions: &FieldDimensions,
     ) -> Result<()> {
-        let ground_to_field: Isometry2<Ground, Field> = self.ground_to_field.require_latest()?;
         let motion_command: MotionCommand = self.motion_command.require_latest()?;
 
         if let MotionCommand::Walk { path, .. } = motion_command {
-            painter.path(
-                ground_to_field,
-                path,
-                Color32::BLUE,
-                Color32::LIGHT_BLUE,
-                0.025,
-            );
+            painter.path(path, Color32::BLUE, Color32::LIGHT_BLUE, 0.025);
         }
         Ok(())
     }

--- a/tools/twix/src/panels/map/layers/path_obstacles.rs
+++ b/tools/twix/src/panels/map/layers/path_obstacles.rs
@@ -5,7 +5,10 @@ use eframe::epaint::{Color32, Stroke};
 
 use communication::client::CyclerOutput;
 use coordinate_systems::Ground;
-use types::{field_dimensions::FieldDimensions, path_obstacles::PathObstacle};
+use types::{
+    field_dimensions::FieldDimensions,
+    path_obstacles::{PathObstacle, PathObstacleShape},
+};
 
 use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
@@ -37,10 +40,10 @@ impl Layer<Ground> for PathObstacles {
         };
         for path_obstacle in path_obstacles {
             match path_obstacle.shape {
-                types::path_obstacles::PathObstacleShape::Circle(circle) => {
+                PathObstacleShape::Circle(circle) => {
                     painter.circle_stroke(circle.center, circle.radius, path_obstacle_stroke)
                 }
-                types::path_obstacles::PathObstacleShape::LineSegment(line_segment) => {
+                PathObstacleShape::LineSegment(line_segment) => {
                     painter.line_segment(line_segment.0, line_segment.1, path_obstacle_stroke)
                 }
             }

--- a/tools/twix/src/panels/map/layers/robot_pose.rs
+++ b/tools/twix/src/panels/map/layers/robot_pose.rs
@@ -1,49 +1,34 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
-use communication::client::CyclerOutput;
-use coordinate_systems::{Field, Ground};
-use linear_algebra::Isometry2;
+use coordinate_systems::Ground;
+use linear_algebra::Pose;
 use types::field_dimensions::FieldDimensions;
 
-use crate::{
-    nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
-};
+use crate::{nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter};
 
-pub struct RobotPose {
-    ground_to_field: ValueBuffer,
-}
+pub struct RobotPose {}
 
-impl Layer for RobotPose {
+impl Layer<Ground> for RobotPose {
     const NAME: &'static str = "Robot Pose";
 
-    fn new(nao: Arc<Nao>) -> Self {
-        let ground_to_field =
-            nao.subscribe_output(CyclerOutput::from_str("Control.main.ground_to_field").unwrap());
-        Self { ground_to_field }
+    fn new(_nao: Arc<Nao>) -> Self {
+        Self {}
     }
 
     fn paint(
         &self,
-        painter: &TwixPainter<Field>,
+        painter: &TwixPainter<Ground>,
         _field_dimensions: &FieldDimensions,
     ) -> Result<()> {
-        let ground_to_field: Isometry2<Ground, Field> = self.ground_to_field.require_latest()?;
-
         let pose_color = Color32::from_white_alpha(187);
         let pose_stroke = Stroke {
             width: 0.02,
             color: Color32::BLACK,
         };
-        painter.pose(
-            ground_to_field.as_pose(),
-            0.15,
-            0.25,
-            pose_color,
-            pose_stroke,
-        );
+        painter.pose(Pose::zero(), 0.15, 0.25, pose_color, pose_stroke);
         Ok(())
     }
 }

--- a/tools/twix/src/panels/map/layers/robot_pose.rs
+++ b/tools/twix/src/panels/map/layers/robot_pose.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::Ground;
-use linear_algebra::Pose;
+use linear_algebra::Pose2;
 use types::field_dimensions::FieldDimensions;
 
 use crate::{nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter};
@@ -28,7 +28,7 @@ impl Layer<Ground> for RobotPose {
             width: 0.02,
             color: Color32::BLACK,
         };
-        painter.pose(Pose::zero(), 0.15, 0.25, pose_color, pose_stroke);
+        painter.pose(Pose2::zero(), 0.15, 0.25, pose_color, pose_stroke);
         Ok(())
     }
 }

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -203,10 +203,9 @@ impl<Frame> TwixPainter<Frame> {
             stroke,
         )));
     }
-
     pub fn pose(
         &self,
-        pose: Pose<Frame>,
+        pose: Pose2<Frame>,
         circle_radius: f32,
         line_length: f32,
         fill_color: Color32,
@@ -392,23 +391,6 @@ impl TwixPainter<Ground> {
         let world_to_camera =
             Similarity2::new(nalgebra::vector![length / 2.0, -width / 2.0], 0.0, 1.0);
         self.with_camera(dimensions, world_to_camera, CoordinateSystem::RightHand)
-    }
-    
-    pub fn pose(
-        &self,
-        pose: Pose2<Field>,
-        circle_radius: f32,
-        line_length: f32,
-        fill_color: Color32,
-        stroke: Stroke,
-    ) {
-        let center = pose.position();
-        self.circle(center, circle_radius, fill_color, stroke);
-        self.line_segment(
-            center,
-            pose.as_transform::<Ground>() * point![line_length, 0.0],
-            stroke,
-        );
     }
 
     pub fn path(


### PR DESCRIPTION
## Introduced Changes
Adds a `Ground` panel to twix to allow showing things from the Map panel not only in field coordinates but also in ground coordinates. This makes it possible to display overlays without having a `ground_to_field` for example the ball.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*

Rebuild twix, connect to a robot and open a Map panel. In the behaviour of the Map panel with `Field` nothing should be changed, with `Ground` selected the overlays should be in relation to the robot (in ground coordinates).
