### PR TITLE
Fix typo in cargo::rerun-if-changed

### DIFF
--- a/crates/hulk/build.rs
+++ b/crates/hulk/build.rs
@@ -6,7 +6,7 @@ use source_analyzer::{pretty::to_string_pretty, structs::Structs};
 fn main() -> Result<()> {
     let cyclers = collect_hulk_cyclers()?;
     for path in cyclers.watch_paths() {
-        println!("cargo:rerun-if-changed={}", path.display());
+        println!("cargo::rerun-if-changed={}", path.display());
     }
 
     println!();

--- a/crates/hulk_behavior_simulator/build.rs
+++ b/crates/hulk_behavior_simulator/build.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
 
     let cyclers = Cyclers::try_from_manifest(manifest, root)?;
     for path in cyclers.watch_paths() {
-        println!("cargo:rerun-if-changed={}", path.display());
+        println!("cargo::rerun-if-changed={}", path.display());
     }
 
     println!();

--- a/crates/hulk_imagine/build.rs
+++ b/crates/hulk_imagine/build.rs
@@ -8,7 +8,7 @@ fn main() -> Result<()> {
     cyclers.cyclers.retain(|cycler| cycler.name == "Vision");
 
     for path in cyclers.watch_paths() {
-        println!("cargo:rerun-if-changed={}", path.display());
+        println!("cargo::rerun-if-changed={}", path.display());
     }
 
     println!();

--- a/crates/hulk_replayer/build.rs
+++ b/crates/hulk_replayer/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
         .cyclers
         .retain(|cycler| cycler.name != "ObjectDetection");
     for path in cyclers.watch_paths() {
-        println!("cargo:rerun-if-changed={}", path.display());
+        println!("cargo::rerun-if-changed={}", path.display());
     }
 
     println!();

--- a/crates/nao_camera/build.rs
+++ b/crates/nao_camera/build.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use bindgen::Builder;
 
 fn main() {
-    println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo::rerun-if-changed=wrapper.h");
 
     let bindings = Builder::default()
         .header("wrapper.h")


### PR DESCRIPTION
## Why? What?

This PR changes `cargo:rerun-if-changed` to the new `cargo::rerun-if-changed` notation.

See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script.

## ToDo / Known Issues

This requires at least rust 1.77, so this is blocked until we have updated everything to at least 1.77.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Build it.
