### PR TITLE
Sacrificial nao

### DIFF
--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -29,6 +29,7 @@ pub mod referee_pose_detection_filter;
 pub mod referee_position_provider;
 pub mod role_assignment;
 pub mod rule_obstacle_composer;
+pub mod sacrificial_lamb;
 pub mod search_suggestor;
 pub mod sensor_data_receiver;
 pub mod sole_pressure_filter;

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -226,11 +226,11 @@ fn send_own_detection_message<T: NetworkInterface>(
     player_number: PlayerNumber,
     time_to_reach_kick_position: Duration,
 ) -> Result<()> {
-    hardware_interface.write_to_network(dbg!(OutgoingMessage::Spl(HulkMessage {
+    hardware_interface.write_to_network(OutgoingMessage::Spl(HulkMessage {
         player_number,
         pose: Isometry2::<Ground, Field>::default().as_pose(),
         is_referee_ready_signal_detected: true,
         ball_position: None,
         time_to_reach_kick_position: Some(time_to_reach_kick_position),
-    })))
+    }))
 }

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -107,10 +107,17 @@ impl RefereePoseDetectionFilter {
         })
     }
 
-    fn update(&mut self, context: &CycleContext<impl NetworkInterface>) -> (bool, bool) {
+    fn update(&mut self, context: &CycleContext<impl NetworkInterface>) -> Result<(bool, bool)> {
+        let time_tagged_persistent_messages =
+            unpack_message_tree(&context.network_message.persistent);
+
+        for (time, message) in time_tagged_persistent_messages {
+            if message.is_referee_ready_signal_detected {
+                self.detection_times[message.player_number] = Some(time);
+            }
+        }
         let own_detected_pose_times =
             unpack_own_detection_tree(&context.detected_referee_pose_kind.persistent);
-
         let mut did_detect_any_referee_this_cycle = false;
 
         for (_, detection) in own_detected_pose_times {
@@ -132,12 +139,18 @@ impl RefereePoseDetectionFilter {
 
         if detected_referee_pose_count >= *context.minimum_number_poses_before_message {
             self.detection_times[*context.player_number] = Some(context.cycle_time.start_time);
+
+            send_own_detection_message(
+                context.hardware_interface.clone(),
+                *context.player_number,
+                *context.time_to_reach_kick_position,
+            )?;
         }
 
-        (
+        Ok((
             detected_referee_pose_count >= *context.minimum_number_poses_before_message,
             did_detect_any_referee_this_cycle,
-        )
+        ))
     }
 }
 
@@ -172,6 +185,19 @@ fn is_in_grace_period(
         < grace_period
 }
 
+fn unpack_message_tree(
+    message_tree: &BTreeMap<SystemTime, Vec<Option<&IncomingMessage>>>,
+) -> BTreeMap<SystemTime, HulkMessage> {
+    message_tree
+        .iter()
+        .flat_map(|(time, messages)| messages.iter().map(|message| (*time, message)))
+        .filter_map(|(time, message)| match message {
+            Some(IncomingMessage::Spl(message)) => Some((time, *message)),
+            _ => None,
+        })
+        .collect()
+}
+
 fn unpack_own_detection_tree(
     pose_kind_tree: &BTreeMap<SystemTime, Vec<Option<&PoseKind>>>,
 ) -> BTreeMap<SystemTime, Option<PoseKind>> {
@@ -183,4 +209,18 @@ fn unpack_own_detection_tree(
                 .map(|&pose_kind| (*time, pose_kind.cloned()))
         })
         .collect()
+}
+
+fn send_own_detection_message<T: NetworkInterface>(
+    hardware_interface: Arc<T>,
+    player_number: PlayerNumber,
+    time_to_reach_kick_position: Duration,
+) -> Result<()> {
+    hardware_interface.write_to_network(dbg!(OutgoingMessage::Spl(HulkMessage {
+        player_number,
+        pose: Isometry2::<Ground, Field>::default().as_pose(),
+        is_referee_ready_signal_detected: true,
+        ball_position: None,
+        time_to_reach_kick_position: Some(time_to_reach_kick_position),
+    })))
 }

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -24,8 +24,8 @@ use types::{
 pub struct RefereePoseDetectionFilter {
     detection_times: Players<Option<SystemTime>>,
     detected_above_arm_poses_queue: VecDeque<bool>,
-    visual_referee_state: VisualRefereeState,
     motion_in_standby_count: usize,
+    visual_referee_state: VisualRefereeState,
 }
 
 #[context]
@@ -78,10 +78,10 @@ impl RefereePoseDetectionFilter {
         Ok(Self {
             visual_referee_state: VisualRefereeState::WaitingForDetections,
             detection_times: Default::default(),
+            motion_in_standby_count: 0,
             detected_above_arm_poses_queue: VecDeque::with_capacity(
                 *context.referee_pose_queue_length,
             ),
-            motion_in_standby_count: 0,
         })
     }
 

--- a/crates/control/src/sacrificial_lamb.rs
+++ b/crates/control/src/sacrificial_lamb.rs
@@ -1,0 +1,170 @@
+use color_eyre::Result;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, SystemTime},
+};
+
+use context_attribute::context;
+use framework::{AdditionalOutput, MainOutput, PerceptionInput};
+use serde::{Deserialize, Serialize};
+use spl_network_messages::{GameControllerStateMessage, Penalty, PlayerNumber};
+use types::{
+    cycle_time::CycleTime, messages::IncomingMessage, players::Players,
+    pose_detection::VisualRefereeState,
+};
+#[derive(Deserialize, Serialize)]
+pub struct SacrificialLamb {
+    detection_times: Players<Option<SystemTime>>,
+    visual_referee_state: VisualRefereeState,
+    motion_in_standby_count: usize,
+}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    network_message: PerceptionInput<Option<IncomingMessage>, "SplNetwork", "filtered_message?">,
+
+    cycle_time: Input<CycleTime, "cycle_time">,
+    majority_vote_is_referee_ready_pose_detected:
+        Input<bool, "majority_vote_is_referee_ready_pose_detected">,
+
+    player_number: Parameter<PlayerNumber, "player_number">,
+    wait_for_opponent_penalties_period:
+        Parameter<Duration, "sacrificial_lamb.wait_for_opponent_penalties_period">,
+    wait_for_own_penalties_period:
+        Parameter<Duration, "sacrificial_lamb.wait_for_own_penalties_period">,
+    sacrificial_lamb: Parameter<PlayerNumber, "sacrificial_lamb.sacrificial_nao_playernumber">,
+
+    visual_referee_state: AdditionalOutput<VisualRefereeState, "visual_referee_state">,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub visual_referee_proceed_to_ready: MainOutput<bool>,
+}
+
+impl SacrificialLamb {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            visual_referee_state: VisualRefereeState::WaitingForDetections,
+            detection_times: Default::default(),
+            motion_in_standby_count: 0,
+        })
+    }
+
+    pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
+        let cycle_start_time = context.cycle_time.start_time;
+
+        let game_controller_message =
+            unpack_game_controller_messages(&context.network_message.persistent);
+
+        let new_motion_in_standby_count = game_controller_message
+            .iter()
+            .map(|message| {
+                message
+                    .hulks_team
+                    .players
+                    .iter()
+                    .filter(|player| {
+                        matches!(player.penalty, Some(Penalty::IllegalMotionInStandby { .. }))
+                    })
+                    .count()
+                    + message
+                        .opponent_team
+                        .players
+                        .iter()
+                        .filter(|player| {
+                            matches!(player.penalty, Some(Penalty::IllegalMotionInStandby { .. }))
+                        })
+                        .count()
+            })
+            .max();
+
+        let motion_in_initial =
+            new_motion_in_standby_count.map_or(false, |new_motion_in_standby_count| {
+                let motion_in_initial = new_motion_in_standby_count > self.motion_in_standby_count;
+                self.motion_in_standby_count = new_motion_in_standby_count;
+                motion_in_initial
+            });
+
+        self.visual_referee_state = match (
+            self.visual_referee_state,
+            context.majority_vote_is_referee_ready_pose_detected,
+            motion_in_initial,
+        ) {
+            (VisualRefereeState::WaitingForDetections, true, motion_in_initial) => {
+                if motion_in_initial {
+                    self.detection_times = Default::default();
+                    VisualRefereeState::WaitingForDetections
+                } else {
+                    VisualRefereeState::WaitingForOpponentPenalties {
+                        active_since: cycle_start_time,
+                    }
+                }
+            }
+            (VisualRefereeState::WaitingForOpponentPenalties { .. }, _, true) => {
+                self.detection_times = Default::default();
+                VisualRefereeState::WaitingForDetections
+            }
+            (VisualRefereeState::WaitingForOpponentPenalties { active_since }, _, false) => {
+                if cycle_start_time
+                    .duration_since(active_since)
+                    .expect("time ran backwards")
+                    >= *context.wait_for_opponent_penalties_period
+                {
+                    if context.player_number == context.sacrificial_lamb {
+                        VisualRefereeState::GoToReady
+                    } else {
+                        VisualRefereeState::WaitingForOwnPenalties {
+                            active_since: cycle_start_time,
+                        }
+                    }
+                } else {
+                    VisualRefereeState::WaitingForOpponentPenalties { active_since }
+                }
+            }
+            (VisualRefereeState::WaitingForOwnPenalties { .. }, _, true) => {
+                self.detection_times = Default::default();
+                VisualRefereeState::WaitingForDetections
+            }
+            (VisualRefereeState::WaitingForOwnPenalties { active_since }, _, false) => {
+                if cycle_start_time
+                    .duration_since(active_since)
+                    .expect("time ran backwards")
+                    >= *context.wait_for_own_penalties_period
+                {
+                    VisualRefereeState::GoToReady
+                } else {
+                    VisualRefereeState::WaitingForOwnPenalties { active_since }
+                }
+            }
+            (current_state, _, _) => current_state,
+        };
+
+        context
+            .visual_referee_state
+            .fill_if_subscribed(|| self.visual_referee_state);
+
+        Ok(MainOutputs {
+            visual_referee_proceed_to_ready: (self.visual_referee_state
+                == VisualRefereeState::GoToReady)
+                .into(),
+        })
+    }
+}
+
+fn unpack_game_controller_messages<'a>(
+    message_tree: &BTreeMap<SystemTime, Vec<Option<&'a IncomingMessage>>>,
+) -> Vec<&'a GameControllerStateMessage> {
+    message_tree
+        .values()
+        .flatten()
+        .filter_map(|message| match message {
+            Some(IncomingMessage::GameController(_, message)) => Some(message),
+            Some(IncomingMessage::Spl(..)) | None => None,
+        })
+        .collect()
+}

--- a/crates/control/src/sacrificial_lamb.rs
+++ b/crates/control/src/sacrificial_lamb.rs
@@ -83,20 +83,20 @@ impl SacrificialLamb {
             })
             .max();
 
-        let motion_in_initial =
+        let motion_in_standby =
             new_motion_in_standby_count.map_or(false, |new_motion_in_standby_count| {
-                let motion_in_initial = new_motion_in_standby_count > self.motion_in_standby_count;
+                let motion_in_standby = new_motion_in_standby_count > self.motion_in_standby_count;
                 self.motion_in_standby_count = new_motion_in_standby_count;
-                motion_in_initial
+                motion_in_standby
             });
 
         self.visual_referee_state = match (
             self.visual_referee_state,
             context.majority_vote_is_referee_ready_pose_detected,
-            motion_in_initial,
+            motion_in_standby,
         ) {
-            (VisualRefereeState::WaitingForDetections, true, motion_in_initial) => {
-                if motion_in_initial {
+            (VisualRefereeState::WaitingForDetections, true, motion_in_standby) => {
+                if motion_in_standby {
                     self.detection_times = Default::default();
                     VisualRefereeState::WaitingForDetections
                 } else {

--- a/crates/hulk_behavior_simulator/src/fake_data.rs
+++ b/crates/hulk_behavior_simulator/src/fake_data.rs
@@ -55,6 +55,7 @@ pub struct MainOutputs {
     pub has_ground_contact: MainOutput<bool>,
     pub hulk_messages: MainOutput<Vec<HulkMessage>>,
     pub majority_vote_is_referee_ready_pose_detected: MainOutput<bool>,
+    pub visual_referee_proceed_to_ready: MainOutput<bool>,
     pub hypothetical_ball_positions: MainOutput<Vec<HypotheticalBallPosition<Ground>>>,
     pub is_localization_converged: MainOutput<bool>,
     pub obstacles: MainOutput<Vec<Obstacle>>,
@@ -89,6 +90,7 @@ impl FakeData {
             majority_vote_is_referee_ready_pose_detected: last_database
                 .majority_vote_is_referee_ready_pose_detected
                 .into(),
+            visual_referee_proceed_to_ready: last_database.visual_referee_proceed_to_ready.into(),
             hypothetical_ball_positions: last_database.hypothetical_ball_positions.clone().into(),
             is_localization_converged: last_database.is_localization_converged.into(),
             obstacles: last_database.obstacles.clone().into(),

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -89,6 +89,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "control::rule_obstacle_composer",
                     "control::referee_position_provider",
                     "control::referee_pose_detection_filter",
+                    "control::sacrificial_lamb",
                     "control::sole_pressure_filter",
                     "control::sonar_filter",
                     "control::search_suggestor",

--- a/crates/types/src/pose_detection.rs
+++ b/crates/types/src/pose_detection.rs
@@ -1,4 +1,4 @@
-use std::ops::Index;
+use std::{ops::Index, time::SystemTime};
 
 use crate::bounding_box::BoundingBox;
 use color_eyre::Result;
@@ -139,4 +139,22 @@ impl HumanPose {
 pub struct RefereePoseCandidate {
     pub pose: HumanPose,
     pub distance_to_referee_position: f32,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+)]
+pub enum VisualRefereeState {
+    WaitingForDetections,
+    WaitingForOpponentPenalties { active_since: SystemTime },
+    WaitingForOwnPenalties { active_since: SystemTime },
+    GoToReady,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1207,6 +1207,17 @@
     },
     "minimum_above_head_arms_detections": 2
   },
+  "sacrificial_lamb": {
+    "wait_for_opponent_penalties_period": {
+      "nanos": 0,
+      "secs": 5
+    },
+    "wait_for_own_penalties_period": {
+      "nanos": 0,
+      "secs": 15
+    },
+    "sacrificial_nao_playernumber": "Three"
+  },
   "ground_contact_detector": {
     "pressure_threshold": 0.6,
     "hysteresis": 0.3,


### PR DESCRIPTION
## Why? What?

Re-enables message sending in `Standby` after referee detection, to enable transition to `Ready` also for robots which do not see referee.
Moreover it implements an sacrificial lamb for the referee pose detection, to avoid penalizing of whole team after false detection.

Fixes #984

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Test at least with 2 robots (1 detecting, 1 sacrificial lamb at the moment playernumber 3). 
Both should wait 5s after detection (wait for penalty of opponent team), then the lamb transitions to `Ready` and if it is not penalized the others transition to `Ready` 20s after detection. 
