### PR TITLE
Remove unnecessary required_checks CI job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,20 +9,6 @@ env:
   CARGO_TARGET_DIR: /__w/hulk/target
   CARGO_TERM_COLOR: always
 jobs:
-  required_checks:
-    name: Require all CI jobs
-    runs-on:
-      - self-hosted
-      - v3
-    needs:
-      - check
-      - format
-      - test
-      - build
-      - build_tools
-    steps:
-      - name: Status message
-        run: echo 'All other jobs exited successfully!'
   check:
     name: Check
     runs-on:


### PR DESCRIPTION
## Introduced Changes

Removes the `required_checks` job because we are now setting it via GitHub branch protection rules to prevent false positive CI checks in merge queues.

Related to #762

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

Remaining of #762

## How to Test

Check that the job is not listed anymore and that we can still merge as usual.