### PR TITLE
increase `foot_pressure_threshold` to improve walking of 31

### DIFF
--- a/etc/parameters/head.P0000074A06S9A900006.json
+++ b/etc/parameters/head.P0000074A06S9A900006.json
@@ -14,5 +14,8 @@
         1.244167685508728
       ]
     }
+  },
+  "walking_engine": {
+    "foot_pressure_threshold": 0.4
   }
 }


### PR DESCRIPTION
## Introduced Changes
Increases the `foot_pressure_threshold` because one of the fsr sensors returns a too high value and now walking looks good again.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Compare walking of robot 31 on main and with this threshold.
