### PR TITLE
Increase penalty box size to prevent keeper getting stuck

### DIFF
--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -23,9 +23,11 @@ pub struct CycleContext {
         RequiredInput<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
     ball_state: Input<Option<BallState>, "ball_state?">,
 
-    center_circle_obstacle_increase: Parameter<f32, "center_circle_obstacle_increase">,
+    center_circle_obstacle_increase:
+        Parameter<f32, "rule_obstacles.center_circle_obstacle_increase">,
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
-    free_kick_obstacle_radius: Parameter<f32, "free_kick_obstacle_radius">,
+    free_kick_obstacle_radius: Parameter<f32, "rule_obstacles.free_kick_obstacle_radius">,
+    penaltykick_box_increase: Parameter<f32, "rule_obstacles.penaltykick_box_increase">,
 }
 
 #[context]
@@ -101,6 +103,7 @@ impl RuleObstacleComposer {
                 let penalty_box_obstacle = create_penalty_box(
                     context.field_dimensions,
                     context.filtered_game_controller_state.kicking_team,
+                    *context.penaltykick_box_increase,
                 );
                 rule_obstacles.push(penalty_box_obstacle);
             }
@@ -113,7 +116,11 @@ impl RuleObstacleComposer {
     }
 }
 
-pub fn create_penalty_box(field_dimensions: &FieldDimensions, kicking_team: Team) -> RuleObstacle {
+pub fn create_penalty_box(
+    field_dimensions: &FieldDimensions,
+    kicking_team: Team,
+    penaltykick_box_increase: f32,
+) -> RuleObstacle {
     let side_factor: f32 = match kicking_team {
         Team::Hulks => 1.0,
         Team::Opponent => -1.0,
@@ -122,11 +129,12 @@ pub fn create_penalty_box(field_dimensions: &FieldDimensions, kicking_team: Team
     };
     let half_field_length = field_dimensions.length / 2.0;
     let half_penalty_area_length = field_dimensions.penalty_area_length / 2.0;
-    let center_x = side_factor * (half_field_length - half_penalty_area_length + 0.1);
+    let center_x = side_factor
+        * (half_field_length - half_penalty_area_length + penaltykick_box_increase / 2.0);
     RuleObstacle::Rectangle(Rectangle::new_with_center_and_size(
         point![center_x, 0.0],
         vector![
-            field_dimensions.penalty_area_length + 0.2,
+            field_dimensions.penalty_area_length + penaltykick_box_increase,
             field_dimensions.penalty_area_width
         ],
     ))

--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -122,11 +122,11 @@ pub fn create_penalty_box(field_dimensions: &FieldDimensions, kicking_team: Team
     };
     let half_field_length = field_dimensions.length / 2.0;
     let half_penalty_area_length = field_dimensions.penalty_area_length / 2.0;
-    let center_x = side_factor * (half_field_length - half_penalty_area_length);
+    let center_x = side_factor * (half_field_length - half_penalty_area_length + 0.1);
     RuleObstacle::Rectangle(Rectangle::new_with_center_and_size(
         point![center_x, 0.0],
         vector![
-            field_dimensions.penalty_area_length,
+            field_dimensions.penalty_area_length + 0.2,
             field_dimensions.penalty_area_width
         ],
     ))

--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -27,7 +27,7 @@ pub struct CycleContext {
         Parameter<f32, "rule_obstacles.center_circle_obstacle_increase">,
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
     free_kick_obstacle_radius: Parameter<f32, "rule_obstacles.free_kick_obstacle_radius">,
-    penaltykick_box_increase: Parameter<f32, "rule_obstacles.penaltykick_box_increase">,
+    penaltykick_box_extension: Parameter<f32, "rule_obstacles.penaltykick_box_extension">,
 }
 
 #[context]
@@ -103,7 +103,7 @@ impl RuleObstacleComposer {
                 let penalty_box_obstacle = create_penalty_box(
                     context.field_dimensions,
                     context.filtered_game_controller_state.kicking_team,
-                    *context.penaltykick_box_increase,
+                    *context.penaltykick_box_extension,
                 );
                 rule_obstacles.push(penalty_box_obstacle);
             }
@@ -119,7 +119,7 @@ impl RuleObstacleComposer {
 pub fn create_penalty_box(
     field_dimensions: &FieldDimensions,
     kicking_team: Team,
-    penaltykick_box_increase: f32,
+    penaltykick_box_extension: f32,
 ) -> RuleObstacle {
     let side_factor: f32 = match kicking_team {
         Team::Hulks => 1.0,
@@ -130,11 +130,11 @@ pub fn create_penalty_box(
     let half_field_length = field_dimensions.length / 2.0;
     let half_penalty_area_length = field_dimensions.penalty_area_length / 2.0;
     let center_x = side_factor
-        * (half_field_length - half_penalty_area_length + penaltykick_box_increase / 2.0);
+        * (half_field_length - half_penalty_area_length + penaltykick_box_extension / 2.0);
     RuleObstacle::Rectangle(Rectangle::new_with_center_and_size(
         point![center_x, 0.0],
         vector![
-            field_dimensions.penalty_area_length + penaltykick_box_increase,
+            field_dimensions.penalty_area_length + penaltykick_box_extension,
             field_dimensions.penalty_area_width
         ],
     ))

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1160,6 +1160,9 @@
     }
   },
   "angular_velocity_smoothing_factor": 0.1,
-  "center_circle_obstacle_increase": 1.2,
-  "free_kick_obstacle_radius": 0.75
+  "rule_obstacles": {
+    "center_circle_obstacle_increase": 1.2,
+    "free_kick_obstacle_radius": 0.75,
+    "penaltykick_box_increase": 0.2
+  }
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1163,6 +1163,6 @@
   "rule_obstacles": {
     "center_circle_obstacle_increase": 1.2,
     "free_kick_obstacle_radius": 0.75,
-    "penaltykick_box_increase": 0.2
+    "penaltykick_box_extension": 0.2
   }
 }

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -117,9 +117,10 @@ impl BehaviorCycler {
                             .as_ref()
                             .unwrap(),
                         own_database.main_outputs.ball_state.as_ref(),
-                        &parameters.center_circle_obstacle_increase,
+                        &parameters.rule_obstacles.center_circle_obstacle_increase,
                         &parameters.field_dimensions,
-                        &parameters.free_kick_obstacle_radius,
+                        &parameters.rule_obstacles.free_kick_obstacle_radius,
+                        &parameters.rule_obstacles.penaltykick_box_increase,
                     ))
                     .wrap_err("failed to execute cycle of node `RuleObstacleComposer`")?
             };

--- a/tools/behavior_simulator/src/cycler.rs
+++ b/tools/behavior_simulator/src/cycler.rs
@@ -120,7 +120,7 @@ impl BehaviorCycler {
                         &parameters.rule_obstacles.center_circle_obstacle_increase,
                         &parameters.field_dimensions,
                         &parameters.rule_obstacles.free_kick_obstacle_radius,
-                        &parameters.rule_obstacles.penaltykick_box_increase,
+                        &parameters.rule_obstacles.penaltykick_box_extension,
                     ))
                     .wrap_err("failed to execute cycle of node `RuleObstacleComposer`")?
             };


### PR DESCRIPTION
## Introduced Changes

Increase the penalty box size by 20cm and shift accordingly
The keeper was getting stuck on the boundary or thinking it was outside the penalty box and would not defend a penalty kick properly.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Optimally merge #811 first.
It can be seen that the keeper now sticks to the line when defending the penalty kick rather than staying behind it and failing to defend properly.