### PR TITLE
Update replay docs to reflect usage changes

### DIFF
--- a/docs/tooling/overview.md
+++ b/docs/tooling/overview.md
@@ -6,6 +6,7 @@ Apart from the NAO code our repository contains several tools to aid in the deve
 - [Twix](./twix.md): Our debugging tool to visualize live data from the NAO or a Webots simulation
 - [Depp](./depp.md): TODO: Irgendwas mit dependencies
 - [Fanta](./fanta.md): TODO: Irgendwas mit live data auf der CLI
+- [Recording & Replay](./recording_and_replay.md): Post-mortem analysis of game data
 - [Machine Learning](./machine-learning.md): Our tooling to create datasets and neural networks
 - [Behavior Simulator](./sprite.md): The simulator and viewer to debug and automatically test behavior
 - [Debugging with GDB/LLDB](./debugging.md): How to use a debugger with our software

--- a/docs/tooling/recording_and_replay.md
+++ b/docs/tooling/recording_and_replay.md
@@ -22,15 +22,11 @@ Data is only recorded during `PrimaryState::Ready`, `PrimaryState::Set`, and `Pr
 ## Replay(er)
 
 Assuming you already recorded some data on a robot, you can now use the "replayer" tool to replay the recorded data.
-First, you need to prepare the data.
-The replayer assumes the recording files in `logs/<cycler_instance>.bincode`.
-All cycler instance files need to be present, regardless whether they were enabled during recording (they will be empty then).
 
-- Download the logs into a `logs` directory within the repository via, e.g., `./pepsi postgame ... logs ...`
-- The `logs` directory contains directories per robot. Move all files of the robot that you want to replay into the `logs` directory.
-- Rename all `*.bincode` files to remove the timestamp from the name to match the path `logs/<cycler_instance>.bincode`.
-- Somehow™ obtain the head and body IDs of the robot that you want to replay
-- Start the replayer tool via `./pepsi run --target replayer -- <BODY_ID> <HEAD_ID>`
+- Download the logs into a `logs` directory within the repository via, e.g., `./pepsi postgame ... my_awesome_replay ...`
+- The `my_awesome_replay` directory now contains directories for each robot. Each robot directory contains one directory with the replay data from one execution of the `hulk` binary.
+  All cycler instance files need to be present, regardless whether they were enabled during recording (they will be empty then).
+- Start the replayer tool by pointing it to the log directory you want to replay, e.g., `./pepsi run --target replayer -- my_awesome_replay/10.1.24.42/12345678`.
 - Connect your Twix to `localhost` and open some panels
 - Move the slider to make data available to Twix. Pro Tip: Click into the text box and use your arrow keys to "animate".
 - ...

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,6 @@ nav:
       - Databases & Types: framework/databases_and_types.md
       - Parameters: framework/parameters.md
       - Communication: framework/communication.md
-      - Recording & Replay: framework/recording_and_replay.md
       - Hardware Interface: framework/hardware_interface.md
       - Thread Communication: framework/thread_communication.md
       - Filtering: framework/filtering.md
@@ -54,6 +53,7 @@ nav:
       - Twix: tooling/twix.md
       - Depp: tooling/depp.md
       - Fanta: tooling/fanta.md
+      - Recording & Replay: tooling/recording_and_replay.md
       - Machine Learning: tooling/machine-learning.md
       - Behavior-Simulator & Sprite: tooling/sprite.md
       - Debugging with GDB/LLDB: tooling/debugging.md


### PR DESCRIPTION
## Introduced Changes

What it says

Also moves the replay docs from `Framework` to `Tooling` as it describes how to use the tooling (pepsi and replayer commands) instead of the framework feature (architecture, implementation, etc.).

Fixes #765 (was already fixed by #772 but now the docs reflect this.)

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

- RTFM
- Check if instructions are clear and work as expected