### PR TITLE
Add new robot numbers to twix

### DIFF
--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -229,7 +229,7 @@ impl App for TwixApp {
                 ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
                     let address_input = CompletionEdit::addresses(
                         &mut self.ip_address,
-                        21..=37,
+                        21..=41,
                         &self.reachable_naos.ips,
                     )
                     .ui(ui);


### PR DESCRIPTION
## Introduced Changes

The new robots number were added to the list on twix so that all the robots can be tested on twix.


## How to Test

Go on twix, and see if the robot numbers 38-41 are now available on twix.
