### PR TITLE
Allow specifying log path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ version = "0.1.0"
 dependencies = [
  "alsa",
  "chrono",
+ "clap 4.5.3",
  "color-eyre",
  "constants",
  "ctrlc",

--- a/crates/code_generation/Cargo.toml
+++ b/crates/code_generation/Cargo.toml
@@ -6,10 +6,10 @@ license.workspace = true
 homepage.workspace = true
 
 [dependencies]
-thiserror = { workspace = true }
 convert_case = { workspace = true }
 itertools = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 source_analyzer = { workspace = true }
 syn = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/hulk_nao/Cargo.toml
+++ b/crates/hulk_nao/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 [dependencies]
 alsa = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true }
 color-eyre = { workspace = true }
 constants = { workspace = true }
 ctrlc = { workspace = true }

--- a/crates/hulk_nao/src/main.rs
+++ b/crates/hulk_nao/src/main.rs
@@ -48,10 +48,10 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
 #[derive(Parser)]
 struct Arguments {
     #[arg(short, long, default_value = "logs")]
-    log_path: String,
+    log_path: PathBuf,
 
     #[arg(short, long, default_value = "etc/parameters/framework.json")]
-    framework_parameters_path: String,
+    framework_parameters_path: PathBuf,
 }
 
 fn main() -> Result<()> {
@@ -67,7 +67,6 @@ fn main() -> Result<()> {
 
     let arguments = Arguments::parse();
     let framework_parameters_path = Path::new(&arguments.framework_parameters_path);
-    let log_path = PathBuf::from(arguments.log_path);
 
     let file =
         File::open(framework_parameters_path).wrap_err("failed to open framework parameters")?;
@@ -88,7 +87,7 @@ fn main() -> Result<()> {
         Arc::new(hardware_interface),
         framework_parameters.communication_addresses,
         framework_parameters.parameters_directory,
-        log_path,
+        arguments.log_path,
         ids.body_id,
         ids.head_id,
         keep_running,

--- a/crates/hulk_webots/src/main.rs
+++ b/crates/hulk_webots/src/main.rs
@@ -71,6 +71,7 @@ fn main() -> Result<()> {
         Arc::new(hardware_interface),
         framework_parameters.communication_addresses,
         framework_parameters.parameters_directory,
+        "logs",
         ids.body_id,
         ids.head_id,
         keep_running,


### PR DESCRIPTION
## Introduced Changes

This PR adds an option to the hulk_nao binary which lets the caller specify where logs should be stored.
It also removes the timestamp from replay files.
The idea is to move the timestamp from the individual file names to the directory file name.

Since the log path defaults to just `logs`, for the time being, this will lead to replay files overwriting older ones until we deploy a new image where the `launchHULK` script creates a directory for each run and points the hulk binary to save its logs there.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

build hulk for nao and upload, then run the following on the nao:
```
cd hulks
bin/hulk --log-path logs/my_awesome_replay
```
This should put all of the bincode files into the specified directory.