### PR TITLE
Plot panel

### DIFF
--- a/tools/twix/src/panels/enum_plot.rs
+++ b/tools/twix/src/panels/enum_plot.rs
@@ -147,12 +147,9 @@ impl EnumPlotPanel {
         }
 
         plot_ui.text(
-            Text::new(
-                PlotPoint { x: text_x, y: 0.9 },
-                name,
-            )
-            .color(Color32::WHITE)
-            .anchor(eframe::emath::Align2::LEFT_TOP),
+            Text::new(PlotPoint { x: text_x, y: 0.9 }, name)
+                .color(Color32::WHITE)
+                .anchor(eframe::emath::Align2::LEFT_TOP),
         );
     }
 

--- a/tools/twix/src/panels/enum_plot.rs
+++ b/tools/twix/src/panels/enum_plot.rs
@@ -117,6 +117,8 @@ impl EnumPlotPanel {
         const BORDER_WIDTH: f32 = 2.0;
 
         let viewport_left_edge = plot_bounds.min()[0];
+        let viewport_right_edge = plot_bounds.max()[0];
+        let min_boxsize_text = viewport_right_edge - viewport_left_edge;
 
         let name = segment.name();
         let color = color_hash(&name);
@@ -137,16 +139,13 @@ impl EnumPlotPanel {
         );
 
         let mut text_x = start + 0.05;
-        if viewport_left_edge > text_x && end > viewport_left_edge{
+        if viewport_left_edge > text_x && end > (viewport_left_edge + (min_boxsize_text / 18.0)) {
             text_x = viewport_left_edge + 0.05;
         }
 
         plot_ui.text(
             Text::new(
-                PlotPoint {
-                    x: text_x,
-                    y: 0.9,
-                },
+                PlotPoint { x: text_x, y: 0.9 },
                 name, //
             )
             .color(Color32::WHITE)

--- a/tools/twix/src/panels/enum_plot.rs
+++ b/tools/twix/src/panels/enum_plot.rs
@@ -115,11 +115,8 @@ impl EnumPlotPanel {
     fn plot_segment(plot_ui: &mut PlotUi, segment: &Segment, plot_bounds: &PlotBounds) {
         const VERTICAL_MARGIN: f64 = 0.05;
         const BORDER_WIDTH: f32 = 2.0;
-        const MIN_SEGMENT_RELATION_FOR_TEXT: f64 = 1.0 / 18.0;
 
         let viewport_left_edge = plot_bounds.min()[0];
-        let viewport_right_edge = plot_bounds.max()[0];
-        let min_boxsize_text = viewport_right_edge - viewport_left_edge;
 
         let name = segment.name();
         let color = color_hash(&name);
@@ -139,12 +136,11 @@ impl EnumPlotPanel {
             .stroke(Stroke::new(BORDER_WIDTH, color)),
         );
 
-        let mut text_x = start + 0.05;
-        if viewport_left_edge > text_x
-            && end > (viewport_left_edge + (min_boxsize_text * MIN_SEGMENT_RELATION_FOR_TEXT))
-        {
-            text_x = viewport_left_edge + 0.05;
-        }
+        let text_x = if start < viewport_left_edge && viewport_left_edge < end {
+            viewport_left_edge + 0.05
+        } else {
+            start + 0.05
+        };
 
         plot_ui.text(
             Text::new(PlotPoint { x: text_x, y: 0.9 }, name)

--- a/tools/twix/src/panels/enum_plot.rs
+++ b/tools/twix/src/panels/enum_plot.rs
@@ -7,7 +7,7 @@ use std::{
 
 use communication::client::CyclerOutput;
 use eframe::{
-    egui::{show_tooltip_at_pointer, viewport, ComboBox, Id, Response, Ui, Widget},
+    egui::{show_tooltip_at_pointer, ComboBox, Id, Response, Ui, Widget},
     epaint::{Color32, Stroke},
 };
 use egui_plot::{Plot, PlotBounds, PlotPoint, PlotUi, Polygon, Text};
@@ -115,6 +115,7 @@ impl EnumPlotPanel {
     fn plot_segment(plot_ui: &mut PlotUi, segment: &Segment, plot_bounds: &PlotBounds) {
         const VERTICAL_MARGIN: f64 = 0.05;
         const BORDER_WIDTH: f32 = 2.0;
+        const MIN_SEGMENT_RELATION_FOR_TEXT: f64 = 1.0 / 18.0;
 
         let viewport_left_edge = plot_bounds.min()[0];
         let viewport_right_edge = plot_bounds.max()[0];
@@ -139,14 +140,16 @@ impl EnumPlotPanel {
         );
 
         let mut text_x = start + 0.05;
-        if viewport_left_edge > text_x && end > (viewport_left_edge + (min_boxsize_text / 18.0)) {
+        if viewport_left_edge > text_x
+            && end > (viewport_left_edge + (min_boxsize_text * MIN_SEGMENT_RELATION_FOR_TEXT))
+        {
             text_x = viewport_left_edge + 0.05;
         }
 
         plot_ui.text(
             Text::new(
                 PlotPoint { x: text_x, y: 0.9 },
-                name, //
+                name,
             )
             .color(Color32::WHITE)
             .anchor(eframe::emath::Align2::LEFT_TOP),


### PR DESCRIPTION
## Introduced Changes

In twix Plot Panel if 'follow' is active the name of the segment stays at the leftmost visible position. It disappears as soon as the segments visible size is 1/18 of the whole bar (that it doesn't overlap too much with the text of the next segment)

Fixes #844

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)
If a segment is smaller then its title, the text overlaps with the title of the next segment.

## How to Test

In twix open Map and Plot Panel, subscribe to e.g. role and change to 'follow'. The change can be observed when a segments left border is not shown on the panel anymore but the title is still there!
