### PR TITLE
Add jump to penalty kick

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -140,6 +140,12 @@ impl Behavior {
                 Some(FilteredGameControllerState {
                     game_phase: GamePhase::PenaltyShootout { .. },
                     ..
+                })
+                | Some(FilteredGameControllerState {
+                    game_state: FilteredGameState::Playing { .. },
+                    kicking_team: Team::Opponent,
+                    sub_state: Some(SubState::PenaltyKick),
+                    ..
                 }) => {
                     actions.push(Action::Jump);
                     actions.push(Action::PrepareJump);

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -3,7 +3,7 @@ use context_attribute::context;
 use coordinate_systems::Ground;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
-use spl_network_messages::{GamePhase, SubState};
+use spl_network_messages::{GamePhase, SubState, Team};
 use types::{
     ball_position::BallPosition, field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
@@ -48,17 +48,15 @@ impl PenaltyShotDirectionEstimation {
             context.primary_state,
             context.filtered_game_controller_state.game_phase,
             context.filtered_game_controller_state.sub_state,
+            context.filtered_game_controller_state.kicking_team,
         ) {
-            (PrimaryState::Set, GamePhase::PenaltyShootout { .. }, _)
-            | (PrimaryState::Set, _, Some(SubState::PenaltyKick)) => {
+            (PrimaryState::Set, GamePhase::PenaltyShootout { .. }, ..)
+            | (PrimaryState::Set, _, Some(SubState::PenaltyKick), Team::Opponent) => {
                 self.last_shot_direction = PenaltyShotDirection::NotMoving;
                 Ok(MainOutputs::default())
             }
-            (
-                PrimaryState::Playing,
-                GamePhase::PenaltyShootout { .. },
-                _,
-            )|(PrimaryState::Playing, _, Some(SubState::PenaltyKick)) => {
+            (PrimaryState::Playing, GamePhase::PenaltyShootout { .. }, ..)
+            | (PrimaryState::Playing, _, Some(SubState::PenaltyKick), Team::Opponent) => {
                 if let PenaltyShotDirection::NotMoving = self.last_shot_direction {
                     if (context.ball_position.position.x()
                         - context.field_dimensions.penalty_marker_distance)

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -3,7 +3,7 @@ use context_attribute::context;
 use coordinate_systems::Ground;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
-use spl_network_messages::GamePhase;
+use spl_network_messages::{GamePhase, SubState};
 use types::{
     ball_position::BallPosition, field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
@@ -47,12 +47,18 @@ impl PenaltyShotDirectionEstimation {
         match (
             context.primary_state,
             context.filtered_game_controller_state.game_phase,
+            context.filtered_game_controller_state.sub_state,
         ) {
-            (PrimaryState::Set, GamePhase::PenaltyShootout { .. }) => {
+            (PrimaryState::Set, GamePhase::PenaltyShootout { .. }, _)
+            | (PrimaryState::Set, _, Some(SubState::PenaltyKick)) => {
                 self.last_shot_direction = PenaltyShotDirection::NotMoving;
                 Ok(MainOutputs::default())
             }
-            (PrimaryState::Playing, GamePhase::PenaltyShootout { .. }) => {
+            (
+                PrimaryState::Playing,
+                GamePhase::PenaltyShootout { .. },
+                Some(SubState::PenaltyKick),
+            ) => {
                 if let PenaltyShotDirection::NotMoving = self.last_shot_direction {
                     if (context.ball_position.position.x()
                         - context.field_dimensions.penalty_marker_distance)

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -57,8 +57,8 @@ impl PenaltyShotDirectionEstimation {
             (
                 PrimaryState::Playing,
                 GamePhase::PenaltyShootout { .. },
-                Some(SubState::PenaltyKick),
-            ) => {
+                _,
+            )|(PrimaryState::Playing, _, Some(SubState::PenaltyKick)) => {
                 if let PenaltyShotDirection::NotMoving = self.last_shot_direction {
                     if (context.ball_position.position.x()
                         - context.field_dimensions.penalty_marker_distance)

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -9,7 +9,7 @@ use framework::{MainOutput, PerceptionInput};
 use hardware::NetworkInterface;
 use linear_algebra::{Isometry2, Point2, Vector};
 use spl_network_messages::{
-    GameControllerReturnMessage, GamePhase, HulkMessage, Penalty, PlayerNumber, Team,
+    GameControllerReturnMessage, GamePhase, HulkMessage, Penalty, PlayerNumber, SubState, Team,
 };
 use types::{
     ball_position::BallPosition,
@@ -355,6 +355,9 @@ fn process_role_state_machine(
                 kicking_team: Team::Opponent,
             } => return (Role::Keeper, false, None),
             _ => {}
+        };
+        if let Some(SubState::PenaltyKick) = game_controller_state.sub_state {
+            return (current_role, false, None);
         }
     }
 


### PR DESCRIPTION
## Introduced Changes

Allow keeper to jump during a penalty kick.
Prevent role changes during penalty kick so that keeper does not become striker and leave the goal.

Fixes #788 
Fixes #250 

## ToDo / Known Issues

Does not apply to replacement keepers. However, as these are not allowed to touch the ball with their hands anyway this is probably the desired behavior.

## Ideas for Next Iterations (Not This PR)

## How to Test

Test in game penalty kick and check if keeper jumps