### PR TITLE
RNG Determinism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,7 @@ dependencies = [
  "path_serde",
  "projection",
  "rand",
+ "rand_chacha",
  "serde",
  "smallvec",
  "spl_network_messages",
@@ -4756,6 +4757,7 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -4775,6 +4777,19 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "ransac"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "geometry",
+ "linear_algebra",
+ "nalgebra",
+ "ordered-float",
+ "rand",
+ "rand_chacha",
 ]
 
 [[package]]
@@ -6172,6 +6187,8 @@ dependencies = [
  "ordered-float",
  "projection",
  "rand",
+ "rand_chacha",
+ "ransac",
  "serde",
  "types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "crates/path_serde",
   "crates/path_serde_derive",
   "crates/projection",
+  "crates/ransac",
   "crates/repository",
   "crates/source_analyzer",
   "crates/spl_network",
@@ -154,7 +155,9 @@ proc-macro2 = { version = "1.0.44", features = ["span-locations"] }
 projection = { path = "crates/projection" }
 quote = "1.0.21"
 rand = "0.8.5"
+rand_chacha = { version = "0.3.1", features = ["serde1"] }
 rand_distr = "0.4.3"
+ransac = { path = "crates/ransac" }
 regex = "1.6.0"
 repository = { path = "crates/repository" }
 reqwest = { version = "0.11.23", features = ["blocking"] }

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -27,6 +27,7 @@ ordered-float = { workspace = true }
 path_serde = { workspace = true }
 projection = { workspace = true }
 rand = {workspace = true}
+rand_chacha = {workspace = true}
 serde = { workspace = true }
 smallvec = { workspace = true }
 spl_network_messages = { workspace = true }

--- a/crates/control/src/visual_referee_filter.rs
+++ b/crates/control/src/visual_referee_filter.rs
@@ -1,5 +1,6 @@
 use num_traits::cast::FromPrimitive;
 use rand::prelude::*;
+use rand_chacha::ChaChaRng;
 use std::{
     net::SocketAddr,
     time::{Duration, SystemTime},
@@ -20,6 +21,7 @@ use types::{
 pub struct VisualRefereeFilter {
     last_primary_state: PrimaryState,
     time_of_last_visual_referee_related_state_change: Option<SystemTime>,
+    random_state: ChaChaRng,
 }
 
 #[context]
@@ -46,6 +48,7 @@ impl VisualRefereeFilter {
         Ok(Self {
             last_primary_state: PrimaryState::Unstiff,
             time_of_last_visual_referee_related_state_change: None,
+            random_state: ChaChaRng::from_entropy(),
         })
     }
 
@@ -93,8 +96,8 @@ impl VisualRefereeFilter {
             }
 
             // Initially a random visual referee decision
-            let mut rng = thread_rng();
-            let gesture = VisualRefereeDecision::from_u32(rng.gen_range(1..=13)).unwrap();
+            let gesture =
+                VisualRefereeDecision::from_u32(self.random_state.gen_range(1..=13)).unwrap();
 
             if let Some(address) = context.game_controller_address {
                 let message = OutgoingMessage::VisualReferee(

--- a/crates/hulk_replayer/src/worker_thread.rs
+++ b/crates/hulk_replayer/src/worker_thread.rs
@@ -29,7 +29,7 @@ pub fn spawn_worker(
                 }
 
                 if let Err(error) = replayer.replay_at(*time.borrow()) {
-                    eprintln!("{error}");
+                    eprintln!("{error:#?}");
                 }
             }
         });

--- a/crates/ransac/Cargo.toml
+++ b/crates/ransac/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ransac"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+approx = { workspace = true }
+geometry = { workspace = true }
+linear_algebra = { workspace = true }
+nalgebra = { workspace = true }
+ordered-float = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }

--- a/crates/ransac/src/lib.rs
+++ b/crates/ransac/src/lib.rs
@@ -1,8 +1,7 @@
 use geometry::line::{Line, Line2};
 use linear_algebra::Point2;
 use ordered_float::NotNan;
-use rand::seq::SliceRandom;
-use rand_chacha::ChaChaRng;
+use rand::{seq::SliceRandom, Rng};
 
 #[derive(Default, Debug, PartialEq)]
 pub struct RansacResult<Frame> {
@@ -23,7 +22,7 @@ impl<Frame> Ransac<Frame> {
 impl<Frame> Ransac<Frame> {
     pub fn next_line(
         &mut self,
-        random_number_generator: &mut ChaChaRng,
+        random_number_generator: &mut impl Rng,
         iterations: usize,
         maximum_score_distance: f32,
         maximum_inclusion_distance: f32,
@@ -73,6 +72,7 @@ mod test {
     use approx::{assert_relative_eq, relative_eq};
     use linear_algebra::point;
     use rand::SeedableRng;
+    use rand_chacha::ChaChaRng;
 
     use super::*;
 

--- a/crates/ransac/src/lib.rs
+++ b/crates/ransac/src/lib.rs
@@ -1,7 +1,8 @@
 use geometry::line::{Line, Line2};
 use linear_algebra::Point2;
 use ordered_float::NotNan;
-use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, SeedableRng};
+use rand::seq::SliceRandom;
+use rand_chacha::ChaChaRng;
 
 #[derive(Default, Debug, PartialEq)]
 pub struct RansacResult<Frame> {
@@ -11,22 +12,18 @@ pub struct RansacResult<Frame> {
 
 pub struct Ransac<Frame> {
     pub unused_points: Vec<Point2<Frame>>,
-    random_number_generator: StdRng,
 }
 
 impl<Frame> Ransac<Frame> {
-    pub fn new(unused_points: Vec<Point2<Frame>>) -> Self {
-        Self {
-            unused_points,
-            random_number_generator: StdRng::from_rng(thread_rng())
-                .expect("Failed to create random number generator"),
-        }
+    pub fn new(unused_points: Vec<Point2<Frame>>) -> Ransac<Frame> {
+        Ransac { unused_points }
     }
 }
 
 impl<Frame> Ransac<Frame> {
     pub fn next_line(
         &mut self,
+        random_number_generator: &mut ChaChaRng,
         iterations: usize,
         maximum_score_distance: f32,
         maximum_inclusion_distance: f32,
@@ -37,6 +34,7 @@ impl<Frame> Ransac<Frame> {
                 used_points: vec![],
             };
         }
+
         let maximum_score_distance_squared = maximum_score_distance * maximum_score_distance;
         let maximum_inclusion_distance_squared =
             maximum_inclusion_distance * maximum_inclusion_distance;
@@ -44,7 +42,7 @@ impl<Frame> Ransac<Frame> {
             .map(|_| {
                 let mut points = self
                     .unused_points
-                    .choose_multiple(&mut self.random_number_generator, 2);
+                    .choose_multiple(random_number_generator, 2);
                 let line = Line(*points.next().unwrap(), *points.next().unwrap());
                 let score: f32 = self
                     .unused_points
@@ -72,43 +70,49 @@ impl<Frame> Ransac<Frame> {
 
 #[cfg(test)]
 mod test {
-    use approx::assert_relative_eq;
+    use approx::{assert_relative_eq, relative_eq};
     use linear_algebra::point;
+    use rand::SeedableRng;
 
     use super::*;
 
     #[derive(Debug, PartialEq, Eq, Default)]
     struct SomeFrame;
 
-    fn ransac_with_seed(unused_points: Vec<Point2<SomeFrame>>, seed: u64) -> Ransac<SomeFrame> {
-        Ransac {
-            unused_points,
-            random_number_generator: StdRng::seed_from_u64(seed),
-        }
-    }
-
     #[test]
     fn ransac_empty_input() {
-        let mut ransac = ransac_with_seed(vec![], 0);
-        assert_eq!(ransac.next_line(10, 5.0, 5.0), RansacResult::default());
+        let mut ransac = Ransac::<SomeFrame>::new(vec![]);
+        let mut rng = ChaChaRng::from_entropy();
+        assert_eq!(
+            ransac.next_line(&mut rng, 10, 5.0, 5.0),
+            RansacResult::default()
+        );
     }
 
     #[test]
     fn ransac_single_point() {
-        let mut ransac = ransac_with_seed(vec![point![15.0, 15.0]], 0);
-        assert_eq!(ransac.next_line(10, 5.0, 5.0), RansacResult::default());
+        let mut ransac = Ransac::<SomeFrame>::new(vec![]);
+        let mut rng = ChaChaRng::from_entropy();
+        assert_eq!(
+            ransac.next_line(&mut rng, 10, 5.0, 5.0),
+            RansacResult::default()
+        );
     }
 
     #[test]
     fn ransac_two_points() {
-        let mut ransac = ransac_with_seed(vec![point![15.0, 15.0], point![30.0, 30.0]], 0);
-        let result = ransac.next_line(10, 5.0, 5.0);
-        assert_relative_eq!(
-            result.line.expect("No line found"),
-            Line(point![15.0, 15.0], point![30.0, 30.0])
-        );
-        assert_relative_eq!(result.used_points[0], point![15.0, 15.0]);
-        assert_relative_eq!(result.used_points[1], point![30.0, 30.0]);
+        let p1 = point![15.0, 15.0];
+        let p2 = point![30.0, 30.0];
+        let mut ransac = Ransac::<SomeFrame>::new(vec![p1, p2]);
+        let mut rng = ChaChaRng::from_entropy();
+        let RansacResult { line, used_points } = ransac.next_line(&mut rng, 10, 5.0, 5.0);
+        let line = line.expect("No line found");
+        println!("{line:#?}");
+        println!("{used_points:#?}");
+
+        assert!(relative_eq!(line, Line(p1, p2)) || relative_eq!(line, Line(p2, p1)));
+        assert!(relative_eq!(used_points[0], p1) || relative_eq!(used_points[0], p2));
+        assert!(relative_eq!(used_points[1], p2) || relative_eq!(used_points[0], p1));
     }
 
     #[test]
@@ -119,8 +123,9 @@ mod test {
             .map(|x| point![x as f32, y_intercept + x as f32 * slope])
             .collect();
 
-        let mut ransac = ransac_with_seed(points.clone(), 0);
-        let result = ransac.next_line(15, 1.0, 1.0);
+        let mut ransac = Ransac::<SomeFrame>::new(points.clone());
+        let mut rng = ChaChaRng::from_entropy();
+        let result = ransac.next_line(&mut rng, 15, 1.0, 1.0);
         let line = result.line.expect("No line was found");
         assert_relative_eq!(line.slope(), slope, epsilon = 0.0001);
         assert_relative_eq!(line.y_axis_intercept(), y_intercept, epsilon = 0.0001);

--- a/crates/vision/Cargo.toml
+++ b/crates/vision/Cargo.toml
@@ -22,5 +22,7 @@ nalgebra = { workspace = true }
 ordered-float = { workspace = true }
 projection = { workspace = true }
 rand = { workspace = true }
+rand_chacha = { workspace = true }
+ransac = { workspace = true }
 serde = { workspace = true }
 types = { workspace = true }

--- a/crates/vision/src/lib.rs
+++ b/crates/vision/src/lib.rs
@@ -8,5 +8,4 @@ pub mod image_segmenter;
 pub mod limb_projector;
 pub mod line_detection;
 pub mod perspective_grid_candidates_provider;
-mod ransac;
 pub mod segment_filter;


### PR DESCRIPTION
## Why? What?

What it says.

Why? To make replays more useful.
Currently nodes like line detection and field border detection run use non-deterministic randomness to generate their output.
Thus, when replaying the same vision frame twice, we will likely get two different sets of detected lines.
The random generator state is now stored inside the nodes, making them fully replayable.

Also makes replayer error messages more useful, instead of "failed to replay frame", it will now print the actual root cause.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Record data, replay it. 
Look at lines in the image panel, they should no longer jump around when replaying the same vision frame.