### PR TITLE
Update game controller messages and consequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,11 +723,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -746,17 +746,17 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -3436,7 +3436,7 @@ dependencies = [
 name = "nao_camera"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen 0.69.4",
  "i2cdev",
  "libc",
  "nix 0.28.0",
@@ -4874,7 +4874,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "bincode",
- "bindgen 0.65.1",
+ "bindgen 0.69.4",
  "color-eyre",
  "coordinate_systems",
  "linear_algebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ bat = { version = "0.23.0", default-features = false, features = [
   "paging",
 ] }
 bincode = "1.3.3"
-bindgen = "0.65.1"
+bindgen = "0.69.4"
 build_script_helpers = { path = "crates/build_script_helpers" }
 byteorder = "1.4.3"
 calibration = { path = "crates/calibration" }

--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -184,8 +184,8 @@ impl Localization {
             }
             (PrimaryState::Playing, PrimaryState::Penalized, _) => {
                 match penalty {
-                    Some(Penalty::IllegalMotionInSet { remaining: _ })
-                    | Some(Penalty::IllegalMotionInInitial { remaining: _ }) => {
+                    Some(Penalty::IllegalMotionInSet { .. })
+                    | Some(Penalty::IllegalMotionInInitial { .. }) => {
                         self.is_penalized_with_motion_in_set_or_initial = true;
                     }
                     Some(_) => {}

--- a/crates/nao_camera/build.rs
+++ b/crates/nao_camera/build.rs
@@ -1,14 +1,14 @@
 use std::env;
 use std::path::PathBuf;
 
-use bindgen::{Builder, CargoCallbacks};
+use bindgen::Builder;
 
 fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
 
     let bindings = Builder::default()
         .header("wrapper.h")
-        .parse_callbacks(Box::new(CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Failed to generate bindings");
 

--- a/crates/spl_network_messages/build.rs
+++ b/crates/spl_network_messages/build.rs
@@ -1,12 +1,12 @@
 use std::{env, path::PathBuf};
 
-use bindgen::{Builder, CargoCallbacks};
+use bindgen::Builder;
 
 fn main() {
     let bindings = Builder::default()
         .header("headers/RoboCupGameControlData.hpp")
         .header("headers/VisualRefereeChallenge.hpp")
-        .parse_callbacks(Box::new(CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .layout_tests(false)
         .fit_macro_constants(true)
         .generate()

--- a/crates/spl_network_messages/headers/RoboCupGameControlData.hpp
+++ b/crates/spl_network_messages/headers/RoboCupGameControlData.hpp
@@ -7,7 +7,7 @@
 #define GAMECONTROLLER_RETURN_PORT 3939
 
 #define GAMECONTROLLER_STRUCT_HEADER  "RGme"
-#define GAMECONTROLLER_STRUCT_VERSION 15
+#define GAMECONTROLLER_STRUCT_VERSION 16
 
 #define MAX_NUM_PLAYERS 20
 
@@ -26,8 +26,8 @@
 #define COMPETITION_PHASE_ROUNDROBIN 0
 #define COMPETITION_PHASE_PLAYOFF    1
 
-#define COMPETITION_TYPE_NORMAL                0
-#define COMPETITION_TYPE_DYNAMIC_BALL_HANDLING 1
+#define COMPETITION_TYPE_NORMAL          0
+#define COMPETITION_TYPE_SHARED_AUTONOMY 1
 
 #define GAME_PHASE_NORMAL       0
 #define GAME_PHASE_PENALTYSHOOT 1
@@ -59,6 +59,7 @@
 #define PENALTY_SPL_LOCAL_GAME_STUCK          8
 #define PENALTY_SPL_ILLEGAL_POSITION_IN_SET   9
 #define PENALTY_SPL_PLAYER_STANCE             10
+#define PENALTY_SPL_ILLEGAL_MOTION_IN_INITIAL 11
 
 #define PENALTY_SUBSTITUTE                    14
 #define PENALTY_MANUAL                        15
@@ -89,7 +90,7 @@ struct RoboCupGameControlData
   uint8_t packetNumber;     // number incremented with each packet sent (with wraparound)
   uint8_t playersPerTeam;   // the number of players on a team
   uint8_t competitionPhase; // phase of the competition (COMPETITION_PHASE_ROUNDROBIN, COMPETITION_PHASE_PLAYOFF)
-  uint8_t competitionType;  // type of the competition (COMPETITION_TYPE_NORMAL, COMPETITION_TYPE_DYNAMIC_BALL_HANDLING)
+  uint8_t competitionType;  // type of the competition (COMPETITION_TYPE_NORMAL, COMPETITION_TYPE_SHARED_AUTONOMY)
   uint8_t gamePhase;        // phase of the game (GAME_PHASE_NORMAL, GAME_PHASE_PENALTYSHOOT, etc)
   uint8_t state;            // state of the game (STATE_READY, STATE_PLAYING, etc)
   uint8_t setPlay;          // active set play (SET_PLAY_NONE, SET_PLAY_GOAL_KICK, etc)

--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -13,10 +13,10 @@ use serialize_hierarchy::SerializeHierarchy;
 use crate::{
     bindings::{
         RoboCupGameControlData, RobotInfo, COMPETITION_PHASE_PLAYOFF, COMPETITION_PHASE_ROUNDROBIN,
-        COMPETITION_TYPE_DYNAMIC_BALL_HANDLING, COMPETITION_TYPE_NORMAL,
-        GAMECONTROLLER_STRUCT_HEADER, GAMECONTROLLER_STRUCT_VERSION, GAME_PHASE_NORMAL,
-        GAME_PHASE_OVERTIME, GAME_PHASE_PENALTYSHOOT, GAME_PHASE_TIMEOUT, MAX_NUM_PLAYERS,
-        PENALTY_MANUAL, PENALTY_NONE, PENALTY_SPL_ILLEGAL_BALL_CONTACT,
+        COMPETITION_TYPE_NORMAL, COMPETITION_TYPE_SHARED_AUTONOMY, GAMECONTROLLER_STRUCT_HEADER,
+        GAMECONTROLLER_STRUCT_VERSION, GAME_PHASE_NORMAL, GAME_PHASE_OVERTIME,
+        GAME_PHASE_PENALTYSHOOT, GAME_PHASE_TIMEOUT, MAX_NUM_PLAYERS, PENALTY_MANUAL, PENALTY_NONE,
+        PENALTY_SPL_ILLEGAL_BALL_CONTACT, PENALTY_SPL_ILLEGAL_MOTION_IN_INITIAL,
         PENALTY_SPL_ILLEGAL_MOTION_IN_SET, PENALTY_SPL_ILLEGAL_POSITION,
         PENALTY_SPL_ILLEGAL_POSITION_IN_SET, PENALTY_SPL_INACTIVE_PLAYER,
         PENALTY_SPL_LEAVING_THE_FIELD, PENALTY_SPL_LOCAL_GAME_STUCK, PENALTY_SPL_PLAYER_PUSHING,
@@ -216,14 +216,14 @@ impl CompetitionPhase {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, SerializeHierarchy)]
 pub enum CompetitionType {
     Normal,
-    DynamicBallHandling,
+    SharedAutonomy,
 }
 
 impl CompetitionType {
     fn try_from(competition_type: u8) -> Result<Self> {
         match competition_type {
             COMPETITION_TYPE_NORMAL => Ok(CompetitionType::Normal),
-            COMPETITION_TYPE_DYNAMIC_BALL_HANDLING => Ok(CompetitionType::DynamicBallHandling),
+            COMPETITION_TYPE_SHARED_AUTONOMY => Ok(CompetitionType::SharedAutonomy),
             _ => bail!("unexpected competition type"),
         }
     }
@@ -415,6 +415,7 @@ impl TryFrom<RobotInfo> for Player {
 pub enum Penalty {
     IllegalBallContact { remaining: Duration },
     PlayerPushing { remaining: Duration },
+    IllegalMotionInInitial { remaining: Duration },
     IllegalMotionInSet { remaining: Duration },
     InactivePlayer { remaining: Duration },
     IllegalPosition { remaining: Duration },
@@ -433,6 +434,9 @@ impl Penalty {
             PENALTY_NONE => Ok(None),
             PENALTY_SPL_ILLEGAL_BALL_CONTACT => Ok(Some(Penalty::IllegalBallContact { remaining })),
             PENALTY_SPL_PLAYER_PUSHING => Ok(Some(Penalty::PlayerPushing { remaining })),
+            PENALTY_SPL_ILLEGAL_MOTION_IN_INITIAL => {
+                Ok(Some(Penalty::IllegalMotionInInitial { remaining }))
+            }
             PENALTY_SPL_ILLEGAL_MOTION_IN_SET => {
                 Ok(Some(Penalty::IllegalMotionInSet { remaining }))
             }


### PR DESCRIPTION
## Introduced Changes

Uses newest game controller headers and deals with illegal motion in initial

Fixes #834 

## ToDo / Known Issues

Fails check currently, there is an issue in the bindings being generated. Definitely need feedback as to why this happens.

## Ideas for Next Iterations (Not This PR)

## How to Test

Using the newest game controller and only after #806 is merged, give the robot a ready signal  for a "false positive". 
Penalize the robot with motion in initial from the newest game controller. The robot should keep its localization