### PR TITLE
Add Y axis offset for penalty poses

### DIFF
--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -85,7 +85,7 @@ pub struct CycleContext {
     player_number: Parameter<PlayerNumber, "player_number">,
     penalized_distance: Parameter<f32, "localization.penalized_distance">,
     penalized_hypothesis_covariance:
-        Parameter<Matrix3<f32>, "localization.initial_hypothesis_covariance">,
+        Parameter<Matrix3<f32>, "localization.penalized_hypothesis_covariance">,
     score_per_good_match: Parameter<f32, "localization.score_per_good_match">,
     use_line_measurements: Parameter<bool, "localization.use_line_measurements">,
     injected_ground_to_field_of_home_after_coin_toss_before_second_half: Parameter<

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -634,6 +634,10 @@
     "minimum_line_length": 0.15,
     "odometry_noise": [0.05, 0.01, 0.008],
     "use_line_measurements": true,
+    "penalized_distance": 0.5,
+    "penalized_hypothesis_covariance": [
+      0.01, 0.0, 0.0, 0.0, 0.002, 0.0, 0.0, 0.0, 0.001
+    ],
     "good_matching_threshold": 0.5,
     "score_per_good_match": 1.0,
     "hypothesis_score_base_increase": 0.1

--- a/etc/parameters/smd/default.json
+++ b/etc/parameters/smd/default.json
@@ -15,5 +15,8 @@
     "goal_inner_width": 1.5,
     "goal_post_diameter": 0.1,
     "goal_depth": 0.5
-  }
+  },
+  "localization": {
+    "penalized_distance" : 0.2
+  } 
 }


### PR DESCRIPTION
## Introduced Changes

What it says.
Also added covariance separately from initial poses because it is now more common that X position is is not at penalty spot.

Fixes #645 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Covariance might need adjustments as testing is conducted, distance must be adjusted based on field that is being played on. If the border of the field is smaller than 50cm, the robots will not be placed closer to field.

## How to Test

Penalize robot in test game, placing it in different positions left and right of the penalty spot and outside of the field (20cm for SMD). Ensure robot localization still settles to being accurate.
