### PR TITLE
Enable serializeHierarchy for tuple structs

### DIFF
--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -55,6 +55,9 @@ mod tests {
         field: bool,
     }
 
+    #[derive(Deserialize, Serialize, SerializeHierarchy)]
+    struct TupleStruct(bool, f32, Inner, Outer);
+
     #[test]
     fn primitive_fields_are_empty() {
         assert_eq!(bool::get_fields(), Default::default());

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -58,6 +58,14 @@ mod tests {
     #[derive(Deserialize, Serialize, SerializeHierarchy)]
     struct TupleStruct(bool, f32, Inner, Outer);
 
+    #[derive(Deserialize, Serialize, SerializeHierarchy)]
+    struct NestedTupleStruct(bool, Inner, TupleStruct);
+
+    #[derive(Deserialize, Serialize, SerializeHierarchy)]
+    struct OuterWithTupleStruct {
+        tuple_struct: TupleStruct,
+    }
+
     #[test]
     fn primitive_fields_are_empty() {
         assert_eq!(bool::get_fields(), Default::default());
@@ -73,6 +81,57 @@ mod tests {
         assert_eq!(
             Outer::get_fields(),
             ["inner".to_string(), "inner.field".to_string()].into()
+        );
+    }
+
+    #[test]
+    fn tuple_struct_fields_contain_fields() {
+        assert_eq!(
+            TupleStruct::get_fields(),
+            ["0", "1", "2", "2.field", "3", "3.inner", "3.inner.field"]
+                .map(|s| s.to_string())
+                .into()
+        );
+    }
+
+    #[test]
+    fn nested_tuple_struct_fields_contain_fields() {
+        assert_eq!(
+            NestedTupleStruct::get_fields(),
+            [
+                "0",
+                "1",
+                "1.field",
+                "2",
+                "2.0",
+                "2.1",
+                "2.2",
+                "2.2.field",
+                "2.3",
+                "2.3.inner",
+                "2.3.inner.field"
+            ]
+            .map(|s| s.to_string())
+            .into()
+        );
+    }
+
+    #[test]
+    fn flat_struct_contains_tuple_struct_fields() {
+        assert_eq!(
+            OuterWithTupleStruct::get_fields(),
+            [
+                "tuple_struct",
+                "tuple_struct.0",
+                "tuple_struct.1",
+                "tuple_struct.2",
+                "tuple_struct.2.field",
+                "tuple_struct.3",
+                "tuple_struct.3.inner",
+                "tuple_struct.3.inner.field"
+            ]
+            .map(|s| s.to_string())
+            .into()
         );
     }
 }

--- a/crates/serialize_hierarchy_derive/src/lib.rs
+++ b/crates/serialize_hierarchy_derive/src/lib.rs
@@ -427,7 +427,7 @@ fn read_fields(input: &DataStruct) -> Vec<Field> {
                 .collect();
             let identifier = field.ident.clone().map_or_else(
                 || IdentOrTupleIndex::TupleIndex(field_index),
-                |identifier| IdentOrTupleIndex::Ident(identifier),
+                IdentOrTupleIndex::Ident,
             );
             let ty = field.ty.clone();
             Field {

--- a/crates/serialize_hierarchy_derive/src/lib.rs
+++ b/crates/serialize_hierarchy_derive/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
 use syn::{
@@ -341,7 +341,8 @@ fn read_fields(input: &DataStruct) -> Vec<Field> {
     input
         .fields
         .iter()
-        .map(|field| {
+        .enumerate()
+        .map(|(field_index, field)| {
             let attributes = field
                 .attrs
                 .iter()
@@ -370,7 +371,7 @@ fn read_fields(input: &DataStruct) -> Vec<Field> {
             let identifier = field
                 .ident
                 .clone()
-                .unwrap_or_else(|| abort!(field, "field has to be named"));
+                .unwrap_or(Ident::new(&format!("_{}", field_index), Span::call_site()));
             let ty = field.ty.clone();
             Field {
                 attributes,


### PR DESCRIPTION
## Introduced Changes

Give the ability to handle Tuple Structs.

- `a.b.c.0` will address the first value of a tuple struct under name `c`.
- ~This is the simplest implementation without changing many other functions that handle the identifier names, etc in the derive.~

Related:
- Tuple indexing with `quote!` - https://github.com/rust-lang/rust/issues/60210

Fixes #147

## ToDo / Known Issues

- [ ] This implementation could be improved with a `match` expression handling `NamedFields` and `UnNamedFields` separately to avoid the `enumerate()` for all cases.
- [ ] There is some repeated code with the `quote` usage. Would be nice to clear them out!
- [x] More tests

## Ideas for Next Iterations (Not This PR)

## How to Test

- Tuple structs should be able to derive `SerializeHierarchy`