### PR TITLE
Download images from meta-nao

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,7 +3991,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "aliveness",
  "bat",

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -527,7 +527,7 @@ async fn download_image(
     let download_path = image_path.with_extension("tmp");
     let urls = [
         format!("http://bighulk.hulks.dev/image/{image_name}"),
-        format!("https://github.com/HULKs/meta-hulks/releases/download/{version}/{image_name}"),
+        format!("https://github.com/HULKs/meta-nao/releases/download/{version}/{image_name}"),
     ];
 
     println!("Downloading image from {}", urls[0]);

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.1.0"
+version = "3.2.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Introduced Changes

We merged meta-hulk into the meta-nao repository recently and updated the download url for the SDK in pepsi, but forgot to update the one for images.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

`pepsi gammaray` should no longer fail with error 404.