### PR TITLE
Allow transition from finished to initial

### DIFF
--- a/crates/control/src/game_controller_state_filter.rs
+++ b/crates/control/src/game_controller_state_filter.rs
@@ -157,6 +157,7 @@ fn next_filtered_state(
     ball_detected_far_from_any_goal: bool,
 ) -> State {
     match (current_state, game_controller_state.game_state) {
+        (State::Finished, GameState::Initial) => State::Initial,
         (State::Finished, _) => match game_controller_state.game_phase {
             GamePhase::PenaltyShootout { .. } => State::Set,
             _ => State::Finished,

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -83,8 +83,12 @@ impl PrimaryStateFilter {
                 )
             }
             (_, _, _, _, Some(filtered_game_controller_state))
-                if self.last_primary_state != PrimaryState::Unstiff
-                    && self.last_primary_state != PrimaryState::Finished =>
+                if {
+                    let finished_to_initial = self.last_primary_state == PrimaryState::Finished
+                        && filtered_game_controller_state.game_state == FilteredGameState::Initial;
+
+                    self.last_primary_state != PrimaryState::Unstiff || finished_to_initial
+                } =>
             {
                 Self::game_state_to_primary_state(
                     filtered_game_controller_state.game_state,

--- a/crates/types/src/filtered_game_state.rs
+++ b/crates/types/src/filtered_game_state.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serialize_hierarchy::SerializeHierarchy;
 use spl_network_messages::Team;
 
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, SerializeHierarchy)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, SerializeHierarchy, PartialEq)]
 pub enum FilteredGameState {
     #[default]
     Initial,


### PR DESCRIPTION
## Introduced Changes

what the title says

Fixes #815 

## How to Test

Put a nao on the field, and play around with the game controller.
Things to try:
- undo finishes
  - this sets the game controller state to `Playing`, not `Initial`. The nao stays in `Finish`.
- connect a nao while the game controller is currently in `Finish`, then start a new game
