### PR TITLE
Camera Error Projection

### DIFF
--- a/crates/ball_filter/src/hypothesis.rs
+++ b/crates/ball_filter/src/hypothesis.rs
@@ -8,7 +8,7 @@ use resting::{RestingPredict, RestingUpdate};
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::Ground;
-use linear_algebra::{vector, IntoFramed, Isometry2, Point2, Vector2};
+use linear_algebra::{vector, IntoFramed, Isometry2, Vector2};
 
 use types::multivariate_normal_distribution::MultivariateNormalDistribution;
 
@@ -19,9 +19,9 @@ pub mod resting;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect)]
 pub struct BallHypothesis {
-    moving: MultivariateNormalDistribution<4>,
-    resting: MultivariateNormalDistribution<2>,
-    last_seen: SystemTime,
+    pub moving: MultivariateNormalDistribution<4>,
+    pub resting: MultivariateNormalDistribution<2>,
+    pub last_seen: SystemTime,
     pub validity: f32,
 }
 
@@ -95,12 +95,11 @@ impl BallHypothesis {
     pub fn update(
         &mut self,
         detection_time: SystemTime,
-        measurement: Point2<Ground>,
-        noise: Matrix2<f32>,
+        measurement: MultivariateNormalDistribution<2>,
     ) {
         self.last_seen = detection_time;
-        MovingUpdate::update(&mut self.moving, measurement, noise);
-        RestingUpdate::update(&mut self.resting, measurement, noise);
+        MovingUpdate::update(&mut self.moving, measurement);
+        RestingUpdate::update(&mut self.resting, measurement);
         self.validity += 1.0;
     }
 

--- a/crates/ball_filter/src/hypothesis/moving.rs
+++ b/crates/ball_filter/src/hypothesis/moving.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use coordinate_systems::Ground;
 use filtering::kalman_filter::KalmanFilter;
-use linear_algebra::{Isometry2, Point2};
-use nalgebra::{matrix, Matrix2, Matrix2x4, Matrix4, Matrix4x2};
+use linear_algebra::Isometry2;
+use nalgebra::{matrix, Matrix2x4, Matrix4, Matrix4x2};
 use types::multivariate_normal_distribution::MultivariateNormalDistribution;
 
 pub(super) trait MovingPredict {
@@ -17,7 +17,7 @@ pub(super) trait MovingPredict {
 }
 
 pub(super) trait MovingUpdate {
-    fn update(&mut self, measurement: Point2<Ground>, noise: Matrix2<f32>);
+    fn update(&mut self, measurement: MultivariateNormalDistribution<2>);
 }
 
 impl MovingPredict for MultivariateNormalDistribution<4> {
@@ -59,7 +59,12 @@ impl MovingPredict for MultivariateNormalDistribution<4> {
 }
 
 impl MovingUpdate for MultivariateNormalDistribution<4> {
-    fn update(&mut self, measurement: Point2<Ground>, noise: Matrix2<f32>) {
-        KalmanFilter::update(self, Matrix2x4::identity(), measurement.inner.coords, noise)
+    fn update(&mut self, measurement: MultivariateNormalDistribution<2>) {
+        KalmanFilter::update(
+            self,
+            Matrix2x4::identity(),
+            measurement.mean,
+            measurement.covariance,
+        )
     }
 }

--- a/crates/ball_filter/src/hypothesis/resting.rs
+++ b/crates/ball_filter/src/hypothesis/resting.rs
@@ -1,6 +1,6 @@
 use coordinate_systems::Ground;
 use filtering::kalman_filter::KalmanFilter;
-use linear_algebra::{Isometry2, Point2};
+use linear_algebra::Isometry2;
 use nalgebra::Matrix2;
 use types::multivariate_normal_distribution::MultivariateNormalDistribution;
 
@@ -13,7 +13,7 @@ pub(super) trait RestingPredict {
 }
 
 pub(super) trait RestingUpdate {
-    fn update(&mut self, measurement: Point2<Ground>, noise: Matrix2<f32>);
+    fn update(&mut self, measurement: MultivariateNormalDistribution<2>);
 }
 
 impl RestingPredict for MultivariateNormalDistribution<2> {
@@ -36,7 +36,12 @@ impl RestingPredict for MultivariateNormalDistribution<2> {
 }
 
 impl RestingUpdate for MultivariateNormalDistribution<2> {
-    fn update(&mut self, measurement: Point2<Ground>, noise: Matrix2<f32>) {
-        KalmanFilter::update(self, Matrix2::identity(), measurement.inner.coords, noise)
+    fn update(&mut self, measurement: MultivariateNormalDistribution<2>) {
+        KalmanFilter::update(
+            self,
+            Matrix2::identity(),
+            measurement.mean,
+            measurement.covariance,
+        )
     }
 }

--- a/crates/ball_filter/src/lib.rs
+++ b/crates/ball_filter/src/lib.rs
@@ -67,8 +67,7 @@ impl BallFilter {
     pub fn update(
         &mut self,
         detection_time: SystemTime,
-        measurement: Point2<Ground>,
-        noise: Matrix2<f32>,
+        measurement: MultivariateNormalDistribution<2>,
         matching_criterion: impl Fn(&BallHypothesis) -> bool,
     ) -> bool {
         let mut number_of_matching_hypotheses = 0;
@@ -79,7 +78,7 @@ impl BallFilter {
             .filter(|hypothesis| matching_criterion(hypothesis))
         {
             number_of_matching_hypotheses += 1;
-            hypothesis.update(detection_time, measurement, noise)
+            hypothesis.update(detection_time, measurement)
         }
 
         number_of_matching_hypotheses > 0

--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -135,11 +135,9 @@ impl BallFilter {
                         mean_position,
                     ) < filter_parameters.measurement_matching_distance
                 };
-                let measurement_noise = ball.percept_in_ground.covariance;
                 let is_any_hypothesis_updated = self.ball_filter.update(
                     detection_time,
-                    mean_position,
-                    measurement_noise,
+                    ball.percept_in_ground,
                     is_hypothesis_detected,
                 );
                 if !is_any_hypothesis_updated {

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -5,7 +5,7 @@ use context_attribute::context;
 use framework::{MainOutput, PerceptionInput};
 use serde::{Deserialize, Serialize};
 use types::{
-    ball::BallDetection,
+    ball::BallPercept,
     color::Rgb,
     cycle_time::CycleTime,
     filtered_whistle::FilteredWhistle,
@@ -37,8 +37,8 @@ pub struct CycleContext {
     is_own_referee_ready_pose_detected: Input<bool, "is_referee_ready_pose_detected">,
     did_detect_any_referee_this_cycle: Input<bool, "did_detect_any_referee_this_cycle">,
 
-    balls_bottom: PerceptionInput<Option<Vec<BallDetection>>, "VisionBottom", "balls?">,
-    balls_top: PerceptionInput<Option<Vec<BallDetection>>, "VisionTop", "balls?">,
+    balls_bottom: PerceptionInput<Option<Vec<BallPercept>>, "VisionBottom", "balls?">,
+    balls_top: PerceptionInput<Option<Vec<BallPercept>>, "VisionTop", "balls?">,
     network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message?">,
     sensor_data: Input<SensorData, "sensor_data">,
 }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -5,7 +5,7 @@ use context_attribute::context;
 use framework::{MainOutput, PerceptionInput};
 use serde::{Deserialize, Serialize};
 use types::{
-    ball::Ball,
+    ball::BallDetection,
     color::Rgb,
     cycle_time::CycleTime,
     filtered_whistle::FilteredWhistle,
@@ -37,8 +37,8 @@ pub struct CycleContext {
     is_own_referee_ready_pose_detected: Input<bool, "is_referee_ready_pose_detected">,
     did_detect_any_referee_this_cycle: Input<bool, "did_detect_any_referee_this_cycle">,
 
-    balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
-    balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,
+    balls_bottom: PerceptionInput<Option<Vec<BallDetection>>, "VisionBottom", "balls?">,
+    balls_top: PerceptionInput<Option<Vec<BallDetection>>, "VisionTop", "balls?">,
     network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message?">,
     sensor_data: Input<SensorData, "sensor_data">,
 }

--- a/crates/projection/src/camera_projection.rs
+++ b/crates/projection/src/camera_projection.rs
@@ -1,5 +1,5 @@
-use coordinate_systems::{Camera, Pixel};
-use linear_algebra::{point, Isometry3, Point2, Point3, Transform};
+use coordinate_systems::{Camera, NormalizedDeviceCoordinates, Pixel};
+use linear_algebra::{point, Isometry3, Point2, Point3, Transform, Vector3};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,11 @@ impl<From> CameraProjection<From> {
     pub fn project(&self, point: Point3<From>) -> Point2<Pixel> {
         let point_in_camera = self.extrinsic * point;
         self.intrinsic.project(point_in_camera.coords())
+    }
+
+    pub fn transform(&self, point: Point3<From>) -> Vector3<NormalizedDeviceCoordinates> {
+        let point_in_camera = self.extrinsic * point;
+        self.intrinsic.transform(point_in_camera.coords())
     }
 
     pub fn inverse(&self, z: f32) -> InverseCameraProjection<From> {
@@ -78,6 +83,10 @@ impl<To> InverseCameraProjection<To> {
     pub fn back_project_unchecked(&self, point: Point2<Pixel>) -> Point3<To> {
         let point_to = self.back_project.inner * point.inner.to_homogeneous();
         point![point_to.x / point_to.z, point_to.y / point_to.z, self.z]
+    }
+
+    pub fn as_matrix(&self) -> nalgebra::Matrix3<f32> {
+        self.back_project.inner
     }
 }
 

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -4,11 +4,12 @@ pub mod camera_projection;
 pub mod horizon;
 pub mod intrinsic;
 
+use nalgebra::{matrix, Matrix2};
 use thiserror::Error;
 
 use crate::camera_matrix::CameraMatrix;
 use coordinate_systems::{Camera, Ground, Pixel, Robot};
-use linear_algebra::{point, vector, Isometry3, Point2, Point3, Vector3};
+use linear_algebra::{point, vector, Isometry3, Point2, Point3, Vector2, Vector3};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -25,25 +26,30 @@ pub enum Error {
 pub trait Projection {
     fn bearing(&self, pixel_coordinates: Point2<Pixel>) -> Vector3<Camera>;
     fn camera_to_pixel(&self, camera_ray: Vector3<Camera>) -> Result<Point2<Pixel>, Error>;
-    fn pixel_to_ground(&self, pixel_coordinates: Point2<Pixel>) -> Result<Point2<Ground>, Error>;
-    fn pixel_to_ground_with_z(
+    fn get_pixel_radius(
         &self,
+        radius_in_ground_coordinates: f32,
         pixel_coordinates: Point2<Pixel>,
-        z: f32,
-    ) -> Result<Point2<Ground>, Error>;
+    ) -> Result<f32, Error>;
     fn ground_to_pixel(&self, ground_coordinates: Point2<Ground>) -> Result<Point2<Pixel>, Error>;
     fn ground_with_z_to_pixel(
         &self,
         ground_coordinates: Point2<Ground>,
         z: f32,
     ) -> Result<Point2<Pixel>, Error>;
-    fn robot_to_pixel(&self, robot_coordinates: Point3<Robot>) -> Result<Point2<Pixel>, Error>;
-    fn get_pixel_radius(
-        &self,
-        radius_in_ground_coordinates: f32,
-        pixel_coordinates: Point2<Pixel>,
-    ) -> Result<f32, Error>;
     fn is_above_horizon(&self, pixel: Point2<Pixel>, plane_height: f32) -> bool;
+    fn pixel_to_ground(&self, pixel_coordinates: Point2<Pixel>) -> Result<Point2<Ground>, Error>;
+    fn pixel_to_ground_with_z(
+        &self,
+        pixel_coordinates: Point2<Pixel>,
+        z: f32,
+    ) -> Result<Point2<Ground>, Error>;
+    fn project_noise_to_ground(
+        &self,
+        ground_coordinates: Point2<Ground>,
+        noise: Vector2<Pixel>,
+    ) -> Result<Matrix2<f32>, Error>;
+    fn robot_to_pixel(&self, robot_coordinates: Point3<Robot>) -> Result<Point2<Pixel>, Error>;
 }
 
 impl Projection for CameraMatrix {
@@ -138,6 +144,29 @@ impl Projection for CameraMatrix {
         );
 
         Ok(self.image_size.y() * angle / self.field_of_view.y)
+    }
+
+    fn project_noise_to_ground(
+        &self,
+        ground_coordinates: Point2<Ground>,
+        noise: Vector2<Pixel>,
+    ) -> Result<Matrix2<f32>, Error> {
+        let gamma = self
+            .ground_to_pixel
+            .transform(point![ground_coordinates.x(), ground_coordinates.y(), 0.0])
+            .z();
+        let inverse = self.pixel_to_ground.as_matrix();
+
+        let x = ground_coordinates.x();
+        let y = ground_coordinates.y();
+
+        let noise_projection = gamma
+            * matrix![
+                inverse.m11 - inverse.m31 * x, inverse.m12 - inverse.m32 * x;
+                inverse.m21 - inverse.m31 * y, inverse.m22 - inverse.m32 * y;
+            ];
+
+        Ok(noise_projection * Matrix2::from_diagonal(&noise.inner) * noise_projection.transpose())
     }
 
     fn bearing(&self, pixel_coordinates: Point2<Pixel>) -> Vector3<Camera> {

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -146,6 +146,7 @@ impl Projection for CameraMatrix {
         Ok(self.image_size.y() * angle / self.field_of_view.y)
     }
 
+    /// Projection based on <https://arxiv.org/abs/2312.08952>
     fn project_noise_to_ground(
         &self,
         ground_coordinates: Point2<Ground>,

--- a/crates/types/src/ball.rs
+++ b/crates/types/src/ball.rs
@@ -16,7 +16,7 @@ pub struct CandidateEvaluation {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
-pub struct BallDetection {
-    pub detection: MultivariateNormalDistribution<2>,
+pub struct BallPercept {
+    pub percept_in_ground: MultivariateNormalDistribution<2>,
     pub image_location: Circle<Pixel>,
 }

--- a/crates/types/src/ball.rs
+++ b/crates/types/src/ball.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use approx_derive::{AbsDiffEq, RelativeEq};
-use coordinate_systems::{Ground, Pixel};
+use coordinate_systems::Pixel;
 use geometry::circle::Circle;
-use linear_algebra::Point2;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
+
+use crate::multivariate_normal_distribution::MultivariateNormalDistribution;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, PathSerialize, PathIntrospect)]
 pub struct CandidateEvaluation {
@@ -15,20 +15,8 @@ pub struct CandidateEvaluation {
     pub merge_weight: Option<f32>,
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Deserialize,
-    Serialize,
-    PathSerialize,
-    PathDeserialize,
-    PathIntrospect,
-    AbsDiffEq,
-    RelativeEq,
-    PartialEq,
-)]
-#[abs_diff_eq(epsilon_type = f32)]
-pub struct Ball {
-    pub position: Point2<Ground>,
+#[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
+pub struct BallDetection {
+    pub detection: MultivariateNormalDistribution<2>,
     pub image_location: Circle<Pixel>,
 }

--- a/crates/types/src/multivariate_normal_distribution.rs
+++ b/crates/types/src/multivariate_normal_distribution.rs
@@ -3,7 +3,15 @@ use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+    PartialEq,
 )]
 pub struct MultivariateNormalDistribution<const DIMENSION: usize> {
     pub mean: SVector<f32, DIMENSION>,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -309,6 +309,7 @@ pub struct BallDetectionParameters {
     pub image_containment_merge_factor: f32,
     pub cluster_merge_radius_factor: f32,
     pub ball_radius_enlargement_factor: f32,
+    pub variance_of_detection: Vector2<Pixel>,
 }
 
 #[derive(

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -1,7 +1,7 @@
 use std::ops::{Index, Range};
 use std::{path::PathBuf, time::Duration};
 
-use coordinate_systems::{Field, Ground, NormalizedPixel};
+use coordinate_systems::{Field, Ground, NormalizedPixel, Pixel};
 use linear_algebra::{Point2, Pose2, Vector2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
@@ -309,7 +309,7 @@ pub struct BallDetectionParameters {
     pub image_containment_merge_factor: f32,
     pub cluster_merge_radius_factor: f32,
     pub ball_radius_enlargement_factor: f32,
-    pub variance_of_detection: Vector2<Pixel>,
+    pub detection_noise: Vector2<Pixel>,
 }
 
 #[derive(

--- a/crates/vision/src/ball_detection.rs
+++ b/crates/vision/src/ball_detection.rs
@@ -138,7 +138,7 @@ impl BallDetection {
         let balls = project_balls_to_ground(
             &clusters,
             context.camera_matrix,
-            context.parameters.variance_of_detection,
+            context.parameters.detection_noise,
             *context.ball_radius,
         );
 
@@ -511,7 +511,7 @@ mod tests {
             image_containment_merge_factor: 1.0,
             cluster_merge_radius_factor: 1.5,
             ball_radius_enlargement_factor: 2.0,
-            variance_of_detection: vector![0.0, 0.0],
+            detection_noise: vector![0.0, 0.0],
         };
         let perspective_grid_candidates = PerspectiveGridCandidates {
             candidates: vec![Circle {

--- a/crates/vision/src/feet_detection.rs
+++ b/crates/vision/src/feet_detection.rs
@@ -12,7 +12,7 @@ use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{distance, point, Point2};
 use projection::{camera_matrix::CameraMatrix, Projection};
 use types::{
-    ball::BallDetection,
+    ball::BallPercept,
     detected_feet::{ClusterPoint, CountedCluster, DetectedFeet},
     filtered_segments::FilteredSegments,
     image_segments::{EdgeType, ScanLine, Segment},
@@ -40,7 +40,7 @@ pub struct CycleContext {
     minimum_samples_per_cluster:
         Parameter<usize, "feet_detection.$cycler_instance.minimum_samples_per_cluster">,
 
-    balls: RequiredInput<Option<Vec<BallDetection>>, "balls?">,
+    balls: RequiredInput<Option<Vec<BallPercept>>, "balls?">,
     camera_matrix: RequiredInput<Option<CameraMatrix>, "camera_matrix?">,
     filtered_segments: Input<FilteredSegments, "filtered_segments">,
     line_data: RequiredInput<Option<LineData>, "line_data?">,
@@ -100,7 +100,7 @@ fn extract_segment_cluster_points(
     filtered_segments: &FilteredSegments,
     minimum_consecutive_segments: usize,
     minimum_luminance_standard_deviation: f32,
-    balls: &[BallDetection],
+    balls: &[BallPercept],
     line_data: &LineData,
     camera_matrix: &CameraMatrix,
 ) -> Vec<ClusterPoint> {
@@ -139,7 +139,7 @@ fn extract_segment_cluster_points(
 fn find_last_consecutive_cluster(
     scan_line: &ScanLine,
     line_data: &LineData,
-    balls: &[BallDetection],
+    balls: &[BallPercept],
     minimum_consecutive_segments: usize,
 ) -> Option<Vec<Segment>> {
     let filtered_segments = scan_line.segments.iter().filter(|segment| {

--- a/crates/vision/src/feet_detection.rs
+++ b/crates/vision/src/feet_detection.rs
@@ -12,7 +12,7 @@ use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{distance, point, Point2};
 use projection::{camera_matrix::CameraMatrix, Projection};
 use types::{
-    ball::Ball,
+    ball::BallDetection,
     detected_feet::{ClusterPoint, CountedCluster, DetectedFeet},
     filtered_segments::FilteredSegments,
     image_segments::{EdgeType, ScanLine, Segment},
@@ -40,7 +40,7 @@ pub struct CycleContext {
     minimum_samples_per_cluster:
         Parameter<usize, "feet_detection.$cycler_instance.minimum_samples_per_cluster">,
 
-    balls: RequiredInput<Option<Vec<Ball>>, "balls?">,
+    balls: RequiredInput<Option<Vec<BallDetection>>, "balls?">,
     camera_matrix: RequiredInput<Option<CameraMatrix>, "camera_matrix?">,
     filtered_segments: Input<FilteredSegments, "filtered_segments">,
     line_data: RequiredInput<Option<LineData>, "line_data?">,
@@ -100,7 +100,7 @@ fn extract_segment_cluster_points(
     filtered_segments: &FilteredSegments,
     minimum_consecutive_segments: usize,
     minimum_luminance_standard_deviation: f32,
-    balls: &[Ball],
+    balls: &[BallDetection],
     line_data: &LineData,
     camera_matrix: &CameraMatrix,
 ) -> Vec<ClusterPoint> {
@@ -139,7 +139,7 @@ fn extract_segment_cluster_points(
 fn find_last_consecutive_cluster(
     scan_line: &ScanLine,
     line_data: &LineData,
-    balls: &[Ball],
+    balls: &[BallDetection],
     minimum_consecutive_segments: usize,
 ) -> Option<Vec<Segment>> {
     let filtered_segments = scan_line.segments.iter().filter(|segment| {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -50,7 +50,7 @@
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
       "ball_radius_enlargement_factor": 2.0,
-      "variance_of_detection": [4.0, 4.0]
+      "detection_noise": [4.0, 4.0]
     },
     "vision_bottom": {
       "minimal_radius": 42.0,
@@ -65,7 +65,7 @@
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
       "ball_radius_enlargement_factor": 2.0,
-      "variance_of_detection": [4.0, 4.0]
+      "detection_noise": [4.0, 4.0]
     }
   },
   "camera_matrix_parameters": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -49,7 +49,8 @@
       "correction_proximity_merge_factor": 1.0,
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
-      "ball_radius_enlargement_factor": 2.0
+      "ball_radius_enlargement_factor": 2.0,
+      "variance_of_detection": [4.0, 4.0]
     },
     "vision_bottom": {
       "minimal_radius": 42.0,
@@ -63,7 +64,8 @@
       "correction_proximity_merge_factor": 1.0,
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
-      "ball_radius_enlargement_factor": 2.0
+      "ball_radius_enlargement_factor": 2.0,
+      "variance_of_detection": [4.0, 4.0]
     }
   },
   "camera_matrix_parameters": {

--- a/tools/twix/src/panels/image/overlays/ball_detection.rs
+++ b/tools/twix/src/panels/image/overlays/ball_detection.rs
@@ -5,7 +5,7 @@ use communication::client::{Cycler, CyclerOutput};
 use coordinate_systems::Pixel;
 use eframe::epaint::{Color32, Stroke};
 use geometry::circle::Circle;
-use types::ball::{Ball, CandidateEvaluation};
+use types::ball::{BallDetection as BallMeasurement, CandidateEvaluation};
 
 use crate::{
     panels::image::overlay::Overlay, twix_painter::TwixPainter, value_buffer::ValueBuffer,
@@ -60,7 +60,7 @@ impl Overlay for BallDetection {
             );
         }
 
-        let balls: Vec<Ball> = self.balls.require_latest()?;
+        let balls: Vec<BallMeasurement> = self.balls.require_latest()?;
         for ball in balls.iter() {
             let circle = ball.image_location;
             painter.circle_stroke(

--- a/tools/twix/src/panels/image/overlays/ball_detection.rs
+++ b/tools/twix/src/panels/image/overlays/ball_detection.rs
@@ -5,7 +5,7 @@ use communication::client::{Cycler, CyclerOutput};
 use coordinate_systems::Pixel;
 use eframe::epaint::{Color32, Stroke};
 use geometry::circle::Circle;
-use types::ball::{BallDetection as BallMeasurement, CandidateEvaluation};
+use types::ball::{BallPercept as BallMeasurement, CandidateEvaluation};
 
 use crate::{
     panels::image::overlay::Overlay, twix_painter::TwixPainter, value_buffer::ValueBuffer,

--- a/tools/twix/src/panels/map/layers/ball_measurements.rs
+++ b/tools/twix/src/panels/map/layers/ball_measurements.rs
@@ -6,7 +6,7 @@ use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::Ground;
 use linear_algebra::Point2;
-use types::{ball::BallMeasurement as BallDetection, field_dimensions::FieldDimensions};
+use types::{ball::BallDetection, field_dimensions::FieldDimensions};
 
 use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,

--- a/tools/twix/src/panels/map/layers/ball_measurements.rs
+++ b/tools/twix/src/panels/map/layers/ball_measurements.rs
@@ -6,7 +6,7 @@ use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::Ground;
 use linear_algebra::Point2;
-use types::{ball::BallDetection, field_dimensions::FieldDimensions};
+use types::{ball::BallPercept, field_dimensions::FieldDimensions};
 
 use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
@@ -44,12 +44,12 @@ impl Layer<Ground> for BallMeasurement {
         painter: &TwixPainter<Ground>,
         _field_dimensions: &FieldDimensions,
     ) -> Result<()> {
-        let balls_top: Vec<BallDetection> = self.detected_balls_top.parse_latest()?;
-        let balls_bottom: Vec<BallDetection> = self.detected_balls_bottom.parse_latest()?;
+        let balls_top: Vec<BallPercept> = self.detected_balls_top.parse_latest()?;
+        let balls_bottom: Vec<BallPercept> = self.detected_balls_bottom.parse_latest()?;
 
         for ball in balls_top.iter().chain(balls_bottom.iter()) {
-            let position = Point2::from(ball.detection.mean);
-            let covariance = ball.detection.covariance;
+            let position = Point2::from(ball.percept_in_ground.mean);
+            let covariance = ball.percept_in_ground.covariance;
 
             let stroke = Stroke::new(0.01, Color32::BLACK);
             painter.covariance(

--- a/tools/twix/src/panels/map/layers/ball_measurements.rs
+++ b/tools/twix/src/panels/map/layers/ball_measurements.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use color_eyre::Result;
+use communication::client::{Cycler, CyclerOutput, Output};
+use eframe::epaint::{Color32, Stroke};
+
+use coordinate_systems::Ground;
+use linear_algebra::Point2;
+use types::{ball::BallMeasurement as BallDetection, field_dimensions::FieldDimensions};
+
+use crate::{
+    nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
+};
+
+pub struct BallMeasurement {
+    detected_balls_top: ValueBuffer,
+    detected_balls_bottom: ValueBuffer,
+}
+
+impl Layer<Ground> for BallMeasurement {
+    const NAME: &'static str = "Ball Measurements";
+
+    fn new(nao: Arc<Nao>) -> Self {
+        let detected_balls_top = nao.subscribe_output(CyclerOutput {
+            cycler: Cycler::VisionTop,
+            output: Output::Main {
+                path: "balls".to_string(),
+            },
+        });
+        let detected_balls_bottom = nao.subscribe_output(CyclerOutput {
+            cycler: Cycler::VisionBottom,
+            output: Output::Main {
+                path: "balls".to_string(),
+            },
+        });
+        Self {
+            detected_balls_bottom,
+            detected_balls_top,
+        }
+    }
+
+    fn paint(
+        &self,
+        painter: &TwixPainter<Ground>,
+        _field_dimensions: &FieldDimensions,
+    ) -> Result<()> {
+        let balls_top: Vec<BallDetection> = self.detected_balls_top.parse_latest()?;
+        let balls_bottom: Vec<BallDetection> = self.detected_balls_bottom.parse_latest()?;
+
+        for ball in balls_top.iter().chain(balls_bottom.iter()) {
+            let position = Point2::from(ball.detection.mean);
+            let covariance = ball.detection.covariance;
+
+            let stroke = Stroke::new(0.01, Color32::BLACK);
+            painter.covariance(
+                position,
+                covariance,
+                stroke,
+                Color32::YELLOW.gamma_multiply(0.5),
+            );
+            painter.ball(position, 0.07);
+        }
+
+        Ok(())
+    }
+}

--- a/tools/twix/src/panels/map/layers/ball_position.rs
+++ b/tools/twix/src/panels/map/layers/ball_position.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr, sync::Arc};
 use color_eyre::Result;
 use eframe::epaint::Color32;
 
-use ball_filter::BallPosition;
+use ball_filter::BallPosition as FilteredPosition;
 use communication::client::CyclerOutput;
 use coordinate_systems::{Field, Ground};
 use linear_algebra::Isometry2;
@@ -13,12 +13,12 @@ use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::ValueBuffer,
 };
 
-pub struct BallPositionLayer {
+pub struct BallPosition {
     ground_to_field: ValueBuffer,
     ball_position: ValueBuffer,
 }
 
-impl Layer<Field> for BallPositionLayer {
+impl Layer<Field> for BallPosition {
     const NAME: &'static str = "Ball Position";
 
     fn new(nao: Arc<Nao>) -> Self {
@@ -41,7 +41,7 @@ impl Layer<Field> for BallPositionLayer {
     ) -> Result<()> {
         let ground_to_fields: Vec<Option<Isometry2<Ground, Field>>> =
             self.ground_to_field.parse_buffered()?;
-        let ball_positions: Vec<Option<BallPosition<Ground>>> =
+        let ball_positions: Vec<Option<FilteredPosition<Ground>>> =
             self.ball_position.parse_buffered()?;
 
         for (ball, ground_to_field) in ball_positions

--- a/tools/twix/src/panels/map/layers/mod.rs
+++ b/tools/twix/src/panels/map/layers/mod.rs
@@ -1,4 +1,5 @@
 mod ball_filter;
+mod ball_measurements;
 mod ball_position;
 mod ball_search_heatmap;
 mod behavior_simulator;
@@ -19,6 +20,7 @@ mod walking;
 
 pub use self::behavior_simulator::BehaviorSimulator;
 pub use ball_filter::BallFilter;
+pub use ball_measurements::BallMeasurement;
 pub use ball_position::BallPositionLayer as BallPosition;
 pub use ball_search_heatmap::BallSearchHeatmap;
 pub use feet_detection::FeetDetection;

--- a/tools/twix/src/panels/map/layers/mod.rs
+++ b/tools/twix/src/panels/map/layers/mod.rs
@@ -21,7 +21,7 @@ mod walking;
 pub use self::behavior_simulator::BehaviorSimulator;
 pub use ball_filter::BallFilter;
 pub use ball_measurements::BallMeasurement;
-pub use ball_position::BallPositionLayer as BallPosition;
+pub use ball_position::BallPosition;
 pub use ball_search_heatmap::BallSearchHeatmap;
 pub use feet_detection::FeetDetection;
 pub use field::Field;

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -81,6 +81,7 @@ pub struct MapPanel {
     robot_pose: EnabledLayer<layers::RobotPose, Ground>,
     referee_position: EnabledLayer<layers::RefereePosition, Field>,
     pose_detection: EnabledLayer<layers::PoseDetection, Field>,
+    ball_measurement: EnabledLayer<layers::BallMeasurement, Ground>,
     ball_position: EnabledLayer<layers::BallPosition, Field>,
     kick_decisions: EnabledLayer<layers::KickDecisions, Ground>,
     feet_detection: EnabledLayer<layers::FeetDetection, Ground>,
@@ -105,6 +106,7 @@ impl Panel for MapPanel {
         let referee_position = EnabledLayer::new(nao.clone(), value, true);
         let robot_pose = EnabledLayer::new(nao.clone(), value, true);
         let pose_detection = EnabledLayer::new(nao.clone(), value, true);
+        let ball_measurement = EnabledLayer::new(nao.clone(), value, false);
         let ball_position = EnabledLayer::new(nao.clone(), value, true);
         let kick_decisions = EnabledLayer::new(nao.clone(), value, false);
         let feet_detection = EnabledLayer::new(nao.clone(), value, false);
@@ -133,6 +135,7 @@ impl Panel for MapPanel {
             robot_pose,
             pose_detection,
             referee_position,
+            ball_measurement,
             ball_position,
             kick_decisions,
             feet_detection,
@@ -157,6 +160,7 @@ impl Panel for MapPanel {
             "pose_detection": self.referee_position.save(),
             "robot_pose": self.robot_pose.save(),
             "referee_position": self.referee_position.save(),
+            "ball_measurement": self.ball_measurement.save(),
             "ball_position": self.ball_position.save(),
             "kick_decisions": self.kick_decisions.save(),
             "feet_detection": self.feet_detection.save(),
@@ -183,6 +187,7 @@ impl Widget for &mut MapPanel {
                 self.pose_detection.checkbox(ui);
                 self.robot_pose.checkbox(ui);
                 self.referee_position.checkbox(ui);
+                self.ball_measurement.checkbox(ui);
                 self.ball_position.checkbox(ui);
                 self.kick_decisions.checkbox(ui);
                 self.feet_detection.checkbox(ui);
@@ -269,6 +274,9 @@ impl Widget for &mut MapPanel {
             .generic_paint(&painter, ground_to_field, &field_dimensions);
         let _ = self
             .pose_detection
+            .generic_paint(&painter, ground_to_field, &field_dimensions);
+        let _ = self
+            .ball_measurement
             .generic_paint(&painter, ground_to_field, &field_dimensions);
         let _ = self
             .ball_position

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -383,7 +383,7 @@ impl<World> TwixPainter<World> {
         } else if b == 0.0 && a < c {
             FRAC_PI_2
         } else {
-            b.atan2(l1 - a)
+            (l1 - a).atan2(b)
         };
         self.ellipse(position, l1.sqrt(), l2.sqrt(), theta, stroke, fill_color)
     }


### PR DESCRIPTION
## Why? What?

Propagate measurement noise in the image through the camera matrix. This makes the uncertainty computation more exact. To account for the robot moving, the uncertainty in image coordinates is scaled by a filtered gyro velocity norm.

Depends on #1044.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Put a ball in front of the robot and look at the new twix map overlay "Ball Measurements". The covariance is now dependent on the location of the ball relative to the robot. The ellipse is not correctly rotated, the issue is only in drawing, and will be fixed in #1036 
