### PR TITLE
RustFest2024 - Logging improvements suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
  "flate2",
  "globset",
  "grep-cli",
- "nu-ansi-term",
+ "nu-ansi-term 0.47.0",
  "once_cell",
  "path_abs",
  "plist",
@@ -1440,6 +1440,7 @@ dependencies = [
  "smallvec",
  "spl_network_messages",
  "splines",
+ "tracing",
  "types",
  "walking_engine",
 ]
@@ -2228,6 +2229,8 @@ dependencies = [
  "fern",
  "log",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3979,6 +3982,16 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df031e117bca634c262e9bd3173776844b6c17a90b3741c9163663b4385af76"
@@ -4387,6 +4400,12 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -5935,14 +5954,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "nu-ansi-term 0.46.0",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -32,5 +32,6 @@ serde = { workspace = true }
 smallvec = { workspace = true }
 spl_network_messages = { workspace = true }
 splines = { workspace = true }
+tracing = "0.1.40"
 types = { workspace = true }
 walking_engine = { workspace = true }

--- a/crates/control/src/a_star.rs
+++ b/crates/control/src/a_star.rs
@@ -43,7 +43,7 @@ where
 /// `destination` is the index of the target tile.
 /// `success` is true if it reached the target, false otherwise.
 /// `steps` is a vector of each step towards the target, *including* the starting position.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct NavigationPath {
     pub destination: usize,
     pub success: bool,

--- a/crates/control/src/path_planner.rs
+++ b/crates/control/src/path_planner.rs
@@ -1,8 +1,10 @@
 use color_eyre::{eyre::eyre, Result};
 use geometry::{arc::Arc, circle::Circle, direction::Direction, line_segment::LineSegment};
 use linear_algebra::{distance, point, vector, Isometry2, Orientation2, Point2};
+use log::{info, warn};
 use ordered_float::NotNan;
 use smallvec::SmallVec;
+use tracing::warn_span;
 
 use coordinate_systems::{Field, Ground};
 use types::{
@@ -307,6 +309,13 @@ impl PathPlanner {
         let navigation_path = a_star_search(0, 1, self);
 
         if !navigation_path.success {
+            // This warning is used for regular logging
+            // it will be logged into a file (see function setup_logger in crates/hulk_nao/src/main.rs)
+            warn!(target: "control", "Path not found: {:?}", navigation_path);
+
+            // This warning is used for Tokio related logging using "tracing" crate
+            // see function setup_logger in tools/fanta/src/main.rs)
+            warn_span! {"Path not found: {:?}", navigation_path};
             return Ok(None);
         }
 

--- a/tools/fanta/Cargo.toml
+++ b/tools/fanta/Cargo.toml
@@ -12,3 +12,5 @@ communication = { workspace = true }
 fern = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"

--- a/tools/fanta/src/main.rs
+++ b/tools/fanta/src/main.rs
@@ -24,6 +24,24 @@ struct CommandlineArguments {
 async fn main() -> Result<()> {
     setup_logger()?;
 
+    // create a subscriber for logs used by "tracing" crate
+    // for emitting log messages, see crates/control/src/path_planner.rs, line 318
+    let subscriber = tracing_subscriber::fmt()
+        // Use a more compact, abbreviated log format
+        .compact()
+        // Display source code file paths
+        .with_file(true)
+        // Display source code line numbers
+        .with_line_number(true)
+        // Display the thread ID an event was recorded on
+        .with_thread_ids(true)
+        // Don't display the event's target (module path)
+        .with_target(false)
+        // Build the subscriber
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber)?;
+
     let arguments = CommandlineArguments::parse();
     let output_to_subscribe = CyclerOutput::from_str(&arguments.path)?;
     let communication = Communication::new(Some(format!("ws://{}:1337", arguments.address)), true);


### PR DESCRIPTION
## Why? What?

This draft PR contains suggestions on logging improvements discussed with the HULK team during RustFest 2024 in Zurich. It is supposed to serve as an inspiration for using logging in the hulk codebase.

We discussed two possible approaches:

1. Improve general logging
2. Use logging for tracing asynchronous communication between different parts of the robot system and debug tools.

## Improve general logging

Current logging using `fern` crate could be enhanced by:

- using different "types" of logs for different purposes
- specifying logs with the `target` attribute and name of the crate (see changes in the `path_planner.rs`)
- define a separate config for these logs as well as their output (stdout, file, ...), (see change in the `setup_logger` function)

## Use logging for tracing asynchronous communication

The idea is to use crate `tracing` for emitting log spans on one side and creating subscribers to these log on the other side.

For this you need to:

- add crates [tracing](https://docs.rs/tracing) and [tracing-subscriber](https://docs.rs/tracing-subscriber)
- create a default or custom subscriber + define its configuration (see the changes in the `tools/fanta/src/main.rs`)
- emit log spans wherever you want to log details worth logging (see changes in the `path_planner.rs`)

## Sources
Fern setup: [example](https://github.com/daboross/fern/blob/main/examples/cmd-program.rs)
Tracing used in Tokio: [page](https://tokio.rs/tokio/topics/tracing)

## Possible next steps:
Create custom subscribers for a particular purpose: [documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/index.html)
Use `tokio-console` for more logging, integrate with telemetry: [documentation](https://tokio.rs/tokio/topics/tracing-next-steps)