### PR TITLE
Disable look around in Ready

### DIFF
--- a/crates/control/src/behavior/look_around.rs
+++ b/crates/control/src/behavior/look_around.rs
@@ -16,7 +16,7 @@ pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
             }),
             _,
         ) => None,
-        (_,PrimaryState::Playing) => Some(MotionCommand::Stand {
+        (_, PrimaryState::Playing) => Some(MotionCommand::Stand {
             head: types::motion_command::HeadMotion::LookAround,
         }),
         _ => None,


### PR DESCRIPTION
## Introduced Changes

As it says in the title

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

see if robots still do look around in ready
