### PR TITLE
Time error projected kalman filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/filtering/src/lib.rs
+++ b/crates/filtering/src/lib.rs
@@ -6,3 +6,4 @@ pub mod orientation_filtering;
 pub mod pose_filter;
 pub mod statistics;
 pub mod tap_detector;
+pub mod time_error_projected_kalman_filter;

--- a/crates/filtering/src/time_error_projected_kalman_filter.rs
+++ b/crates/filtering/src/time_error_projected_kalman_filter.rs
@@ -1,0 +1,66 @@
+use nalgebra::{SMatrix, SVector};
+use types::multivariate_normal_distribution::MultivariateNormalDistribution;
+
+use crate::kalman_filter::KalmanFilter;
+
+pub trait TimeErrorProjectedKalmanFilter<const STATE_DIMENSION: usize> {
+    fn predict<const CONTROL_DIMENSION: usize>(
+        &mut self,
+        state_prediction: SMatrix<f32, STATE_DIMENSION, STATE_DIMENSION>,
+        control_input_model: SMatrix<f32, STATE_DIMENSION, CONTROL_DIMENSION>,
+        control: SVector<f32, CONTROL_DIMENSION>,
+        process_noise: SMatrix<f32, STATE_DIMENSION, STATE_DIMENSION>,
+    );
+    fn update<const MEASUREMENT_DIMENSION: usize>(
+        &mut self,
+        measurement_prediction: SMatrix<f32, MEASUREMENT_DIMENSION, STATE_DIMENSION>,
+        measurement: SVector<f32, MEASUREMENT_DIMENSION>,
+        measurement_noise: SMatrix<f32, MEASUREMENT_DIMENSION, MEASUREMENT_DIMENSION>,
+        state_derivative: SVector<f32, STATE_DIMENSION>,
+        measurement_time_noise: f32,
+    );
+}
+
+impl<const STATE_DIMENSION: usize> TimeErrorProjectedKalmanFilter<STATE_DIMENSION>
+    for MultivariateNormalDistribution<STATE_DIMENSION>
+{
+    fn predict<const CONTROL_DIMENSION: usize>(
+        &mut self,
+        state_prediction: SMatrix<f32, STATE_DIMENSION, STATE_DIMENSION>,
+        control_input_model: SMatrix<f32, STATE_DIMENSION, CONTROL_DIMENSION>,
+        control: SVector<f32, CONTROL_DIMENSION>,
+        process_noise: SMatrix<f32, STATE_DIMENSION, STATE_DIMENSION>,
+    ) {
+        KalmanFilter::<STATE_DIMENSION>::predict(
+            self,
+            state_prediction,
+            control_input_model,
+            control,
+            process_noise,
+        )
+    }
+
+    fn update<const MEASUREMENT_DIMENSION: usize>(
+        &mut self,
+        measurement_prediction: SMatrix<f32, MEASUREMENT_DIMENSION, STATE_DIMENSION>,
+        measurement: SVector<f32, MEASUREMENT_DIMENSION>,
+        measurement_noise: SMatrix<f32, MEASUREMENT_DIMENSION, MEASUREMENT_DIMENSION>,
+        state_derivative: SVector<f32, STATE_DIMENSION>,
+        measurement_noise_variance: f32,
+    ) {
+        let residual = measurement - measurement_prediction * self.mean;
+        let time_error_adjusted_covariance = self.covariance
+            + measurement_noise_variance * state_derivative * state_derivative.transpose();
+        let residual_covariance = measurement_prediction
+            * time_error_adjusted_covariance
+            * measurement_prediction.transpose()
+            + measurement_noise;
+        let kalman_gain = self.covariance
+            * measurement_prediction.transpose()
+            * residual_covariance
+                .try_inverse()
+                .expect("Residual covariance matrix is not invertible");
+        self.mean += kalman_gain * residual;
+        self.covariance -= kalman_gain * measurement_prediction * self.covariance;
+    }
+}

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -328,6 +328,7 @@ pub struct BallFilterParameters {
     pub validity_discard_threshold: f32,
     pub velocity_decay_factor: f32,
     pub resting_ball_velocity_threshold: f32,
+    pub measurement_time_noise: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -322,6 +322,7 @@
     "process_noise": [0.005, 0.005, 0.2, 0.2],
     "measurement_noise_moving": [0.5, 2.0],
     "measurement_noise_resting": [300.0, 500.0],
+    "measurement_time_noise": 40.0,
     "initial_covariance": [0.5, 0.5, 0.5, 0.5],
     "resting_ball_velocity_threshold": 0.25,
     "visible_validity_exponential_decay_factor": 0.96,

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -344,7 +344,7 @@ impl<Frame> TwixPainter<Frame> {
         } else if b == 0.0 && a < c {
             FRAC_PI_2
         } else {
-            b.atan2(l1 - a)
+            (l1 - a).atan2(b)
         };
         self.ellipse(position, l1.sqrt(), l2.sqrt(), theta, stroke, fill_color)
     }


### PR DESCRIPTION
## Why? What?

Mitigates the effects of inaccurate measurement times.
The innovation covariance is adjusted by the derivative of the state, causing the filter to be more uncertain in the direction of state change.
Also fixes the covariance plotting in twix, which had an incorrect orientation before.

Fixes #

## ToDo / Known Issues

- Not sure how to deal with the current code duplication?


*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
* Use the `Ball Filter` overlay in twix
* When the ball rolls towards the robot, the covariance should be elongated along the velocity direction of the ball
