### PR TITLE
Reduce visural referee false positives during setup

### DIFF
--- a/crates/control/src/behavior/initial.rs
+++ b/crates/control/src/behavior/initial.rs
@@ -36,11 +36,11 @@ fn look_at_referee(
     expected_referee_position: Option<Point2<Field>>,
     world_state: WorldState,
 ) -> Option<MotionCommand> {
-    let ground_to_field = world_state.robot.ground_to_field?;
-    let expected_referee_position = expected_referee_position?;
     if world_state.filtered_game_controller_state?.game_state != FilteredGameState::Standby {
         return None;
     }
+    let ground_to_field = world_state.robot.ground_to_field?;
+    let expected_referee_position = expected_referee_position?;
 
     let position = ground_to_field.as_pose().position();
 

--- a/crates/control/src/motion/look_at.rs
+++ b/crates/control/src/motion/look_at.rs
@@ -29,6 +29,8 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
+    last_motion_command: CyclerState<MotionCommand, "last_motion_command">,
+
     camera_matrices: Input<Option<CameraMatrices>, "camera_matrices?">,
     cycle_time: Input<CycleTime, "cycle_time">,
     ground_to_robot: Input<Option<Isometry3<Ground, Robot>>, "ground_to_robot?">,
@@ -57,6 +59,8 @@ impl LookAt {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        *context.last_motion_command = context.motion_command.clone();
+
         let cycle_start_time = context.cycle_time.start_time;
         let measured_head_angles = context.sensor_data.positions.head;
         let default_output = Ok(MainOutputs {

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -22,8 +22,7 @@ pub struct RefereePoseDetectionFilter {
 
 #[context]
 pub struct CreationContext {
-    referee_pose_queue_length:
-        Parameter<usize, "object_detection.object_detection_top.referee_pose_queue_length">,
+    referee_pose_queue_length: Parameter<usize, "pose_detection.referee_pose_queue_length">,
 }
 
 #[context]
@@ -48,12 +47,9 @@ pub struct CycleContext {
     player_referee_detection_times:
         AdditionalOutput<Players<Option<SystemTime>>, "player_referee_detection_times">,
 
-    referee_pose_queue_length:
-        Parameter<usize, "object_detection.object_detection_top.referee_pose_queue_length">,
-    minimum_number_poses_before_message: Parameter<
-        usize,
-        "object_detection.object_detection_top.minimum_number_poses_before_message",
-    >,
+    referee_pose_queue_length: Parameter<usize, "pose_detection.referee_pose_queue_length">,
+    minimum_number_poses_before_message:
+        Parameter<usize, "pose_detection.minimum_number_poses_before_message">,
 
     referee_pose_queue: AdditionalOutput<VecDeque<bool>, "referee_pose_queue">,
 }
@@ -120,15 +116,6 @@ impl RefereePoseDetectionFilter {
         if !should_look_for_referee {
             self.detection_times = Default::default();
             return (false, false);
-        }
-
-        let time_tagged_persistent_messages =
-            unpack_message_tree(&context.network_message.persistent);
-
-        for (time, message) in time_tagged_persistent_messages {
-            if message.is_referee_ready_signal_detected {
-                self.detection_times[message.player_number] = Some(time);
-            }
         }
 
         let own_detected_pose_times =

--- a/crates/object_detection/src/pose_detection.rs
+++ b/crates/object_detection/src/pose_detection.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use types::{
     bounding_box::BoundingBox,
     color::Rgb,
+    cycle_time::CycleTime,
     motion_command::MotionCommand,
     pose_detection::{HumanPose, Keypoints},
     ycbcr422_image::YCbCr422Image,
@@ -54,14 +55,14 @@ pub struct CycleContext {
     inference_duration: AdditionalOutput<Duration, "inference_duration">,
     postprocess_duration: AdditionalOutput<Duration, "postprocess_duration">,
 
+    cycle_time: Input<CycleTime, "cycle_time">,
     image: Input<YCbCr422Image, "image">,
     motion_command: Input<MotionCommand, "Control", "motion_command">,
 
     intersection_over_union_threshold:
-        Parameter<f32, "object_detection.$cycler_instance.intersection_over_union_threshold">,
-    keypoint_confidence_threshold:
-        Parameter<f32, "object_detection.$cycler_instance.keypoint_confidence_threshold">,
-    enable: Parameter<bool, "object_detection.$cycler_instance.enable">,
+        Parameter<f32, "pose_detection.intersection_over_union_threshold">,
+    keypoint_confidence_threshold: Parameter<f32, "pose_detection.keypoint_confidence_threshold">,
+    enable: Parameter<bool, "pose_detection.enable">,
 }
 
 #[context]

--- a/crates/object_detection/src/pose_interpretation.rs
+++ b/crates/object_detection/src/pose_interpretation.rs
@@ -37,13 +37,11 @@ pub struct CycleContext {
     fall_state: Input<FallState, "Control", "fall_state">,
 
     player_number: Parameter<PlayerNumber, "player_number">,
-    keypoint_confidence_threshold:
-        Parameter<f32, "object_detection.$cycler_instance.keypoint_confidence_threshold">,
+    keypoint_confidence_threshold: Parameter<f32, "pose_detection.keypoint_confidence_threshold">,
     distance_to_referee_position_threshold:
-        Parameter<f32, "object_detection.$cycler_instance.distance_to_referee_position_threshold">,
-    foot_z_offset: Parameter<f32, "object_detection.$cycler_instance.foot_z_offset">,
-    shoulder_angle_threshold:
-        Parameter<f32, "object_detection.$cycler_instance.shoulder_angle_threshold">,
+        Parameter<f32, "pose_detection.distance_to_referee_position_threshold">,
+    foot_z_offset: Parameter<f32, "pose_detection.foot_z_offset">,
+    shoulder_angle_threshold: Parameter<f32, "pose_detection.shoulder_angle_threshold">,
 
     detected_pose_kinds: AdditionalOutput<Vec<PoseKindPosition<Field>>, "detected_pose_kinds">,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1,6 +1,5 @@
 {
-  "object_detection": {
-    "object_detection_top": {
+  "pose_detection": {
       "enable": false,
       "intersection_over_union_threshold": 0.45,
       "distance_to_referee_position_threshold": 2.0,
@@ -9,8 +8,7 @@
       "foot_z_offset": 0.05,
       "referee_pose_queue_length": 8,
       "minimum_number_poses_before_message": 5
-    }
-  },
+    },
   "feet_detection": {
     "vision_top": {
       "enable": true,

--- a/tools/twix/src/panels/image/overlays/pose_detection.rs
+++ b/tools/twix/src/panels/image/overlays/pose_detection.rs
@@ -54,9 +54,9 @@ impl Overlay for PoseDetection {
                     path: "human_poses".to_string(),
                 },
             })),
-            keypoint_confidence_threshold: Some(nao.subscribe_parameter(
-                "object_detection.object_detection_top.keypoint_confidence_threshold",
-            )),
+            keypoint_confidence_threshold: Some(
+                nao.subscribe_parameter("pose_detection.keypoint_confidence_threshold"),
+            ),
         }
     }
 

--- a/tools/twix/src/panels/map/layers/referee_position.rs
+++ b/tools/twix/src/panels/map/layers/referee_position.rs
@@ -22,9 +22,8 @@ impl Layer<Field> for RefereePosition {
         let expected_referee_position = nao.subscribe_output(
             CyclerOutput::from_str("Control.main.expected_referee_position").unwrap(),
         );
-        let distance_to_referee_position_threshold = nao.subscribe_parameter(
-            "object_detection.object_detection_top.distance_to_referee_position_threshold",
-        );
+        let distance_to_referee_position_threshold =
+            nao.subscribe_parameter("pose_detection.distance_to_referee_position_threshold");
         Self {
             expected_referee_position,
             distance_to_referee_position_threshold,


### PR DESCRIPTION
## Why? What?

During setup of NAOs, i.e. when carrying them to the field and temporary stiffing them, a lot of false positives in the visual referee pose detection occurred. This PR resets the detection times, which are used for the decision to go to Ready.
Previous changes of this PR have been moved to #1093.

Fixes #999 partially 

## Ideas for Next Iterations (Not This PR)

## How to Test

- Setup a NAO for visual referee
- In twix subscribe `detection_times` and see if it is reset to default when not in Standby
