### PR TITLE
clear error message when NAO with hardware id doesn't exist

### DIFF
--- a/tools/pepsi/src/player_number.rs
+++ b/tools/pepsi/src/player_number.rs
@@ -45,7 +45,7 @@ pub async fn player_number(arguments: Arguments, repository: &Repository) -> Res
         arguments.assignments,
         "Setting player number...",
         |assignment, _progress_bar| {
-            let hardware = &hardware_ids
+            let hardware_id = &hardware_ids
                 .get(&assignment.nao_number.number)
                 .unwrap_or_else(|| {
                     panic!(
@@ -53,7 +53,7 @@ pub async fn player_number(arguments: Arguments, repository: &Repository) -> Res
                         &assignment.nao_number.number
                     )
                 });
-            let head_id = &hardware.head_id;
+            let head_id = &hardware_id.head_id;
             async move {
                 repository
                     .set_player_number(head_id, assignment.player_number)

--- a/tools/pepsi/src/player_number.rs
+++ b/tools/pepsi/src/player_number.rs
@@ -45,7 +45,15 @@ pub async fn player_number(arguments: Arguments, repository: &Repository) -> Res
         arguments.assignments,
         "Setting player number...",
         |assignment, _progress_bar| {
-            let head_id = &hardware_ids[&assignment.nao_number.number].head_id;
+            let hardware = &hardware_ids
+                .get(&assignment.nao_number.number)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "NAO with Hardware ID {} does not exist",
+                        &assignment.nao_number.number
+                    )
+                });
+            let head_id = &hardware.head_id;
             async move {
                 repository
                     .set_player_number(head_id, assignment.player_number)

--- a/tools/pepsi/src/player_number.rs
+++ b/tools/pepsi/src/player_number.rs
@@ -48,7 +48,7 @@ pub async fn player_number(arguments: Arguments, repository: &Repository) -> Res
             let number = assignment.nao_number.number;
             let hardware_id = hardware_ids
                 .get(&number)
-                .ok_or_else(|| eyre!("NAO with Hardware ID {number} does not exist",))?;
+                .ok_or_else(|| eyre!("NAO with Hardware ID {number} does not exist"))?;
             repository
                 .set_player_number(&hardware_id.head_id, assignment.player_number)
                 .await

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -52,7 +52,8 @@ impl ProgressIndicator {
             .map(|(progress, item)| {
                 progress.enable_steady_tick();
                 progress.set_message(message);
-                async move { progress.finish_with(task(item, progress.progress.clone()).await) }
+                let future = task(item, progress.progress.clone());
+                async move { progress.finish_with(future.await) }
             })
             .collect::<FuturesUnordered<_>>()
             .collect::<Vec<_>>()

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -39,7 +39,7 @@ impl ProgressIndicator {
     pub async fn map_tasks<T, F, M>(
         items: impl IntoIterator<Item = T>,
         message: &'static str,
-        task: impl Fn(T, ProgressBar) -> F + Copy,
+        task: impl Fn(T, ProgressBar) -> F,
     ) where
         T: ToString,
         F: Future<Output = Result<M>>,


### PR DESCRIPTION
## Why? What?

Gives a more clear error message when a hardware ID that doesn't exist is used.

Fixes #719

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Previously:
```
pepsi playernumber 88:1
[80:1] ⠙ Setting player number...                                                                                                                                                                                                                                                     The application panicked (crashed).
Message:  no entry found for key
Location: tools/pepsi/src/player_number.rs:48
```
Now:
```
pepsi playernumber 80:1 81:2
[80:1] ✗
   0: NAO with Hardware ID 80 does not exist

Location:
   tools/pepsi/src/player_number.rs:51
[81:2] ✗
   0: NAO with Hardware ID 81 does not exist

Location:
   tools/pepsi/src/player_number.rs:51
```