### PR TITLE
Hybrid alignment fix

### DIFF
--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -216,7 +216,8 @@ pub fn hybrid_alignment(
 
     let angle_limit = ((distance_to_target - distance_to_be_aligned)
         / (hybrid_align_distance - distance_to_be_aligned))
-        .clamp(0.0, 1.0) * PI;
+        .clamp(0.0, 1.0)
+        * PI;
 
     let orientation = clamp_around(
         Orientation2::identity(),

--- a/crates/linear_algebra/src/framed_nalgebra.rs
+++ b/crates/linear_algebra/src/framed_nalgebra.rs
@@ -332,8 +332,8 @@ impl<Frame> Orientation2<Frame> {
         Self::wrap(self.inner.slerp(&other.inner, t))
     }
 
-    pub fn rotation_to(&self, other: Self) -> Self {
-        Self::wrap(self.inner.rotation_to(&other.inner))
+    pub fn rotation_to(&self, other: Self) -> UnitComplex<Frame, Frame> {
+        UnitComplex::wrap(self.inner.rotation_to(&other.inner))
     }
 }
 

--- a/crates/linear_algebra/src/framed_nalgebra.rs
+++ b/crates/linear_algebra/src/framed_nalgebra.rs
@@ -100,11 +100,11 @@ where
     }
 
     pub fn x_axis() -> Self {
-        Framed::wrap(*SVector::x_axis())
+        Self::wrap(*SVector::x_axis())
     }
 
     pub fn y_axis() -> Self {
-        Framed::wrap(*SVector::y_axis())
+        Self::wrap(*SVector::y_axis())
     }
 }
 
@@ -125,15 +125,15 @@ where
     }
 
     pub fn x_axis() -> Self {
-        Framed::wrap(*SVector::x_axis())
+        Self::wrap(*SVector::x_axis())
     }
 
     pub fn y_axis() -> Self {
-        Framed::wrap(*SVector::y_axis())
+        Self::wrap(*SVector::y_axis())
     }
 
     pub fn z_axis() -> Self {
-        Framed::wrap(*SVector::z_axis())
+        Self::wrap(*SVector::z_axis())
     }
 
     pub fn xy(&self) -> Vector2<Frame, Scalar> {
@@ -261,11 +261,11 @@ where
 
 impl<Frame> Pose<Frame> {
     pub fn new(translation: Vector2<Frame, f32>, angle: f32) -> Self {
-        Pose::wrap(nalgebra::Isometry2::new(translation.inner, angle))
+        Self::wrap(nalgebra::Isometry2::new(translation.inner, angle))
     }
 
     pub fn from_parts(position: Point2<Frame, f32>, orientation: Orientation2<Frame>) -> Self {
-        Pose::wrap(nalgebra::Isometry2::from_parts(
+        Self::wrap(nalgebra::Isometry2::from_parts(
             position.inner.into(),
             orientation.inner,
         ))
@@ -314,7 +314,7 @@ impl<Frame> Orientation2<Frame> {
     }
 
     pub fn from_vector(direction: Vector2<Frame>) -> Self {
-        Orientation2::wrap(nalgebra::UnitComplex::rotation_between(
+        Self::wrap(nalgebra::UnitComplex::rotation_between(
             &nalgebra::Vector2::x_axis(),
             &direction.inner,
         ))

--- a/crates/linear_algebra/src/transform_nalgebra.rs
+++ b/crates/linear_algebra/src/transform_nalgebra.rs
@@ -126,6 +126,10 @@ impl<From, To> UnitComplex<From, To> {
         Transform::<To, From, _>::wrap(self.inner.inverse())
     }
 
+    pub fn clamp_angle<To2>(&self, min: f32, max: f32) -> UnitComplex<From, To2> {
+        UnitComplex::new(self.angle().clamp(min, max))
+    }
+
     pub fn as_orientation(&self) -> Orientation2<To> {
         Orientation2::wrap(self.inner)
     }

--- a/crates/linear_algebra/src/transform_nalgebra.rs
+++ b/crates/linear_algebra/src/transform_nalgebra.rs
@@ -108,11 +108,11 @@ impl<From, To> core::convert::From<nalgebra::UnitQuaternion<f32>> for Isometry3<
 
 impl<From, To> UnitComplex<From, To> {
     pub fn new(angle: f32) -> Self {
-        UnitComplex::wrap(nalgebra::UnitComplex::new(angle))
+        Self::wrap(nalgebra::UnitComplex::new(angle))
     }
 
     pub fn from_vector(direction: Vector2<To>) -> Self {
-        UnitComplex::wrap(nalgebra::UnitComplex::rotation_between(
+        Self::wrap(nalgebra::UnitComplex::rotation_between(
             &nalgebra::Vector2::x_axis(),
             &direction.inner,
         ))
@@ -129,11 +129,10 @@ impl<From, To> UnitComplex<From, To> {
     pub fn as_orientation(&self) -> Orientation2<To> {
         Orientation2::wrap(self.inner)
     }
-
 }
 
 impl<Frame> UnitComplex<Frame, Frame> {
     pub fn rotation_between(a: Vector2<Frame>, b: Vector2<Frame>) -> Self {
-        UnitComplex::wrap(nalgebra::UnitComplex::rotation_between(&a.inner, &b.inner))
+        Self::wrap(nalgebra::UnitComplex::rotation_between(&a.inner, &b.inner))
     }
 }

--- a/crates/linear_algebra/src/transform_nalgebra.rs
+++ b/crates/linear_algebra/src/transform_nalgebra.rs
@@ -125,6 +125,11 @@ impl<From, To> UnitComplex<From, To> {
     pub fn inverse(&self) -> UnitComplex<To, From> {
         Transform::<To, From, _>::wrap(self.inner.inverse())
     }
+
+    pub fn as_orientation(&self) -> Orientation2<To> {
+        Orientation2::wrap(self.inner)
+    }
+
 }
 
 impl<Frame> UnitComplex<Frame, Frame> {


### PR DESCRIPTION
## Introduced Changes

Hybrid alignment was completely bronek when approaching a target position from the opposite direction. See associated issue for problem details.

This PR changes the hybrid alignment behavior to slowly reduce the allowed deviation from the target orientation based on the distance to the target.
Effectively, there is a cone of allowed orientations around the target orientations which shrinks when the robot gets closer.
The requested orientation then the current robot orientation (Identity in Ground), clamped to this allowed region.

Fixes #643 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)



## How to Test

Set up game with at least a kick off striker and a game controller running.
After the striker scores a goal, it runs back to the kick off position, if the robot crosses the X axis of the target position within the hybrid align distance, it should no longer try to turn the other way and get stuck.
In every other situation, it should behave just like before.