### PR TITLE
Wrap `print` in lua to use rust IO

### DIFF
--- a/tools/behavior_simulator/src/simulator.rs
+++ b/tools/behavior_simulator/src/simulator.rs
@@ -39,9 +39,8 @@ impl Simulator {
         let lua = Lua::new();
 
         let print = lua.create_function(|_, arguments: Variadic<String>| {
-            for to_string in arguments {
-                println!("{to_string}");
-            }
+            let line = arguments.join("\t");
+            println!("{line}");
             Ok(())
         })?;
         lua.globals().set("print", print)?;


### PR DESCRIPTION
## Why? What?

Not sure whether this the correct or best way to do it, but this reroutes the lua prints through the rust universe and results in proper behavior in `cargo test`... only print when the test failed...

ah, and fixes some typos

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

run `cargo test --workspace` -> There should be no behavior simulator test case output like `Hello world from Lua`
