### PR TITLE
Message filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,7 @@ dependencies = [
  "hardware",
  "log",
  "serde",
+ "spl_network_messages",
  "thiserror",
  "tokio",
  "types",

--- a/crates/control/src/game_controller_filter.rs
+++ b/crates/control/src/game_controller_filter.rs
@@ -20,7 +20,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
-    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message">,
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message?">,
 }
 
 #[context]

--- a/crates/control/src/game_controller_filter.rs
+++ b/crates/control/src/game_controller_filter.rs
@@ -20,7 +20,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
-    network_message: PerceptionInput<IncomingMessage, "SplNetwork", "message">,
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message">,
 }
 
 #[context]
@@ -42,6 +42,7 @@ impl GameControllerFilter {
             .network_message
             .persistent
             .values()
+            .flatten()
             .flatten()
             .filter_map(|message| match message {
                 IncomingMessage::GameController(message) => Some(message),

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -37,7 +37,7 @@ pub struct CycleContext {
 
     balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
     balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,
-    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message">,
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message?">,
     sensor_data: Input<SensorData, "sensor_data">,
 }
 
@@ -176,7 +176,7 @@ impl LedStatus {
                 messages
                     .iter()
                     .flatten()
-                    .any(|message| matches!(message, IncomingMessage::GameController(_)))
+                    .any(|&message| matches!(message, IncomingMessage::GameController(_)))
                     .then_some(timestamp)
             })
         {

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -37,7 +37,7 @@ pub struct CycleContext {
 
     balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
     balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,
-    network_message: PerceptionInput<IncomingMessage, "SplNetwork", "message">,
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message">,
     sensor_data: Input<SensorData, "sensor_data">,
 }
 
@@ -175,6 +175,7 @@ impl LedStatus {
             .find_map(|(timestamp, messages)| {
                 messages
                     .iter()
+                    .flatten()
                     .any(|message| matches!(message, IncomingMessage::GameController(_)))
                     .then_some(timestamp)
             })

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -249,7 +249,7 @@ impl RoleAssignment {
                     ground_to_field,
                     context.ball_position,
                     primary_state,
-                    Some(&spl_message),
+                    Some(spl_message),
                     Some(*context.time_to_reach_kick_position),
                     send_spl_striker_message,
                     team_ball,

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -50,7 +50,7 @@ pub struct CycleContext {
     primary_state: Input<PrimaryState, "primary_state">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
     cycle_time: Input<CycleTime, "cycle_time">,
-    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message">,
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message?">,
     time_to_reach_kick_position: CyclerState<Duration, "time_to_reach_kick_position">,
 
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
@@ -214,12 +214,11 @@ impl RoleAssignment {
         let mut spl_messages = context
             .network_message
             .persistent
-            .values()
-            .flatten()
+            .into_values()
             .flatten()
             .filter_map(|message| match message {
-                IncomingMessage::GameController(_) => None,
-                IncomingMessage::Spl(message) => Some(message),
+                Some(IncomingMessage::GameController(_)) | None => None,
+                Some(IncomingMessage::Spl(message)) => Some(message),
             })
             .peekable();
         if spl_messages.peek().is_none() {
@@ -250,7 +249,7 @@ impl RoleAssignment {
                     ground_to_field,
                     context.ball_position,
                     primary_state,
-                    Some(spl_message),
+                    Some(&spl_message),
                     Some(*context.time_to_reach_kick_position),
                     send_spl_striker_message,
                     team_ball,

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -50,7 +50,7 @@ pub struct CycleContext {
     primary_state: Input<PrimaryState, "primary_state">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
     cycle_time: Input<CycleTime, "cycle_time">,
-    network_message: PerceptionInput<IncomingMessage, "SplNetwork", "message">,
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message">,
     time_to_reach_kick_position: CyclerState<Duration, "time_to_reach_kick_position">,
 
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
@@ -215,6 +215,7 @@ impl RoleAssignment {
             .network_message
             .persistent
             .values()
+            .flatten()
             .flatten()
             .filter_map(|message| match message {
                 IncomingMessage::GameController(_) => None,

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -88,7 +88,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                 kind: CyclerKind::Perception,
                 instances: vec![""],
                 setup_nodes: vec!["spl_network::message_receiver"],
-                nodes: vec![],
+                nodes: vec!["spl_network::message_filter"],
             },
             CyclerManifest {
                 name: "Audio",

--- a/crates/hulk_webots/src/hardware_interface.rs
+++ b/crates/hulk_webots/src/hardware_interface.rs
@@ -327,7 +327,7 @@ impl NetworkInterface for HardwareInterface {
     fn read_from_network(&self) -> Result<IncomingMessage> {
         self.async_runtime.block_on(async {
             select! {
-                result =  self.spl_network_endpoint.read() => {
+                result = self.spl_network_endpoint.read() => {
                     result.map_err(Error::from)
                 },
                 _ = self.keep_running.cancelled() => {

--- a/crates/spl_network/Cargo.toml
+++ b/crates/spl_network/Cargo.toml
@@ -13,6 +13,7 @@ framework = { workspace = true }
 hardware = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+spl_network_messages = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 types = { workspace = true }

--- a/crates/spl_network/src/lib.rs
+++ b/crates/spl_network/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod endpoint;
-pub mod message_receiver;
 pub mod message_filter;
+pub mod message_receiver;

--- a/crates/spl_network/src/lib.rs
+++ b/crates/spl_network/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod endpoint;
 pub mod message_receiver;
+pub mod message_filter;

--- a/crates/spl_network/src/message_filter.rs
+++ b/crates/spl_network/src/message_filter.rs
@@ -1,0 +1,44 @@
+use color_eyre::{eyre::Ok, Result};
+use context_attribute::context;
+use framework::MainOutput;
+use serde::{Deserialize, Serialize};
+use spl_network_messages::PlayerNumber;
+use types::messages::IncomingMessage;
+
+#[derive(Deserialize, Serialize)]
+pub struct MessageFilter {}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    message: Input<IncomingMessage, "message">,
+    player_number: Parameter<PlayerNumber, "player_number">,
+}
+
+#[context]
+pub struct MainOutputs {
+    pub filtered_message: MainOutput<Option<IncomingMessage>>,
+}
+
+impl MessageFilter {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        let message = match context.message {
+            IncomingMessage::GameController(message) => {
+                Some(IncomingMessage::GameController(message.clone()))
+            }
+            IncomingMessage::Spl(message) if message.player_number == *context.player_number => {
+                Some(IncomingMessage::Spl(*message))
+            }
+            _ => None,
+        };
+        Ok(MainOutputs {
+            filtered_message: message.into(),
+        })
+    }
+}

--- a/crates/spl_network/src/message_filter.rs
+++ b/crates/spl_network/src/message_filter.rs
@@ -32,7 +32,7 @@ impl MessageFilter {
             IncomingMessage::GameController(message) => {
                 Some(IncomingMessage::GameController(message.clone()))
             }
-            IncomingMessage::Spl(message) if message.player_number == *context.player_number => {
+            IncomingMessage::Spl(message) if message.player_number != *context.player_number => {
                 Some(IncomingMessage::Spl(*message))
             }
             _ => None,

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -100,7 +100,7 @@ impl BehaviorCycler {
         own_database: &mut Database,
         cycler_state: &mut CyclerState,
         parameters: &Parameters,
-        incoming_messages: BTreeMap<SystemTime, Vec<&IncomingMessage>>,
+        incoming_messages: BTreeMap<SystemTime, Vec<Option<&IncomingMessage>>>,
     ) -> Result<()> {
         if own_database
             .main_outputs

--- a/tools/behavior_simulator/src/robot.rs
+++ b/tools/behavior_simulator/src/robot.rs
@@ -75,7 +75,10 @@ impl Robot {
         })
     }
 
-    pub fn cycle(&mut self, messages: BTreeMap<SystemTime, Vec<&IncomingMessage>>) -> Result<()> {
+    pub fn cycle(
+        &mut self,
+        messages: BTreeMap<SystemTime, Vec<Option<&IncomingMessage>>>,
+    ) -> Result<()> {
         self.cycler.cycle(
             &mut self.database,
             &mut self.cycler_state,

--- a/tools/behavior_simulator/src/state.rs
+++ b/tools/behavior_simulator/src/state.rs
@@ -189,12 +189,17 @@ impl State {
         for (player_number, robot) in self.robots.iter_mut() {
             let incoming_messages: Vec<_> = incoming_messages
                 .iter()
-                .filter_map(|(sender, message)| {
+                .map(|(sender, message)| {
                     (sender != player_number).then_some(IncomingMessage::Spl(*message))
                 })
                 .collect();
-            let messages_with_time =
-                BTreeMap::from_iter([(now, incoming_messages.iter().collect())]);
+            let messages_with_time = BTreeMap::from_iter([(
+                now,
+                incoming_messages
+                    .iter()
+                    .map(|message| message.as_ref())
+                    .collect(),
+            )]);
 
             robot.database.main_outputs.cycle_time.start_time = now;
 


### PR DESCRIPTION
## Introduced Changes

Fixes #786 by filtering the received broadcast messages sent by the player's own number.
One can now not longer receive any messages that contain the own player number even though there might be another robot with the same player number. 


## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

I don't have a good idea, I tested it with adding debug prints for the received messages and then started a game with two players.
