### PR TITLE
Image zZoom für Alex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,48 +253,47 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -634,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
@@ -1262,9 +1261,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -3336,12 +3335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/coordinate_systems/src/lib.rs
+++ b/crates/coordinate_systems/src/lib.rs
@@ -126,7 +126,7 @@ generate_coordinate_system!(
     /// See [official documentation](http://doc.aldebaran.com/2-8/family/nao_technical/masses_naov6.html#right-foot)
     RightSole,
     /// 2D Coordinate System for Twix Widgets
-    /// 
+    ///
     /// Origin: top left corner of the image
     /// X axis points right
     /// Y axis points down

--- a/crates/coordinate_systems/src/lib.rs
+++ b/crates/coordinate_systems/src/lib.rs
@@ -126,7 +126,7 @@ generate_coordinate_system!(
     /// See [official documentation](http://doc.aldebaran.com/2-8/family/nao_technical/masses_naov6.html#right-foot)
     RightSole,
     /// 2D Coordinate System for Twix Widgets
-    ///   
+    /// 
     /// Origin: top left corner of the image
     /// X axis points right
     /// Y axis points down

--- a/crates/coordinate_systems/src/lib.rs
+++ b/crates/coordinate_systems/src/lib.rs
@@ -125,4 +125,10 @@ generate_coordinate_system!(
     /// Same as [RightFoot] but shifted down to the sole.
     /// See [official documentation](http://doc.aldebaran.com/2-8/family/nao_technical/masses_naov6.html#right-foot)
     RightSole,
+    /// 2D Coordinate System for Twix Widgets
+    ///   
+    /// Origin: top left corner of the image
+    /// X axis points right
+    /// Y axis points down
+    Screen,
 );

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -60,7 +60,7 @@ mod selectable_panel_macro;
 mod twix_painter;
 mod value_buffer;
 mod visuals;
-pub mod zoom_and_pan;
+mod zoom_and_pan;
 
 #[derive(Debug, Parser)]
 struct Arguments {

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -60,6 +60,7 @@ mod selectable_panel_macro;
 mod twix_painter;
 mod value_buffer;
 mod visuals;
+pub mod zoom_and_pan;
 
 #[derive(Debug, Parser)]
 struct Arguments {

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr, sync::Arc};
 
 use color_eyre::{eyre::eyre, Result};
 use coordinate_systems::Pixel;
-use eframe::egui::{vec2, ComboBox, Response, Sense, SizeHint, TextureOptions, Ui, Widget};
+use eframe::egui::{ComboBox, Response, SizeHint, TextureOptions, Ui, Widget};
 use geometry::rectangle::Rectangle;
 use log::error;
 use nalgebra::Similarity2;
@@ -153,8 +153,8 @@ impl Widget for &mut ImagePanel {
             self.overlays
                 .combo_box(ui, self.cycler_selector.selected_cycler());
         });
-        let (rect, response) = ui.allocate_at_least(vec2(640.0, 480.0), Sense::click_and_drag());
-        let mut painter = TwixPainter::paint_at(ui, rect).with_camera(
+        let (response, painter) = TwixPainter::allocate_new(ui);
+        let mut painter = painter.with_camera(
             vector![640.0, 480.0],
             Similarity2::identity(),
             CoordinateSystem::LeftHand,

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -14,7 +14,7 @@ use linear_algebra::{point, vector, IntoTransform};
 
 use crate::{
     image_buffer::ImageBuffer, nao::Nao, panel::Panel, twix_painter::TwixPainter,
-    zoom_and_pan::ZoomAndPanManager,
+    zoom_and_pan::ZoomAndPanTransform,
 };
 
 use self::{cycler_selector::VisionCyclerSelector, overlay::Overlays};
@@ -48,7 +48,7 @@ pub struct ImagePanel {
     cycler_selector: VisionCyclerSelector,
     overlays: Overlays,
     image_kind: ImageKind,
-    zoom_and_pan: ZoomAndPanManager,
+    zoom_and_pan: ZoomAndPanTransform,
 }
 
 impl Panel for ImagePanel {
@@ -92,7 +92,7 @@ impl Panel for ImagePanel {
             cycler_selector,
             overlays,
             image_kind,
-            zoom_and_pan: ZoomAndPanManager::default(),
+            zoom_and_pan: ZoomAndPanTransform::default(),
         }
     }
 
@@ -152,7 +152,7 @@ impl Widget for &mut ImagePanel {
         });
         let (response, painter) = TwixPainter::allocate_new(ui);
         let mut painter = painter.with_camera(vector![640.0, 480.0], Similarity2::identity());
-        painter.append_transform(self.zoom_and_pan.transformation().framed_transform());
+        painter.append_transform(self.zoom_and_pan.transformation.framed_transform());
         let _ = self
             .show_image(&painter)
             .map_err(|error| ui.label(format!("{error:#?}")));

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -10,13 +10,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_value, json, Value};
 
 use communication::client::{Cycler, CyclerOutput, Output};
-use linear_algebra::{point, vector};
+use linear_algebra::{point, vector, IntoTransform};
 
 use crate::{
-    image_buffer::ImageBuffer,
-    nao::Nao,
-    panel::Panel,
-    twix_painter::{CoordinateSystem, TwixPainter},
+    image_buffer::ImageBuffer, nao::Nao, panel::Panel, twix_painter::TwixPainter,
     zoom_and_pan::ZoomAndPanManager,
 };
 
@@ -154,12 +151,8 @@ impl Widget for &mut ImagePanel {
                 .combo_box(ui, self.cycler_selector.selected_cycler());
         });
         let (response, painter) = TwixPainter::allocate_new(ui);
-        let mut painter = painter.with_camera(
-            vector![640.0, 480.0],
-            Similarity2::identity(),
-            CoordinateSystem::LeftHand,
-        );
-        painter.append_transform(self.zoom_and_pan.transformation());
+        let mut painter = painter.with_camera(vector![640.0, 480.0], Similarity2::identity());
+        painter.append_transform(self.zoom_and_pan.transformation().framed_transform());
         let _ = self
             .show_image(&painter)
             .map_err(|error| ui.label(format!("{error:#?}")));

--- a/tools/twix/src/panels/image_color_select.rs
+++ b/tools/twix/src/panels/image_color_select.rs
@@ -27,7 +27,7 @@ use crate::{
     image_buffer::ImageBuffer,
     nao::Nao,
     panel::Panel,
-    twix_painter::{CoordinateSystem, TwixPainter},
+    twix_painter::TwixPainter,
 };
 
 use super::image::cycler_selector::VisionCyclerSelector;
@@ -195,7 +195,6 @@ impl Widget for &mut ImageColorSelectPanel {
         let painter = TwixPainter::<Pixel>::paint_at(ui, response.rect).with_camera(
             vector![image.width() as f32, image.height() as f32],
             Similarity2::identity(),
-            CoordinateSystem::LeftHand,
         );
 
         if let Some(hover_position) = response.hover_pos() {

--- a/tools/twix/src/panels/image_color_select.rs
+++ b/tools/twix/src/panels/image_color_select.rs
@@ -23,12 +23,7 @@ use types::{
     ycbcr422_image::YCbCr422Image,
 };
 
-use crate::{
-    image_buffer::ImageBuffer,
-    nao::Nao,
-    panel::Panel,
-    twix_painter::TwixPainter,
-};
+use crate::{image_buffer::ImageBuffer, nao::Nao, panel::Panel, twix_painter::TwixPainter};
 
 use super::image::cycler_selector::VisionCyclerSelector;
 

--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -20,7 +20,7 @@ use types::{
 use crate::{
     nao::Nao,
     panel::Panel,
-    twix_painter::{CoordinateSystem, TwixPainter},
+    twix_painter::TwixPainter,
     value_buffer::ValueBuffer,
 };
 
@@ -165,7 +165,6 @@ impl Widget for &mut ImageSegmentsPanel {
         let painter = painter.with_camera(
             vector![640.0, 480.0],
             Similarity2::identity(),
-            CoordinateSystem::LeftHand,
         );
         if let Some(hover_pos) = response.hover_pos() {
             let image_coords = painter.transform_pixel_to_world(hover_pos);

--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -17,12 +17,7 @@ use types::{
     image_segments::ImageSegments,
 };
 
-use crate::{
-    nao::Nao,
-    panel::Panel,
-    twix_painter::TwixPainter,
-    value_buffer::ValueBuffer,
-};
+use crate::{nao::Nao, panel::Panel, twix_painter::TwixPainter, value_buffer::ValueBuffer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 enum ColorMode {
@@ -162,10 +157,7 @@ impl Widget for &mut ImageSegmentsPanel {
         };
 
         let (mut response, painter) = TwixPainter::<Pixel>::allocate_new(ui);
-        let painter = painter.with_camera(
-            vector![640.0, 480.0],
-            Similarity2::identity(),
-        );
+        let painter = painter.with_camera(vector![640.0, 480.0], Similarity2::identity());
         if let Some(hover_pos) = response.hover_pos() {
             let image_coords = painter.transform_pixel_to_world(hover_pos);
             let x = image_coords.x().round() as u16;

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -10,10 +10,7 @@ use serde_json::{from_value, json, Value};
 use types::{self, field_dimensions::FieldDimensions};
 
 use crate::{
-    nao::Nao,
-    panel::Panel,
-    twix_painter::TwixPainter,
-    value_buffer::ValueBuffer,
+    nao::Nao, panel::Panel, twix_painter::TwixPainter, value_buffer::ValueBuffer,
     zoom_and_pan::ZoomAndPanManager,
 };
 

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -11,7 +11,7 @@ use types::{self, field_dimensions::FieldDimensions};
 
 use crate::{
     nao::Nao, panel::Panel, twix_painter::TwixPainter, value_buffer::ValueBuffer,
-    zoom_and_pan::ZoomAndPanManager,
+    zoom_and_pan::ZoomAndPanTransform,
 };
 
 use self::layer::{EnabledLayer, Layer};
@@ -64,7 +64,7 @@ pub struct MapPanel {
 
     field_dimensions: ValueBuffer,
     ground_to_field: ValueBuffer,
-    zoom_and_pan: ZoomAndPanManager,
+    zoom_and_pan: ZoomAndPanTransform,
 
     field: EnabledLayer<layers::Field, Field>,
     image_segments: EnabledLayer<layers::ImageSegments, Ground>,
@@ -112,7 +112,7 @@ impl Panel for MapPanel {
         let field_dimensions = nao.subscribe_parameter("field_dimensions");
         let ground_to_field =
             nao.subscribe_output(CyclerOutput::from_str("Control.main.ground_to_field").unwrap());
-        let zoom_and_pan = ZoomAndPanManager::default();
+        let zoom_and_pan = ZoomAndPanTransform::default();
         Self {
             current_plot_type: PlotType::Field,
             field_dimensions,
@@ -206,13 +206,13 @@ impl Widget for &mut MapPanel {
             PlotType::Field => {
                 let (response, painter) = TwixPainter::allocate_new(ui);
                 let mut painter = painter.with_map_transforms(&field_dimensions);
-                painter.append_transform(self.zoom_and_pan.transformation().framed_transform());
+                painter.append_transform(self.zoom_and_pan.transformation.framed_transform());
                 (response, painter)
             }
             PlotType::Ground => {
                 let (response, painter) = TwixPainter::allocate_new(ui);
                 let mut painter = painter.with_ground_transforms();
-                painter.append_transform(self.zoom_and_pan.transformation().framed_transform());
+                painter.append_transform(self.zoom_and_pan.transformation.framed_transform());
 
                 (response, painter.transform_painter(ground_to_field))
             }

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use communication::client::CyclerOutput;
 use coordinate_systems::{Field, Ground};
 use eframe::egui::{ComboBox, Ui, Widget};
-use linear_algebra::Isometry2;
+use linear_algebra::{IntoTransform, Isometry2};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, json, Value};
 use types::{self, field_dimensions::FieldDimensions};
@@ -206,13 +206,13 @@ impl Widget for &mut MapPanel {
             PlotType::Field => {
                 let (response, painter) = TwixPainter::allocate_new(ui);
                 let mut painter = painter.with_map_transforms(&field_dimensions);
-                painter.append_transform(self.zoom_and_pan.transformation());
+                painter.append_transform(self.zoom_and_pan.transformation().framed_transform());
                 (response, painter)
             }
             PlotType::Ground => {
                 let (response, painter) = TwixPainter::allocate_new(ui);
                 let mut painter = painter.with_ground_transforms();
-                painter.append_transform(self.zoom_and_pan.transformation());
+                painter.append_transform(self.zoom_and_pan.transformation().framed_transform());
 
                 (response, painter.transform_painter(ground_to_field))
             }

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -3,14 +3,19 @@ use std::{str::FromStr, sync::Arc};
 use color_eyre::Result;
 use communication::client::CyclerOutput;
 use coordinate_systems::{Field, Ground};
-use eframe::egui::{ComboBox, Response, Ui, Widget};
+use eframe::egui::{ComboBox, Ui, Widget};
 use linear_algebra::Isometry2;
-use nalgebra::{vector, Similarity2, Translation2};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, json, Value};
 use types::{self, field_dimensions::FieldDimensions};
 
-use crate::{nao::Nao, panel::Panel, twix_painter::TwixPainter, value_buffer::ValueBuffer};
+use crate::{
+    nao::Nao,
+    panel::Panel,
+    twix_painter::TwixPainter,
+    value_buffer::ValueBuffer,
+    zoom_and_pan::ZoomAndPanManager,
+};
 
 use self::layer::{EnabledLayer, Layer};
 
@@ -62,7 +67,7 @@ pub struct MapPanel {
 
     field_dimensions: ValueBuffer,
     ground_to_field: ValueBuffer,
-    transformation: Similarity2<f32>,
+    zoom_and_pan: ZoomAndPanManager,
 
     field: EnabledLayer<layers::Field, Field>,
     image_segments: EnabledLayer<layers::ImageSegments, Ground>,
@@ -110,12 +115,12 @@ impl Panel for MapPanel {
         let field_dimensions = nao.subscribe_parameter("field_dimensions");
         let ground_to_field =
             nao.subscribe_output(CyclerOutput::from_str("Control.main.ground_to_field").unwrap());
-        let transformation = Similarity2::identity();
+        let zoom_and_pan = ZoomAndPanManager::default();
         Self {
             current_plot_type: PlotType::Field,
             field_dimensions,
             ground_to_field,
-            transformation,
+            zoom_and_pan,
             field,
             image_segments,
             line_correspondences,
@@ -204,13 +209,13 @@ impl Widget for &mut MapPanel {
             PlotType::Field => {
                 let (response, painter) = TwixPainter::allocate_new(ui);
                 let mut painter = painter.with_map_transforms(&field_dimensions);
-                painter.append_transform(self.transformation);
+                painter.append_transform(self.zoom_and_pan.transformation());
                 (response, painter)
             }
             PlotType::Ground => {
                 let (response, painter) = TwixPainter::allocate_new(ui);
                 let mut painter = painter.with_ground_transforms();
-                painter.append_transform(self.transformation);
+                painter.append_transform(self.zoom_and_pan.transformation());
 
                 (response, painter.transform_painter(ground_to_field))
             }
@@ -272,39 +277,7 @@ impl Widget for &mut MapPanel {
             .walking
             .generic_paint(&painter, ground_to_field, &field_dimensions);
 
-        self.apply_zoom_and_pan(ui, &mut painter, &response);
-        if response.double_clicked() {
-            self.transformation = Similarity2::identity();
-        }
-
+        self.zoom_and_pan.apply(ui, &mut painter, &response);
         response
-    }
-}
-
-impl MapPanel {
-    fn apply_zoom_and_pan(
-        &mut self,
-        ui: &mut Ui,
-        painter: &mut TwixPainter<Field>,
-        response: &Response,
-    ) {
-        let pointer_position = match ui.input(|input| input.pointer.interact_pos()) {
-            Some(position) if response.rect.contains(position) => position,
-            _ => return,
-        };
-
-        let pointer_in_world_before_zoom = painter.transform_pixel_to_world(pointer_position);
-        let zoom_factor = 1.01_f32.powf(ui.input(|input| input.smooth_scroll_delta.y));
-        let zoom_transform = Similarity2::from_scaling(zoom_factor);
-        painter.append_transform(zoom_transform);
-        let pointer_in_pixel_after_zoom =
-            painter.transform_world_to_pixel(pointer_in_world_before_zoom);
-        let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
-        let pixel_drag = vector![response.drag_delta().x, -response.drag_delta().y];
-        self.transformation.append_scaling_mut(zoom_factor);
-        self.transformation
-            .append_translation_mut(&Translation2::from(
-                pixel_drag + vector![shift_from_zoom.x, -shift_from_zoom.y],
-            ));
     }
 }

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -117,7 +117,7 @@ impl<Frame> TwixPainter<Frame> {
         self.painter.ctx()
     }
 
-    pub fn is_right_handed(&self) -> bool{
+    pub fn is_right_handed(&self) -> bool {
         self.camera_coordinate_system.y_scale() >= 0.0
     }
 

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -22,6 +22,7 @@ pub struct TwixPainter<Frame> {
     world_to_pixel: ScreenTransform<Frame>,
     frame: PhantomData<Frame>,
 }
+
 trait Convert {
     fn as_pos2(&self) -> Pos2;
 }

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -24,15 +24,10 @@ pub struct TwixPainter<Frame> {
 }
 trait Convert {
     fn as_pos2(&self) -> Pos2;
-    fn as_point(position: Pos2) -> Self;
 }
 impl Convert for Point2<Screen> {
     fn as_pos2(&self) -> Pos2 {
         Pos2::new(self.x(), self.y())
-    }
-
-    fn as_point(position: Pos2) -> Self {
-        point!(position.x, position.y)
     }
 }
 

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -4,14 +4,14 @@ use std::{
 };
 
 use eframe::{
-    egui::{Painter, Response, Sense, Ui},
+    egui::{pos2, Context, Painter, Response, Sense, TextureId, Ui},
     emath::{Pos2, Rect},
     epaint::{Color32, PathShape, Shape, Stroke},
 };
 use nalgebra::{Rotation2, SMatrix, Similarity2};
 
 use coordinate_systems::{Field, Ground};
-use geometry::{arc::Arc, circle::Circle, direction::Direction};
+use geometry::{arc::Arc, circle::Circle, direction::Direction, rectangle::Rectangle};
 use linear_algebra::{point, vector, IntoTransform, Isometry2, Point2, Pose2, Vector2};
 use types::{field_dimensions::FieldDimensions, planned_path::PathSegment};
 
@@ -111,6 +111,14 @@ impl<Frame> TwixPainter<Frame> {
 
     pub fn append_transform(&mut self, transformation: Similarity2<f32>) {
         self.world_to_pixel = transformation * self.world_to_pixel;
+    }
+
+    pub fn context(&self) -> &Context {
+        self.painter.ctx()
+    }
+
+    pub fn is_right_handed(&self) -> bool{
+        self.camera_coordinate_system.y_scale() >= 0.0
     }
 
     pub fn arc(&self, arc: Arc<Frame>, orientation: Direction, stroke: Stroke) {
@@ -392,6 +400,18 @@ impl<Frame> TwixPainter<Frame> {
     ) {
         let position = self.transform_world_to_pixel(position);
         self.painter.text(position, align, text, font_id, color);
+    }
+
+    pub fn image(&self, texture_id: TextureId, rect: Rectangle<Frame>) {
+        let Rectangle { min, max } = rect;
+        let min = self.transform_world_to_pixel(min);
+        let max = self.transform_world_to_pixel(max);
+        self.painter.image(
+            texture_id,
+            Rect::from_two_pos(min, max),
+            Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
+            Color32::WHITE,
+        );
     }
 }
 impl TwixPainter<Ground> {

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -26,6 +26,7 @@ pub struct TwixPainter<Frame> {
 trait Convert {
     fn as_pos2(&self) -> Pos2;
 }
+
 impl Convert for Point2<Screen> {
     fn as_pos2(&self) -> Pos2 {
         Pos2::new(self.x(), self.y())
@@ -110,6 +111,7 @@ impl<Frame> TwixPainter<Frame> {
     pub fn context(&self) -> &Context {
         self.painter.ctx()
     }
+
     pub fn scaling(&self) -> f32 {
         self.world_to_pixel
             .inner

--- a/tools/twix/src/zoom_and_pan.rs
+++ b/tools/twix/src/zoom_and_pan.rs
@@ -36,9 +36,15 @@ impl ZoomAndPanManager {
             vector![response.drag_delta().x, -response.drag_delta().y]
         };
         self.transformation.append_scaling_mut(zoom_factor);
+        let zoom_shift = if painter.is_right_handed() {
+            vector![shift_from_zoom.x, shift_from_zoom.y]
+        }
+        else{
+            vector![shift_from_zoom.x, -shift_from_zoom.y]
+        };
         self.transformation
             .append_translation_mut(&Translation2::from(
-                pixel_drag + vector![shift_from_zoom.x, -shift_from_zoom.y],
+                pixel_drag + zoom_shift,
             ));
     }
     pub fn transformation(&self) -> Similarity2<f32> {

--- a/tools/twix/src/zoom_and_pan.rs
+++ b/tools/twix/src/zoom_and_pan.rs
@@ -1,0 +1,47 @@
+use eframe::egui::{Response, Ui};
+use nalgebra::{vector, Similarity2, Translation2};
+
+use crate::twix_painter::TwixPainter;
+
+#[derive(Default)]
+pub struct ZoomAndPanManager {
+    transformation: Similarity2<f32>,
+}
+
+impl ZoomAndPanManager {
+    pub fn apply<Frame>(
+        &mut self,
+        ui: &mut Ui,
+        painter: &mut TwixPainter<Frame>,
+        response: &Response,
+    ) {
+        if response.double_clicked() {
+            self.transformation = Similarity2::identity();
+        }
+        let pointer_position = match ui.input(|input| input.pointer.interact_pos()) {
+            Some(position) if response.rect.contains(position) => position,
+            _ => return,
+        };
+
+        let pointer_in_world_before_zoom = painter.transform_pixel_to_world(pointer_position);
+        let zoom_factor = 1.01_f32.powf(ui.input(|input| input.smooth_scroll_delta.y));
+        let zoom_transform = Similarity2::from_scaling(zoom_factor);
+        painter.append_transform(zoom_transform);
+        let pointer_in_pixel_after_zoom =
+            painter.transform_world_to_pixel(pointer_in_world_before_zoom);
+        let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
+        let pixel_drag = if painter.is_right_handed() {
+            vector![response.drag_delta().x, response.drag_delta().y]
+        } else {
+            vector![response.drag_delta().x, -response.drag_delta().y]
+        };
+        self.transformation.append_scaling_mut(zoom_factor);
+        self.transformation
+            .append_translation_mut(&Translation2::from(
+                pixel_drag + vector![shift_from_zoom.x, -shift_from_zoom.y],
+            ));
+    }
+    pub fn transformation(&self) -> Similarity2<f32> {
+        self.transformation
+    }
+}

--- a/tools/twix/src/zoom_and_pan.rs
+++ b/tools/twix/src/zoom_and_pan.rs
@@ -38,14 +38,11 @@ impl ZoomAndPanManager {
         self.transformation.append_scaling_mut(zoom_factor);
         let zoom_shift = if painter.is_right_handed() {
             vector![shift_from_zoom.x, shift_from_zoom.y]
-        }
-        else{
+        } else {
             vector![shift_from_zoom.x, -shift_from_zoom.y]
         };
         self.transformation
-            .append_translation_mut(&Translation2::from(
-                pixel_drag + zoom_shift,
-            ));
+            .append_translation_mut(&Translation2::from(pixel_drag + zoom_shift));
     }
     pub fn transformation(&self) -> Similarity2<f32> {
         self.transformation

--- a/tools/twix/src/zoom_and_pan.rs
+++ b/tools/twix/src/zoom_and_pan.rs
@@ -5,11 +5,11 @@ use nalgebra::{vector, Similarity2, Translation2};
 use crate::twix_painter::TwixPainter;
 
 #[derive(Default)]
-pub struct ZoomAndPanManager {
-    transformation: Similarity2<f32>,
+pub struct ZoomAndPanTransform {
+    pub transformation: Similarity2<f32>,
 }
 
-impl ZoomAndPanManager {
+impl ZoomAndPanTransform {
     pub fn apply<Frame>(
         &mut self,
         ui: &mut Ui,
@@ -36,8 +36,5 @@ impl ZoomAndPanManager {
         let zoom_shift = vector![shift_from_zoom.x, shift_from_zoom.y];
         self.transformation
             .append_translation_mut(&Translation2::from(pixel_drag + zoom_shift));
-    }
-    pub fn transformation(&self) -> Similarity2<f32> {
-        self.transformation
     }
 }

--- a/tools/twix/src/zoom_and_pan.rs
+++ b/tools/twix/src/zoom_and_pan.rs
@@ -1,4 +1,5 @@
 use eframe::egui::{Response, Ui};
+use linear_algebra::IntoTransform;
 use nalgebra::{vector, Similarity2, Translation2};
 
 use crate::twix_painter::TwixPainter;
@@ -26,21 +27,13 @@ impl ZoomAndPanManager {
         let pointer_in_world_before_zoom = painter.transform_pixel_to_world(pointer_position);
         let zoom_factor = 1.01_f32.powf(ui.input(|input| input.smooth_scroll_delta.y));
         let zoom_transform = Similarity2::from_scaling(zoom_factor);
-        painter.append_transform(zoom_transform);
+        painter.append_transform(zoom_transform.framed_transform());
         let pointer_in_pixel_after_zoom =
             painter.transform_world_to_pixel(pointer_in_world_before_zoom);
         let shift_from_zoom = pointer_position - pointer_in_pixel_after_zoom;
-        let pixel_drag = if painter.is_right_handed() {
-            vector![response.drag_delta().x, response.drag_delta().y]
-        } else {
-            vector![response.drag_delta().x, -response.drag_delta().y]
-        };
+        let pixel_drag = vector![response.drag_delta().x, response.drag_delta().y];
         self.transformation.append_scaling_mut(zoom_factor);
-        let zoom_shift = if painter.is_right_handed() {
-            vector![shift_from_zoom.x, shift_from_zoom.y]
-        } else {
-            vector![shift_from_zoom.x, -shift_from_zoom.y]
-        };
+        let zoom_shift = vector![shift_from_zoom.x, shift_from_zoom.y];
         self.transformation
             .append_translation_mut(&Translation2::from(pixel_drag + zoom_shift));
     }


### PR DESCRIPTION
## Why? What?

Make image panel zoomable. This makes the image panel function more consistently to other panels. Really helpful for calibrating pose detection, as the confidences around the pose keypoints are really close together and otherwise not distinguishable.  


## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- scroll and drag the image in the image panel
