### PR TITLE
Schnagger

### DIFF
--- a/crates/hulk_replayer/src/replayer.rs
+++ b/crates/hulk_replayer/src/replayer.rs
@@ -33,8 +33,11 @@ pub fn replayer() -> Result<()> {
 
     let file =
         File::open(framework_parameters_path).wrap_err("failed to open framework parameters")?;
-    let framework_parameters: FrameworkParameters =
+    let mut framework_parameters: FrameworkParameters =
         from_reader(file).wrap_err("failed to parse framework parameters")?;
+    if framework_parameters.communication_addresses.is_none() {
+        framework_parameters.communication_addresses = Some("[::1]:1337".to_string());
+    }
 
     let hardware_interface = ReplayerHardwareInterface {
         ids: Ids {


### PR DESCRIPTION
## Introduced Changes

Enables communication server if it is disabled in `framework.json` because it makes no sense to replay something without communication.

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

It's perfect

## How to Test

Start the replayer with `null` in `communication_addresses` and observe that you can still connect to the communication server.