### PR TITLE
Twix: configurable keybindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5959,6 +5959,7 @@ dependencies = [
  "communication",
  "convert_case 0.6.0",
  "coordinate_systems",
+ "dirs",
  "eframe",
  "egui_dock",
  "egui_extras",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5979,7 +5979,9 @@ dependencies = [
  "repository",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
+ "toml",
  "types",
  "walking_engine",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ convert_case = "0.6.0"
 coordinate_systems = { path = "crates/coordinate_systems" }
 ctrlc = { version = "3.2.3", features = ["termination"] }
 derive_more = "0.99.17"
+dirs = "5.0.1"
 eframe = { version = "0.27.2", features = ["persistence"] }
 egui_dock = { version = "0.12.0", features = ["serde"] }
 egui_extras = { version = "0.27.2", features = ["image"] }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -34,6 +34,8 @@ projection = { workspace = true }
 repository = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
+toml = { workspace = true }
 types = { workspace = true }
 walking_engine = { workspace = true }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -7,13 +7,14 @@ homepage.workspace = true
 
 [dependencies]
 aliveness = { workspace = true }
+argument_parsers = { workspace = true }
 bincode = { workspace = true }
 clap = { workspace = true }
-argument_parsers = { workspace = true }
 color-eyre = { workspace = true }
 communication = { workspace = true }
 convert_case = { workspace = true }
 coordinate_systems = { workspace = true }
+dirs = { workspace = true }
 eframe = { workspace = true }
 egui_dock = { workspace = true }
 egui_extras = { workspace = true }

--- a/tools/twix/default.toml
+++ b/tools/twix/default.toml
@@ -1,0 +1,16 @@
+[keys]
+"C-t" = "open_split"
+
+"C-r" = "reconnect"
+
+"C-o" = "focus_address"
+"C-p" = "focus_panel"
+
+"C-h" = "focus_left"
+"C-j" = "focus_below"
+"C-k" = "focus_above"
+"C-l" = "focus_right"
+
+"C-w" = "close_tab"
+"C-d" = "duplicate_tab"
+

--- a/tools/twix/default.toml
+++ b/tools/twix/default.toml
@@ -1,16 +1,16 @@
 [keys]
-"C-t" = "open_split"
+C-t = "open_split"
 
-"C-r" = "reconnect"
+C-r = "reconnect"
 
-"C-o" = "focus_address"
-"C-p" = "focus_panel"
+C-o = "focus_address"
+C-p = "focus_panel"
 
-"C-h" = "focus_left"
-"C-j" = "focus_below"
-"C-k" = "focus_above"
-"C-l" = "focus_right"
+C-h = "focus_left"
+C-j = "focus_below"
+C-k = "focus_above"
+C-l = "focus_right"
 
-"C-w" = "close_tab"
-"C-d" = "duplicate_tab"
+C-w = "close_tab"
+C-d = "duplicate_tab"
 

--- a/tools/twix/src/configuration.rs
+++ b/tools/twix/src/configuration.rs
@@ -78,16 +78,17 @@ mod tests {
         let mut config_1: Configuration = toml::from_str(
             r#"
                 [keys]
-                "C-a" = "focus_left"
-                "C-S-a" = "reconnect"
+                C-a = "focus_left"
+                C-S-a = "reconnect"
             "#,
         )
         .unwrap();
+
         let config_2: Configuration = toml::from_str(
             r#"
                 [keys]
-                "C-c" = "focus_left"
-                "C-A" = "focus_right"
+                C-c = "focus_left"
+                C-A = "focus_right"
             "#,
         )
         .unwrap();
@@ -99,9 +100,9 @@ mod tests {
             toml::from_str(
                 r#"
                 [keys]
-                "C-a" = "focus_left"
-                "C-A" = "focus_right"
-                "C-c" = "focus_left"
+                C-a = "focus_left"
+                C-A = "focus_right"
+                C-c = "focus_left"
             "#
             )
             .unwrap()

--- a/tools/twix/src/configuration.rs
+++ b/tools/twix/src/configuration.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+mod keys;
+
+#[derive(Debug, Deserialize)]
+pub struct Configuration {
+    pub keys: keys::Keybinds,
+}
+
+impl Configuration {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ()> {
+        let config_file = r#"
+            [keys]
+            "C-t" = "open_split"
+            "C-t" = "open_split"
+        "#;
+
+        let configuration: Configuration = toml::from_str(config_file).unwrap();
+
+        Ok(configuration)
+    }
+}

--- a/tools/twix/src/configuration.rs
+++ b/tools/twix/src/configuration.rs
@@ -1,9 +1,11 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use thiserror::Error;
 
-mod keys;
+pub mod keys;
+
+const DEFAULT_CONFIG: &str = include_str!("../default.toml");
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -13,17 +15,96 @@ pub enum Error {
     Parsing(#[from] toml::de::Error),
 }
 
+fn config_path() -> PathBuf {
+    let mut result = dirs::config_dir().unwrap();
+    result.extend(["twix", "config.toml"]);
+
+    result
+}
+
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug, Deserialize)]
 pub struct Configuration {
     pub keys: keys::Keybinds,
 }
 
 impl Configuration {
-    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let config_file = std::fs::read_to_string(path)?;
+    pub fn load() -> Result<Self, Error> {
+        Self::load_at_path(config_path())
+    }
 
-        let configuration: Configuration = toml::from_str(&config_file)?;
+    pub fn load_at_path(path: impl AsRef<Path>) -> Result<Self, Error> {
+        match std::fs::read_to_string(&path) {
+            Ok(config_file) => {
+                let mut configuration: Configuration = toml::from_str(&config_file)?;
 
-        Ok(configuration)
+                configuration.merge(Self::load_default());
+
+                Ok(configuration)
+            }
+            Err(error) => {
+                log::info!(
+                    "Could not load config file at {}: {error}",
+                    path.as_ref().display()
+                );
+
+                Ok(Self::load_default())
+            }
+        }
+    }
+
+    fn load_default() -> Self {
+        toml::from_str(DEFAULT_CONFIG).unwrap()
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        let Self { keys } = other;
+
+        self.keys.merge(keys);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Configuration, DEFAULT_CONFIG};
+
+    #[test]
+    fn parse_default_config() {
+        toml::from_str::<Configuration>(DEFAULT_CONFIG).expect("failed to parse default.toml");
+    }
+
+    #[test]
+    fn merge_configs() {
+        let mut config_1: Configuration = toml::from_str(
+            r#"
+                [keys]
+                "C-a" = "focus_left"
+                "C-S-a" = "reconnect"
+            "#,
+        )
+        .unwrap();
+        let config_2: Configuration = toml::from_str(
+            r#"
+                [keys]
+                "C-c" = "focus_left"
+                "C-A" = "focus_right"
+            "#,
+        )
+        .unwrap();
+
+        config_1.merge(config_2);
+
+        assert_eq!(
+            config_1,
+            toml::from_str(
+                r#"
+                [keys]
+                "C-a" = "focus_left"
+                "C-A" = "focus_right"
+                "C-c" = "focus_left"
+            "#
+            )
+            .unwrap()
+        );
     }
 }

--- a/tools/twix/src/configuration.rs
+++ b/tools/twix/src/configuration.rs
@@ -37,9 +37,10 @@ impl Configuration {
     pub fn load_at_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         match std::fs::read_to_string(&path) {
             Ok(config_file) => {
-                let mut configuration: Configuration = toml::from_str(&config_file)?;
+                let mut configuration = Self::load_default();
+                let user_configuration: Configuration = toml::from_str(&config_file)?;
 
-                configuration.merge(Self::load_default());
+                configuration.merge(user_configuration);
 
                 Ok(configuration)
             }

--- a/tools/twix/src/configuration.rs
+++ b/tools/twix/src/configuration.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use thiserror::Error;
 
+pub mod keybind_plugin;
 pub mod keys;
 
 const DEFAULT_CONFIG: &str = include_str!("../default.toml");

--- a/tools/twix/src/configuration.rs
+++ b/tools/twix/src/configuration.rs
@@ -1,8 +1,17 @@
 use std::path::Path;
 
 use serde::Deserialize;
+use thiserror::Error;
 
 mod keys;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TOML parsing error: {0}")]
+    Parsing(#[from] toml::de::Error),
+}
 
 #[derive(Debug, Deserialize)]
 pub struct Configuration {
@@ -10,14 +19,10 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn load(path: impl AsRef<Path>) -> Result<Self, ()> {
-        let config_file = r#"
-            [keys]
-            "C-t" = "open_split"
-            "C-t" = "open_split"
-        "#;
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let config_file = std::fs::read_to_string(path)?;
 
-        let configuration: Configuration = toml::from_str(config_file).unwrap();
+        let configuration: Configuration = toml::from_str(&config_file)?;
 
         Ok(configuration)
     }

--- a/tools/twix/src/configuration/keybind_plugin.rs
+++ b/tools/twix/src/configuration/keybind_plugin.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use eframe::egui::{Context, Id, InputState};
+
+use super::keys::{KeybindAction, Keybinds};
+
+type ActionList = Arc<Vec<KeybindAction>>;
+
+pub fn register(ctx: &Context) {
+    ctx.on_begin_frame("keybinds", Arc::new(begin_frame))
+}
+
+fn begin_frame(ctx: &Context) {
+    if let Some(keybinds) = ctx.data(|data| data.get_temp::<Arc<Keybinds>>(Id::NULL)) {
+        let actions = ctx.input_mut(|input| read_actions(keybinds, input));
+
+        ctx.data_mut(|data| data.insert_temp::<ActionList>(Id::NULL, Arc::new(actions)))
+    }
+}
+
+fn read_actions(keybinds: Arc<Keybinds>, input: &mut InputState) -> Vec<KeybindAction> {
+    let mut actions = Vec::new();
+
+    input.events.retain(|event| {
+        if let eframe::egui::Event::Key {
+            key,
+            pressed: true,
+            modifiers,
+            ..
+        } = event
+        {
+            for (trigger, action) in keybinds.iter() {
+                if trigger.key == *key && modifiers.matches_exact(trigger.modifiers) {
+                    actions.push(*action);
+                    return false;
+                }
+            }
+        }
+        true
+    });
+
+    actions
+}
+
+pub fn set_keybinds(ctx: &Context, keybinds: Arc<Keybinds>) {
+    ctx.data_mut(|data| data.insert_temp(Id::NULL, keybinds));
+}
+
+pub fn keybind_pressed(ctx: &Context, action: KeybindAction) -> bool {
+    ctx.data(|data| {
+        data.get_temp::<ActionList>(Id::NULL)
+            .is_some_and(|actions| actions.contains(&action))
+    })
+}

--- a/tools/twix/src/configuration/keys.rs
+++ b/tools/twix/src/configuration/keys.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt};
 
-use eframe::egui::{InputState, Key, Modifiers};
+use eframe::egui::{Key, Modifiers};
 use serde::{
     de::{self, Deserializer},
     Deserialize,
@@ -44,7 +44,7 @@ impl KeybindTrigger {
     pub fn parse_modifier(value: &&str) -> Result<Modifiers, Error> {
         match *value {
             "A" => Ok(Modifiers::ALT),
-            "C" => Ok(Modifiers::CTRL | Modifiers::COMMAND),
+            "C" => Ok(Modifiers::CTRL),
             "S" => Ok(Modifiers::SHIFT),
             _ => Err(Error::InvalidModifier(String::from(*value))),
         }
@@ -122,35 +122,12 @@ impl Keybinds {
         }
     }
 
-    pub fn read_actions(&self, input: &mut InputState) -> Vec<KeybindAction> {
-        let mut actions = Vec::new();
-
-        input.events.retain(|event| {
-            let eframe::egui::Event::Key {
-                key,
-                pressed: true,
-                modifiers,
-                ..
-            } = event
-            else {
-                return true;
-            };
-
-            for (trigger, action) in &self.keybinds {
-                if trigger.key == *key && trigger.modifiers.matches_exact(*modifiers) {
-                    actions.push(*action);
-                    return false;
-                }
-            }
-
-            true
-        });
-
-        actions
-    }
-
     pub fn merge(&mut self, other: Self) {
         self.keybinds.extend(other.keybinds);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&KeybindTrigger, &KeybindAction)> {
+        self.keybinds.iter()
     }
 }
 

--- a/tools/twix/src/configuration/keys.rs
+++ b/tools/twix/src/configuration/keys.rs
@@ -1,0 +1,210 @@
+use std::fmt;
+use std::ops::BitOr;
+
+use serde::{
+    de::{self, Deserializer},
+    Deserialize,
+};
+
+use eframe::egui::{Key, Modifiers};
+use thiserror::Error;
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid modifier `{0}`")]
+    InvalidModifier(String),
+    #[error("Invalid key `{0}`")]
+    InvalidKey(String),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeybindAction {
+    OpenSplit,
+    OpenTab,
+    Reconnect,
+}
+
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug)]
+pub struct KeybindTrigger {
+    pub key: Key,
+    pub modifiers: Modifiers,
+}
+
+impl KeybindTrigger {
+    pub fn parse_modifier(value: &&str) -> Result<Modifiers, Error> {
+        match *value {
+            "A" => Ok(Modifiers::ALT),
+            "C" => Ok(Modifiers::COMMAND),
+            "S" => Ok(Modifiers::SHIFT),
+            _ => Err(Error::InvalidModifier(String::from(*value))),
+        }
+    }
+
+    pub fn parse(v: &str) -> Result<Self, Error> {
+        let parts = v.split('-').collect::<Vec<_>>();
+
+        let Some((raw_key, raw_modifiers)) = parts.split_last() else {
+            return Err(Error::InvalidKey(v.into()));
+        };
+
+        let is_single_ascii_uppercase_letter =
+            matches!(raw_key.as_bytes(), [letter] if letter.is_ascii_uppercase());
+
+        let Some(key) = Key::from_name(raw_key) else {
+            return Err(Error::InvalidKey(v.into()));
+        };
+
+        let modifiers = raw_modifiers
+            .iter()
+            .map(KeybindTrigger::parse_modifier)
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .copied()
+            .fold(
+                Modifiers {
+                    shift: is_single_ascii_uppercase_letter,
+                    ..Modifiers::NONE
+                },
+                Modifiers::bitor,
+            );
+
+        Ok(Self { key, modifiers })
+    }
+}
+
+impl<'de> Deserialize<'de> for KeybindTrigger {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = KeybindTrigger;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                KeybindTrigger::parse(v).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+#[derive(Debug)]
+pub struct Keybind {
+    pub trigger: KeybindTrigger,
+    pub action: KeybindAction,
+}
+
+#[derive(Debug)]
+pub struct Keybinds {
+    pub keys: Vec<Keybind>,
+}
+
+impl Keybinds {
+    pub fn new() -> Self {
+        Self { keys: Vec::new() }
+    }
+}
+
+impl<'de> Deserialize<'de> for Keybinds {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Keybinds;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a map")
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Keybinds::new())
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut keys = Vec::new();
+
+                while let Some((trigger, action)) = visitor.next_entry()? {
+                    keys.push(Keybind { trigger, action });
+                }
+
+                Ok(Keybinds { keys })
+            }
+        }
+
+        deserializer.deserialize_map(Visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use eframe::egui::{Key, Modifiers};
+
+    use super::{Error, KeybindTrigger};
+
+    #[test]
+    fn parse_triggers() {
+        assert_eq!(
+            KeybindTrigger::parse("C-x"),
+            Ok(KeybindTrigger {
+                key: Key::X,
+                modifiers: Modifiers::COMMAND
+            })
+        );
+
+        assert_eq!(
+            KeybindTrigger::parse("A-S-Esc"),
+            Ok(KeybindTrigger {
+                key: Key::Escape,
+                modifiers: Modifiers::ALT | Modifiers::SHIFT
+            })
+        );
+
+        assert_eq!(
+            KeybindTrigger::parse("C-ArrowDown"),
+            Ok(KeybindTrigger {
+                key: Key::ArrowDown,
+                modifiers: Modifiers::COMMAND
+            })
+        );
+
+        assert_eq!(
+            KeybindTrigger::parse("F1"),
+            Ok(KeybindTrigger {
+                key: Key::F1,
+                modifiers: Modifiers::NONE
+            })
+        );
+
+        assert_eq!(
+            KeybindTrigger::parse("X-X"),
+            Err(Error::InvalidModifier("X".into()))
+        );
+
+        assert_eq!(
+            KeybindTrigger::parse("XX"),
+            Err(Error::InvalidKey("XX".into()))
+        );
+    }
+}

--- a/tools/twix/src/configuration/keys.rs
+++ b/tools/twix/src/configuration/keys.rs
@@ -29,7 +29,7 @@ pub enum KeybindAction {
     FocusLeft,
     FocusPanel,
     FocusRight,
-    None,
+    NoOp,
     OpenSplit,
     Reconnect,
 }

--- a/tools/twix/src/configuration/keys.rs
+++ b/tools/twix/src/configuration/keys.rs
@@ -182,7 +182,7 @@ mod tests {
             KeybindTrigger::parse("C-x"),
             Ok(KeybindTrigger {
                 key: Key::X,
-                modifiers: Modifiers::COMMAND
+                modifiers: Modifiers::CTRL
             })
         );
 
@@ -198,7 +198,7 @@ mod tests {
             KeybindTrigger::parse("C-ArrowDown"),
             Ok(KeybindTrigger {
                 key: Key::ArrowDown,
-                modifiers: Modifiers::COMMAND
+                modifiers: Modifiers::CTRL
             })
         );
 

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -45,6 +45,7 @@ use visuals::Visuals;
 
 mod change_buffer;
 mod completion_edit;
+mod configuration;
 mod image_buffer;
 mod nao;
 mod panel;

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -17,7 +17,7 @@ use color_eyre::{
 use communication::client::ConnectionStatus;
 use completion_edit::CompletionEdit;
 use configuration::{
-    keybind_plugin::{self, keybind_pressed},
+    keybind_plugin::{self, KeybindSystem},
     keys::KeybindAction,
     Configuration,
 };
@@ -226,7 +226,7 @@ impl TwixApp {
         let context = creation_context.egui_ctx.clone();
 
         keybind_plugin::register(&context);
-        keybind_plugin::set_keybinds(&context, Arc::new(configuration.keys));
+        context.set_keybinds(Arc::new(configuration.keys));
 
         let reachable_naos = ReachableNaos::new(context.clone());
         nao.on_update(move || context.request_repaint());
@@ -377,7 +377,7 @@ impl App for TwixApp {
                     if address_input.gained_focus() {
                         self.reachable_naos.query_reachability();
                     }
-                    if keybind_pressed(context, KeybindAction::FocusAddress) {
+                    if context.keybind_pressed(KeybindAction::FocusAddress) {
                         address_input.request_focus();
                         CompletionEdit::select_all(&self.ip_address, ui, address_input.id);
                     }
@@ -402,7 +402,7 @@ impl App for TwixApp {
                     {
                         self.nao.set_connect(self.connection_intent);
                     }
-                    if keybind_pressed(context, KeybindAction::Reconnect) {
+                    if context.keybind_pressed(KeybindAction::Reconnect) {
                         self.nao.set_connect(false);
                         self.connection_intent = true;
                         self.nao.set_connect(true);
@@ -424,7 +424,7 @@ impl App for TwixApp {
                         "Panel",
                     )
                     .ui(ui);
-                    if keybind_pressed(context, KeybindAction::FocusPanel) {
+                    if context.keybind_pressed(KeybindAction::FocusPanel) {
                         panel_input.request_focus();
                         CompletionEdit::select_all(&self.panel_selection, ui, panel_input.id);
                     }
@@ -460,7 +460,7 @@ impl App for TwixApp {
             })
         });
         CentralPanel::default().show(context, |ui| {
-            if keybind_pressed(context, KeybindAction::OpenSplit) {
+            if context.keybind_pressed(KeybindAction::OpenSplit) {
                 let tab = SelectablePanel::TextPanel(TextPanel::new(self.nao.clone(), None));
                 if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                     let node = &mut self.dock_state[surface_index][node_id];
@@ -483,28 +483,28 @@ impl App for TwixApp {
                 }
             }
 
-            if keybind_pressed(context, KeybindAction::FocusLeft) {
+            if context.keybind_pressed(KeybindAction::FocusLeft) {
                 if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                     self.focus_left(node_id, surface_index);
                 }
             }
-            if keybind_pressed(context, KeybindAction::FocusBelow) {
+            if context.keybind_pressed(KeybindAction::FocusBelow) {
                 if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                     self.focus_below(node_id, surface_index);
                 }
             }
-            if keybind_pressed(context, KeybindAction::FocusAbove) {
+            if context.keybind_pressed(KeybindAction::FocusAbove) {
                 if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                     self.focus_above(node_id, surface_index);
                 }
             }
-            if keybind_pressed(context, KeybindAction::FocusRight) {
+            if context.keybind_pressed(KeybindAction::FocusRight) {
                 if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                     self.focus_right(node_id, surface_index);
                 }
             }
 
-            if keybind_pressed(context, KeybindAction::DuplicateTab) {
+            if context.keybind_pressed(KeybindAction::DuplicateTab) {
                 if let Some((_, tab)) = self.dock_state.find_active_focused() {
                     let new_tab = &tab.panel.save();
                     self.dock_state.push_to_focused_leaf(Tab::from(
@@ -513,7 +513,7 @@ impl App for TwixApp {
                 }
             }
 
-            if keybind_pressed(context, KeybindAction::CloseTab) {
+            if context.keybind_pressed(KeybindAction::CloseTab) {
                 if let Some((surface_index, node_id)) = self.dock_state.focused_leaf() {
                     let active_node = &mut self.dock_state[surface_index][node_id];
                     if let Node::Leaf { active, tabs, .. } = active_node {


### PR DESCRIPTION
## Introduced Changes

- Twix loads a config file on startup (`.config/twix/config.toml` on Linux)
  - Path is up for debate, other idea: `.config/hulks/twix.toml`
- There is a default config which is compiled into the binary and merged with the user config (`tools/twix/default.toml`)
- Currently, the config only contains a single table `keys`, containing key bindings.
- The format for specifying keybinds is similar to that of Helix or Vim and should feel familiar to many of us. Examples:
  - `C-x`: CTRL+x
  - `C-X` or `C-S-x`: CTRL+SHIFT+x
  - `C-A-ArrowUp`: CTRL+ALT+Arrow key up
  - `C-S-Esc`: CTRL+SHIFT+Escape
- For a list of mappable keys, see [this](https://github.com/emilk/egui/blob/c1eb3f884db8bc4f52dbae4f261619cee651f411/crates/egui/src/data/key.rs#L298-L413)
- Each mappable actions is a simple enum entry, see `KeybindAction`
- In GUI code, we can now use `if context.keybind_pressed(KeybindAction::Whatever) {...}` to do something when a keybind is pressed.

Before merging, we need to get a mac user to confirm that it works on their machine.

## Example user config
```toml
# Remap navigation keys for non-vim users
[keys]
C-h = "no_op"
C-j = "no_op"
C-k = "no_op"
C-l = "no_op"

C-ArrowLeft = "focus_left"
C-ArrowDown = "focus_below"
C-ArrowUp = "focus_above"
C-ArrowRight = "focus_right"
```

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

- Add more mappable actions
- Config hot-reloading???

## How to Test

By default, all keybinds previously defined should still work the same.
Create a user config file, and play around with it.
