### PR TITLE
Allow symlinks for log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ rust-toolchain.toml
 
 site/
 
-logs/
+logs


### PR DESCRIPTION
## Introduced Changes

I wanted to share the log directory between my git worktrees, but the `logs/` pattern in the gitignore file does not ignore a symlink name `logs`.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Create a symlink called `logs` in the root of the repo and run `git status`. It should no longer be detected as an untracked file.