### PR TITLE
Discard hypothesis when losing ground contact

### DIFF
--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -210,14 +210,14 @@ impl Localization {
             }
             (PrimaryState::Penalized, _, _)
                 if primary_state != PrimaryState::Penalized
-                    && self.time_when_penalized_clicked.map_or(true, |time| {
+                    && (self.time_when_penalized_clicked.map_or(true, |time| {
                         context
                             .cycle_time
                             .start_time
                             .duration_since(time)
                             .expect("time ran backwards")
                             > *context.tentative_penalized_duration
-                    }) =>
+                    }) || !context.has_ground_contact) =>
             {
                 if self.is_penalized_with_motion_in_set_or_initial {
                     if self.was_picked_up_while_penalized_with_motion_in_set_or_initial {


### PR DESCRIPTION
## Introduced Changes

This PR adds also generating the proper penalized position hypothesis as soon as the robot is penalized and looses ground contact (i.e. discarding the current one).

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Upload to a robot and have fun with penalizing, undoing, picking up, etc.
