### PR TITLE
Rule Balls in Heatmap

### DIFF
--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -7,10 +7,13 @@ use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{point, Isometry2, Point2};
 use nalgebra::{clamp, DMatrix};
 use serde::{Deserialize, Serialize};
+use spl_network_messages::{SubState, Team};
 use types::{
     ball_position::{BallPosition, HypotheticalBallPosition},
-    field_dimensions::FieldDimensions,
+    field_dimensions::{FieldDimensions, Half, Side},
+    filtered_game_controller_state::FilteredGameControllerState,
     parameters::SearchSuggestorParameters,
+    primary_state::PrimaryState,
 };
 
 #[derive(Deserialize, Serialize)]
@@ -27,10 +30,16 @@ pub struct CreationContext {
 #[context]
 pub struct CycleContext {
     search_suggestor_configuration: Parameter<SearchSuggestorParameters, "search_suggestor">,
+    field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
+
     ball_position: Input<Option<BallPosition<Ground>>, "ball_position?">,
     hypothetical_ball_positions:
         Input<Vec<HypotheticalBallPosition<Ground>>, "hypothetical_ball_positions">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
+    primary_state: Input<PrimaryState, "primary_state">,
+    filtered_game_controller_state:
+        Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
+
     heatmap: AdditionalOutput<DMatrix<f32>, "ball_search_heatmap">,
 }
 
@@ -52,19 +61,14 @@ impl SearchSuggestor {
         );
         let heatmap = Heatmap {
             map: DMatrix::from_element(heatmap_length, heatmap_width, 0.0),
-            field_dimensions: context.field_dimensions.clone(),
+            field_dimensions: *context.field_dimensions,
             cells_per_meter: context.search_suggestor_configuration.cells_per_meter,
         };
         Ok(Self { heatmap })
     }
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
-        self.update_heatmap(
-            context.ball_position,
-            context.hypothetical_ball_positions,
-            context.ground_to_field.copied(),
-            context.search_suggestor_configuration.heatmap_decay_factor,
-        );
+        self.update_heatmap(&context);
         let suggested_search_position = self
             .heatmap
             .get_maximum_position(context.search_suggestor_configuration.minimum_validity);
@@ -78,26 +82,32 @@ impl SearchSuggestor {
         })
     }
 
-    fn update_heatmap(
-        &mut self,
-        ball_position: Option<&BallPosition<Ground>>,
-        hypothetical_ball_positions: &Vec<HypotheticalBallPosition<Ground>>,
-        ground_to_field: Option<Isometry2<Ground, Field>>,
-        heatmap_decay_factor: f32,
-    ) {
-        if let Some(ball_position) = ball_position {
-            if let Some(ground_to_field) = ground_to_field {
+    fn update_heatmap(&mut self, context: &CycleContext) {
+        if let Some(ball_position) = context.ball_position {
+            if let Some(ground_to_field) = context.ground_to_field {
                 self.heatmap[ground_to_field * ball_position.position] = 1.0;
             }
         }
-        for ball_hypothesis in hypothetical_ball_positions {
-            if let Some(ground_to_field) = ground_to_field {
+        for ball_hypothesis in context.hypothetical_ball_positions {
+            if let Some(ground_to_field) = context.ground_to_field {
                 let ball_hypothesis_position = ground_to_field * ball_hypothesis.position;
                 self.heatmap[ball_hypothesis_position] =
                     (self.heatmap[ball_hypothesis_position] + ball_hypothesis.validity) / 2.0;
             }
         }
-        self.heatmap.map.scale_mut(1.0 - heatmap_decay_factor);
+        if let Some(filtered_game_controller_state) = context.filtered_game_controller_state {
+            for rule_ball_hypothesis in get_rule_hypotheses(
+                *context.primary_state,
+                *filtered_game_controller_state,
+                *context.field_dimensions,
+            ) {
+                self.heatmap[rule_ball_hypothesis] = 1.0;
+            }
+        }
+
+        self.heatmap
+            .map
+            .scale_mut(1.0 - context.search_suggestor_configuration.heatmap_decay_factor);
     }
 }
 
@@ -149,5 +159,47 @@ impl IndexMut<Point2<Field>> for Heatmap {
     fn index_mut(&mut self, field_point: Point2<Field>) -> &mut Self::Output {
         let heatmap_point = self.field_to_heatmap(field_point);
         &mut self.map[heatmap_point]
+    }
+}
+
+fn get_rule_hypotheses(
+    primary_state: PrimaryState,
+    filtered_game_controller_state: FilteredGameControllerState,
+    field_dimensions: FieldDimensions,
+) -> Vec<Point2<Field>> {
+    let kicking_team_half =
+        conservative_kicking_team_half(filtered_game_controller_state.kicking_team);
+
+    match (primary_state, filtered_game_controller_state.sub_state) {
+        (PrimaryState::Ready, Some(SubState::PenaltyKick)) => {
+            let kick_half = kicking_team_half.mirror();
+            vec![field_dimensions.penalty_spot(kick_half)]
+        }
+        // Kick-off
+        (PrimaryState::Ready, None) => vec![field_dimensions.center()],
+        (PrimaryState::Playing, Some(SubState::CornerKick)) => {
+            let kick_half = kicking_team_half.mirror();
+            vec![
+                field_dimensions.corner(kick_half, Side::Left),
+                field_dimensions.corner(kick_half, Side::Right),
+            ]
+        }
+        (PrimaryState::Playing, Some(SubState::GoalKick)) => {
+            let kick_half = kicking_team_half;
+            vec![
+                field_dimensions.corner(kick_half, Side::Left),
+                field_dimensions.corner(kick_half, Side::Right),
+            ]
+        }
+        (_, _) => Vec::new(),
+    }
+}
+
+fn conservative_kicking_team_half(kicking_team: Team) -> Half {
+    match kicking_team {
+        Team::Opponent => Half::Opponent,
+        Team::Hulks => Half::Own,
+        // If uncertain, assume opponent is kicking
+        Team::Uncertain => Half::Opponent,
     }
 }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -187,8 +187,8 @@ fn get_rule_hypotheses(
         (PrimaryState::Playing, Some(SubState::GoalKick)) => {
             let kick_half = kicking_team_half;
             vec![
-                field_dimensions.corner(kick_half, Side::Left),
-                field_dimensions.corner(kick_half, Side::Right),
+                field_dimensions.goal_box_corner(kick_half, Side::Left),
+                field_dimensions.goal_box_corner(kick_half, Side::Right),
             ]
         }
         (_, _) => Vec::new(),

--- a/crates/types/src/field_dimensions.rs
+++ b/crates/types/src/field_dimensions.rs
@@ -92,8 +92,8 @@ impl FieldDimensions {
     }
 
     pub fn goal_box_corner(&self, half: Half, side: Side) -> Point2<Field> {
-        let unsigned_x = self.length / 2.0 - self.penalty_area_length;
-        let unsigned_y = self.penalty_area_width / 2.0;
+        let unsigned_x = self.length / 2.0 - self.goal_box_area_length;
+        let unsigned_y = self.goal_box_area_width / 2.0;
         point![unsigned_x * half.sign(), unsigned_y * side.sign()]
     }
 

--- a/crates/types/src/field_dimensions.rs
+++ b/crates/types/src/field_dimensions.rs
@@ -1,12 +1,20 @@
 use serde::{Deserialize, Serialize};
 
-use linear_algebra::Point2;
+use linear_algebra::{point, Point2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
 use coordinate_systems::Field;
 
 #[derive(
-    Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
 )]
 pub struct FieldDimensions {
     pub ball_radius: f32,
@@ -26,6 +34,42 @@ pub struct FieldDimensions {
     pub goal_depth: f32,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Half {
+    Own,
+    Opponent,
+}
+
+impl Half {
+    fn sign(self) -> f32 {
+        match self {
+            Half::Own => -1.0,
+            Half::Opponent => 1.0,
+        }
+    }
+
+    pub fn mirror(self) -> Self {
+        match self {
+            Half::Own => Half::Opponent,
+            Half::Opponent => Half::Own,
+        }
+    }
+}
+
+pub enum Side {
+    Left,
+    Right,
+}
+
+impl Side {
+    fn sign(self) -> f32 {
+        match self {
+            Side::Left => 1.0,
+            Side::Right => -1.0,
+        }
+    }
+}
+
 impl FieldDimensions {
     pub fn is_inside_field(&self, position: Point2<Field>) -> bool {
         position.x().abs() < self.length / 2.0 && position.y().abs() < self.width / 2.0
@@ -34,5 +78,26 @@ impl FieldDimensions {
     pub fn is_inside_any_goal_box(&self, position: Point2<Field>) -> bool {
         position.x().abs() > self.length / 2.0 - self.goal_box_area_length
             && position.y().abs() < self.goal_box_area_width / 2.0
+    }
+
+    pub fn penalty_spot(&self, half: Half) -> Point2<Field> {
+        let unsigned_x = self.length / 2.0 - self.penalty_marker_distance;
+        point![unsigned_x * half.sign(), 0.0]
+    }
+
+    pub fn corner(&self, half: Half, side: Side) -> Point2<Field> {
+        let unsigned_x = self.length / 2.0;
+        let unsigned_y = self.width / 2.0;
+        point![unsigned_x * half.sign(), unsigned_y * side.sign()]
+    }
+
+    pub fn goal_box_corner(&self, half: Half, side: Side) -> Point2<Field> {
+        let unsigned_x = self.length / 2.0 - self.penalty_area_length;
+        let unsigned_y = self.penalty_area_width / 2.0;
+        point![unsigned_x * half.sign(), unsigned_y * side.sign()]
+    }
+
+    pub fn center(&self) -> Point2<Field> {
+        Point2::origin()
     }
 }


### PR DESCRIPTION
## Why? What?

Adds "heat" to the ball search heat map in positions where a ball might be according to the rules.
Currently covers kick off, penalty kicks, goal kicks and corner kicks.
Not handled are kick-in and pushing free kick.
Kick-in because it can happen on any point on the side lines.
Pushing free kick does **not** need special handling because the ball doesn't (or isn't supposed to) move.

N.b. I haven't tested this with a game controller yet, so I'm not sure if the conditions are quite correct.

Fixes #994 
Fixes #514

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Handle kick-in somehow, maybe by projecting the existing heat to the nearest side line.

## How to Test

Check heatmap in the relevant situations.