### PR TITLE
fix removal of voting for VR

### DIFF
--- a/crates/control/src/game_controller_state_filter.rs
+++ b/crates/control/src/game_controller_state_filter.rs
@@ -27,7 +27,7 @@ pub struct CycleContext {
     ball_position: Input<Option<BallPosition<Ground>>, "ball_position?">,
     cycle_time: Input<CycleTime, "cycle_time">,
     filtered_whistle: Input<FilteredWhistle, "filtered_whistle">,
-    is_referee_ready_pose_detected: Input<bool, "is_referee_ready_pose_detected">,
+    is_referee_ready_pose_detected: Input<bool, "majority_vote_is_referee_ready_pose_detected">,
     game_controller_state: RequiredInput<Option<GameControllerState>, "game_controller_state?">,
     config: Parameter<GameStateFilterParameters, "game_state_filter">,
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,

--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -34,7 +34,7 @@ pub struct CycleContext {
     cycle_time: Input<CycleTime, "cycle_time">,
     filtered_whistle: Input<FilteredWhistle, "filtered_whistle">,
     role: Input<Role, "role">,
-    is_own_referee_initial_pose_detected: Input<bool, "is_referee_ready_pose_detected">,
+    is_own_referee_ready_pose_detected: Input<bool, "is_referee_ready_pose_detected">,
 
     balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
     balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,
@@ -178,7 +178,7 @@ impl LedStatus {
             context.primary_state,
             context.role,
             ball_percepts,
-            *context.is_own_referee_initial_pose_detected,
+            *context.is_own_referee_ready_pose_detected,
         );
 
         if let Some(latest_game_controller_message_time) = context
@@ -270,7 +270,7 @@ impl LedStatus {
         primary_state: &PrimaryState,
         role: &Role,
         ball_percepts: BallPercepts,
-        is_own_referee_initial_pose_detected: bool,
+        is_own_referee_ready_pose_detected: bool,
     ) -> (Eye, Eye) {
         match primary_state {
             PrimaryState::Unstiff => {
@@ -306,7 +306,7 @@ impl LedStatus {
                     Role::Striker => Rgb::RED,
                     Role::StrikerSupporter => Rgb::TURQUOISE,
                 };
-                let referee_color = if is_own_referee_initial_pose_detected {
+                let referee_color = if is_own_referee_ready_pose_detected {
                     Some(Rgb::PURPLE)
                 } else {
                     None

--- a/crates/hulk_behavior_simulator/src/fake_data.rs
+++ b/crates/hulk_behavior_simulator/src/fake_data.rs
@@ -54,7 +54,7 @@ pub struct MainOutputs {
     pub game_controller_address: MainOutput<Option<SocketAddr>>,
     pub has_ground_contact: MainOutput<bool>,
     pub hulk_messages: MainOutput<Vec<HulkMessage>>,
-    pub is_referee_ready_pose_detected: MainOutput<bool>,
+    pub majority_vote_is_referee_ready_pose_detected: MainOutput<bool>,
     pub hypothetical_ball_positions: MainOutput<Vec<HypotheticalBallPosition<Ground>>>,
     pub is_localization_converged: MainOutput<bool>,
     pub obstacles: MainOutput<Vec<Obstacle>>,
@@ -86,7 +86,9 @@ impl FakeData {
             game_controller_address: last_database.game_controller_address.into(),
             has_ground_contact: last_database.has_ground_contact.into(),
             hulk_messages: last_database.hulk_messages.clone().into(),
-            is_referee_ready_pose_detected: last_database.is_referee_ready_pose_detected.into(),
+            majority_vote_is_referee_ready_pose_detected: last_database
+                .majority_vote_is_referee_ready_pose_detected
+                .into(),
             hypothetical_ball_positions: last_database.hypothetical_ball_positions.clone().into(),
             is_localization_converged: last_database.is_localization_converged.into(),
             obstacles: last_database.obstacles.clone().into(),


### PR DESCRIPTION
## Why? What?
It fixes the issue that robots do not transition from `Initial` -> `Ready` with only 1 robot voting for it. 
Also it renames the booleans which represent the initial referee pose detection to hopefully prevent this mistake in the future. If there are renaming suggestions I'm open to rename again.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Test with only one robot the `Initial` -> `Ready` transition and compare results to main. It should not start walking with this fix as 2 independent detections are needed for the transition. (Assumes that #1064 is already merged, otherwise increase `minimum_above_head_arms_detections` >= 2.
