### PR TITLE
Enable visual referee recording

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1,7 +1,7 @@
 {
   "object_detection": {
     "object_detection_top": {
-      "enable": false,
+      "enable": true,
       "intersection_over_union_threshold": 0.45,
       "distance_to_referee_position_threshold": 2.0,
       "keypoint_confidence_threshold": 0.2,
@@ -1387,7 +1387,7 @@
     "goal_depth": 0.5
   },
   "player_number": "Seven",
-  "recorded_primary_states": ["Ready", "Set", "Playing"],
+  "recorded_primary_states": ["Standby", "Ready", "Set", "Playing"],
   "spl_network": {
     "game_controller_return_message_interval": {
       "nanos": 0,

--- a/etc/parameters/framework.json
+++ b/etc/parameters/framework.json
@@ -3,7 +3,6 @@
   "hardware_parameters": "etc/parameters/hardware.json",
   "parameters_directory": "etc/parameters",
   "recording_intervals": {
-    "Control": 1,
-    "ObjectDetectionTop": 1
+    "Control": 1
   }
 }

--- a/etc/parameters/framework.json
+++ b/etc/parameters/framework.json
@@ -3,6 +3,7 @@
   "hardware_parameters": "etc/parameters/hardware.json",
   "parameters_directory": "etc/parameters",
   "recording_intervals": {
-    "Control": 1
+    "Control": 1,
+    "ObjectDetectionTop": 1
   }
 }


### PR DESCRIPTION
## Why? What?

Enables visual referee by default and sets the `Standby` state to be recorded.

## How to Test

Record a visual referee scenario and run the replayer with the `--features "with_object_detection"`. Requires openvino to be installed locally. 
This may change as is tracked in #1095.