### PR TITLE
Move pose detection toggle

### DIFF
--- a/crates/control/src/behavior/initial.rs
+++ b/crates/control/src/behavior/initial.rs
@@ -12,6 +12,7 @@ use types::{
 pub fn execute(
     world_state: &WorldState,
     expected_referee_position: Option<Point2<Field>>,
+    enable_pose_detection: bool,
 ) -> Option<MotionCommand> {
     if world_state.robot.primary_state == PrimaryState::Initial {
         return Some(MotionCommand::Initial {
@@ -21,12 +22,15 @@ pub fn execute(
     }
     if world_state.robot.primary_state == PrimaryState::Standby {
         return Some(
-            look_at_referee(expected_referee_position, world_state.clone()).unwrap_or(
-                MotionCommand::Initial {
-                    head: HeadMotion::Center,
-                    should_look_for_referee: false,
-                },
-            ),
+            look_at_referee(
+                expected_referee_position,
+                world_state.clone(),
+                enable_pose_detection,
+            )
+            .unwrap_or(MotionCommand::Initial {
+                head: HeadMotion::Center,
+                should_look_for_referee: false,
+            }),
         );
     }
     None
@@ -35,10 +39,13 @@ pub fn execute(
 fn look_at_referee(
     expected_referee_position: Option<Point2<Field>>,
     world_state: WorldState,
+    enable_pose_detection: bool,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let expected_referee_position = expected_referee_position?;
-    if world_state.filtered_game_controller_state?.game_state != FilteredGameState::Standby {
+    if !enable_pose_detection
+        || world_state.filtered_game_controller_state?.game_state != FilteredGameState::Standby
+    {
         return None;
     }
 

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -69,6 +69,7 @@ pub struct CycleContext {
     lost_ball_parameters: Parameter<LostBallParameters, "behavior.lost_ball">,
     intercept_ball_parameters: Parameter<InterceptBallParameters, "behavior.intercept_ball">,
     maximum_step_size: Parameter<Step, "step_planner.max_step_size">,
+    enable_pose_detection: Parameter<bool, "object_detection.object_detection_top.enable">,
 }
 
 #[context]
@@ -247,9 +248,11 @@ impl Behavior {
                     Action::Unstiff => unstiff::execute(world_state),
                     Action::SitDown => sit_down::execute(world_state),
                     Action::Penalize => penalize::execute(world_state),
-                    Action::Initial => {
-                        initial::execute(world_state, context.expected_referee_position.cloned())
-                    }
+                    Action::Initial => initial::execute(
+                        world_state,
+                        context.expected_referee_position.cloned(),
+                        *context.enable_pose_detection,
+                    ),
                     Action::FallSafely => {
                         fall_safely::execute(world_state, *context.has_ground_contact)
                     }


### PR DESCRIPTION
## Why? What?

Moves the application of the `pose_detection.enable` parameter to behavior. This makes sense logically, as its a behavior decision. Additionally, as this is applied in the `MotionCommand::Initial`, this toggle is now also reflected in the head motion of the nao. If pose detection is disabled, the nao will remain simply look forward. If it is enabled, the nao will look to the referee.
This makes it easy to see, if pose detection is actually enabled or not.

## How to Test

- Set the nao up for visual referee/Ready.
- In twix, toggle the parameter `pose_detection.enable`.