### PR TITLE
Anakin stop panicking

### DIFF
--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -39,10 +39,13 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
                 let keep_running = keep_running.clone();
                 std::panic::set_hook(Box::new(move |panic_info| {
                     keep_running.cancel();
+                    eprint!("panic occurred");
                     if let Some(payload) = panic_info.payload().downcast_ref::<&str>() {
-                        eprintln!("panic occurred: {payload:?} {:?}", panic_info.location());
-                    } else {
-                        eprintln!("panic occurred");
+                        eprint!(": {payload:?}");
+                    }
+                    eprintln!();
+                    if let Some(location) = panic_info.location() {
+                        eprintln!("\n{location}");
                     }
                 }));
             }

--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -43,6 +43,9 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
                     if let Some(payload) = panic_info.payload().downcast_ref::<&str>() {
                         eprint!(": {payload:?}");
                     }
+                    if let Some(payload) = panic_info.payload().downcast_ref::<String>() {
+                        eprint!(": {payload:?}");
+                    }
                     eprintln!();
                     if let Some(location) = panic_info.location() {
                         eprintln!("\n{location}");


### PR DESCRIPTION
## Introduced Changes

Upon panic, always prints location regardless of payload.
On main, only the payload of `panic!("hello world")` is printed, but not the one of `panic!("{some_variable}")`.

We only checked for `&str`, but panic with format string has a `String` payload.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)


## How to Test

Insert panics somehwere and observe how they are printed.