### PR TITLE
Add more descriptive OpenVino error message + installation information.

### DIFF
--- a/crates/object_detection/src/pose_detection.rs
+++ b/crates/object_detection/src/pose_detection.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use color_eyre::{
-    eyre::{bail, Context, ContextCompat},
+    eyre::{bail, eyre, Context, ContextCompat},
     Result,
 };
 use context_attribute::context;
@@ -89,8 +89,10 @@ impl PoseDetection {
                 weights_path
                     .to_str()
                     .wrap_err("failed to get detection weights path")?,
-            )
-            .wrap_err("failed to create detection network")?;
+            ).map_err(|error| match error{
+                openvino::InferenceError::GeneralError => eyre!("General Error: Please ensure OpenVino is installed properly with the required components."),
+                _=> eyre!("failed to create detection network: {error}")
+            })?;
 
         let number_of_inputs = network
             .get_inputs_len()

--- a/crates/object_detection/src/pose_detection.rs
+++ b/crates/object_detection/src/pose_detection.rs
@@ -90,7 +90,7 @@ impl PoseDetection {
                     .to_str()
                     .wrap_err("failed to get detection weights path")?,
             ).map_err(|error| match error{
-                openvino::InferenceError::GeneralError => eyre!("General Error: Please ensure OpenVino is installed properly with the required components."),
+                openvino::InferenceError::GeneralError => eyre!("General Error: Please ensure that you have a complete & working OpenVino installation."),
                 _=> eyre!("failed to create detection network: {error}")
             })?;
 

--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -41,6 +41,10 @@ Use your distribution's package manager to install the following dependencies:
     ```sh
     sudo apt install git git-lfs clang python3 zstd xz-utils file rsync
     ```
+### OpenVino:tm: runtime for Neural Networks
+
+You will also need to install the OpenVino:tm: runtime for Webots. The HULKs SDK already contains the runtime for use with the NAOs.
+- [Installation Instructions (Linux)](https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-linux.html)
 
 ## Cloning the Repository
 


### PR DESCRIPTION
## Why? What?

- There is no mention of OpenVino requirements for Webots usage.
- OpenVino load errors are not explanatory enough in `ObjectDetection`, I spent quite some time to figure out why I got this "General Error" -> needed to install some additional components.

### Related issues
- #1047
- #1037

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Launching for Webots will end up with the current status (#1047) *without* an OpenVino error.

```bash
./pepsi run
...
 Finished `incremental` profile [optimized] target(s) in 7m 21s
     Running `target/incremental/hulk_webots`
The Webots simulation world is not yet ready, pending until loading is done...
Warning: Webots [R2023b] and libController [] versions are not the same for Robot 'webots2'! Different versions can lead to undefined behavior.
2024-06-20 14:31:10  openvino_finder      INFO  Attempting to find library: libopenvino_c.so
2024-06-20 14:31:10  openvino_finder     DEBUG  Searching in: ......./libopenvino_c.so
...
...
2024-06-20 14:31:10  openvino_finder     DEBUG  Searching in: /lib/libopenvino_c.so
2024-06-20 14:31:10  openvino_finder     DEBUG  Searching in: /usr/lib64/libopenvino_c.so
2024-06-20 14:31:10  openvino_finder      INFO  Found library at path: /usr/lib64/libopenvino_c.so
cycler thread VisionTop returned error: 
   0: failed to execute cycle of cycler `VisionTop`
   1: failed to execute cycle of `ImageReceiver`
   2: termination requested

Location:
   crates/hulk_webots/src/hardware_interface.rs:297
```
