### PR TITLE
Add support for aach64 SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,7 +4497,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    env::{self, current_dir},
+    env::{self, consts::ARCH, current_dir},
     ffi::OsStr,
     fmt::Display,
     fs::Permissions,
@@ -338,7 +338,7 @@ impl Repository {
 
         if !sdk.exists() {
             let downloads_directory = installation_directory.join("downloads");
-            let installer_name = format!("HULKs-OS-x86_64-toolchain-{version}.sh");
+            let installer_name = format!("HULKs-OS-{ARCH}-toolchain-{version}.sh");
             let installer_path = downloads_directory.join(&installer_name);
             if !installer_path.exists() {
                 download_sdk(&downloads_directory, version, &installer_name)

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.10.0"
+version = "3.11.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Why? What?

This PR adds support for using aarch64 SDKs.

## ToDo / Known Issues

We currently don't have any linux aarch64 users, so testing this might be difficult.

## Ideas for Next Iterations (Not This PR)

None

## How to Test

```sh
./pepsi build --target nao
```
