### PR TITLE
make catching steps toggleable

### DIFF
--- a/crates/control/src/fall_state_estimation.rs
+++ b/crates/control/src/fall_state_estimation.rs
@@ -51,6 +51,10 @@ pub struct CycleContext {
         Parameter<f32, "fall_state_estimation.difference_to_sitting_threshold">,
     falling_angle_threshold_forward:
         Parameter<Vector2<Robot>, "fall_state_estimation.falling_angle_threshold_forward">,
+    falling_angle_threshold_forward_with_catching_steps: Parameter<
+        Vector2<Robot>,
+        "fall_state_estimation.falling_angle_threshold_forward_with_catching_steps",
+    >,
     falling_timeout: Parameter<Duration, "fall_state_estimation.falling_timeout">,
     gravitational_acceleration_threshold:
         Parameter<f32, "fall_state_estimation.gravitational_acceleration_threshold">,
@@ -58,6 +62,7 @@ pub struct CycleContext {
         Parameter<Vector3<Robot>, "fall_state_estimation.gravitational_force_sitting">,
     gravity_acceleration: Parameter<f32, "physical_constants.gravity_acceleration">,
     sitting_pose: Parameter<Joints<f32>, "fall_state_estimation.sitting_pose">,
+    use_catching_steps: Parameter<bool, "walking_engine.catching_steps.use_catching_steps">,
 
     sensor_data: Input<SensorData, "sensor_data">,
     cycle_time: Input<CycleTime, "cycle_time">,
@@ -141,9 +146,14 @@ impl FallStateEstimation {
             None
         };
 
+        let falling_angle_threshold = if *context.use_catching_steps {
+            context.falling_angle_threshold_forward_with_catching_steps
+        } else {
+            context.falling_angle_threshold_forward
+        };
+
         let falling_direction = {
-            if !(context.falling_angle_threshold_forward.x()
-                ..context.falling_angle_threshold_forward.y())
+            if !(falling_angle_threshold.x()..falling_angle_threshold.y())
                 .contains(&estimated_pitch)
             {
                 let side = {

--- a/crates/walking_engine/src/mode/walking.rs
+++ b/crates/walking_engine/src/mode/walking.rs
@@ -1,4 +1,9 @@
-use super::{kicking::Kicking, stopping::Stopping, Mode, WalkTransition};
+use super::{
+    catching::{is_in_support_polygon, Catching},
+    kicking::Kicking,
+    stopping::Stopping,
+    Mode, WalkTransition,
+};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 use types::{
@@ -60,23 +65,24 @@ impl WalkTransition for Walking {
     fn walk(self, context: &Context, requested_step: Step) -> Mode {
         let current_step = self.step;
 
-        // let Some(&robot_to_ground) = context.robot_to_ground else {
-        //     return Mode::Stopping(Stopping::new(context, current_step.plan.support_side));
-        // };
+        if context.parameters.catching_steps.use_catching_steps {
+            let Some(&robot_to_ground) = context.robot_to_ground else {
+                return Mode::Stopping(Stopping::new(context, current_step.plan.support_side));
+            };
 
-        // if !is_in_support_polygon(
-        //     &context.parameters.catching_steps,
-        //     &context.current_joints,
-        //     robot_to_ground,
-        //     *context.center_of_mass,
-        // ) {
-        //     return Mode::Catching(Catching::new(
-        //         context,
-        //         current_step.plan.support_side,
-        //         robot_to_ground,
-        //     ));
-        // };
-
+            if !is_in_support_polygon(
+                &context.parameters.catching_steps,
+                &context.current_joints,
+                robot_to_ground,
+                *context.center_of_mass,
+            ) {
+                return Mode::Catching(Catching::new(
+                    context,
+                    current_step.plan.support_side,
+                    robot_to_ground,
+                ));
+            };
+        }
         if current_step.is_timeouted(context.parameters) {
             return Mode::Walking(Walking::new(
                 context,

--- a/crates/walking_engine/src/parameters.rs
+++ b/crates/walking_engine/src/parameters.rs
@@ -84,6 +84,7 @@ pub struct GyroBalancingParameters {
     PathIntrospect,
 )]
 pub struct CatchingStepsParameters {
+    pub use_catching_steps: bool,
     pub toe_offset: f32,
     pub heel_offset: f32,
     pub max_adjustment: f32,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -421,6 +421,7 @@
       "walk_height": 0.22
     },
     "catching_steps": {
+      "use_catching_steps" : false,
       "toe_offset": 0.09,
       "heel_offset": -0.035,
       "max_adjustment": 0.05,
@@ -678,6 +679,7 @@
     "gravitational_acceleration_threshold": 7.0,
     "gravitational_force_sitting": [3.6, 0.0, 8.8],
     "falling_angle_threshold_forward": [-0.3, 0.5],
+    "falling_angle_threshold_forward_with_catching_steps": [-0.45, 0.6],
     "falling_timeout": {
       "nanos": 0,
       "secs": 1


### PR DESCRIPTION
## Why? What?

#887 Disabled catching steps by means of commenting out code and modifying parameters to adjust for a earlier needed fall protection.
This PR allows for catching steps to be toggled on and off based on a single parameter.
Additionally it introduces the old fall angle threshold to be used when catching steps are enabled.

This is done both for code cleanliness and useability of catching steps, as well as a prerequisite for #1019 so that these new catching steps can just as easily be disabled and enabled when desired.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Change the new ```use_catching_steps``` parameter between true and false and observe the presence or absence of catching steps