### PR TITLE
Eye color for referee percept 

### DIFF
--- a/crates/control/src/led_status.rs
+++ b/crates/control/src/led_status.rs
@@ -35,6 +35,7 @@ pub struct CycleContext {
     filtered_whistle: Input<FilteredWhistle, "filtered_whistle">,
     role: Input<Role, "role">,
     is_own_referee_ready_pose_detected: Input<bool, "is_referee_ready_pose_detected">,
+    did_detect_any_referee_this_cycle: Input<bool, "did_detect_any_referee_this_cycle">,
 
     balls_bottom: PerceptionInput<Option<Vec<Ball>>, "VisionBottom", "balls?">,
     balls_top: PerceptionInput<Option<Vec<Ball>>, "VisionTop", "balls?">,
@@ -179,6 +180,7 @@ impl LedStatus {
             context.role,
             ball_percepts,
             *context.is_own_referee_ready_pose_detected,
+            *context.did_detect_any_referee_this_cycle,
         );
 
         if let Some(latest_game_controller_message_time) = context
@@ -271,6 +273,7 @@ impl LedStatus {
         role: &Role,
         ball_percepts: BallPercepts,
         is_own_referee_ready_pose_detected: bool,
+        did_detect_any_referee_this_cycle: bool,
     ) -> (Eye, Eye) {
         match primary_state {
             PrimaryState::Unstiff => {
@@ -306,7 +309,12 @@ impl LedStatus {
                     Role::Striker => Rgb::RED,
                     Role::StrikerSupporter => Rgb::TURQUOISE,
                 };
-                let referee_color = if is_own_referee_ready_pose_detected {
+                let filtered_referee_ready_color = if is_own_referee_ready_pose_detected {
+                    Some(Rgb::YELLOW)
+                } else {
+                    None
+                };
+                let referee_ready_percept_color = if did_detect_any_referee_this_cycle {
                     Some(Rgb::PURPLE)
                 } else {
                     None
@@ -314,29 +322,41 @@ impl LedStatus {
                 (
                     Eye {
                         color_at_0: ball_color_top
-                            .or(referee_color)
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
                             .or(ball_background_color)
                             .unwrap_or(Rgb::BLACK),
                         color_at_45: ball_color_top
-                            .or(referee_color)
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
                             .or(ball_background_color)
                             .unwrap_or(Rgb::BLACK),
-                        color_at_90: ball_background_color.unwrap_or(Rgb::BLACK),
+                        color_at_90: ball_background_color
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
+                            .unwrap_or(Rgb::BLACK),
                         color_at_135: ball_color_bottom
-                            .or(referee_color)
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
                             .or(ball_background_color)
                             .unwrap_or(Rgb::BLACK),
                         color_at_180: ball_color_bottom
-                            .or(referee_color)
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
                             .or(ball_background_color)
                             .unwrap_or(Rgb::BLACK),
                         color_at_225: ball_color_bottom
-                            .or(referee_color)
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
                             .or(ball_background_color)
                             .unwrap_or(Rgb::BLACK),
-                        color_at_270: ball_background_color.unwrap_or(Rgb::BLACK),
+                        color_at_270: ball_background_color
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
+                            .unwrap_or(Rgb::BLACK),
                         color_at_315: ball_color_top
-                            .or(referee_color)
+                            .or(filtered_referee_ready_color)
+                            .or(referee_ready_percept_color)
                             .or(ball_background_color)
                             .unwrap_or(Rgb::BLACK),
                     },


### PR DESCRIPTION
## Why? What?

As wished for this introduces eye color for each above arms pose percept being in the given radius around the referee at the T-junction (inside `distance_to_referee_position_threshold`). The chosen color is purple as it is better visible when flickering. 
Moreover the eye color is changed to yellow, when the robot is voting for referee pose detected, meaning its queue has enough above arms detected. 
As a result for each single percept the left eye flickers purple and when raising the arms long enough it changes to a continuous yellow color. 

Naming depends on #1065 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
Deploy NAO as 4 or 7, start GameController, place NAO at its initial position, raise arms at T-junction and watch led colors (firstly purple flickering, after `minimum_number_poses_before_message` successive percepts change to continuous yellow). When only testing with one NAO it should not start walking, therefore it is possible to test a bit. Also test raising and take down again after one or two percepts and see only purple flickering.
