### PR TITLE
Realtime priority for realtime cyclers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3970,7 +3970,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "aliveness",
  "bat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "color-eyre",
+ "libc",
  "parking_lot",
  "serde",
 ]
@@ -2673,6 +2674,7 @@ dependencies = [
  "hardware",
  "hulk_manifest",
  "ittapi",
+ "libc",
  "linear_algebra",
  "nalgebra",
  "serde",

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -384,7 +384,7 @@ fn generate_start_method(cycler_kind: CyclerKind) -> TokenStream {
         CyclerKind::Perception => quote! {
             unsafe {
                 let priority = libc::sched_param {
-                    sched_priority: 10,
+                    sched_priority: 5,
                 };
                 let process_id = libc::getpid();
                 assert!(process_id > 0, "failed to get process id");

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -381,7 +381,8 @@ fn generate_consumer_identifiers(cyclers: &Cyclers) -> Vec<Ident> {
 
 fn generate_start_method(cycler_kind: CyclerKind) -> TokenStream {
     let scheduler_tokens = match cycler_kind {
-        CyclerKind::Perception => quote! {
+        CyclerKind::Perception => TokenStream::new(),
+        CyclerKind::RealTime => quote! {
             unsafe {
                 let priority = libc::sched_param {
                     sched_priority: 5,
@@ -397,7 +398,6 @@ fn generate_start_method(cycler_kind: CyclerKind) -> TokenStream {
                 assert!(set_scheduler_return_value == 0, "failed to set scheduler");
             }
         },
-        CyclerKind::RealTime => TokenStream::new(),
     };
 
     quote! {

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -13,7 +13,7 @@ pub const HULA_DBUS_PATH: &str = "/org/hulks/HuLA";
 pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "7.0.1";
+pub const OS_VERSION: &str = "7.0.2";
 pub const SDK_VERSION: &str = "7.0.0";
 lazy_static! {
     pub static ref HARDWARE_IDS: HashMap<u8, HardwareId> = {

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -8,6 +8,6 @@ homepage.workspace = true
 [dependencies]
 bincode = { workspace = true }
 color-eyre = { workspace = true }
+libc = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-libc = { workspace = true }

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -10,3 +10,4 @@ bincode = { workspace = true }
 color-eyre = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+libc = { workspace = true }

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -17,6 +17,7 @@ framework = { workspace = true }
 geometry = { workspace = true }
 hardware = { workspace = true }
 ittapi = {  workspace = true }
+libc = { workspace = true }
 linear_algebra = { workspace = true }
 nalgebra = { workspace = true }
 serde = { workspace = true }

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.3.0"
+version = "3.4.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Introduced Changes

Makes cyclers with realtime kind also use a realtime scheduler with priority 20. This should (?) fix issues of other cyclers stealing ressources from Control.

Fixes #

## ToDo / Known Issues
- We need the capability `sys_cap_nice` on the `hulk` binary before merging this PR. Otherwise we can only launch with sudo

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
* Check if process starts up and robot behaves normally
