### PR TITLE
Record poses by forwarding them via control

### DIFF
--- a/tools/twix/src/panels/image/overlays/pose_detection.rs
+++ b/tools/twix/src/panels/image/overlays/pose_detection.rs
@@ -32,8 +32,8 @@ const POSE_SKELETON: [(usize, usize); 16] = [
 ];
 
 pub struct PoseDetection {
-    human_poses: Option<ValueBuffer>,
-    keypoint_confidence_threshold: Option<ValueBuffer>,
+    human_poses: ValueBuffer,
+    keypoint_confidence_threshold: ValueBuffer,
 }
 
 impl Overlay for PoseDetection {
@@ -42,37 +42,30 @@ impl Overlay for PoseDetection {
     fn new(nao: Arc<Nao>, selected_cycler: Cycler) -> Self {
         if selected_cycler != Cycler::VisionTop {
             warn!("PoseDetection only works with the vision top cycler instance!");
-            return Self {
-                human_poses: None,
-                keypoint_confidence_threshold: None,
-            };
+            // TODO: Handle != Cycler::VisionTop
         };
         Self {
-            human_poses: Some(nao.subscribe_output(CyclerOutput {
-                cycler: Cycler::ObjectDetectionTop,
-                output: Output::Main {
-                    path: "human_poses".to_string(),
+            human_poses: nao.subscribe_output(CyclerOutput {
+                cycler: Cycler::Control,
+                output: Output::Additional {
+                    path: "human_poses_forwarded".to_string(),
                 },
-            })),
-            keypoint_confidence_threshold: Some(nao.subscribe_parameter(
+            }),
+            keypoint_confidence_threshold: nao.subscribe_parameter(
                 "object_detection.object_detection_top.keypoint_confidence_threshold",
-            )),
+            ),
         }
     }
 
     fn paint(&self, painter: &crate::twix_painter::TwixPainter<Pixel>) -> Result<()> {
-        let (Some(human_poses), Some(keypoint_confidence_threshold)) = (
-            self.human_poses.as_ref(),
-            self.keypoint_confidence_threshold.as_ref(),
-        ) else {
-            return Ok(());
-        };
-        let human_poses: Vec<HumanPose> = human_poses.require_latest()?;
-        let keypoint_confidence_threshold: f32 = keypoint_confidence_threshold.require_latest()?;
+        let human_poses: Vec<HumanPose> = self.human_poses.require_latest()?;
+        let keypoint_confidence_threshold: f32 = self
+            .keypoint_confidence_threshold
+            .require_latest()
+            .unwrap_or(0.0);
 
         for pose in human_poses {
             let keypoints: [Keypoint; 17] = pose.keypoints.into();
-
             // draw keypoints
             for keypoint in keypoints.iter() {
                 if keypoint.confidence < keypoint_confidence_threshold {


### PR DESCRIPTION
## Introduced Changes

Allows recording of the `human_poses` Output in the `ObjectDetectionTop` Cycler, even if that Cycler is not recorded. 
This is done by forwarding the `human_poses` as a `PerceptionInput` via `control::referee_pose_detection_filter`, which is recorded. 
Eventually, the pose detection should be moved to Control anyway, and then the pose may be forwarded from there. 

## ToDo / Known Issues

- [ ] Check if all `HumanPose`s that are given as an Output from `object_detection_top::pose_detection` are present in the recorded vector.

## Ideas for Next Iterations (Not This PR)

- [ ] Move the pose filtering to Control and then expose `human_poses` from there.

## How to Test

Record with pose detection running. In the recording make sure the human_poses_forwarded have some content during the detections and see if the keypoints are drawn in the `Pose Detection` overlay in twix.