### PR TITLE
increases radius for non strikers

### DIFF
--- a/crates/control/src/dribble_path_planner.rs
+++ b/crates/control/src/dribble_path_planner.rs
@@ -48,7 +48,7 @@ pub fn plan(
     } else {
         let mut obstacles = world_state.obstacles.clone();
         for obstacle in &mut obstacles {
-            if obstacle.kind == ObstacleKind::GoalPost {
+            if matches!(obstacle.kind, ObstacleKind::GoalPost) {
                 obstacle.radius_at_hip_height = (obstacle.radius_at_hip_height
                     - dribbling_parameters.goalpost_radius_decrease)
                     .max(0.0);

--- a/crates/control/src/dribble_path_planner.rs
+++ b/crates/control/src/dribble_path_planner.rs
@@ -50,7 +50,7 @@ pub fn plan(
         for obstacle in &mut obstacles {
             if matches!(obstacle.kind, ObstacleKind::GoalPost) {
                 obstacle.radius_at_hip_height = (obstacle.radius_at_hip_height
-                    - dribbling_parameters.goalpost_radius_decrease)
+                    - dribbling_parameters.goal_post_radius_decrease)
                     .max(0.0);
             }
         }

--- a/crates/control/src/dribble_path_planner.rs
+++ b/crates/control/src/dribble_path_planner.rs
@@ -1,10 +1,10 @@
 use framework::AdditionalOutput;
 use spl_network_messages::Team;
 use std::f32::consts::PI;
-use types::obstacles::ObstacleKind;
 use types::{
-    filtered_game_controller_state::FilteredGameControllerState, parameters::DribblingParameters,
-    path_obstacles::PathObstacle, planned_path::PathSegment, world_state::WorldState,
+    filtered_game_controller_state::FilteredGameControllerState, obstacles::ObstacleKind,
+    parameters::DribblingParameters, path_obstacles::PathObstacle, planned_path::PathSegment,
+    world_state::WorldState,
 };
 
 use crate::behavior::walk_to_pose::WalkPathPlanner;

--- a/crates/control/src/obstacle_filter.rs
+++ b/crates/control/src/obstacle_filter.rs
@@ -206,10 +206,6 @@ impl ObstacleFilter {
             })
             .map(|hypothesis| {
                 let (radius_at_hip_height, radius_at_foot_height) = match hypothesis.obstacle_kind {
-                    ObstacleKind::GoalPost => (
-                        *context.goal_post_obstacle_radius,
-                        *context.goal_post_obstacle_radius,
-                    ),
                     ObstacleKind::Robot => (
                         *context.robot_obstacle_radius_at_hip_height,
                         *context.robot_obstacle_radius_at_foot_height,
@@ -232,7 +228,7 @@ impl ObstacleFilter {
         let goal_posts =
             calculate_goal_post_positions(current_ground_to_field.copied(), field_dimensions);
         let goal_post_obstacles = goal_posts.into_iter().map(|goal_post| {
-            Obstacle::goal_post(goal_post, field_dimensions.goal_post_diameter / 2.0)
+            Obstacle::goal_post(goal_post, *context.goal_post_obstacle_radius)
         });
         context
             .obstacle_filter_hypotheses

--- a/crates/control/src/obstacle_filter.rs
+++ b/crates/control/src/obstacle_filter.rs
@@ -227,9 +227,9 @@ impl ObstacleFilter {
         let current_ground_to_field = context.ground_to_field.get(&cycle_start_time);
         let goal_posts =
             calculate_goal_post_positions(current_ground_to_field.copied(), field_dimensions);
-        let goal_post_obstacles = goal_posts.into_iter().map(|goal_post| {
-            Obstacle::goal_post(goal_post, *context.goal_post_obstacle_radius)
-        });
+        let goal_post_obstacles = goal_posts
+            .into_iter()
+            .map(|goal_post| Obstacle::goal_post(goal_post, *context.goal_post_obstacle_radius));
         context
             .obstacle_filter_hypotheses
             .fill_if_subscribed(|| self.hypotheses.clone());

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -121,7 +121,7 @@ pub struct DribblingParameters {
     pub distance_to_be_aligned: f32,
     pub angle_to_approach_ball_from_threshold: f32,
     pub ignore_robot_when_near_ball_radius: f32,
-    pub goalpost_radius_decrease: f32,
+    pub goal_post_radius_decrease: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -121,6 +121,7 @@ pub struct DribblingParameters {
     pub distance_to_be_aligned: f32,
     pub angle_to_approach_ball_from_threshold: f32,
     pub ignore_robot_when_near_ball_radius: f32,
+    pub goalpost_radius_decrease: f32,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, SerializeHierarchy)]

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -380,7 +380,7 @@
     "robot_obstacle_radius_at_hip_height": 0.2,
     "robot_obstacle_radius_at_foot_height": 0.2,
     "unknown_obstacle_radius": 0.125,
-    "goal_post_obstacle_radius": 0.2
+    "goal_post_obstacle_radius": 0.4
   },
   "role_assignment": {
     "forced_role": null,
@@ -904,7 +904,8 @@
       "hybrid_align_distance": 0.5,
       "distance_to_be_aligned": 0.1,
       "angle_to_approach_ball_from_threshold": 0.78,
-      "ignore_robot_when_near_ball_radius": 0.6
+      "ignore_robot_when_near_ball_radius": 0.6,
+      "goalpost_radius_decrease": 0.2
     },
     "walk_and_stand": {
       "hysteresis": [0.05, 0.05],

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -905,7 +905,7 @@
       "distance_to_be_aligned": 0.1,
       "angle_to_approach_ball_from_threshold": 0.78,
       "ignore_robot_when_near_ball_radius": 0.6,
-      "goalpost_radius_decrease": 0.2
+      "goal_post_radius_decrease": 0.2
     },
     "walk_and_stand": {
       "hysteresis": [0.05, 0.05],


### PR DESCRIPTION
## Introduced Changes

increases radius for non strikers to avoid colliding with the goalpost. The new parameter goalpost_radius_decrease will decrease the goalpost_radius for the striker to maintain the current behaviour. 

## Ideas for Next Iterations (Not This PR)

currently if the ball is closer than 60 cm the striker ignores obstacles, although goalpost exists. Think about better behaviour. 

## How to Test

First with Gamecontroller. First without the ball. The goalkeeper should make a large radius around the goalpost. Secondly with the ball closed to the robot (> 60cm), it should make a smaller radius (= 20 cm around the goalpost) 
