### PR TITLE
Panikmache

### DIFF
--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -39,11 +39,7 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
                 let keep_running = keep_running.clone();
                 std::panic::set_hook(Box::new(move |panic_info| {
                     keep_running.cancel();
-                    if let Some(payload) = panic_info.payload().downcast_ref::<&str>() {
-                        eprintln!("panic occurred: {payload:?} {:?}", panic_info.location());
-                    } else {
-                        eprintln!("panic occurred");
-                    }
+                    eprintln!("{panic_info}");
                 }));
             }
 


### PR DESCRIPTION
## Introduced Changes

Previously:

```
panic occurred: Any { .. }
```

With this PR:

```
panicked at crates/control/src/button_filter.rs:52:9:
Was ist denn mit Carsten los?
```

Fixes #

## ToDo / Known Issues

It's still perfect

## Ideas for Next Iterations (Not This PR)

It's still perfect

## How to Test

Add a `panic!()` into some node and observe the way more fancy error messages afterwards