### PR TITLE
supercharge twix navigation

### DIFF
--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -21,7 +21,7 @@ use eframe::{
         CentralPanel, Context, Id, Key, Layout, Modifiers, TopBottomPanel, Ui, Widget, WidgetText,
     },
     emath::Align,
-    epaint::{Color32, Rounding, Stroke},
+    epaint::{Color32, Rounding},
     run_native, App, CreationContext, Frame, NativeOptions, Storage,
 };
 use egui_dock::{DockArea, DockState, Node, NodeIndex, Split, SurfaceIndex, TabAddAlign, TabIndex};
@@ -535,8 +535,11 @@ impl App for TwixApp {
             if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                 let node = &self.dock_state[surface_index][node_id];
                 let rect = node.rect().unwrap();
-                ui.painter()
-                    .rect_stroke(rect, Rounding::same(4.0), Stroke::new(1.0, Color32::RED));
+                ui.painter().rect_stroke(
+                    rect,
+                    Rounding::same(4.0),
+                    ui.style().visuals.widgets.active.bg_stroke,
+                );
             }
         });
     }


### PR DESCRIPTION
## Introduced Changes

Navigate twix like a tiling window manager.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

- Use `CTRL+T` to open a new split with a text panel (previously a new tab, but who needs tabs?!)
- Use `CTRL+HJKL` to navigate in splits
- Use `CTRL+R` to (re-)connect