### PR TITLE
Parallel/ multiple read() access for Webots Camera

### DIFF
--- a/crates/hulk_webots/src/camera.rs
+++ b/crates/hulk_webots/src/camera.rs
@@ -6,7 +6,7 @@ use std::arch::x86_64::{
 };
 
 use color_eyre::{
-    eyre::{eyre, WrapErr},
+    eyre::{OptionExt, WrapErr},
     Result,
 };
 use parking_lot::{Condvar, Mutex};
@@ -67,8 +67,9 @@ impl Camera {
             let mut bgra_buffer = self.buffer.lock();
             self.buffer_updated.wait(&mut bgra_buffer);
             bgra_buffer
+                .clone()
                 .take()
-                .ok_or_else(|| eyre!("no updated image found"))?
+                .ok_or_eyre("no updated image found")?
         };
         assert_eq!(bgra_buffer.len(), 4 * 640 * 480);
         let mut ycbcr_buffer = vec![


### PR DESCRIPTION
## Why? What?

As described in #1047 , the issue boils down to the way how the webots cameras are read from.

Compared to the `hulks_nao` camera, there isn't a queue of images, but a `Option<Vec<u8>>`. When `read()` is called, this option is emptied by calling `take()` resulting in the next `read()` call triggering an error (due to empty option) that happens *before*  `update_image()` is called.

Possible Solutions:
1. Clone the buffer and take -> no need to change the condition variable's announcing mechanism. Also the second cycler will get the same image (i.e. object detection)
2. Switch to `tokio` based approach done in #564 but I think this is overkill for the job.
3. Change how the condition variable is notified, use `notify_once` instead of `notify_all` -> two different cycles calling `read()` on same camera will get images from other times as things are now deferred. Additionally, the second cycler will wait for the next image.

This PR took the option 1, the simplest. IMO the possible drawbacks are lesser than the additional complexities we introduce from other methods.

Fixes #1047, #1034

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Things should run on Webots fine, can test with Twix, etc.
Users with OpenVino errors should refer to #1068 and ensure their installation is done properly.