### PR TITLE
Stay in Calibration

### DIFF
--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -72,6 +72,8 @@ impl PrimaryStateFilter {
                 PrimaryState::Unstiff
             }
 
+            (PrimaryState::Calibration, ..) => PrimaryState::Calibration,
+
             (PrimaryState::Initial, _, _, true, _) => PrimaryState::Calibration,
 
             // GameController transitions (entering listening mode and staying within)


### PR DESCRIPTION
## Introduced Changes

One liner. When in calibration stay in calibration as per SPL rule state transitions.

Fixes #824 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Enter calibration while a game controller is running and the NAO is connected to the wireless network of that game controller. Before this change the NAO would immediately go back into initial and now stays in calibration.
