### PR TITLE
Default penalties for 5v5

### DIFF
--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -455,3 +455,11 @@ impl Penalty {
         }
     }
 }
+
+impl Default for Penalty {
+    fn default() -> Self {
+        Self::RequestForPickup {
+            remaining: Duration::ZERO,
+        }
+    }
+}

--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -55,8 +55,16 @@ impl From<TeamState> for Players<Option<Penalty>> {
             three: team_state.players[2].penalty,
             four: team_state.players[3].penalty,
             five: team_state.players[4].penalty,
-            six: team_state.players[5].penalty,
-            seven: team_state.players[6].penalty,
+            six: team_state
+                .players
+                .get(5)
+                .map(|player| player.penalty)
+                .unwrap_or_default(),
+            seven: team_state
+                .players
+                .get(6)
+                .map(|player| player.penalty)
+                .unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
## Introduced Changes

Assigns PickedUp penalties to 6 and 7 in 5v5 matches.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

- Start game controller in challenger shield mode
- Robot shouldn't crash anymore when receiving a game controller state message with <7 penalties.