### PR TITLE
Visual referee message transmission decision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "approx"
@@ -322,7 +322,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -739,7 +739,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.60",
+ "syn 2.0.61",
  "which",
 ]
 
@@ -762,7 +762,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.60",
+ "syn 2.0.61",
  "which",
 ]
 
@@ -935,7 +935,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
@@ -1134,7 +1134,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1213,7 +1213,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "source_analyzer",
- "syn 2.0.60",
+ "syn 2.0.61",
  "thiserror",
 ]
 
@@ -1407,7 +1407,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2025,7 +2025,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2037,7 +2037,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2119,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2341,7 +2341,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2433,7 +2433,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2508,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3988,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
  "serde",
@@ -4010,7 +4010,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4024,11 +4024,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -4071,7 +4070,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4279,7 +4278,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4454,9 +4453,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path_abs"
@@ -4484,7 +4483,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4636,12 +4635,12 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4698,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5000,9 +4999,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -5072,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safe_arch"
@@ -5130,11 +5129,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5143,9 +5142,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5153,9 +5152,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -5172,14 +5171,14 @@ source = "git+https://github.com/h3ndrk/serde.git?rev=4fec5aac7d42a4ac1fc10af037
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -5194,7 +5193,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -5398,7 +5397,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.60",
+ "syn 2.0.61",
  "thiserror",
  "threadbound",
  "toposort-scc",
@@ -5538,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5641,22 +5640,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -5784,7 +5783,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -5811,16 +5810,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5876,7 +5874,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.7",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -5910,7 +5908,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -6275,7 +6273,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -6309,7 +6307,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7005,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
@@ -7172,22 +7170,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]

--- a/crates/control/src/behavior/initial.rs
+++ b/crates/control/src/behavior/initial.rs
@@ -1,5 +1,5 @@
-use coordinate_systems::{Field, Ground};
-use linear_algebra::{Isometry2, Point2};
+use coordinate_systems::Field;
+use linear_algebra::Point2;
 use spl_network_messages::PlayerNumber;
 use types::{
     camera_position::CameraPosition,
@@ -18,24 +18,20 @@ pub fn execute(
     }
 
     Some(
-        look_at_referee(
-            world_state.robot.ground_to_field,
-            expected_referee_position,
-            world_state.clone(),
-        )
-        .unwrap_or(MotionCommand::Initial {
-            head: HeadMotion::Center,
-            should_look_for_referee: false,
-        }),
+        look_at_referee(expected_referee_position, world_state.clone()).unwrap_or(
+            MotionCommand::Initial {
+                head: HeadMotion::Center,
+                should_look_for_referee: false,
+            },
+        ),
     )
 }
 
 fn look_at_referee(
-    ground_to_field: Option<Isometry2<Ground, Field>>,
     expected_referee_position: Option<Point2<Field>>,
     world_state: WorldState,
 ) -> Option<MotionCommand> {
-    let ground_to_field = ground_to_field?;
+    let ground_to_field = world_state.robot.ground_to_field?;
     let expected_referee_position = expected_referee_position?;
     if world_state.filtered_game_controller_state?.game_state != FilteredGameState::Initial {
         return None;

--- a/crates/control/src/behavior/initial.rs
+++ b/crates/control/src/behavior/initial.rs
@@ -3,7 +3,6 @@ use linear_algebra::{Isometry2, Point2};
 use spl_network_messages::PlayerNumber;
 use types::{
     camera_position::CameraPosition,
-    filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState,
     motion_command::{HeadMotion, ImageRegion, MotionCommand},
     primary_state::PrimaryState,
@@ -21,7 +20,6 @@ pub fn execute(
     Some(
         look_at_referee(
             world_state.robot.ground_to_field,
-            world_state.filtered_game_controller_state,
             expected_referee_position,
             world_state.clone(),
         )
@@ -34,13 +32,12 @@ pub fn execute(
 
 fn look_at_referee(
     ground_to_field: Option<Isometry2<Ground, Field>>,
-    filtered_game_controller_state: Option<FilteredGameControllerState>,
     expected_referee_position: Option<Point2<Field>>,
     world_state: WorldState,
 ) -> Option<MotionCommand> {
     let ground_to_field = ground_to_field?;
     let expected_referee_position = expected_referee_position?;
-    if filtered_game_controller_state?.game_state != FilteredGameState::Initial {
+    if world_state.filtered_game_controller_state?.game_state != FilteredGameState::Initial {
         return None;
     }
 

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -34,6 +34,7 @@ pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
     filtered_whistle: Input<FilteredWhistle, "filtered_whistle">,
     role: Input<Role, "role">,
+    is_own_referee_initial_pose_detected: Input<bool, "is_own_referee_initial_pose_detected">,
 
     balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
     balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,
@@ -165,6 +166,7 @@ impl LedStatus {
             at_least_one_ball_data_bottom,
             last_ball_data_top_too_old,
             last_ball_data_bottom_too_old,
+            *context.is_own_referee_initial_pose_detected,
         );
 
         if let Some(latest_game_controller_message_time) = context
@@ -259,6 +261,7 @@ impl LedStatus {
         at_least_one_ball_data_bottom: bool,
         last_ball_data_top_too_old: bool,
         last_ball_data_bottom_too_old: bool,
+        is_own_referee_initial_pose_detected: bool,
     ) -> (Eye, Eye) {
         match primary_state {
             PrimaryState::Unstiff => {
@@ -293,17 +296,20 @@ impl LedStatus {
                     Role::Striker => Rgb::RED,
                     Role::StrikerSupporter => Rgb::TURQUOISE,
                 };
+                let referee_color = if is_own_referee_initial_pose_detected {
+                    Some(Rgb::PURPLE)
+                } else {
+                    None
+                };
                 (
                     Eye {
-                        color_at_0: ball_color_top
-                            .unwrap_or_else(|| ball_background_color.unwrap_or(Rgb::BLACK)),
+                        color_at_0: referee_color.unwrap_or(Rgb::BLACK),
                         color_at_45: ball_color_top
                             .unwrap_or_else(|| ball_background_color.unwrap_or(Rgb::BLACK)),
                         color_at_90: ball_background_color.unwrap_or(Rgb::BLACK),
                         color_at_135: ball_color_bottom
                             .unwrap_or_else(|| ball_background_color.unwrap_or(Rgb::BLACK)),
-                        color_at_180: ball_color_bottom
-                            .unwrap_or_else(|| ball_background_color.unwrap_or(Rgb::BLACK)),
+                        color_at_180: referee_color.unwrap_or(Rgb::BLACK),
                         color_at_225: ball_color_bottom
                             .unwrap_or_else(|| ball_background_color.unwrap_or(Rgb::BLACK)),
                         color_at_270: ball_background_color.unwrap_or(Rgb::BLACK),

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     time::{Duration, SystemTime},
 };
 
@@ -17,10 +17,14 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct RefereePoseDetectionFilter {
     detection_times: Players<Option<SystemTime>>,
+    own_detected_above_arm_poses_queue: VecDeque<bool>,
 }
 
 #[context]
-pub struct CreationContext {}
+pub struct CreationContext {
+    referee_pose_queue_length:
+        Parameter<usize, "object_detection.object_detection_top.referee_pose_queue_length">,
+}
 
 #[context]
 pub struct CycleContext {
@@ -42,18 +46,31 @@ pub struct CycleContext {
 
     player_referee_detection_times:
         AdditionalOutput<Players<Option<SystemTime>>, "player_referee_detection_times">,
+
+    referee_pose_queue_length:
+        Parameter<usize, "object_detection.object_detection_top.referee_pose_queue_length">,
+    minimum_number_poses_before_message: Parameter<
+        usize,
+        "object_detection.object_detection_top.minimum_number_poses_before_message",
+    >,
+
+    referee_pose_queue: AdditionalOutput<VecDeque<bool>, "referee_pose_queue">,
 }
 
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
     pub is_referee_initial_pose_detected: MainOutput<bool>,
+    pub is_own_referee_initial_pose_detected: MainOutput<bool>,
 }
 
 impl RefereePoseDetectionFilter {
-    pub fn new(_context: CreationContext) -> Result<Self> {
+    pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
             detection_times: Default::default(),
+            own_detected_above_arm_poses_queue: VecDeque::with_capacity(
+                *context.referee_pose_queue_length,
+            ),
         })
     }
 
@@ -63,7 +80,7 @@ impl RefereePoseDetectionFilter {
     ) -> Result<MainOutputs> {
         let cycle_start_time = context.cycle_time.start_time;
 
-        self.update(&context)?;
+        let is_own_referee_initial_pose_detected = self.update(&context)?;
 
         let is_referee_initial_pose_detected = decide(
             self.detection_times,
@@ -76,22 +93,40 @@ impl RefereePoseDetectionFilter {
             .player_referee_detection_times
             .fill_if_subscribed(|| self.detection_times);
 
+        context
+            .referee_pose_queue
+            .fill_if_subscribed(|| self.own_detected_above_arm_poses_queue.clone());
+
         Ok(MainOutputs {
             is_referee_initial_pose_detected: is_referee_initial_pose_detected.into(),
+            is_own_referee_initial_pose_detected: is_own_referee_initial_pose_detected.into(),
         })
     }
 
-    fn update(&mut self, context: &CycleContext<impl NetworkInterface>) -> Result<()> {
+    fn update(&mut self, context: &CycleContext<impl NetworkInterface>) -> Result<bool> {
         let own_detected_pose_times =
             unpack_own_detection_tree(&context.detected_referee_pose_kind.persistent);
 
-        if let Some((time, _)) = own_detected_pose_times
-            .into_iter()
-            .find(|(_, pose_kind)| *pose_kind == PoseKind::AboveHeadArms)
-        {
-            self.detection_times[*context.player_number] = Some(time);
+        for (_, detection) in own_detected_pose_times {
+            self.own_detected_above_arm_poses_queue.push_front(
+                detection.map_or(false, |pose_kind| pose_kind == PoseKind::AboveHeadArms),
+            );
         }
-        Ok(())
+
+        self.own_detected_above_arm_poses_queue
+            .truncate(*context.referee_pose_queue_length);
+
+        let detected_referee_pose_count = self
+            .own_detected_above_arm_poses_queue
+            .iter()
+            .filter(|x| **x)
+            .count();
+
+        if detected_referee_pose_count >= *context.minimum_number_poses_before_message {
+            self.detection_times[*context.player_number] = Some(context.cycle_time.start_time);
+        }
+
+        Ok(detected_referee_pose_count >= *context.minimum_number_poses_before_message)
     }
 }
 
@@ -128,10 +163,13 @@ fn is_in_grace_period(
 
 fn unpack_own_detection_tree(
     pose_kind_tree: &BTreeMap<SystemTime, Vec<Option<&PoseKind>>>,
-) -> BTreeMap<SystemTime, PoseKind> {
+) -> BTreeMap<SystemTime, Option<PoseKind>> {
     pose_kind_tree
         .iter()
-        .flat_map(|(time, pose_kinds)| pose_kinds.iter().map(|&pose_kind| (*time, pose_kind)))
-        .filter_map(|(time, pose_kind)| Some(time).zip(pose_kind.cloned()))
+        .flat_map(|(time, pose_kinds)| {
+            pose_kinds
+                .iter()
+                .map(|&pose_kind| (*time, pose_kind.cloned()))
+        })
         .collect()
 }

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -60,8 +60,8 @@ pub struct CycleContext {
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
+    pub majority_vote_is_referee_initial_pose_detected: MainOutput<bool>,
     pub is_referee_initial_pose_detected: MainOutput<bool>,
-    pub is_own_referee_initial_pose_detected: MainOutput<bool>,
 }
 
 impl RefereePoseDetectionFilter {
@@ -80,9 +80,9 @@ impl RefereePoseDetectionFilter {
     ) -> Result<MainOutputs> {
         let cycle_start_time = context.cycle_time.start_time;
 
-        let is_own_referee_initial_pose_detected = self.update(&context);
+        let is_referee_initial_pose_detected = self.update(&context);
 
-        let is_referee_initial_pose_detected = decide(
+        let majority_vote_is_referee_initial_pose_detected = decide(
             self.detection_times,
             cycle_start_time,
             *context.initial_message_grace_period,
@@ -98,8 +98,9 @@ impl RefereePoseDetectionFilter {
             .fill_if_subscribed(|| self.detected_above_arm_poses_queue.clone());
 
         Ok(MainOutputs {
+            majority_vote_is_referee_initial_pose_detected:
+                majority_vote_is_referee_initial_pose_detected.into(),
             is_referee_initial_pose_detected: is_referee_initial_pose_detected.into(),
-            is_own_referee_initial_pose_detected: is_own_referee_initial_pose_detected.into(),
         })
     }
 

--- a/crates/path_serde/src/not_supported.rs
+++ b/crates/path_serde/src/not_supported.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
     net::SocketAddr,
     path::PathBuf,
     time::{Duration, SystemTime},
@@ -110,3 +110,4 @@ implement_as_not_supported!(SocketAddr);
 implement_as_not_supported!(String);
 implement_as_not_supported!(SystemTime);
 implement_as_not_supported!(Vec<T>, T);
+implement_as_not_supported!(VecDeque<T>, T);

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1,7 +1,7 @@
 {
   "object_detection": {
     "object_detection_top": {
-      "enable": false,
+      "enable": true,
       "intersection_over_union_threshold": 0.45,
       "distance_to_referee_position_threshold": 2.0,
       "keypoint_confidence_threshold": 0.2,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1197,7 +1197,7 @@
       "nanos": 0,
       "secs": 3
     },
-    "minimum_above_head_arms_detections": 2
+    "minimum_above_head_arms_detections": 1
   },
   "ground_contact_detector": {
     "pressure_threshold": 0.6,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1,7 +1,7 @@
 {
   "object_detection": {
     "object_detection_top": {
-      "enable": true,
+      "enable": false,
       "intersection_over_union_threshold": 0.45,
       "distance_to_referee_position_threshold": 2.0,
       "keypoint_confidence_threshold": 0.2,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -6,7 +6,9 @@
       "distance_to_referee_position_threshold": 2.0,
       "keypoint_confidence_threshold": 0.2,
       "shoulder_angle_threshold": 0.2,
-      "foot_z_offset": 0.05
+      "foot_z_offset": 0.05,
+      "referee_pose_queue_length": 4,
+      "minimum_number_poses_before_message": 3
     }
   },
   "feet_detection": {


### PR DESCRIPTION
## Introduced Changes
Introduces a queue to reduce the number of messages sent in `Initial` and reduce false positives.
At the moment the queue has a length of 4 and if there are 3 detections out of those 4 the robot changes to `Ready`. Please suggest other values if this is not sufficient.
A detected pose can be seen by two purple leds in the left eye of the NAO. 

Depends on #806 

Addresses #818

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
Test with NAO if it takes longer as in #806 to change from `Initial` -> `Ready` with a running game controller. 
And can use `Control.additional_outputs.referee_pose_queue` in twix to see the queue.

