### PR TITLE
Add missing aliveness completions for pepsi ping

### DIFF
--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -72,13 +72,14 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const COMPLETION_SUBCOMMANDS: [(&str, &str); 14] = [
+            const COMPLETION_SUBCOMMANDS: [(&str, &str); 15] = [
                 ("aliveness", ""),
                 ("gammaray", ""),
                 ("hulk", ""),
                 ("logs", "delete"),
                 ("logs", "downloads"),
                 ("logs", "show"),
+                ("ping", ""),
                 ("postgame", ""),
                 ("poweroff", ""),
                 ("reboot", ""),


### PR DESCRIPTION
## Introduced Changes

This PR adds the missing (fish) aliveness completions for ping. While this may not that useful, it should be included for the sake of completeness.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Generate new completions, type `pepsi ping` and hit tab.
