### PR TITLE
Durchdrängeln

### DIFF
--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -97,7 +97,7 @@ impl<'cycle> WalkPathPlanner<'cycle> {
             .plan(Point::origin(), clamped_target_in_robot)
             .unwrap();
         path_obstacles_output.fill_if_subscribed(|| planner.obstacles.clone());
-        path.unwrap_or_else(|| direct_path(Point::origin(), Point::origin()))
+        path.unwrap_or_else(|| direct_path(Point::origin(), target_in_ground))
     }
 
     pub fn walk_with_obstacle_avoiding_arms(


### PR DESCRIPTION
## Why? What?

Currently when the dribble path planner cannot find a valid path, it just outputs a path with a "zero" segment, causing the robot to be stuck in place.
With this PR it just walks to the target ignoring all obstacles. Hopefully this is sensible in the short term and path planning can kick in again after a short period of time.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
