### PR TITLE
Replay parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
  "linear_algebra",
  "nalgebra",
  "serde",
+ "serde_json",
  "serialize_hierarchy",
  "source_analyzer",
  "spl_network",

--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -249,11 +249,13 @@ fn generate_recording_thread(cyclers: &Cyclers) -> TokenStream {
     quote! {
         {
             let keep_running = keep_running.clone();
+            let parameters_reader = communication_server.get_parameters_reader();
             std::thread::Builder::new()
                 .name("Recording".to_string())
                 .spawn(move || -> color_eyre::Result<()> {
                     let result = (|| {
                         use std::io::Write;
+                        std::fs::write(log_path.as_ref().join("default.json"), serde_json::to_string_pretty(&*parameters_reader.next())?)?;
                         #(#file_creations)*
                         for recording_frame in recording_receiver {
                             match recording_frame {

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -13,7 +13,7 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "7.0.0";
+pub const OS_VERSION: &str = "7.0.1";
 pub const SDK_VERSION: &str = "7.0.0";
 lazy_static! {
     pub static ref HARDWARE_IDS: HashMap<u8, HardwareId> = {

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -20,6 +20,7 @@ ittapi = {  workspace = true }
 linear_algebra = { workspace = true }
 nalgebra = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serialize_hierarchy = { workspace = true }
 spl_network = { workspace = true }
 spl_network_messages = { workspace = true }


### PR DESCRIPTION
## Introduced Changes

Based on #771
The hulk binary now saves the flattened initial parameters to the log path.
Flattened in this case refers to the merging of default.json and location/robot -specific parameters.

Replay is then pointed to the log directory as the parameters directory from which it loads the bincode files and initial parameters.

Fixes #764 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

## How to Test

Create a replay with this branch, ideally on a nao, download it and start the replayer with it.
Check via twix whether the parameters are correct, e.g. check if the `camera_matrix_parameters` match the robot-specific ones in `etc/parameters/head.[...].json`