### PR TITLE
Penalty shootout keeper improvements

### DIFF
--- a/crates/control/src/game_controller_state_filter.rs
+++ b/crates/control/src/game_controller_state_filter.rs
@@ -132,7 +132,7 @@ impl GameControllerStateFilter {
             }
         }
         if let State::Playing { .. } = self.state {
-            self.whistle_in_set_ball_position.take();
+            self.whistle_in_set_ball_position = None;
         }
 
         let ball_detected_far_from_kick_off_point = ball_position

--- a/crates/control/src/game_controller_state_filter.rs
+++ b/crates/control/src/game_controller_state_filter.rs
@@ -4,7 +4,7 @@ use ball_filter::BallPosition;
 use color_eyre::Result;
 use context_attribute::context;
 use coordinate_systems::{Field, Ground};
-use framework::{AdditionalOutput, MainOutput};
+use framework::MainOutput;
 use linear_algebra::{distance, Isometry2, Point2, Vector2};
 use serde::{Deserialize, Serialize};
 use spl_network_messages::{GamePhase, GameState, Team};
@@ -35,14 +35,12 @@ pub struct CycleContext {
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
 
     ground_to_field: CyclerState<Isometry2<Ground, Field>, "ground_to_field">,
-
-    whistle_in_set_ball_position:
-        AdditionalOutput<Option<Point2<Field>>, "whistle_in_set_ball_position">,
 }
 
 #[context]
 pub struct MainOutputs {
     pub filtered_game_controller_state: MainOutput<Option<FilteredGameControllerState>>,
+    pub whistle_in_set_ball_position: MainOutput<Option<Point2<Ground>>>,
 }
 
 impl GameControllerStateFilter {
@@ -54,7 +52,7 @@ impl GameControllerStateFilter {
         })
     }
 
-    pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let game_states = self.filter_game_states(
             *context.ground_to_field,
             context.ball_position,
@@ -79,12 +77,13 @@ impl GameControllerStateFilter {
                 .game_controller_state
                 .hulks_team_is_home_after_coin_toss,
         };
-        context
-            .whistle_in_set_ball_position
-            .fill_if_subscribed(|| self.whistle_in_set_ball_position);
 
         Ok(MainOutputs {
             filtered_game_controller_state: Some(filtered_game_controller_state).into(),
+            whistle_in_set_ball_position: self
+                .whistle_in_set_ball_position
+                .map(|ball_position| context.ground_to_field.inverse() * ball_position)
+                .into(),
         })
     }
 

--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -153,8 +153,8 @@ impl Localization {
                     .clone_from(&self.hypotheses);
             }
             (
+                _,
                 PrimaryState::Set,
-                PrimaryState::Playing,
                 Some(GamePhase::PenaltyShootout {
                     kicking_team: Team::Hulks,
                 }),
@@ -173,8 +173,8 @@ impl Localization {
                     .clone_from(&self.hypotheses);
             }
             (
+                _,
                 PrimaryState::Set,
-                PrimaryState::Playing,
                 Some(GamePhase::PenaltyShootout {
                     kicking_team: Team::Opponent,
                 }),

--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -174,7 +174,7 @@ impl Localization {
             }
             (
                 _,
-                PrimaryState::Set,
+                PrimaryState::Set | PrimaryState::Playing,
                 Some(GamePhase::PenaltyShootout {
                     kicking_team: Team::Opponent,
                 }),

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -7,8 +7,10 @@ use linear_algebra::{Isometry2, Point2};
 use serde::{Deserialize, Serialize};
 use spl_network_messages::{GamePhase, SubState, Team};
 use types::{
-    field_dimensions::FieldDimensions, filtered_game_controller_state::FilteredGameControllerState,
-    penalty_shot_direction::PenaltyShotDirection, primary_state::PrimaryState,
+    field_dimensions::{FieldDimensions, Half},
+    filtered_game_controller_state::FilteredGameControllerState,
+    penalty_shot_direction::PenaltyShotDirection,
+    primary_state::PrimaryState,
 };
 
 #[derive(Deserialize, Serialize)]
@@ -65,10 +67,7 @@ impl PenaltyShotDirectionEstimation {
             (PrimaryState::Playing, GamePhase::PenaltyShootout { .. }, ..)
             | (PrimaryState::Playing, _, Some(SubState::PenaltyKick), Team::Opponent) => {
                 let penalty_marker_position_in_ground = context.ground_to_field.inverse()
-                    * FieldDimensions::penalty_spot(
-                        context.field_dimensions,
-                        types::field_dimensions::Half::Own,
-                    );
+                    * FieldDimensions::penalty_spot(context.field_dimensions, Half::Own);
                 let reference_position = self
                     .placed_ball_position
                     .unwrap_or(penalty_marker_position_in_ground);

--- a/crates/control/src/penalty_shot_direction_estimation.rs
+++ b/crates/control/src/penalty_shot_direction_estimation.rs
@@ -25,7 +25,7 @@ pub struct CycleContext {
     moving_distance_threshold:
         Parameter<f32, "penalty_shot_direction_estimation.moving_distance_threshold">,
     minimum_robot_radius_at_foot_height:
-        Parameter<f32, "path_planning.minimum_robot_radius_at_foot_height">,
+        Parameter<f32, "behavior.path_planning.minimum_robot_radius_at_foot_height">,
 
     ball_position: RequiredInput<Option<BallPosition<Ground>>, "ball_position?">,
     filtered_game_controller_state:

--- a/crates/types/src/field_dimensions.rs
+++ b/crates/types/src/field_dimensions.rs
@@ -96,7 +96,6 @@ impl FieldDimensions {
         let unsigned_y = self.goal_box_area_width / 2.0;
         point![unsigned_x * half.sign(), unsigned_y * side.sign()]
     }
-
     pub fn center(&self) -> Point2<Field> {
         Point2::origin()
     }

--- a/crates/types/src/field_dimensions.rs
+++ b/crates/types/src/field_dimensions.rs
@@ -96,6 +96,7 @@ impl FieldDimensions {
         let unsigned_y = self.goal_box_area_width / 2.0;
         point![unsigned_x * half.sign(), unsigned_y * side.sign()]
     }
+
     pub fn center(&self) -> Point2<Field> {
         Point2::origin()
     }


### PR DESCRIPTION
## Why? What?

- Correctly set location during set phase of penalty shootout to prevent robot randomely jerking head because localization keeps generating alternating field sides
- Turn off active vision during penalty shootout to prevent keeper looking up and down between ball and 1m in front of self
- Use whistle in set ball position to determine penalty shot direction to counter for poor camera matrix
- Use a y distance threshold other than zero, specifically require a distance to be greater than one where the linear projection of the ball would lead to it rolling past the robots feet. If the threshold is not met it probably makes more sense to remain standing

Mitigates #997 and #546
Fixes #477 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

The y direction threshold can be further adapted to accommodate for a wide stance once implemented

## How to Test

Do penalty shootout I guess. A slightly off camera matrix should no longer lead to immediate jumping. And if the ball rolls straight at the robot he should remain standing.
