### PR TITLE
Robustify SDK installation

### DIFF
--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -339,6 +339,7 @@ impl Repository {
                     .wrap_err("failed to download SDK")?;
             }
             if sdk.exists() {
+                println!("Removing incomplete SDK directory...");
                 remove_dir_all(&sdk)
                     .await
                     .wrap_err("failed to remove old SDK directory")?;

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -29,8 +29,8 @@ use serde_json::{from_slice, from_str, to_string_pretty, to_value, Value};
 use tempfile::{tempdir, TempDir};
 use tokio::{
     fs::{
-        create_dir_all, read_dir, read_link, read_to_string, remove_file, rename, set_permissions,
-        symlink, try_exists, write, File,
+        create_dir_all, read_dir, read_link, read_to_string, remove_dir_all, remove_file, rename,
+        set_permissions, symlink, try_exists, write, File,
     },
     io::AsyncReadExt,
     process::Command,
@@ -338,6 +338,12 @@ impl Repository {
                     .await
                     .wrap_err("failed to download SDK")?;
             }
+            if sdk.exists() {
+                remove_dir_all(&sdk)
+                    .await
+                    .wrap_err("failed to remove old SDK directory")?;
+            }
+
             File::create(&incomplete_marker)
                 .await
                 .wrap_err("failed to create marker")?;


### PR DESCRIPTION
## Why? What?

SDK installation leads to an inconsistent state when interrupted, see linked issue.
This PR solves the issue by creating a marker file before installing the sdk and only removing the marker again when installation finishes successfully. Thus, a failed or aborted installation will not be mistaken for a successful one because the "is already installed check" fails if the marker file is present.

Fixes #1052 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

0. Make sure you don't have the most recent sdk installed (remove or rename the 7.4.2 directory)
1. Begin sdk installation `./pepsi sdk install`
2. Abort sdk installation during extraction
3. Try to build for nao `./pepsi build --target nao`

On main this should fail due to the sdk installation being incomplete.
With this change, the command in step 3 will prompt for sdk installation again.