### PR TITLE
Don't compress rsync stream

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -88,7 +88,6 @@ impl Nao {
         let ssh_flags = self.get_ssh_flags().join(" ");
         command
             .stdout(Stdio::piped())
-            .arg("--compress")
             .arg("--recursive")
             .arg("--times")
             .arg("--no-inc-recursive")


### PR DESCRIPTION
## Introduced Changes

With compression:
```
[10.1.24.38] ⠏ Downloading logs:         166.54M  10%   26.23MB/s    0:00:50
```
Without compression
```
[10.1.24.38] ⣆ Downloading logs:         480.18M  31%   91.69MB/s    0:00:11
```

Fixes #833 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Download logs