### PR TITLE
Fix typo in object detection feature for replayer

### DIFF
--- a/crates/hulk_replayer/Cargo.toml
+++ b/crates/hulk_replayer/Cargo.toml
@@ -21,7 +21,7 @@ energy_optimization = { workspace = true }
 framework = { workspace = true }
 geometry = { workspace = true }
 hardware = { workspace = true }
-ittapi = {  workspace = true }
+ittapi = { workspace = true }
 linear_algebra = { workspace = true }
 nalgebra = { workspace = true }
 object_detection = { workspace = true }
@@ -44,4 +44,4 @@ hulk_manifest = { workspace = true }
 source_analyzer = { workspace = true }
 
 [features]
-with_detection = []
+with_object_detection = []


### PR DESCRIPTION
## Why? What?

Fixes a typo in the feature name of the object detection feature, which enables the execution of the `ObjectDetectionTop` cycler when replaying.  

## How to Test

Run a replay which recorded the ObjectDetectionTop cycler. This has to be done as a cargo command, with the `--features "with_object_detection"`, as the `--features` flag is not yet exposed to pepsi. Issue is tracked in #1095.