### PR TITLE
Keep current hypothesis for accidental penalizations

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -672,7 +672,7 @@
     "score_per_good_match": 1.0,
     "tentative_penalized_duration": {
       "nanos": 0,
-      "secs": 4
+      "secs": 12
     },
     "hypothesis_score_base_increase": 0.1
   },

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -670,6 +670,10 @@
     ],
     "good_matching_threshold": 0.5,
     "score_per_good_match": 1.0,
+    "tentative_penalized_duration": {
+      "nanos": 0,
+      "secs": 4
+    },
     "hypothesis_score_base_increase": 0.1
   },
   "odometry": {


### PR DESCRIPTION
## Introduced Changes

Does what it says by introducing `localization.tentative_penalized_duration`.

Fixes #896.

## ToDo / Known Issues

Still does a look around after being unpenalized, this should be fine since accidental penalization should not occur to often.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Upload to a robot, start a game, penalize a robot and undo the action before and after `tentative_penalized_duration`.
