### PR TITLE
Flash hardware ids to `/media/internal/`

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -14,7 +14,7 @@ pub const HULA_DBUS_SERVICE: &str = "org.hulks.hula";
 pub const HULA_SOCKET_PATH: &str = "/tmp/hula";
 pub const OS_IS_NOT_LINUX: bool = !cfg!(target_os = "linux");
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
-pub const OS_VERSION: &str = "7.5.0";
+pub const OS_VERSION: &str = "7.5.1";
 pub const SDK_VERSION: &str = "7.5.0";
 
 lazy_static! {

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -83,7 +83,7 @@ impl Nao {
         command
     }
 
-    fn rsync_with_nao(&self, mkpath: bool) -> Command {
+    pub fn rsync_with_nao(&self, mkpath: bool) -> Command {
         let mut command = Command::new("rsync");
         let ssh_flags = self.get_ssh_flags().join(" ");
         command
@@ -376,8 +376,7 @@ impl Nao {
             .wrap_err("failed to execute rsync command")?;
 
         monitor_rsync_progress_with(rsync, progress_callback).await?;
-
-        self.reboot().await
+        Ok(())
     }
 }
 

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
         Command::Completions(arguments) => completions(arguments, Arguments::command())
             .await
             .wrap_err("failed to execute completion command")?,
-        Command::Gammaray(arguments) => gammaray(arguments)
+        Command::Gammaray(arguments) => gammaray(arguments, &repository?)
             .await
             .wrap_err("failed to execute gammaray command")?,
         Command::Hulk(arguments) => hulk(arguments)


### PR DESCRIPTION
## Why? What?

The `7.5.1` image depends on a `hardware_ids.json` in `/media/internal/` to setup the network. This PR adds an uploading step to the pepsi gammaray to place the `json` to this destination.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Flash a robot with the newest image and using `pepsi gammaray`