### PR TITLE
add zero moment point calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/control/src/fall_state_estimation.rs
+++ b/crates/control/src/fall_state_estimation.rs
@@ -35,7 +35,6 @@ pub struct CreationContext {
 #[context]
 pub struct CycleContext {
     filtered_angular_velocity: AdditionalOutput<Vector3<Robot>, "filtered_angular_velocity">,
-    // filtered_linear_acceleration: AdditionalOutput<Vector3<Robot>, "filtered_linear_acceleration">,
     filtered_roll_pitch: AdditionalOutput<Vector2<Robot>, "filtered_roll_pitch">,
     fallen_down_gravitational_difference:
         AdditionalOutput<f32, "fallen_down_gravitational_difference">,
@@ -243,9 +242,6 @@ impl FallStateEstimation {
         context
             .filtered_roll_pitch
             .fill_if_subscribed(|| self.roll_pitch_filter.state());
-        // context
-        //     .filtered_linear_acceleration
-        //     .fill_if_subscribed(|| self.linear_acceleration_filter.state());
         context
             .filtered_angular_velocity
             .fill_if_subscribed(|| self.angular_velocity_filter.state());

--- a/crates/control/src/fall_state_estimation.rs
+++ b/crates/control/src/fall_state_estimation.rs
@@ -35,7 +35,7 @@ pub struct CreationContext {
 #[context]
 pub struct CycleContext {
     filtered_angular_velocity: AdditionalOutput<Vector3<Robot>, "filtered_angular_velocity">,
-    filtered_linear_acceleration: AdditionalOutput<Vector3<Robot>, "filtered_linear_acceleration">,
+    // filtered_linear_acceleration: AdditionalOutput<Vector3<Robot>, "filtered_linear_acceleration">,
     filtered_roll_pitch: AdditionalOutput<Vector2<Robot>, "filtered_roll_pitch">,
     fallen_down_gravitational_difference:
         AdditionalOutput<f32, "fallen_down_gravitational_difference">,
@@ -67,6 +67,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub fall_state: MainOutput<FallState>,
+    pub filtered_linear_acceleration: MainOutput<Vector3<Robot>>,
 }
 
 impl FallStateEstimation {
@@ -242,9 +243,9 @@ impl FallStateEstimation {
         context
             .filtered_roll_pitch
             .fill_if_subscribed(|| self.roll_pitch_filter.state());
-        context
-            .filtered_linear_acceleration
-            .fill_if_subscribed(|| self.linear_acceleration_filter.state());
+        // context
+        //     .filtered_linear_acceleration
+        //     .fill_if_subscribed(|| self.linear_acceleration_filter.state());
         context
             .filtered_angular_velocity
             .fill_if_subscribed(|| self.angular_velocity_filter.state());
@@ -257,6 +258,7 @@ impl FallStateEstimation {
 
         Ok(MainOutputs {
             fall_state: fall_state.into(),
+            filtered_linear_acceleration: self.linear_acceleration_filter.state().into(),
         })
     }
 

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -38,3 +38,4 @@ pub mod time_to_reach_kick_position;
 pub mod visual_referee_filter;
 pub mod whistle_filter;
 pub mod world_state_composer;
+pub mod zero_moment_point_provider;

--- a/crates/control/src/zero_moment_point_provider.rs
+++ b/crates/control/src/zero_moment_point_provider.rs
@@ -1,0 +1,69 @@
+use color_eyre::Result;
+use context_attribute::context;
+use coordinate_systems::{Ground, Robot};
+use framework::MainOutput;
+use linear_algebra::{point, vector, Point3, Rotation3};
+use serde::{Deserialize, Serialize};
+use types::sensor_data::SensorData;
+
+#[derive(Deserialize, Serialize)]
+pub struct ZeroMomentPointProvider {}
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    center_of_mass: Input<Point3<Robot>, "center_of_mass">,
+    sensor_data: Input<SensorData, "sensor_data">,
+}
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub zero_moment_point: MainOutput<Point3<Robot>>,
+}
+
+impl ZeroMomentPointProvider {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        const GRAVITATIONAL_CONSTANT: f32 = 9.81;
+
+        let imu_orientation = Rotation3::<Ground, Robot>::from_euler_angles(
+            context.sensor_data.inertial_measurement_unit.roll_pitch.x(),
+            context.sensor_data.inertial_measurement_unit.roll_pitch.y(),
+            0.0,
+        );
+
+        let g = (imu_orientation * vector![0.0, 0.0, -GRAVITATIONAL_CONSTANT])
+            .inner
+            .z;
+
+        let y_com = context.center_of_mass.y();
+        let x_com = context.center_of_mass.x();
+        let z = context.center_of_mass.z();
+
+        let x_hat = context
+            .sensor_data
+            .inertial_measurement_unit
+            .linear_acceleration
+            .x();
+        let y_hat = context
+            .sensor_data
+            .inertial_measurement_unit
+            .linear_acceleration
+            .y();
+        let x_zero_moment_point_in_robot = ((x_com * g) + (x_hat * z)) / g;
+        let y_zero_moment_point_in_robot = ((y_com * g) + (y_hat * z)) / g;
+
+        let zero_moment_point: Point3<Robot> = point![
+            x_zero_moment_point_in_robot,
+            y_zero_moment_point_in_robot,
+            0.0
+        ];
+        Ok(MainOutputs {
+            zero_moment_point: zero_moment_point.into(),
+        })
+    }
+}

--- a/crates/control/src/zero_moment_point_provider.rs
+++ b/crates/control/src/zero_moment_point_provider.rs
@@ -1,23 +1,33 @@
 use color_eyre::Result;
 use context_attribute::context;
 use coordinate_systems::{Ground, Robot};
+use filtering::low_pass_filter::LowPassFilter;
 use framework::MainOutput;
 use linear_algebra::{point, Isometry3, Point3, Vector3};
 use serde::{Deserialize, Serialize};
 use types::sensor_data::SensorData;
 
 #[derive(Deserialize, Serialize)]
-pub struct ZeroMomentPointProvider {}
+pub struct ZeroMomentPointProvider {
+    linear_acceleration_filter: LowPassFilter<Vector3<Robot>>,
+}
+
 #[context]
-pub struct CreationContext {}
+pub struct CreationContext {
+    linear_acceleration_low_pass_factor:
+        Parameter<f32, "zero_moment_point.linear_acceleration_low_pass_factor">,
+}
 
 #[context]
 pub struct CycleContext {
     center_of_mass: Input<Point3<Robot>, "center_of_mass">,
     sensor_data: Input<SensorData, "sensor_data">,
+
+    gravity_acceleration: Parameter<f32, "physical_constants.gravity_acceleration">,
+
     robot_to_ground: RequiredInput<Option<Isometry3<Robot, Ground>>, "robot_to_ground?">,
-    filtered_linear_acceleration: Input<Vector3<Robot>, "filtered_linear_acceleration">,
 }
+
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
@@ -25,33 +35,37 @@ pub struct MainOutputs {
 }
 
 impl ZeroMomentPointProvider {
-    pub fn new(_context: CreationContext) -> Result<Self> {
-        Ok(Self {})
+    pub fn new(context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            linear_acceleration_filter: LowPassFilter::with_smoothing_factor(
+                Vector3::zeros(),
+                *context.linear_acceleration_low_pass_factor,
+            ),
+        })
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        const GRAVITATIONAL_CONSTANT: f32 = 9.81;
-
-        let center_of_mass_in_ground = context.robot_to_ground * *context.center_of_mass;
-        let x_com = center_of_mass_in_ground.x();
-        let y_com = center_of_mass_in_ground.y();
-        let z_com = center_of_mass_in_ground.z();
-
-        let _unfitlered_imu_rotated_parallel_to_ground = context.robot_to_ground
-            * context
+        self.linear_acceleration_filter.update(
+            context
                 .sensor_data
                 .inertial_measurement_unit
-                .linear_acceleration;
-        let imu_rotated_parallel_to_ground =
-            context.robot_to_ground * *context.filtered_linear_acceleration;
-        let x_acceleration_parallel_to_ground = imu_rotated_parallel_to_ground.x();
-        let y_acceleration_parallel_to_ground = imu_rotated_parallel_to_ground.y();
-        let x_zero_moment_point_in_robot = ((x_com * GRAVITATIONAL_CONSTANT)
-            + (x_acceleration_parallel_to_ground * z_com))
-            / GRAVITATIONAL_CONSTANT;
-        let y_zero_moment_point_in_robot = ((y_com * GRAVITATIONAL_CONSTANT)
-            + (y_acceleration_parallel_to_ground * z_com))
-            / GRAVITATIONAL_CONSTANT;
+                .linear_acceleration,
+        );
+
+        let center_of_mass_in_ground = context.robot_to_ground * *context.center_of_mass;
+        let x_center_of_mass = center_of_mass_in_ground.x();
+        let y_center_of_mass = center_of_mass_in_ground.y();
+        let z_center_of_mass = center_of_mass_in_ground.z();
+
+        let linear_acceleration = context.robot_to_ground * self.linear_acceleration_filter.state();
+        let x_acceleration_parallel_to_ground = linear_acceleration.x();
+        let y_acceleration_parallel_to_ground = linear_acceleration.y();
+        let x_zero_moment_point_in_robot = ((x_center_of_mass * context.gravity_acceleration)
+            + (x_acceleration_parallel_to_ground * z_center_of_mass))
+            / context.gravity_acceleration;
+        let y_zero_moment_point_in_robot = ((y_center_of_mass * context.gravity_acceleration)
+            + (y_acceleration_parallel_to_ground * z_center_of_mass))
+            / context.gravity_acceleration;
 
         let zero_moment_point: Point3<Ground> = point![
             x_zero_moment_point_in_robot,

--- a/crates/control/src/zero_moment_point_provider.rs
+++ b/crates/control/src/zero_moment_point_provider.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use coordinate_systems::{Ground, Robot};
 use framework::MainOutput;
-use linear_algebra::{point, vector, Point3, Rotation3};
+use linear_algebra::{point, Point3, Rotation3};
 use serde::{Deserialize, Serialize};
 use types::sensor_data::SensorData;
 

--- a/crates/control/src/zero_moment_point_provider.rs
+++ b/crates/control/src/zero_moment_point_provider.rs
@@ -44,12 +44,14 @@ impl ZeroMomentPointProvider {
                 .linear_acceleration;
         let imu_rotated_parallel_to_ground =
             context.robot_to_ground * *context.filtered_linear_acceleration;
-        let x_hat = imu_rotated_parallel_to_ground.x();
-        let y_hat = imu_rotated_parallel_to_ground.y();
-        let x_zero_moment_point_in_robot =
-            ((x_com * GRAVITATIONAL_CONSTANT) + (x_hat * z_com)) / GRAVITATIONAL_CONSTANT;
-        let y_zero_moment_point_in_robot =
-            ((y_com * GRAVITATIONAL_CONSTANT) + (y_hat * z_com)) / GRAVITATIONAL_CONSTANT;
+        let x_acceleration_parallel_to_ground = imu_rotated_parallel_to_ground.x();
+        let y_acceleration_parallel_to_ground = imu_rotated_parallel_to_ground.y();
+        let x_zero_moment_point_in_robot = ((x_com * GRAVITATIONAL_CONSTANT)
+            + (x_acceleration_parallel_to_ground * z_com))
+            / GRAVITATIONAL_CONSTANT;
+        let y_zero_moment_point_in_robot = ((y_com * GRAVITATIONAL_CONSTANT)
+            + (y_acceleration_parallel_to_ground * z_com))
+            / GRAVITATIONAL_CONSTANT;
 
         let zero_moment_point: Point3<Ground> = point![
             x_zero_moment_point_in_robot,

--- a/crates/control/src/zero_moment_point_provider.rs
+++ b/crates/control/src/zero_moment_point_provider.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use coordinate_systems::{Ground, Robot};
 use framework::MainOutput;
-use linear_algebra::{point, Isometry3, Point3};
+use linear_algebra::{point, Isometry3, Point3, Vector3};
 use serde::{Deserialize, Serialize};
 use types::sensor_data::SensorData;
 
@@ -16,6 +16,7 @@ pub struct CycleContext {
     center_of_mass: Input<Point3<Robot>, "center_of_mass">,
     sensor_data: Input<SensorData, "sensor_data">,
     robot_to_ground: RequiredInput<Option<Isometry3<Robot, Ground>>, "robot_to_ground?">,
+    filtered_linear_acceleration: Input<Vector3<Robot>, "filtered_linear_acceleration">,
 }
 #[context]
 #[derive(Default)]
@@ -36,11 +37,13 @@ impl ZeroMomentPointProvider {
         let y_com = center_of_mass_in_ground.y();
         let z_com = center_of_mass_in_ground.z();
 
-        let imu_rotated_parallel_to_ground = context.robot_to_ground
+        let _unfitlered_imu_rotated_parallel_to_ground = context.robot_to_ground
             * context
                 .sensor_data
                 .inertial_measurement_unit
                 .linear_acceleration;
+        let imu_rotated_parallel_to_ground =
+            context.robot_to_ground * *context.filtered_linear_acceleration;
         let x_hat = imu_rotated_parallel_to_ground.x();
         let y_hat = imu_rotated_parallel_to_ground.y();
         let x_zero_moment_point_in_robot =

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -96,6 +96,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "control::visual_referee_filter",
                     "control::whistle_filter",
                     "control::world_state_composer",
+                    "control::zero_moment_point_provider",
                 ],
             },
             CyclerManifest {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -398,6 +398,9 @@
     "translation_exponent": 1.5,
     "rotation_exponent": 2.0
   },
+  "zero_moment_point": {
+    "linear_acceleration_low_pass_factor": 0.05
+  },
   "whistle_filter": {
     "buffer_length": 20,
     "minimum_detections": 2
@@ -1428,5 +1431,8 @@
     "heatmap_decay_factor": 0.002,
     "minimum_validity": 0.01
   },
-  "stand_up_stiffness_upper_body": 0.5
+  "stand_up_stiffness_upper_body": 0.5,
+  "physical_constants": {
+    "gravity_acceleration": 9.81
+  }
 }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/panels/map/layers/walking.rs
+++ b/tools/twix/src/panels/map/layers/walking.rs
@@ -29,6 +29,7 @@ pub struct Walking {
     step_plan: ValueBuffer,
     center_of_mass: ValueBuffer,
     robot_to_walk: ValueBuffer,
+    zero_moment_point: ValueBuffer,
 }
 
 impl Layer<Ground> for Walking {
@@ -51,6 +52,8 @@ impl Layer<Ground> for Walking {
         let robot_to_walk = nao.subscribe_output(
             CyclerOutput::from_str("Control.additional.walking.robot_to_walk").unwrap(),
         );
+        let zero_moment_point =
+            nao.subscribe_output(CyclerOutput::from_str("Control.main.zero_moment_point").unwrap());
         Self {
             robot_to_ground,
             robot_kinematics,
@@ -59,6 +62,7 @@ impl Layer<Ground> for Walking {
             step_plan,
             center_of_mass,
             robot_to_walk,
+            zero_moment_point,
         }
     }
 
@@ -75,6 +79,7 @@ impl Layer<Ground> for Walking {
         let center_of_mass: Point3<Robot> = self.center_of_mass.require_latest()?;
         let center_of_mass_in_ground = robot_to_ground * center_of_mass;
         let robot_to_walk: Isometry3<Robot, Walk> = self.robot_to_walk.require_latest()?;
+        let zero_moment_point: Point3<Ground> = self.zero_moment_point.require_latest()?;
 
         paint_actuated_feet(
             painter,
@@ -118,6 +123,13 @@ impl Layer<Ground> for Walking {
             center_of_mass_in_ground.xy(),
             0.01,
             Color32::RED,
+            Stroke::new(0.001, Color32::BLACK),
+        );
+
+        painter.circle(
+            zero_moment_point.xy(),
+            0.01,
+            Color32::GRAY,
             Stroke::new(0.001, Color32::BLACK),
         );
 

--- a/tools/twix/src/panels/map/layers/walking.rs
+++ b/tools/twix/src/panels/map/layers/walking.rs
@@ -5,7 +5,7 @@ use communication::client::CyclerOutput;
 use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::{Ground, Robot, Walk};
-use linear_algebra::{point, vector, Isometry3, Point3, Pose2, Pose3};
+use linear_algebra::{point, vector, Isometry3, Point2, Point3, Pose2, Pose3};
 use types::{
     field_dimensions::FieldDimensions, joints::body::BodyJoints, robot_kinematics::RobotKinematics,
     step_plan::Step, support_foot::Side,
@@ -79,7 +79,7 @@ impl Layer<Ground> for Walking {
         let center_of_mass: Point3<Robot> = self.center_of_mass.require_latest()?;
         let center_of_mass_in_ground = robot_to_ground * center_of_mass;
         let robot_to_walk: Isometry3<Robot, Walk> = self.robot_to_walk.require_latest()?;
-        let zero_moment_point: Point3<Ground> = self.zero_moment_point.require_latest()?;
+        let zero_moment_point: Point2<Ground> = self.zero_moment_point.require_latest()?;
 
         paint_actuated_feet(
             painter,
@@ -127,7 +127,7 @@ impl Layer<Ground> for Walking {
         );
 
         painter.circle(
-            zero_moment_point.xy(),
+            zero_moment_point,
             0.01,
             Color32::GRAY,
             Stroke::new(0.001, Color32::BLACK),


### PR DESCRIPTION
## Introduced Changes

Add calculation for Zero Moment Point based on my project thesis.
Make gravity a parameter.
~To filter it the low-pass filtered IMU data from the the fall state estimation is used instead of a running average.~
 
This PR only introduces the calculation, but does not use it for anything, future PRs will use the zero moment point.
This one is already in request for review in order to introduce smaller but easier to review changes.

Fixes #

## ToDo / Known Issues

- [x] Filter point location or IMU data
- [X] Output in twix panel

## Ideas for Next Iterations (Not This PR)

See #1019

## How to Test

Most easily seen using the replayer or with the help of a second person.
Let robot walk and maybe push it occasionally. The twix map panel with the walking overlay will now show a gray point for the ZMP.
