### PR TITLE
Animation Mode

### DIFF
--- a/crates/control/src/behavior/animation.rs
+++ b/crates/control/src/behavior/animation.rs
@@ -2,7 +2,7 @@ use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_st
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
-        PrimaryState::Animation {stiff} => Some(MotionCommand::Animation {stiff}),
+        PrimaryState::Animation { stiff } => Some(MotionCommand::Animation { stiff }),
         _ => None,
     }
 }

--- a/crates/control/src/behavior/animation.rs
+++ b/crates/control/src/behavior/animation.rs
@@ -1,0 +1,8 @@
+use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_state::WorldState};
+
+pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
+    match world_state.robot.primary_state {
+        PrimaryState::Animation => Some(MotionCommand::Animation),
+        _ => None,
+    }
+}

--- a/crates/control/src/behavior/animation.rs
+++ b/crates/control/src/behavior/animation.rs
@@ -2,7 +2,7 @@ use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_st
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
-        PrimaryState::Animation => Some(MotionCommand::Animation),
+        PrimaryState::Animation => Some(MotionCommand::Animation {stiff: false}),
         _ => None,
     }
 }

--- a/crates/control/src/behavior/animation.rs
+++ b/crates/control/src/behavior/animation.rs
@@ -2,7 +2,7 @@ use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_st
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
-        PrimaryState::Animation => Some(MotionCommand::Animation {stiff: false}),
+        PrimaryState::Animation {stiff} => Some(MotionCommand::Animation {stiff}),
         _ => None,
     }
 }

--- a/crates/control/src/behavior/animationstiff.rs
+++ b/crates/control/src/behavior/animationstiff.rs
@@ -2,7 +2,7 @@ use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_st
 
 pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
     match world_state.robot.primary_state {
-        PrimaryState::AnimationStiff => Some(MotionCommand::AnimationStiff),
+        PrimaryState::AnimationStiff => Some(MotionCommand::Animation { stiff: true }),
         _ => None,
     }
 }

--- a/crates/control/src/behavior/animationstiff.rs
+++ b/crates/control/src/behavior/animationstiff.rs
@@ -1,0 +1,8 @@
+use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_state::WorldState};
+
+pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
+    match world_state.robot.primary_state {
+        PrimaryState::AnimationStiff => Some(MotionCommand::AnimationStiff),
+        _ => None,
+    }
+}

--- a/crates/control/src/behavior/animationstiff.rs
+++ b/crates/control/src/behavior/animationstiff.rs
@@ -1,8 +1,0 @@
-use types::{motion_command::MotionCommand, primary_state::PrimaryState, world_state::WorldState};
-
-pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
-    match world_state.robot.primary_state {
-        PrimaryState::AnimationStiff => Some(MotionCommand::Animation { stiff: true }),
-        _ => None,
-    }
-}

--- a/crates/control/src/behavior/mod.rs
+++ b/crates/control/src/behavior/mod.rs
@@ -1,3 +1,4 @@
+mod animation;
 mod calibrate;
 mod defend;
 mod dribble;
@@ -21,4 +22,3 @@ mod unstiff;
 mod walk_to_kick_off;
 mod walk_to_penalty_kick;
 pub mod walk_to_pose;
-mod animation;

--- a/crates/control/src/behavior/mod.rs
+++ b/crates/control/src/behavior/mod.rs
@@ -22,4 +22,3 @@ mod walk_to_kick_off;
 mod walk_to_penalty_kick;
 pub mod walk_to_pose;
 mod animation;
-mod animationstiff;

--- a/crates/control/src/behavior/mod.rs
+++ b/crates/control/src/behavior/mod.rs
@@ -21,3 +21,5 @@ mod unstiff;
 mod walk_to_kick_off;
 mod walk_to_penalty_kick;
 pub mod walk_to_pose;
+mod animation;
+mod animationstiff;

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -30,7 +30,7 @@ use types::{
 use crate::dribble_path_planner;
 
 use super::{
-    calibrate,
+    animation, calibrate,
     defend::Defend,
     dribble, fall_safely,
     head::LookAction,
@@ -38,7 +38,6 @@ use super::{
     prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off,
     walk_to_penalty_kick,
     walk_to_pose::{WalkAndStand, WalkPathPlanner},
-    animation,
 };
 
 #[derive(Deserialize, Serialize)]

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -125,7 +125,6 @@ impl Behavior {
         }
 
         let mut actions = vec![
-            Action::Animation,
             Action::Unstiff,
             Action::SitDown,
             Action::Penalize,
@@ -136,6 +135,7 @@ impl Behavior {
             Action::Stand,
             Action::InterceptBall,
             Action::Calibrate,
+            Action::Animation,
             Action::Animationstiff
         ];
 

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -38,7 +38,7 @@ use super::{
     prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off,
     walk_to_penalty_kick,
     walk_to_pose::{WalkAndStand, WalkPathPlanner},
-    animation, calibrate, defend::Defend, dribble, fall_safely, head::LookAction, initial, intercept_ball, jump, look_around, lost_ball, penalize, prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off, walk_to_penalty_kick, walk_to_pose::{WalkAndStand, WalkPathPlanner}
+    animation,
 };
 
 #[derive(Deserialize, Serialize)]
@@ -126,6 +126,7 @@ impl Behavior {
 
         let mut actions = vec![
             Action::Unstiff,
+            Action::Animation,
             Action::SitDown,
             Action::Penalize,
             Action::Initial,
@@ -135,7 +136,6 @@ impl Behavior {
             Action::Stand,
             Action::InterceptBall,
             Action::Calibrate,
-            Action::Animation,
         ];
 
         if let Some(active_since) = self.active_since {

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -38,6 +38,7 @@ use super::{
     prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off,
     walk_to_penalty_kick,
     walk_to_pose::{WalkAndStand, WalkPathPlanner},
+    animation, animationstiff, calibrate, defend::Defend, dribble, fall_safely, head::LookAction, initial, intercept_ball, jump, look_around, lost_ball, penalize, prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off, walk_to_penalty_kick, walk_to_pose::{WalkAndStand, WalkPathPlanner}
 };
 
 #[derive(Deserialize, Serialize)]
@@ -124,6 +125,7 @@ impl Behavior {
         }
 
         let mut actions = vec![
+            Action::Animation,
             Action::Unstiff,
             Action::SitDown,
             Action::Penalize,
@@ -134,6 +136,7 @@ impl Behavior {
             Action::Stand,
             Action::InterceptBall,
             Action::Calibrate,
+            Action::Animationstiff
         ];
 
         if let Some(active_since) = self.active_since {
@@ -244,6 +247,8 @@ impl Behavior {
             .iter()
             .find_map(|action| {
                 let motion_command = match action {
+                    Action::Animation => animation::execute(world_state),
+                    Action::Animationstiff => animationstiff::execute(world_state),
                     Action::Unstiff => unstiff::execute(world_state),
                     Action::SitDown => sit_down::execute(world_state),
                     Action::Penalize => penalize::execute(world_state),

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -38,7 +38,7 @@ use super::{
     prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off,
     walk_to_penalty_kick,
     walk_to_pose::{WalkAndStand, WalkPathPlanner},
-    animation, animationstiff, calibrate, defend::Defend, dribble, fall_safely, head::LookAction, initial, intercept_ball, jump, look_around, lost_ball, penalize, prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off, walk_to_penalty_kick, walk_to_pose::{WalkAndStand, WalkPathPlanner}
+    animation, calibrate, defend::Defend, dribble, fall_safely, head::LookAction, initial, intercept_ball, jump, look_around, lost_ball, penalize, prepare_jump, search, sit_down, stand, stand_up, support, unstiff, walk_to_kick_off, walk_to_penalty_kick, walk_to_pose::{WalkAndStand, WalkPathPlanner}
 };
 
 #[derive(Deserialize, Serialize)]
@@ -136,7 +136,6 @@ impl Behavior {
             Action::InterceptBall,
             Action::Calibrate,
             Action::Animation,
-            Action::Animationstiff
         ];
 
         if let Some(active_since) = self.active_since {
@@ -248,7 +247,6 @@ impl Behavior {
             .find_map(|action| {
                 let motion_command = match action {
                     Action::Animation => animation::execute(world_state),
-                    Action::Animationstiff => animationstiff::execute(world_state),
                     Action::Unstiff => unstiff::execute(world_state),
                     Action::SitDown => sit_down::execute(world_state),
                     Action::Penalize => penalize::execute(world_state),

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -96,7 +96,7 @@ impl ButtonFilter {
                 .unwrap()
                 >= calibration_buttons_timeout;
 
-        let animation_button_touched = touch_sensors.head_rear; 
+        let animation_button_touched = touch_sensors.head_rear;
 
         let animation_button_touched_initially =
             animation_button_touched && !self.last_animation_button_touched;
@@ -113,14 +113,12 @@ impl ButtonFilter {
                 .unwrap()
                 >= animation_button_timeout;
 
-             
-
         Ok(MainOutputs {
             buttons: Buttons {
                 is_chest_button_pressed_once: self.chest_button_tap_detector.is_single_tapped,
                 head_buttons_touched: debounced_head_buttons_touched,
                 calibration_buttons_touched: debounced_calibration_buttons_touched,
-                animation_button_touched: debounced_animation_button_touched,    
+                animation_button_touched: debounced_animation_button_touched,
             }
             .into(),
         })

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -14,7 +14,8 @@ pub struct ButtonFilter {
     last_head_buttons_touched: bool,
     calibration_buttons_touched: SystemTime,
     last_calibration_buttons_touched: bool,
-    animation_button_touched: SystemTime, 
+    animation_button_touched: SystemTime,
+    animation_button_released: TapDetector,
     last_animation_button_touched: bool,
 }
 
@@ -47,6 +48,7 @@ impl ButtonFilter {
             last_calibration_buttons_touched: false,
             animation_button_touched: UNIX_EPOCH,
             last_animation_button_touched: false,
+            animation_button_released: TapDetector::default(),
         })
     }
 

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -90,7 +90,8 @@ impl ButtonFilter {
 
         Ok(MainOutputs {
             buttons: Buttons {
-                is_chest_button_pressed: self.chest_button_tap_detector.is_single_tapped(),
+                is_chest_button_pressed_once: self.chest_button_tap_detector.is_single_tapped,
+                is_chest_button_pressed_twice: self.chest_button_tap_detector.is_double_tapped,
                 head_buttons_touched: debounced_head_buttons_touched,
                 calibration_buttons_touched: debounced_calibration_buttons_touched,
             }
@@ -98,3 +99,6 @@ impl ButtonFilter {
         })
     }
 }
+
+// I inserted this under MainOutputs Buttons
+//is_chest_button_pressed_twice: self.chest_button_tap_detector.is_double_tapped(),

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -39,12 +39,6 @@ impl ButtonFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             chest_button_tap_detector: TapDetector::default(),
-            //head_buttons_touched: UNIX_EPOCH,
-            //last_head_buttons_touched: false,
-            //calibration_buttons_touched: UNIX_EPOCH,
-            //last_calibration_buttons_touched: false,
-            //animation_buttons_touched: UNIX_EPOCH,
-            //last_animation_button_touched: false,
             debounced_head_button:DebounceButton::default(),
             debounced_calibration_button: DebounceButton::default(),
             debounced_animation_button: DebounceButton::default(),

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -39,7 +39,7 @@ impl ButtonFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             chest_button_tap_detector: TapDetector::default(),
-            debounced_head_button:DebounceButton::default(),
+            debounced_head_button: DebounceButton::default(),
             debounced_calibration_button: DebounceButton::default(),
             debounced_animation_button: DebounceButton::default(),
             animation_button_released: TapDetector::default(),
@@ -64,11 +64,12 @@ impl ButtonFilter {
         );
 
         let calibration_buttons_touched = touch_sensors.chest_button && touch_sensors.head_front;
-        let debounced_calibration_buttons_touched = self.debounced_calibration_button.debounce_button(
-            calibration_buttons_touched,
-            context.cycle_time.start_time,
-            calibration_buttons_timeout,
-        );
+        let debounced_calibration_buttons_touched =
+            self.debounced_calibration_button.debounce_button(
+                calibration_buttons_touched,
+                context.cycle_time.start_time,
+                calibration_buttons_timeout,
+            );
 
         let animation_buttons_touched = touch_sensors.head_rear;
 
@@ -91,33 +92,37 @@ impl ButtonFilter {
 }
 
 #[derive(Deserialize, Serialize)]
-struct DebounceButton{
-    last_button_touched:bool,
-    button_touched_time:SystemTime,
+struct DebounceButton {
+    last_button_touched: bool,
+    button_touched_time: SystemTime,
 }
 
 impl Default for DebounceButton {
     fn default() -> Self {
-        Self { last_button_touched: Default::default(), button_touched_time: UNIX_EPOCH }
+        Self {
+            last_button_touched: Default::default(),
+            button_touched_time: UNIX_EPOCH,
+        }
     }
 }
 
 impl DebounceButton {
+    pub fn debounce_button(
+        &mut self,
+        button_touched: bool,
+        current_time: SystemTime,
+        timeout: Duration,
+    ) -> bool {
+        let button_touched_initially = button_touched && !self.last_button_touched;
+        if button_touched_initially {
+            self.button_touched_time = current_time;
+        }
+        self.last_button_touched = button_touched;
 
-   pub fn debounce_button(
-    &mut self,
-    button_touched: bool,
-    current_time: SystemTime,
-    timeout: Duration,
-) -> bool {
-    let button_touched_initially = button_touched && !self.last_button_touched;
-    if button_touched_initially {
-        self.button_touched_time = current_time;
+        button_touched
+            && current_time
+                .duration_since(self.button_touched_time)
+                .unwrap()
+                >= timeout
     }
-    self.last_button_touched = button_touched;
-
-    button_touched && current_time.duration_since(self.button_touched_time).unwrap() >= timeout
-} 
 }
-
-

--- a/crates/control/src/button_filter.rs
+++ b/crates/control/src/button_filter.rs
@@ -1,8 +1,8 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use color_eyre::Result;
 use context_attribute::context;
-use filtering::tap_detector::TapDetector;
+use filtering::{debounce_button::DebounceButton, tap_detector::TapDetector};
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
 use types::{buttons::Buttons, cycle_time::CycleTime, sensor_data::SensorData};
@@ -81,48 +81,12 @@ impl ButtonFilter {
 
         Ok(MainOutputs {
             buttons: Buttons {
-                is_chest_button_pressed_once: self.chest_button_tap_detector.is_single_tapped,
+                is_chest_button_pressed_once: self.chest_button_tap_detector.is_single_tapped(),
                 head_buttons_touched: debounced_head_buttons_touched,
                 calibration_buttons_touched: debounced_calibration_buttons_touched,
                 animation_buttons_touched: debounced_animation_buttons_touched,
             }
             .into(),
         })
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-struct DebounceButton {
-    last_button_touched: bool,
-    button_touched_time: SystemTime,
-}
-
-impl Default for DebounceButton {
-    fn default() -> Self {
-        Self {
-            last_button_touched: Default::default(),
-            button_touched_time: UNIX_EPOCH,
-        }
-    }
-}
-
-impl DebounceButton {
-    pub fn debounce_button(
-        &mut self,
-        button_touched: bool,
-        current_time: SystemTime,
-        timeout: Duration,
-    ) -> bool {
-        let button_touched_initially = button_touched && !self.last_button_touched;
-        if button_touched_initially {
-            self.button_touched_time = current_time;
-        }
-        self.last_button_touched = button_touched;
-
-        button_touched
-            && current_time
-                .duration_since(self.button_touched_time)
-                .unwrap()
-                >= timeout
     }
 }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -283,8 +283,7 @@ impl LedStatus {
     ) -> (Eye, Eye) {
         match primary_state {
             PrimaryState::Unstiff
-            | PrimaryState::Animation { stiff: true }
-            | PrimaryState::Animation { stiff: false } => {
+            | PrimaryState::Animation {..} => {
                 let rainbow_eye = Self::get_rainbow_eye(cycle_start_time);
                 (rainbow_eye, rainbow_eye)
             }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -282,7 +282,7 @@ impl LedStatus {
         did_detect_any_referee_this_cycle: bool,
     ) -> (Eye, Eye) {
         match primary_state {
-            PrimaryState::Unstiff | PrimaryState::Animation {stiff: true} => {
+            PrimaryState::Unstiff | PrimaryState::Animation {stiff: true} | PrimaryState::Animation {stiff: false} => {
                 let rainbow_eye = Self::get_rainbow_eye(cycle_start_time);
                 (rainbow_eye, rainbow_eye)
             }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -84,6 +84,14 @@ impl LedStatus {
                 true => Rgb::BLUE,
                 false => Rgb::BLACK,
             },
+            PrimaryState::Animation => match self.blink_state {
+                true => Rgb::TURQUOISE,
+                false => Rgb::PURPLE,
+            },
+            PrimaryState::AnimationStiff => match self.blink_state {
+                true => Rgb::TURQUOISE,
+                false => Rgb::GREEN,
+            },
             PrimaryState::Initial => Rgb::BLACK,
             PrimaryState::Ready => Rgb::BLUE,
             PrimaryState::Set => Rgb::YELLOW,
@@ -277,7 +285,7 @@ impl LedStatus {
         did_detect_any_referee_this_cycle: bool,
     ) -> (Eye, Eye) {
         match primary_state {
-            PrimaryState::Unstiff => {
+            PrimaryState::Unstiff | PrimaryState::Animation => {
                 let rainbow_eye = Self::get_rainbow_eye(cycle_start_time);
                 (rainbow_eye, rainbow_eye)
             }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -97,7 +97,6 @@ impl LedStatus {
             PrimaryState::Finished => Rgb::BLACK,
             PrimaryState::Calibration => Rgb::PURPLE,
             PrimaryState::Standby => Rgb::TURQUOISE,
-            PrimaryState::Animation => Rgb::TURQUOISE
         };
 
         let at_least_one_ball_top =
@@ -282,8 +281,7 @@ impl LedStatus {
         did_detect_any_referee_this_cycle: bool,
     ) -> (Eye, Eye) {
         match primary_state {
-            PrimaryState::Unstiff
-            | PrimaryState::Animation {..} => {
+            PrimaryState::Unstiff | PrimaryState::Animation { .. } => {
                 let rainbow_eye = Self::get_rainbow_eye(cycle_start_time);
                 (rainbow_eye, rainbow_eye)
             }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -92,6 +92,7 @@ impl LedStatus {
             PrimaryState::Finished => Rgb::BLACK,
             PrimaryState::Calibration => Rgb::PURPLE,
             PrimaryState::Standby => Rgb::TURQUOISE,
+            PrimaryState::Animation => Rgb::TURQUOISE
         };
 
         let at_least_one_ball_top =

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -84,11 +84,11 @@ impl LedStatus {
                 true => Rgb::BLUE,
                 false => Rgb::BLACK,
             },
-            PrimaryState::Animation => match self.blink_state {
+            PrimaryState::Animation {stiff: false}=> match self.blink_state {
                 true => Rgb::TURQUOISE,
                 false => Rgb::PINK,
             },
-            PrimaryState::AnimationStiff => match self.blink_state {
+            PrimaryState::Animation {stiff:true} => match self.blink_state {
                 true => Rgb::PURPLE,
                 false => Rgb::GREEN,
             },
@@ -285,7 +285,7 @@ impl LedStatus {
         did_detect_any_referee_this_cycle: bool,
     ) -> (Eye, Eye) {
         match primary_state {
-            PrimaryState::Unstiff | PrimaryState::Animation => {
+            PrimaryState::Unstiff | PrimaryState::Animation {stiff: true} => {
                 let rainbow_eye = Self::get_rainbow_eye(cycle_start_time);
                 (rainbow_eye, rainbow_eye)
             }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -84,11 +84,11 @@ impl LedStatus {
                 true => Rgb::BLUE,
                 false => Rgb::BLACK,
             },
-            PrimaryState::Animation {stiff: false}=> match self.blink_state {
+            PrimaryState::Animation { stiff: false } => match self.blink_state {
                 true => Rgb::PINK,
                 false => Rgb::ORANGE,
             },
-            PrimaryState::Animation {stiff:true} => Rgb::TURQUOISE,
+            PrimaryState::Animation { stiff: true } => Rgb::TURQUOISE,
             PrimaryState::Initial => Rgb::BLACK,
             PrimaryState::Ready => Rgb::BLUE,
             PrimaryState::Set => Rgb::YELLOW,
@@ -282,7 +282,9 @@ impl LedStatus {
         did_detect_any_referee_this_cycle: bool,
     ) -> (Eye, Eye) {
         match primary_state {
-            PrimaryState::Unstiff | PrimaryState::Animation {stiff: true} | PrimaryState::Animation {stiff: false} => {
+            PrimaryState::Unstiff
+            | PrimaryState::Animation { stiff: true }
+            | PrimaryState::Animation { stiff: false } => {
                 let rainbow_eye = Self::get_rainbow_eye(cycle_start_time);
                 (rainbow_eye, rainbow_eye)
             }

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -85,13 +85,10 @@ impl LedStatus {
                 false => Rgb::BLACK,
             },
             PrimaryState::Animation {stiff: false}=> match self.blink_state {
-                true => Rgb::TURQUOISE,
-                false => Rgb::PINK,
+                true => Rgb::PINK,
+                false => Rgb::ORANGE,
             },
-            PrimaryState::Animation {stiff:true} => match self.blink_state {
-                true => Rgb::PURPLE,
-                false => Rgb::GREEN,
-            },
+            PrimaryState::Animation {stiff:true} => Rgb::TURQUOISE,
             PrimaryState::Initial => Rgb::BLACK,
             PrimaryState::Ready => Rgb::BLUE,
             PrimaryState::Set => Rgb::YELLOW,

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -86,10 +86,10 @@ impl LedStatus {
             },
             PrimaryState::Animation => match self.blink_state {
                 true => Rgb::TURQUOISE,
-                false => Rgb::PURPLE,
+                false => Rgb::PINK,
             },
             PrimaryState::AnimationStiff => match self.blink_state {
-                true => Rgb::TURQUOISE,
+                true => Rgb::PURPLE,
                 false => Rgb::GREEN,
             },
             PrimaryState::Initial => Rgb::BLACK,

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -1,14 +1,10 @@
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
-use hardware::PathsInterface;
 use serde::{Deserialize, Serialize};
 use types::{
-    condition_input::ConditionInput,
-    cycle_time::CycleTime,
     joints::Joints,
     motion_command::MotionCommand,
-    motion_selection::MotionSelection,
     motor_commands::MotorCommands,
     sensor_data::SensorData,
 };
@@ -20,14 +16,11 @@ pub struct Animation {
 
 #[context]
 pub struct CreationContext {
-    hardware_interface: HardwareInterface,
+    
 }
 
 #[context]
 pub struct CycleContext {
-    condition_input: Input<ConditionInput, "condition_input">,
-    cycle_time: Input<CycleTime, "cycle_time">,
-    motion_selection: Input<MotionSelection, "motion_selection">,
     sensor_data: Input<SensorData, "sensor_data">,
     motion_command: Input<MotionCommand, "motion_command">,
 }
@@ -39,8 +32,7 @@ pub struct MainOutputs {
 }
 
 impl Animation {
-    pub fn new(context: CreationContext<impl PathsInterface>) -> Result<Self> {
-        let paths = context.hardware_interface.get_paths();
+    pub fn new(context: CreationContext) -> Result<Self> {
         Ok(Self {
             save_joints_value: Joints::default(),
         })

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -3,9 +3,7 @@ use context_attribute::context;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
 use types::{
-    joints::Joints,
-    motion_command::MotionCommand,
-    motor_commands::MotorCommands,
+    joints::Joints, motion_command::MotionCommand, motor_commands::MotorCommands,
     sensor_data::SensorData,
 };
 
@@ -15,9 +13,7 @@ pub struct Animation {
 }
 
 #[context]
-pub struct CreationContext {
-    
-}
+pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
@@ -49,8 +45,11 @@ impl Animation {
         };
         let output = match context.motion_command {
             MotionCommand::Animation { stiff: true } => animation_stiff_command,
-            MotionCommand::Animation { stiff: false } => {self.save_joints_value = context.sensor_data.positions; animation_unstiff_command},
-                                                     _=> Default::default(),
+            MotionCommand::Animation { stiff: false } => {
+                self.save_joints_value = context.sensor_data.positions;
+                animation_unstiff_command
+            }
+            _ => Default::default(),
         };
 
         Ok(MainOutputs {

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use color_eyre::Result;
+use context_attribute::context;
+use framework::MainOutput;
+use hardware::PathsInterface;
+use motionfile::MotionFile;
+use serde::{Deserialize, Serialize};
+use types::{
+    condition_input::ConditionInput,
+    cycle_time::CycleTime,
+    joints::Joints,
+    motion_command::{self, MotionCommand},
+    motion_selection::{self, MotionSafeExits, MotionSelection, MotionType},
+    motor_commands::{self, MotorCommands},
+    sensor_data::SensorData,
+};
+
+#[derive(Deserialize, Serialize)]
+pub struct Animation {
+    save_joints_value: Joints<f32>, //here we want to output joint values
+}
+
+#[context]
+pub struct CreationContext {
+    hardware_interface: HardwareInterface,
+}
+
+#[context]
+pub struct CycleContext {
+    condition_input: Input<ConditionInput, "condition_input">,
+    cycle_time: Input<CycleTime, "cycle_time">,
+    motion_selection: Input<MotionSelection, "motion_selection">,
+    sensor_data: Input<SensorData, "sensor_data">,
+    motion_command: Input<MotionCommand, "motion_command">,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub animation_positions: MainOutput<MotorCommands<Joints<f32>>>,
+}
+
+impl Animation {
+    pub fn new(context: CreationContext<impl PathsInterface>) -> Result<Self> {
+        let paths = context.hardware_interface.get_paths();
+        Ok(Self {
+            save_joints_value: Joints::default(),
+        })
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        let animation_unstiff_command = MotorCommands {
+            positions: context.sensor_data.positions,
+            stiffnesses: Joints::fill(0.0),
+        };
+        let animation_stiff_command = MotorCommands {
+            positions: self.save_joints_value,
+            stiffnesses: Joints::fill(1.0),
+        };
+        let output = match context.motion_command {
+            MotionCommand::Animation { stiff: true } => animation_stiff_command,
+            MotionCommand::Animation { stiff: false } => {self.save_joints_value = context.sensor_data.positions; animation_unstiff_command},
+                                                     _=> Default::default(),
+        };
+
+        Ok(MainOutputs {
+            animation_positions: framework::MainOutput { value: output },
+        })
+    }
+}

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -28,7 +28,7 @@ pub struct CycleContext {
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
-    pub animation_positions: MainOutput<MotorCommands<Joints<f32>>>,
+    pub animation_commands: MainOutput<MotorCommands<Joints<f32>>>,
 }
 
 impl Animation {
@@ -54,7 +54,7 @@ impl Animation {
         };
 
         Ok(MainOutputs {
-            animation_positions: framework::MainOutput { value: output },
+            animation_commands: framework::MainOutput { value: output },
         })
     }
 }

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -32,7 +32,7 @@ pub struct MainOutputs {
 }
 
 impl Animation {
-    pub fn new(context: CreationContext) -> Result<Self> {
+    pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             save_joints_value: Joints::default(),
         })

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -1,18 +1,15 @@
-use std::time::Duration;
-
 use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
-use motionfile::MotionFile;
 use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
     joints::Joints,
-    motion_command::{self, MotionCommand},
-    motion_selection::{self, MotionSafeExits, MotionSelection, MotionType},
-    motor_commands::{self, MotorCommands},
+    motion_command::MotionCommand,
+    motion_selection::MotionSelection,
+    motor_commands::MotorCommands,
     sensor_data::SensorData,
 };
 

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -9,7 +9,7 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct Animation {
-    save_joints_value: Joints<f32>,
+    saved_joint_values: Joints<f32>,
 }
 
 #[context]
@@ -30,7 +30,7 @@ pub struct MainOutputs {
 impl Animation {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
-            save_joints_value: Joints::default(),
+            saved_joint_values: Joints::default(),
         })
     }
 
@@ -40,13 +40,13 @@ impl Animation {
             stiffnesses: Joints::fill(0.0),
         };
         let animation_stiff_command = MotorCommands {
-            positions: self.save_joints_value,
+            positions: self.saved_joint_values,
             stiffnesses: Joints::fill(1.0),
         };
         let output = match context.motion_command {
             MotionCommand::Animation { stiff: true } => animation_stiff_command,
             MotionCommand::Animation { stiff: false } => {
-                self.save_joints_value = context.sensor_data.positions;
+                self.saved_joint_values = context.sensor_data.positions;
                 animation_unstiff_command
             }
             _ => Default::default(),

--- a/crates/control/src/motion/animation.rs
+++ b/crates/control/src/motion/animation.rs
@@ -9,7 +9,7 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct Animation {
-    save_joints_value: Joints<f32>, //here we want to output joint values
+    save_joints_value: Joints<f32>,
 }
 
 #[context]

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -25,7 +25,7 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
-    animation_commands: Input<MotorCommands<Joints<f32>>, "animation_commands">, 
+    animation_commands: Input<MotorCommands<Joints<f32>>, "animation_commands">,
     arms_up_squat_joints_command: Input<MotorCommands<Joints<f32>>, "arms_up_squat_joints_command">,
     jump_left_joints_command: Input<MotorCommands<Joints<f32>>, "jump_left_joints_command">,
     jump_right_joints_command: Input<MotorCommands<Joints<f32>>, "jump_right_joints_command">,

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -25,6 +25,7 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
+    animation_commands: Input<MotorCommands<Joints<f32>>, "animation_commands">, 
     arms_up_squat_joints_command: Input<MotorCommands<Joints<f32>>, "arms_up_squat_joints_command">,
     jump_left_joints_command: Input<MotorCommands<Joints<f32>>, "jump_left_joints_command">,
     jump_right_joints_command: Input<MotorCommands<Joints<f32>>, "jump_right_joints_command">,
@@ -99,8 +100,8 @@ impl DispatchingInterpolator {
                 MotionType::StandUpFront => *context.stand_up_front_positions,
                 MotionType::StandUpSitting => *context.stand_up_sitting_positions,
                 MotionType::Unstiff => panic!("Dispatching Unstiff doesn't make sense"),
-                MotionType::Animation => panic!("Dispatching Animation doesn't make sense"),
-                MotionType::AnimationStiff => panic!("Dispatching AnimationStiff should not happen"),
+                MotionType::Animation => context.animation_commands.positions,
+                MotionType::AnimationStiff => context.animation_commands.positions,
                 MotionType::Walk => Joints::from_head_and_body(
                     HeadJoints::fill(0.0),
                     context.walk_motor_commands.positions,

--- a/crates/control/src/motion/dispatching_interpolator.rs
+++ b/crates/control/src/motion/dispatching_interpolator.rs
@@ -99,6 +99,8 @@ impl DispatchingInterpolator {
                 MotionType::StandUpFront => *context.stand_up_front_positions,
                 MotionType::StandUpSitting => *context.stand_up_sitting_positions,
                 MotionType::Unstiff => panic!("Dispatching Unstiff doesn't make sense"),
+                MotionType::Animation => panic!("Dispatching Animation doesn't make sense"),
+                MotionType::AnimationStiff => panic!("Dispatching AnimationStiff should not happen"),
                 MotionType::Walk => Joints::from_head_and_body(
                     HeadJoints::fill(0.0),
                     context.walk_motor_commands.positions,

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -133,6 +133,14 @@ impl HeadMotion {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
+            Some(HeadMotionCommand::Animation) => HeadMotorCommands {
+                positions: context.sensor_data.positions.head,
+                stiffnesses: HeadJoints::fill(0.0),
+            },
+            Some(HeadMotionCommand::AnimationStiff) => HeadMotorCommands {
+                positions: context.sensor_data.positions.head,
+                stiffnesses: HeadJoints::fill(1.0),
+            },
             Some(HeadMotionCommand::ZeroAngles) | None => MotorCommands {
                 positions: Default::default(),
                 stiffnesses,

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -133,11 +133,11 @@ impl HeadMotion {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
-            Some(HeadMotionCommand::Animation) => HeadMotorCommands {
+            Some(HeadMotionCommand::Animation) => MotorCommands {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
-            Some(HeadMotionCommand::AnimationStiff) => HeadMotorCommands {
+            Some(HeadMotionCommand::AnimationStiff) => MotorCommands {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(1.0),
             },

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -133,11 +133,11 @@ impl HeadMotion {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
-            Some(HeadMotionCommand::Animation {stiff:false}) => MotorCommands {
+            Some(HeadMotionCommand::Animation { stiff: false }) => MotorCommands {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
-            Some(HeadMotionCommand::Animation {stiff:true}) => MotorCommands {
+            Some(HeadMotionCommand::Animation { stiff: true }) => MotorCommands {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(1.0),
             },

--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -133,11 +133,11 @@ impl HeadMotion {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
-            Some(HeadMotionCommand::Animation) => MotorCommands {
+            Some(HeadMotionCommand::Animation {stiff:false}) => MotorCommands {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(0.0),
             },
-            Some(HeadMotionCommand::AnimationStiff) => MotorCommands {
+            Some(HeadMotionCommand::Animation {stiff:true}) => MotorCommands {
                 positions: context.sensor_data.positions.head,
                 stiffnesses: HeadJoints::fill(1.0),
             },

--- a/crates/control/src/motion/mod.rs
+++ b/crates/control/src/motion/mod.rs
@@ -1,3 +1,4 @@
+pub mod animation;
 pub mod arms_up_squat;
 pub mod command_sender;
 pub mod condition_input_provider;

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -86,8 +86,8 @@ fn motion_type_from_command(command: &MotionCommand) -> MotionType {
             Kind::Sitting => MotionType::StandUpSitting,
         },
         MotionCommand::Unstiff => MotionType::Unstiff,
-        MotionCommand::Animation => MotionType::Animation,
-        MotionCommand::AnimationStiff => MotionType::AnimationStiff,
+        MotionCommand::Animation { stiff: false } => MotionType::Animation,
+        MotionCommand::Animation { stiff: true } => MotionType::AnimationStiff,
         MotionCommand::Walk { .. } => MotionType::Walk,
         MotionCommand::InWalkKick { .. } => MotionType::Walk,
     }
@@ -117,6 +117,10 @@ fn transition_motion(
         (MotionType::Dispatching, true, _, _) => to,
         (MotionType::Stand, _, MotionType::Walk, _) => MotionType::Walk,
         (MotionType::Walk, _, MotionType::Stand, _) => MotionType::Stand,
+        (MotionType::Unstiff | MotionType::AnimationStiff, true, MotionType::Animation, _) => {
+            MotionType::Animation
+        }
+        (MotionType::Animation, true, MotionType::AnimationStiff, _) => MotionType::AnimationStiff,
         (from, true, to, _) if from != to => MotionType::Dispatching,
         _ => from,
     }

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -86,6 +86,8 @@ fn motion_type_from_command(command: &MotionCommand) -> MotionType {
             Kind::Sitting => MotionType::StandUpSitting,
         },
         MotionCommand::Unstiff => MotionType::Unstiff,
+        MotionCommand::Animation => MotionType::Animation,
+        MotionCommand::AnimationStiff => MotionType::AnimationStiff,
         MotionCommand::Walk { .. } => MotionType::Walk,
         MotionCommand::InWalkKick { .. } => MotionType::Walk,
     }

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -64,7 +64,7 @@ impl MotorCommandCollector {
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let measured_positions = context.sensor_data.positions;
         let _current_positions = context.sensor_data.positions;
-        let animation = context.animation_commands;    
+        let animation = context.animation_commands;
         let dispatching_command = context.dispatching_command;
         let fall_protection_positions = context.fall_protection_command.positions;
         let fall_protection_stiffnesses = context.fall_protection_command.stiffnesses;

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -21,6 +21,7 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
+    animation_positions: Input<MotorCommands<Joints<f32>>, "animation_positions">,
     arms_up_squat_joints_command: Input<MotorCommands<Joints<f32>>, "arms_up_squat_joints_command">,
     dispatching_command: Input<MotorCommands<Joints<f32>>, "dispatching_command">,
     fall_protection_command: Input<MotorCommands<Joints<f32>>, "fall_protection_command">,
@@ -62,6 +63,8 @@ impl MotorCommandCollector {
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let measured_positions = context.sensor_data.positions;
+        let current_positions = context.sensor_data.positions;
+        let animation_positions = context.animation_positions;    
         let dispatching_command = context.dispatching_command;
         let fall_protection_positions = context.fall_protection_command.positions;
         let fall_protection_stiffnesses = context.fall_protection_command.stiffnesses;

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -21,7 +21,7 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
-    animation_positions: Input<MotorCommands<Joints<f32>>, "animation_positions">,
+    animation_commands: Input<MotorCommands<Joints<f32>>, "animation_commands">,
     arms_up_squat_joints_command: Input<MotorCommands<Joints<f32>>, "arms_up_squat_joints_command">,
     dispatching_command: Input<MotorCommands<Joints<f32>>, "dispatching_command">,
     fall_protection_command: Input<MotorCommands<Joints<f32>>, "fall_protection_command">,
@@ -63,8 +63,8 @@ impl MotorCommandCollector {
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let measured_positions = context.sensor_data.positions;
-        let current_positions = context.sensor_data.positions;
-        let animation = context.animation_positions;    
+        let _current_positions = context.sensor_data.positions;
+        let animation = context.animation_commands;    
         let dispatching_command = context.dispatching_command;
         let fall_protection_positions = context.fall_protection_command.positions;
         let fall_protection_stiffnesses = context.fall_protection_command.stiffnesses;

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -64,7 +64,7 @@ impl MotorCommandCollector {
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let measured_positions = context.sensor_data.positions;
         let current_positions = context.sensor_data.positions;
-        let animation_positions = context.animation_positions;    
+        let animation = context.animation_positions;    
         let dispatching_command = context.dispatching_command;
         let fall_protection_positions = context.fall_protection_command.positions;
         let fall_protection_stiffnesses = context.fall_protection_command.stiffnesses;
@@ -80,8 +80,8 @@ impl MotorCommandCollector {
         let walk = context.walk_motor_commands;
 
         let (positions, stiffnesses) = match motion_selection.current_motion {
-            MotionType::Animation => (current_positions, Joints::fill(0.0)),
-            MotionType::AnimationStiff => (current_positions, Joints::fill(1.0)),
+            MotionType::Animation => (animation.positions, animation.stiffnesses),
+            MotionType::AnimationStiff => (animation.positions, animation.stiffnesses),
             MotionType::ArmsUpSquat => (arms_up_squat.positions, arms_up_squat.stiffnesses),
             MotionType::Dispatching => {
                 self.current_minimizer.reset();

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -77,6 +77,8 @@ impl MotorCommandCollector {
         let walk = context.walk_motor_commands;
 
         let (positions, stiffnesses) = match motion_selection.current_motion {
+            MotionType::Animation => (current_positions, Joints::fill(0.0)),
+            MotionType::AnimationStiff => (current_positions, Joints::fill(1.0)),
             MotionType::ArmsUpSquat => (arms_up_squat.positions, arms_up_squat.stiffnesses),
             MotionType::Dispatching => {
                 self.current_minimizer.reset();

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -166,7 +166,6 @@ impl MotorCommandCollector {
             ),
         };
 
-
         let compensated_positions = positions + *context.joint_calibration_offsets;
         let motor_commands = MotorCommands {
             positions: compensated_positions,

--- a/crates/control/src/motion/motor_commands_collector.rs
+++ b/crates/control/src/motion/motor_commands_collector.rs
@@ -63,7 +63,6 @@ impl MotorCommandCollector {
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
         let measured_positions = context.sensor_data.positions;
-        let _current_positions = context.sensor_data.positions;
         let animation = context.animation_commands;
         let dispatching_command = context.dispatching_command;
         let fall_protection_positions = context.fall_protection_command.positions;
@@ -167,8 +166,7 @@ impl MotorCommandCollector {
             ),
         };
 
-        // The actuators use the raw sensor data (not corrected like current_positions) in their feedback loops,
-        // thus the compensation is required to make them reach the actual desired position.
+
         let compensated_positions = positions + *context.joint_calibration_offsets;
         let motor_commands = MotorCommands {
             positions: compensated_positions,

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -64,7 +64,7 @@ impl PrimaryStateFilter {
             context.buttons.is_chest_button_pressed_once,
             context.buttons.calibration_buttons_touched,
             context.filtered_game_controller_state,               //these four lines translate to four positions down there (_,_,_,_)
-            context.buttons.is_chest_button_pressed_twice,
+            context.buttons.animation_button_touched,
         ) {
             // Animation transitions 
             
@@ -91,7 +91,7 @@ impl PrimaryStateFilter {
                     is_penalized,
                 )
             }
-            (_, _, _, _, Some(filtered_game_controller_state))
+            (_, _, _, _, Some(filtered_game_controller_state),_)
                 if {
                     let finished_to_initial = self.last_primary_state == PrimaryState::Finished
                         && filtered_game_controller_state.game_state == FilteredGameState::Initial;

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -63,12 +63,11 @@ impl PrimaryStateFilter {
             context.buttons.head_buttons_touched,
             context.buttons.is_chest_button_pressed_once,
             context.buttons.calibration_buttons_touched,
-            context.filtered_game_controller_state,               //these four lines translate to four positions down there (_,_,_,_)
+            context.filtered_game_controller_state, //these four lines translate to four positions down there (_,_,_,_)
             context.buttons.animation_button_touched,
         ) {
-            // Animation transitions 
-            
-            
+            // Animation transitions
+
             // Unstiff transitions (entering and exiting)
             (last_primary_state, true, _, _, _, _) => {
                 if last_primary_state != PrimaryState::Unstiff {
@@ -84,14 +83,14 @@ impl PrimaryStateFilter {
             (PrimaryState::Initial, _, _, true, _, _) => PrimaryState::Calibration,
 
             // GameController transitions (entering listening mode and staying within)
-            (PrimaryState::Unstiff, _, true, _, Some(filtered_game_controller_state),_)
-            | (PrimaryState::Finished, _, true, _, Some(filtered_game_controller_state),_) => {
+            (PrimaryState::Unstiff, _, true, _, Some(filtered_game_controller_state), _)
+            | (PrimaryState::Finished, _, true, _, Some(filtered_game_controller_state), _) => {
                 Self::game_state_to_primary_state(
                     filtered_game_controller_state.game_state,
                     is_penalized,
                 )
             }
-            (_, _, _, _, Some(filtered_game_controller_state),_)
+            (_, _, _, _, Some(filtered_game_controller_state), _)
                 if {
                     let finished_to_initial = self.last_primary_state == PrimaryState::Finished
                         && filtered_game_controller_state.game_state == FilteredGameState::Initial;
@@ -107,8 +106,17 @@ impl PrimaryStateFilter {
 
             // non-GameController transitions
             (PrimaryState::Unstiff, _, true, _, None, _) => PrimaryState::Initial,
-            (PrimaryState::Unstiff|PrimaryState::Animation {stiff:true}, _, false, _, None, true) => PrimaryState::Animation {stiff:false}, //here double tap = true & single tap = false => Animation mode
-            (PrimaryState::Animation{..}, _, true, _, None, false) => PrimaryState::Animation {stiff:true},
+            (
+                PrimaryState::Unstiff | PrimaryState::Animation { stiff: true },
+                _,
+                false,
+                _,
+                None,
+                true,
+            ) => PrimaryState::Animation { stiff: false }, //here double tap = true & single tap = false => Animation mode
+            (PrimaryState::Animation { .. }, _, true, _, None, false) => {
+                PrimaryState::Animation { stiff: true }
+            }
             (PrimaryState::Finished, _, true, _, None, _) => PrimaryState::Initial,
             (PrimaryState::Initial, _, true, _, None, _) => PrimaryState::Penalized,
             (PrimaryState::Penalized, _, true, _, None, _) => PrimaryState::Playing,

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -107,8 +107,8 @@ impl PrimaryStateFilter {
 
             // non-GameController transitions
             (PrimaryState::Unstiff, _, true, _, None, _) => PrimaryState::Initial,
-            (PrimaryState::Unstiff, _, false, _, None, true) => PrimaryState::Animation, //here double tap = true & single tap = false => Animation mode
-            (PrimaryState::Animation, _, false, _, None, true) => PrimaryState::AnimationStiff,
+            (PrimaryState::Unstiff|PrimaryState::Animation {stiff:true}, _, false, _, None, true) => PrimaryState::Animation {stiff:false}, //here double tap = true & single tap = false => Animation mode
+            (PrimaryState::Animation{..}, _, true, _, None, false) => PrimaryState::Animation {stiff:true},
             (PrimaryState::Finished, _, true, _, None, _) => PrimaryState::Initial,
             (PrimaryState::Initial, _, true, _, None, _) => PrimaryState::Penalized,
             (PrimaryState::Penalized, _, true, _, None, _) => PrimaryState::Playing,

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -63,10 +63,9 @@ impl PrimaryStateFilter {
             context.buttons.head_buttons_touched,
             context.buttons.is_chest_button_pressed_once,
             context.buttons.calibration_buttons_touched,
-            context.filtered_game_controller_state, 
+            context.filtered_game_controller_state,
             context.buttons.animation_buttons_touched,
         ) {
-
             // Unstiff transitions (entering and exiting)
             (last_primary_state, true, _, _, _, _) => {
                 if last_primary_state != PrimaryState::Unstiff {
@@ -112,7 +111,7 @@ impl PrimaryStateFilter {
                 _,
                 None,
                 true,
-            ) => PrimaryState::Animation { stiff: false }, 
+            ) => PrimaryState::Animation { stiff: false },
             (PrimaryState::Animation { .. }, _, true, _, None, false) => {
                 PrimaryState::Animation { stiff: true }
             }

--- a/crates/control/src/primary_state_filter.rs
+++ b/crates/control/src/primary_state_filter.rs
@@ -63,10 +63,9 @@ impl PrimaryStateFilter {
             context.buttons.head_buttons_touched,
             context.buttons.is_chest_button_pressed_once,
             context.buttons.calibration_buttons_touched,
-            context.filtered_game_controller_state, //these four lines translate to four positions down there (_,_,_,_)
-            context.buttons.animation_button_touched,
+            context.filtered_game_controller_state, 
+            context.buttons.animation_buttons_touched,
         ) {
-            // Animation transitions
 
             // Unstiff transitions (entering and exiting)
             (last_primary_state, true, _, _, _, _) => {
@@ -113,7 +112,7 @@ impl PrimaryStateFilter {
                 _,
                 None,
                 true,
-            ) => PrimaryState::Animation { stiff: false }, //here double tap = true & single tap = false => Animation mode
+            ) => PrimaryState::Animation { stiff: false }, 
             (PrimaryState::Animation { .. }, _, true, _, None, false) => {
                 PrimaryState::Animation { stiff: true }
             }

--- a/crates/filtering/src/debounce_button.rs
+++ b/crates/filtering/src/debounce_button.rs
@@ -1,0 +1,39 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct DebounceButton {
+    last_button_touched: bool,
+    button_touched_time: SystemTime,
+}
+
+impl Default for DebounceButton {
+    fn default() -> Self {
+        Self {
+            last_button_touched: Default::default(),
+            button_touched_time: UNIX_EPOCH,
+        }
+    }
+}
+
+impl DebounceButton {
+    pub fn debounce_button(
+        &mut self,
+        button_touched: bool,
+        current_time: SystemTime,
+        timeout: Duration,
+    ) -> bool {
+        let button_touched_initially = button_touched && !self.last_button_touched;
+        if button_touched_initially {
+            self.button_touched_time = current_time;
+        }
+        self.last_button_touched = button_touched;
+
+        button_touched
+            && current_time
+                .duration_since(self.button_touched_time)
+                .unwrap()
+                >= timeout
+    }
+}

--- a/crates/filtering/src/lib.rs
+++ b/crates/filtering/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod debounce_button;
 pub mod hysteresis;
 pub mod kalman_filter;
 pub mod low_pass_filter;

--- a/crates/filtering/src/tap_detector.rs
+++ b/crates/filtering/src/tap_detector.rs
@@ -21,16 +21,15 @@ impl TapDetector {
         //             //compares the type Duration with the 500 ms, if it's less than that, double tap is true
         //             self.is_single_tapped = false;
         //             self.is_double_tapped = true;
-        //         } 
+        //         }
         //     }
-        // } 
+        // }
         // self.last_reading = sensor_reading;
     }
-    
+
     pub fn is_single_tapped(&self) -> bool {
         self.is_single_tapped
     }
-  
 }
 // to detect double tap, detect two falling edges,
 // we need detect tap time, but the time between tap has to not be too long, else it should be a single tap,

--- a/crates/filtering/src/tap_detector.rs
+++ b/crates/filtering/src/tap_detector.rs
@@ -1,36 +1,35 @@
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
 
 #[derive(Default, Deserialize, Serialize)]
 /// Detects an falling edge of two state sensor reading
 pub struct TapDetector {
     last_reading: bool,
     pub is_single_tapped: bool,
-    pub is_double_tapped: bool,
-    #[serde(skip_serializing, skip_deserializing)] //this is suppose to somehow avoid the error
-    last_tap_time: Option<Instant>, //stores the time value for the last tapped
 }
 
 impl TapDetector {
     pub fn update(&mut self, sensor_reading: bool) {
         self.is_single_tapped = self.last_reading && !sensor_reading;
-        //self.last_reading = sensor_reading;
-
-        self.is_double_tapped = false;
-        if self.is_single_tapped {
-            if let Some(last_tap_time) = self.last_tap_time {
-                //defining the last_tap_time
-                let time_since_last_tap: Duration = Instant::now().duration_since(last_tap_time); //defining the Duration
-                if time_since_last_tap <= Duration::from_millis(500) {
-                    //compares the type Duration with the 1000 ms, if it's less than that, double tap is true
-                    self.is_single_tapped = false;
-                    self.is_double_tapped = true;
-                } 
-            }
-        } 
         self.last_reading = sensor_reading;
-    }
 
+        // self.is_double_tapped = false;
+        // if self.is_single_tapped {
+        //     if let Some(last_tap_time) = self.last_tap_time {
+        //         //defining the last_tap_time
+        //         let time_since_last_tap: Duration = Instant::now().duration_since(last_tap_time); //defining the Duration
+        //         if time_since_last_tap <= Duration::from_millis(500) {
+        //             //compares the type Duration with the 500 ms, if it's less than that, double tap is true
+        //             self.is_single_tapped = false;
+        //             self.is_double_tapped = true;
+        //         } 
+        //     }
+        // } 
+        // self.last_reading = sensor_reading;
+    }
+    
+    pub fn is_single_tapped(&self) -> bool {
+        self.is_single_tapped
+    }
   
 }
 // to detect double tap, detect two falling edges,

--- a/crates/filtering/src/tap_detector.rs
+++ b/crates/filtering/src/tap_detector.rs
@@ -1,19 +1,41 @@
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 #[derive(Default, Deserialize, Serialize)]
 /// Detects an falling edge of two state sensor reading
 pub struct TapDetector {
     last_reading: bool,
-    is_single_tapped: bool,
+    pub is_single_tapped: bool,
+    pub is_double_tapped: bool,
+    #[serde(skip_serializing, skip_deserializing)] //this is suppose to somehow avoid the error
+    last_tap_time: Option<Instant>, //stores the time value for the last tapped
 }
 
 impl TapDetector {
     pub fn update(&mut self, sensor_reading: bool) {
         self.is_single_tapped = self.last_reading && !sensor_reading;
+        //self.last_reading = sensor_reading;
+
+        self.is_double_tapped = false;
+        if self.is_single_tapped {
+            if let Some(last_tap_time) = self.last_tap_time {
+                //defining the last_tap_time
+                let time_since_last_tap: Duration = Instant::now().duration_since(last_tap_time); //defining the Duration
+                if time_since_last_tap <= Duration::from_millis(500) {
+                    //compares the type Duration with the 1000 ms, if it's less than that, double tap is true
+                    self.is_single_tapped = false;
+                    self.is_double_tapped = true;
+                } 
+            }
+        } 
         self.last_reading = sensor_reading;
     }
 
-    pub fn is_single_tapped(&self) -> bool {
-        self.is_single_tapped
-    }
+  
 }
+// to detect double tap, detect two falling edges,
+// we need detect tap time, but the time between tap has to not be too long, else it should be a single tap,
+// store the time between taps, if falling edge detected within 1s, then double tap detected.
+// go into button filter then and add double tap there as well
+// then this double tap can be the entry to animation mode?
+// add a pb fn is_double_tapped?

--- a/crates/filtering/src/tap_detector.rs
+++ b/crates/filtering/src/tap_detector.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Deserialize, Serialize)]
-/// Detects an falling edge of two state sensor reading
 pub struct TapDetector {
     last_reading: bool,
     pub is_single_tapped: bool,
@@ -11,29 +10,9 @@ impl TapDetector {
     pub fn update(&mut self, sensor_reading: bool) {
         self.is_single_tapped = self.last_reading && !sensor_reading;
         self.last_reading = sensor_reading;
-
-        // self.is_double_tapped = false;
-        // if self.is_single_tapped {
-        //     if let Some(last_tap_time) = self.last_tap_time {
-        //         //defining the last_tap_time
-        //         let time_since_last_tap: Duration = Instant::now().duration_since(last_tap_time); //defining the Duration
-        //         if time_since_last_tap <= Duration::from_millis(500) {
-        //             //compares the type Duration with the 500 ms, if it's less than that, double tap is true
-        //             self.is_single_tapped = false;
-        //             self.is_double_tapped = true;
-        //         }
-        //     }
-        // }
-        // self.last_reading = sensor_reading;
     }
 
     pub fn is_single_tapped(&self) -> bool {
         self.is_single_tapped
     }
 }
-// to detect double tap, detect two falling edges,
-// we need detect tap time, but the time between tap has to not be too long, else it should be a single tap,
-// store the time between taps, if falling edge detected within 1s, then double tap detected.
-// go into button filter then and add double tap there as well
-// then this double tap can be the entry to animation mode?
-// add a pb fn is_double_tapped?

--- a/crates/filtering/src/tap_detector.rs
+++ b/crates/filtering/src/tap_detector.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Deserialize, Serialize)]
+/// Detects a falling edge of two state sensor readings
 pub struct TapDetector {
     last_reading: bool,
-    pub is_single_tapped: bool,
+    is_single_tapped: bool,
 }
 
 impl TapDetector {

--- a/crates/hulk_behavior_simulator/src/state.rs
+++ b/crates/hulk_behavior_simulator/src/state.rs
@@ -165,6 +165,7 @@ impl State {
                 }
                 HeadMotion::Unstiff => 0.0,
                 HeadMotion::Animation => 0.0,
+                HeadMotion::AnimationStiff => 0.0,
             };
 
             let max_head_rotation_per_cycle =

--- a/crates/hulk_behavior_simulator/src/state.rs
+++ b/crates/hulk_behavior_simulator/src/state.rs
@@ -164,6 +164,7 @@ impl State {
                         + glance_factor * robot.parameters.look_at.glance_angle
                 }
                 HeadMotion::Unstiff => 0.0,
+                HeadMotion::Animation => 0.0,
             };
 
             let max_head_rotation_per_cycle =

--- a/crates/hulk_behavior_simulator/src/state.rs
+++ b/crates/hulk_behavior_simulator/src/state.rs
@@ -164,8 +164,7 @@ impl State {
                         + glance_factor * robot.parameters.look_at.glance_angle
                 }
                 HeadMotion::Unstiff => 0.0,
-                HeadMotion::Animation => 0.0,
-                HeadMotion::AnimationStiff => 0.0,
+                HeadMotion::Animation {..} => 0.0,
             };
 
             let max_head_rotation_per_cycle =

--- a/crates/hulk_behavior_simulator/src/state.rs
+++ b/crates/hulk_behavior_simulator/src/state.rs
@@ -164,7 +164,7 @@ impl State {
                         + glance_factor * robot.parameters.look_at.glance_angle
                 }
                 HeadMotion::Unstiff => 0.0,
-                HeadMotion::Animation {..} => 0.0,
+                HeadMotion::Animation { .. } => 0.0,
             };
 
             let max_head_rotation_per_cycle =

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -59,6 +59,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "control::kinematics_provider",
                     "control::led_status",
                     "control::localization",
+                    "control::motion::animation",
                     "control::motion::arms_up_squat",
                     "control::motion::command_sender",
                     "control::motion::condition_input_provider",

--- a/crates/types/src/action.rs
+++ b/crates/types/src/action.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 )]
 pub enum Action {
     Animation,
-    Animationstiff,
     Calibrate,
     DefendGoal,
     DefendKickOff,

--- a/crates/types/src/action.rs
+++ b/crates/types/src/action.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
     Debug, Clone, Copy, PathSerialize, PathDeserialize, PathIntrospect, Serialize, Deserialize,
 )]
 pub enum Action {
+    Animation,
+    Animationstiff,
     Calibrate,
     DefendGoal,
     DefendKickOff,

--- a/crates/types/src/buttons.rs
+++ b/crates/types/src/buttons.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct Buttons {
     pub is_chest_button_pressed_once: bool,
-    pub is_chest_button_pressed_twice: bool,
     pub head_buttons_touched: bool,
     pub calibration_buttons_touched: bool,
+    pub animation_button_touched: bool,
 }

--- a/crates/types/src/buttons.rs
+++ b/crates/types/src/buttons.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
     Default, Clone, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect, Debug,
 )]
 pub struct Buttons {
-    pub is_chest_button_pressed: bool,
+    pub is_chest_button_pressed_once: bool,
+    pub is_chest_button_pressed_twice: bool,
     pub head_buttons_touched: bool,
     pub calibration_buttons_touched: bool,
 }

--- a/crates/types/src/buttons.rs
+++ b/crates/types/src/buttons.rs
@@ -8,5 +8,5 @@ pub struct Buttons {
     pub is_chest_button_pressed_once: bool,
     pub head_buttons_touched: bool,
     pub calibration_buttons_touched: bool,
-    pub animation_button_touched: bool,
+    pub animation_buttons_touched: bool,
 }

--- a/crates/types/src/color.rs
+++ b/crates/types/src/color.rs
@@ -146,7 +146,8 @@ impl Rgb {
     pub const PURPLE: Rgb = Rgb::new(255, 0, 255);
     pub const TURQUOISE: Rgb = Rgb::new(0, 255, 255);
     pub const WHITE: Rgb = Rgb::new(255, 255, 255);
-    pub const PINK: Rgb = Rgb::new(255, 182, 193);
+    pub const PINK: Rgb = Rgb::new(250, 45, 208);
+    pub const ORANGE: Rgb = Rgb::new(255,69,0); 
 
     pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }

--- a/crates/types/src/color.rs
+++ b/crates/types/src/color.rs
@@ -146,6 +146,7 @@ impl Rgb {
     pub const PURPLE: Rgb = Rgb::new(255, 0, 255);
     pub const TURQUOISE: Rgb = Rgb::new(0, 255, 255);
     pub const WHITE: Rgb = Rgb::new(255, 255, 255);
+    pub const PINK: Rgb = Rgb::new(255, 182, 193);
 
     pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }

--- a/crates/types/src/color.rs
+++ b/crates/types/src/color.rs
@@ -147,7 +147,7 @@ impl Rgb {
     pub const TURQUOISE: Rgb = Rgb::new(0, 255, 255);
     pub const WHITE: Rgb = Rgb::new(255, 255, 255);
     pub const PINK: Rgb = Rgb::new(250, 45, 208);
-    pub const ORANGE: Rgb = Rgb::new(255,69,0); 
+    pub const ORANGE: Rgb = Rgb::new(255, 69, 0);
 
     pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -44,8 +44,10 @@ pub enum MotionCommand {
     },
     #[default]
     Unstiff,
-    Animation,
-    AnimationStiff,
+    Animation {
+        stiff: bool,
+    },
+
     Walk {
         head: HeadMotion,
         path: Vec<PathSegment>,
@@ -73,8 +75,8 @@ impl MotionCommand {
             | MotionCommand::InWalkKick { head, .. } => Some(*head),
             MotionCommand::Penalized => Some(HeadMotion::ZeroAngles),
             MotionCommand::Unstiff => Some(HeadMotion::Unstiff),
-            MotionCommand::Animation => Some(HeadMotion::Animation),
-            MotionCommand::AnimationStiff => Some(HeadMotion::AnimationStiff),
+            MotionCommand::Animation { stiff: false } => Some(HeadMotion::Animation),
+            MotionCommand::Animation { stiff: true } => Some(HeadMotion::AnimationStiff),
             MotionCommand::ArmsUpSquat
             | MotionCommand::FallProtection { .. }
             | MotionCommand::Jump { .. }

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -44,6 +44,8 @@ pub enum MotionCommand {
     },
     #[default]
     Unstiff,
+    Animation,
+    AnimationStiff,
     Walk {
         head: HeadMotion,
         path: Vec<PathSegment>,
@@ -71,6 +73,8 @@ impl MotionCommand {
             | MotionCommand::InWalkKick { head, .. } => Some(*head),
             MotionCommand::Penalized => Some(HeadMotion::ZeroAngles),
             MotionCommand::Unstiff => Some(HeadMotion::Unstiff),
+            MotionCommand::Animation => Some(HeadMotion::Animation),
+            MotionCommand::AnimationStiff => Some(HeadMotion::AnimationStiff),
             MotionCommand::ArmsUpSquat
             | MotionCommand::FallProtection { .. }
             | MotionCommand::Jump { .. }
@@ -126,6 +130,8 @@ pub enum HeadMotion {
         target: Point2<Ground>,
     },
     Unstiff,
+    Animation,
+    AnimationStiff,
 }
 
 #[derive(

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -47,7 +47,6 @@ pub enum MotionCommand {
     Animation {
         stiff: bool,
     },
-
     Walk {
         head: HeadMotion,
         path: Vec<PathSegment>,
@@ -75,8 +74,7 @@ impl MotionCommand {
             | MotionCommand::InWalkKick { head, .. } => Some(*head),
             MotionCommand::Penalized => Some(HeadMotion::ZeroAngles),
             MotionCommand::Unstiff => Some(HeadMotion::Unstiff),
-            MotionCommand::Animation { stiff: false } => Some(HeadMotion::Animation),
-            MotionCommand::Animation { stiff: true } => Some(HeadMotion::AnimationStiff),
+            MotionCommand::Animation { stiff} => Some(HeadMotion::Animation {stiff: *stiff}),
             MotionCommand::ArmsUpSquat
             | MotionCommand::FallProtection { .. }
             | MotionCommand::Jump { .. }
@@ -132,8 +130,9 @@ pub enum HeadMotion {
         target: Point2<Ground>,
     },
     Unstiff,
-    Animation,
-    AnimationStiff,
+    Animation {
+        stiff: bool,
+    },
 }
 
 #[derive(

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -74,7 +74,7 @@ impl MotionCommand {
             | MotionCommand::InWalkKick { head, .. } => Some(*head),
             MotionCommand::Penalized => Some(HeadMotion::ZeroAngles),
             MotionCommand::Unstiff => Some(HeadMotion::Unstiff),
-            MotionCommand::Animation { stiff} => Some(HeadMotion::Animation {stiff: *stiff}),
+            MotionCommand::Animation { stiff } => Some(HeadMotion::Animation { stiff: *stiff }),
             MotionCommand::ArmsUpSquat
             | MotionCommand::FallProtection { .. }
             | MotionCommand::Jump { .. }

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -24,6 +24,8 @@ pub struct MotionSelection {
     PathIntrospect,
 )]
 pub enum MotionType {
+    Animation,
+    AnimationStiff,
     ArmsUpSquat,
     Dispatching,
     FallProtection,
@@ -48,6 +50,8 @@ impl Default for MotionType {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
 pub struct MotionSafeExits {
+    animation: bool,
+    animationstiff: bool,
     arms_up_squat: bool,
     dispatching: bool,
     fall_protection: bool,
@@ -88,6 +92,8 @@ impl MotionSafeExits {
 impl Default for MotionSafeExits {
     fn default() -> Self {
         Self {
+            animation: true,
+            animationstiff: true,
             arms_up_squat: true,
             dispatching: false,
             fall_protection: true,
@@ -111,6 +117,8 @@ impl Index<MotionType> for MotionSafeExits {
 
     fn index(&self, motion_type: MotionType) -> &Self::Output {
         match motion_type {
+            MotionType::Animation => &self.animation,
+            MotionType::AnimationStiff => &self.animationstiff,  
             MotionType::ArmsUpSquat => &self.arms_up_squat,
             MotionType::Dispatching => &self.dispatching,
             MotionType::Initial => &self.initial,
@@ -132,6 +140,8 @@ impl Index<MotionType> for MotionSafeExits {
 impl IndexMut<MotionType> for MotionSafeExits {
     fn index_mut(&mut self, motion_type: MotionType) -> &mut Self::Output {
         match motion_type {
+            MotionType::Animation => &mut self.animation,
+            MotionType::AnimationStiff => &mut self.animationstiff,
             MotionType::ArmsUpSquat => &mut self.arms_up_squat,
             MotionType::Dispatching => &mut self.dispatching,
             MotionType::Initial => &mut self.initial,

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -120,7 +120,7 @@ impl Index<MotionType> for MotionSafeExits {
     fn index(&self, motion_type: MotionType) -> &Self::Output {
         match motion_type {
             MotionType::Animation => &self.animation,
-            MotionType::AnimationStiff => &self.animationstiff,  
+            MotionType::AnimationStiff => &self.animationstiff,
             MotionType::ArmsUpSquat => &self.arms_up_squat,
             MotionType::Dispatching => &self.dispatching,
             MotionType::Initial => &self.initial,

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -71,6 +71,8 @@ pub struct MotionSafeExits {
 impl MotionSafeExits {
     pub fn fill(value: bool) -> Self {
         Self {
+            animation: value,
+            animationstiff: value,
             arms_up_squat: value,
             dispatching: value,
             fall_protection: value,

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -51,7 +51,7 @@ impl Default for MotionType {
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
 pub struct MotionSafeExits {
     animation: bool,
-    animationstiff: bool,
+    animation_stiff: bool,
     arms_up_squat: bool,
     dispatching: bool,
     fall_protection: bool,
@@ -72,7 +72,7 @@ impl MotionSafeExits {
     pub fn fill(value: bool) -> Self {
         Self {
             animation: value,
-            animationstiff: value,
+            animation_stiff: value,
             arms_up_squat: value,
             dispatching: value,
             fall_protection: value,
@@ -95,7 +95,7 @@ impl Default for MotionSafeExits {
     fn default() -> Self {
         Self {
             animation: true,
-            animationstiff: true,
+            animation_stiff: true,
             arms_up_squat: true,
             dispatching: false,
             fall_protection: true,
@@ -120,7 +120,7 @@ impl Index<MotionType> for MotionSafeExits {
     fn index(&self, motion_type: MotionType) -> &Self::Output {
         match motion_type {
             MotionType::Animation => &self.animation,
-            MotionType::AnimationStiff => &self.animationstiff,
+            MotionType::AnimationStiff => &self.animation_stiff,
             MotionType::ArmsUpSquat => &self.arms_up_squat,
             MotionType::Dispatching => &self.dispatching,
             MotionType::Initial => &self.initial,
@@ -143,7 +143,7 @@ impl IndexMut<MotionType> for MotionSafeExits {
     fn index_mut(&mut self, motion_type: MotionType) -> &mut Self::Output {
         match motion_type {
             MotionType::Animation => &mut self.animation,
-            MotionType::AnimationStiff => &mut self.animationstiff,
+            MotionType::AnimationStiff => &mut self.animation_stiff,
             MotionType::ArmsUpSquat => &mut self.arms_up_squat,
             MotionType::Dispatching => &mut self.dispatching,
             MotionType::Initial => &mut self.initial,

--- a/crates/types/src/primary_state.rs
+++ b/crates/types/src/primary_state.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 pub enum PrimaryState {
     #[default]
     Animation,
+    AnimationStiff,
     Unstiff,
     Initial,
     Ready,

--- a/crates/types/src/primary_state.rs
+++ b/crates/types/src/primary_state.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub enum PrimaryState {
     #[default]
+    Animation,
     Unstiff,
     Initial,
     Ready,

--- a/crates/types/src/primary_state.rs
+++ b/crates/types/src/primary_state.rs
@@ -18,7 +18,9 @@ use serde::{Deserialize, Serialize};
 pub enum PrimaryState {
     #[default]
     Unstiff,
-    Animation {stiff: bool},
+    Animation {
+        stiff: bool,
+    },
     Initial,
     Ready,
     Set,

--- a/crates/types/src/primary_state.rs
+++ b/crates/types/src/primary_state.rs
@@ -17,9 +17,9 @@ use serde::{Deserialize, Serialize};
 )]
 pub enum PrimaryState {
     #[default]
+    Unstiff,
     Animation,
     AnimationStiff,
-    Unstiff,
     Initial,
     Ready,
     Set,

--- a/crates/types/src/primary_state.rs
+++ b/crates/types/src/primary_state.rs
@@ -18,8 +18,7 @@ use serde::{Deserialize, Serialize};
 pub enum PrimaryState {
     #[default]
     Unstiff,
-    Animation,
-    AnimationStiff,
+    Animation {stiff: bool},
     Initial,
     Ready,
     Set,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -391,6 +391,10 @@
     "calibration_buttons_timeout": {
       "nanos": 0,
       "secs": 1
+    },
+    "animation_button_timeout": {
+      "nanos": 0,
+      "secs": 2
     }
   },
   "center_head_position": {


### PR DESCRIPTION
## Why? What?

With this PR we have created a new mode for the robot. It is the Photo-shoot Mode, which is called "Animation Mode" in our case. This mode allows you to create different poses for the robots, so that you can take photos!

Before we have the problem that it's difficult to make the robot pose for pictures, because in the normal Unstiff state, the joints are not stiffed, so when a pose is made for photos in this state, the robots joints still move. With this mode, a button can be pressed to make all joints fixed.

Fixes #646 

## Ideas for Next Iterations (Not This PR)

This PR is the first iteration for this mode.  There is still a level of impracticality to make the robot make certain poses, for example, the stand pose, because you have to manually make the robot stand. That becomes difficult because currently we have only one button that controls and changes the stiffness of ALL of the joints. 

Next iteration would be to assign different buttons to move different joints. For example, Head rear button for the arms joints, head front button for the knee joints, etc. That is the improvement that could be done in the next iteration.

## How to Test

To enter the Animation mode:

- First, the robot must be in Unstiff state. 
- Press & Hold "Head rear button" for 3-4 seconds -> Now the robot is in "Animation Unstiff" state 
   -> Animation Unstiff: Chest button blinks Pink/Orange + Rainbow eyes
- Make a pose for the robot -> Press "Chest button" to enter "Animation Stiff" state
   -> Animation Stiff: Chest button lights up Turquoise + Rainbow eyes
- Now take a picture! 
- To go back to "Animation Unstiff", press the "Head rear button" for 3-4 seconds.
- To get out of Animation Mode to Unstiff -> Just press the "Unstiff" head buttons 
