### PR TITLE
Interpret EOF errors as soft errors

### DIFF
--- a/crates/framework/src/recording_index.rs
+++ b/crates/framework/src/recording_index.rs
@@ -38,11 +38,13 @@ impl RecordingIndex {
                 end_of_file_error_as_option(deserialize_from(&mut recording_file))
                     .wrap_err("failed to deserialize timestamp")?
             else {
+                eprintln!("unexpected end of file of recording file while deserializing timestamp");
                 break;
             };
             let Some(length) = end_of_file_error_as_option(deserialize_from(&mut recording_file))
                 .wrap_err("failed to deserialize data length")?
             else {
+                eprintln!("unexpected end of file of recording file while deserializing length");
                 break;
             };
             let header_offset = recording_file
@@ -52,6 +54,10 @@ impl RecordingIndex {
             recording_file
                 .seek(SeekFrom::Current(length as i64))
                 .wrap_err("failed to seek to end of data")?;
+            if offset + header_offset + length as u64 > end_of_file_offset {
+                eprintln!("unexpected end of file of recording file");
+                break;
+            }
             frames.push(RecordingFrameMetadata {
                 timestamp,
                 offset: offset.try_into().unwrap(),


### PR DESCRIPTION
## Introduced Changes

Fixes #767

## ToDo / Known Issues

- How to handle soft errors?

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Use this dumper application for generating a synthetical recording file with correct format:

```rust
use std::{
    fs::File,
    io::{Seek, Write},
    time::SystemTime,
};

use bincode::serialize_into;

fn main() {
    let mut file = File::create("logs/Control.bincode").unwrap();
    dbg!(file.stream_position().unwrap());
    serialize_into(&mut file, &SystemTime::now()).unwrap();
    dbg!(file.stream_position().unwrap());
    serialize_into(&mut file, &42_usize).unwrap();
    dbg!(file.stream_position().unwrap());
    file.write_all(&[42; 42]).unwrap();
    dbg!(file.stream_position().unwrap());
    serialize_into(&mut file, &SystemTime::now()).unwrap();
    dbg!(file.stream_position().unwrap());
    serialize_into(&mut file, &42_usize).unwrap();
    dbg!(file.stream_position().unwrap());
    file.write_all(&[42; 42]).unwrap();
    dbg!(file.stream_position().unwrap());
}
```

```toml
[package]
name = "dumper"
version.workspace = true
edition.workspace = true
license.workspace = true
homepage.workspace = true

[dependencies]
bincode = { workspace = true }
```

Then use the following truncated file sizes for testing:

- Happy path: complete file, should work :tm:
- `truncate -s 100 ...`: this truncates the data, seeking beyond the end of file will not yield any errors
- `truncate -s 82 ...`: now the file has zero data and is truncated exactly after the header, should be same as the previous case
- `truncate -s 81 ...`: the header misses one byte, parsing the length will fail, but the recording index should still contain the first complete frame, the second frame is ignored (soft error)
- `truncate -s 73 ...`: same as the previous case but with the timestamp