### PR TITLE
Remove unused bool fallen in HulkMessage

### DIFF
--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -307,7 +307,6 @@ impl RoleAssignment {
                         .hardware
                         .write_to_network(OutgoingMessage::Spl(HulkMessage {
                             player_number: *context.player_number,
-                            fallen: matches!(context.fall_state, FallState::Fallen { .. }),
                             pose: ground_to_field.as_pose(),
                             is_referee_ready_signal_detected: false,
                             ball_position,

--- a/crates/spl_network_messages/src/lib.rs
+++ b/crates/spl_network_messages/src/lib.rs
@@ -23,7 +23,6 @@ pub use visual_referee_message::{VisualRefereeDecision, VisualRefereeMessage};
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct HulkMessage {
     pub player_number: PlayerNumber,
-    pub fallen: bool,
     pub pose: Pose2<Field>,
     pub is_referee_ready_signal_detected: bool,
     pub ball_position: Option<BallPosition<Field>>,
@@ -101,7 +100,6 @@ mod tests {
     fn maximum_hulk_message_size() {
         let test_message = HulkMessage {
             player_number: PlayerNumber::Seven,
-            fallen: false,
             pose: Pose2::default(),
             is_referee_ready_signal_detected: false,
             ball_position: Some(BallPosition {


### PR DESCRIPTION
## Why? What?

Removes unused ```fallen``` boolean that was a remnant of the time to reach implementation but is entirely unused

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

If CI is green then this open pr closed should be seen