### PR TITLE
Switch to vendored Lua

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,10 +714,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 1.0.109",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -737,10 +737,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.61",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -760,10 +760,10 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.61",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -876,15 +876,6 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "piper",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1431,7 +1422,7 @@ dependencies = [
  "motionfile",
  "nalgebra",
  "num-traits",
- "ordered-float",
+ "ordered-float 3.9.2",
  "path_serde",
  "projection",
  "rand",
@@ -2110,11 +2101,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
 dependencies = [
  "serde",
+ "typeid",
 ]
 
 [[package]]
@@ -2591,7 +2583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
- "bstr 1.9.1",
+ "bstr",
  "log",
  "regex-automata",
  "regex-syntax",
@@ -2732,7 +2724,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea40788c059ab8b622c4d074732750bfb3bd2912e2dd58eabc11798a4d5ad725"
 dependencies = [
- "bstr 1.9.1",
+ "bstr",
  "globset",
  "libc",
  "log",
@@ -3623,6 +3615,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lua-src"
+version = "546.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da0daa7eee611a4c30c8f5ee31af55266e26e573971ba9336d2993e2da129b2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.5.8+5790d25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441f18d9ad792e871fc2f7f2cb8902c386f6f56fdbddef3b835b61475e375346"
+dependencies = [
+ "cc",
+ "which 6.0.1",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3752,19 +3763,32 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.8.10"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb37b0ba91f017aa7ca2b98ef99496827770cd635b4a932a6047c5b4bbe678e"
+checksum = "d111deb18a9c9bd33e1541309f4742523bfab01d276bfa9a27519f6de9c11dc7"
 dependencies = [
- "bstr 0.2.17",
- "cc",
+ "bstr",
  "erased-serde",
+ "mlua-sys",
  "num-traits",
  "once_cell",
  "parking_lot",
- "pkg-config",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a088ed0723df7567f569ba018c5d48c23c501f3878b190b04144dfa5ebfa8abc"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3794,7 +3818,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "num-traits",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
  "thiserror",
@@ -4220,7 +4244,7 @@ dependencies = [
  "nalgebra",
  "ndarray",
  "openvino",
- "ordered-float",
+ "ordered-float 3.9.2",
  "projection",
  "serde",
  "spl_network_messages",
@@ -4367,6 +4391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
  "libredox 0.0.2",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4803,7 +4836,7 @@ dependencies = [
  "geometry",
  "linear_algebra",
  "nalgebra",
- "ordered-float",
+ "ordered-float 3.9.2",
  "rand",
  "rand_chacha",
 ]
@@ -5013,6 +5046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,6 +5204,16 @@ version = "1.0.195"
 source = "git+https://github.com/h3ndrk/serde.git?rev=4fec5aac7d42a4ac1fc10af037f1c85eba29fa36#4fec5aac7d42a4ac1fc10af037f1c85eba29fa36"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -6032,8 +6081,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
 
 [[package]]
 name = "typenum"
@@ -6054,7 +6109,7 @@ dependencies = [
  "image",
  "linear_algebra",
  "nalgebra",
- "ordered-float",
+ "ordered-float 3.9.2",
  "path_serde",
  "serde",
  "spl_network_messages",
@@ -6199,7 +6254,7 @@ dependencies = [
  "itertools 0.10.5",
  "linear_algebra",
  "nalgebra",
- "ordered-float",
+ "ordered-float 3.9.2",
  "projection",
  "rand",
  "rand_chacha",
@@ -6541,7 +6596,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle 0.6.1",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror",
  "web-sys",
@@ -6581,7 +6636,7 @@ dependencies = [
  "profiling",
  "raw-window-handle 0.6.1",
  "renderdoc-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror",
  "wasm-bindgen",
@@ -6611,6 +6666,18 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.34",
+]
+
+[[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.34",
+ "winsafe",
 ]
 
 [[package]]
@@ -7022,6 +7089,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "x11-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ levenberg-marquardt = "0.13.0"
 libc = "0.2.137"
 linear_algebra = { path = "crates/linear_algebra" }
 log = "0.4.17"
-mlua = { version = "0.8.7", features = ["luajit", "serialize", "parking_lot"] }
+mlua = { version = "0.9.7", features = ["luajit", "vendored", "serialize", "parking_lot"] }
 motionfile = { path = "crates/motionfile" }
 buffered_watch = { path = "crates/buffered_watch" }
 nalgebra = { version = "0.32.2", features = ["serde", "serde-serialize"] }

--- a/crates/hulk_behavior_simulator/src/simulator.rs
+++ b/crates/hulk_behavior_simulator/src/simulator.rs
@@ -74,15 +74,16 @@ impl Simulator {
         self.serialze_state()?;
 
         let script_text = read_to_string(&file_name)?;
-        let script = self.lua.load(&script_text).set_name(
-            file_name
-                .as_ref()
-                .file_name()
-                .ok_or_else(|| eyre!("path contains no filename"))?
-                .to_str()
-                .ok_or_else(|| eyre!("filename is not valid unicode"))?,
-        )?;
-        script
+        self.lua
+            .load(&script_text)
+            .set_name(
+                file_name
+                    .as_ref()
+                    .file_name()
+                    .ok_or_else(|| eyre!("path contains no filename"))?
+                    .to_str()
+                    .ok_or_else(|| eyre!("filename is not valid unicode"))?,
+            )
             .exec()
             .wrap_err("failed to execute scenario script")?;
 

--- a/tests/behavior/ball_search.lua
+++ b/tests/behavior/ball_search.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -11,7 +11,7 @@ local game_end_time = -1.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -24,7 +24,7 @@ state.ball = {
 
 function on_cycle()
     if state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
     end
 
     if state.cycle_count == 100 then

--- a/tests/behavior/defender_positioning.lua
+++ b/tests/behavior/defender_positioning.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/demonstration.lua
+++ b/tests/behavior/demonstration.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -15,14 +15,14 @@ spawn_robot(7)
 
 function on_goal()
   print("Goal scored, resetting ball!")
-  print("Ball: " .. inspect(state.ball))
+  -- print("Ball: " .. inspect(state.ball))
   print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
   state.ball = nil
 end
 
 function on_cycle()
   if state.ball == nil and state.cycle_count % 1000 == 0 then
-    print(inspect(state))
+    -- print(inspect(state))
     state.ball = {
       position = { 0.0, 0.0 },
       velocity = { 0.0, 0.0 },

--- a/tests/behavior/deny_keeper_ballsearch.lua
+++ b/tests/behavior/deny_keeper_ballsearch.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -13,7 +13,7 @@ local goal_scored = false
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     goal_scored = true
@@ -22,7 +22,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/golden_goal.lua
+++ b/tests/behavior/golden_goal.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -18,7 +18,7 @@ local goal_scored = false
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     goal_scored = true
@@ -27,7 +27,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/golden_goal_opponent_kickoff.lua
+++ b/tests/behavior/golden_goal_opponent_kickoff.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/golden_goal_striker_penalized.lua
+++ b/tests/behavior/golden_goal_striker_penalized.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/hulks_vs_ghosts.lua
+++ b/tests/behavior/hulks_vs_ghosts.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/ingamepenalty_attacking.lua
+++ b/tests/behavior/ingamepenalty_attacking.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
   print("Goal scored, resetting ball!")
-  print("Ball: " .. inspect(state.ball))
+  -- print("Ball: " .. inspect(state.ball))
   print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
   state.ball = nil
   game_end_time = state.cycle_count + 200
@@ -26,7 +26,7 @@ end
 
 function on_cycle()
   if state.ball == nil and state.cycle_count % 1000 == 0 then
-    print(inspect(state))
+    -- print(inspect(state))
     state.ball = {
       position = { 0.0, 0.0 },
       velocity = { 0.0, 0.0 },

--- a/tests/behavior/ingamepenalty_defending.lua
+++ b/tests/behavior/ingamepenalty_defending.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
   print("Goal scored, resetting ball!")
-  print("Ball: " .. inspect(state.ball))
+  -- print("Ball: " .. inspect(state.ball))
   print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
   state.ball = nil
   game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
   if state.ball == nil and state.cycle_count % 1000 == 0 then
-    print(inspect(state))
+    -- print(inspect(state))
     state.ball = {
       position = { 0.0, 0.0 },
       velocity = { 0.0, 0.0 },

--- a/tests/behavior/ingamepenalty_defending_with_kick.lua
+++ b/tests/behavior/ingamepenalty_defending_with_kick.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
   print("Goal scored, resetting ball!")
-  print("Ball: " .. inspect(state.ball))
+  -- print("Ball: " .. inspect(state.ball))
   print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
   state.ball = nil
   game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
   if state.ball == nil and state.cycle_count % 1000 == 0 then
-    print(inspect(state))
+    -- print(inspect(state))
     state.ball = {
       position = { 0.0, 0.0 },
       velocity = { 0.0, 0.0 },

--- a/tests/behavior/quantum_ball.lua
+++ b/tests/behavior/quantum_ball.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/reappearing_ball_in_front_of_1.lua
+++ b/tests/behavior/reappearing_ball_in_front_of_1.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/replacementkeeper_test.lua
+++ b/tests/behavior/replacementkeeper_test.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/turning_time.lua
+++ b/tests/behavior/turning_time.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 
 function spawn_robot(number)
     table.insert(state.robots, create_robot(number))
@@ -11,7 +11,7 @@ local goal_scored = false
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     goal_scored = true

--- a/tests/behavior/two_replacementkeepers.lua
+++ b/tests/behavior/two_replacementkeepers.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -25,7 +25,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },

--- a/tests/behavior/vanishing_ball.lua
+++ b/tests/behavior/vanishing_ball.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -17,7 +17,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -29,9 +29,9 @@ state.ball = {
 }
 
 function on_cycle()
-    if state.cycle_count % 1000 == 0 then
-        print(inspect(state))
-    end
+    -- if state.cycle_count % 1000 == 0 then
+    --     print(inspect(state))
+    -- end
 
     if state.cycle_count == 100 then
         state.game_controller_state.game_state = "Ready"

--- a/tests/behavior/walkaroundball.lua
+++ b/tests/behavior/walkaroundball.lua
@@ -1,4 +1,4 @@
-local inspect = require 'inspect'
+-- local inspect = require 'inspect'
 print("Hello world from lua!")
 
 function spawn_robot(number)
@@ -11,7 +11,7 @@ local game_end_time = 15000.0
 
 function on_goal()
     print("Goal scored, resetting ball!")
-    print("Ball: " .. inspect(state.ball))
+    -- print("Ball: " .. inspect(state.ball))
     print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
     state.ball = nil
     game_end_time = state.cycle_count + 200
@@ -19,7 +19,7 @@ end
 
 function on_cycle()
     if state.ball == nil and state.cycle_count % 1000 == 0 then
-        print(inspect(state))
+        -- print(inspect(state))
         state.ball = {
             position = { 0.0, 0.0 },
             velocity = { 0.0, 0.0 },


### PR DESCRIPTION
## Why? What?

When compiling `mlua` unvendored, you need to install Lua on your system. Especially under Windoof, this can be painful, therefore we want to switch to a vendored version.

Does not heilmachen #1071 completely because we still need further fixes because we are still using symlinks which are not supported under Windoof.

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

It's perfect

## How to Test

Check that Twix compiles under Windoof