### PR TITLE
kickoff position with rotation

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -17,6 +17,7 @@ use types::{
     motion_command::MotionCommand,
     parameters::{
         BehaviorParameters, InWalkKicksParameters, InterceptBallParameters, LostBallParameters,
+        RolePositionsParameters,
     },
     path_obstacles::PathObstacle,
     planned_path::PathSegment,
@@ -69,7 +70,7 @@ pub struct CycleContext {
     lost_ball_parameters: Parameter<LostBallParameters, "behavior.lost_ball">,
     intercept_ball_parameters: Parameter<InterceptBallParameters, "behavior.intercept_ball">,
     maximum_step_size: Parameter<Step, "step_planner.max_step_size">,
-    striker_set_position: Parameter<Point2<Field>, "behavior.role_positions.striker_set_position">,
+    role_positions: Parameter<RolePositionsParameters, "behavior.role_positions">,
 }
 
 #[context]
@@ -355,7 +356,7 @@ impl Behavior {
                         &walk_and_stand,
                         &look_action,
                         &mut context.path_obstacles_output,
-                        *context.striker_set_position,
+                        context.role_positions.clone(),
                     ),
                     Action::WalkToPenaltyKick => walk_to_penalty_kick::execute(
                         world_state,

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -17,7 +17,6 @@ use types::{
     motion_command::MotionCommand,
     parameters::{
         BehaviorParameters, InWalkKicksParameters, InterceptBallParameters, LostBallParameters,
-        RolePositionsParameters,
     },
     path_obstacles::PathObstacle,
     planned_path::PathSegment,
@@ -70,7 +69,6 @@ pub struct CycleContext {
     lost_ball_parameters: Parameter<LostBallParameters, "behavior.lost_ball">,
     intercept_ball_parameters: Parameter<InterceptBallParameters, "behavior.intercept_ball">,
     maximum_step_size: Parameter<Step, "step_planner.max_step_size">,
-    role_positions: Parameter<RolePositionsParameters, "behavior.role_positions">,
 }
 
 #[context]
@@ -356,7 +354,7 @@ impl Behavior {
                         &walk_and_stand,
                         &look_action,
                         &mut context.path_obstacles_output,
-                        context.role_positions.clone(),
+                        context.parameters.role_positions.striker_kickoff_pose,
                     ),
                     Action::WalkToPenaltyKick => walk_to_penalty_kick::execute(
                         world_state,

--- a/crates/control/src/behavior/walk_to_kick_off.rs
+++ b/crates/control/src/behavior/walk_to_kick_off.rs
@@ -1,10 +1,7 @@
 use coordinate_systems::Field;
 use framework::AdditionalOutput;
-use linear_algebra::{Orientation2, Pose2};
-use types::{
-    motion_command::MotionCommand, parameters::RolePositionsParameters,
-    path_obstacles::PathObstacle, world_state::WorldState,
-};
+use linear_algebra::Pose2;
+use types::{motion_command::MotionCommand, path_obstacles::PathObstacle, world_state::WorldState};
 
 use super::{head::LookAction, walk_to_pose::WalkAndStand};
 
@@ -13,15 +10,11 @@ pub fn execute(
     walk_and_stand: &WalkAndStand,
     look_action: &LookAction,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
-    role_positions: RolePositionsParameters,
+    striker_kickoff_pose: Pose2<Field>,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     walk_and_stand.execute(
-        ground_to_field.inverse()
-            * Pose2::<Field>::from_parts(
-                role_positions.striker_kickoff_position,
-                Orientation2::new(role_positions.striker_kickoff_orientation),
-            ),
+        ground_to_field.inverse() * striker_kickoff_pose,
         look_action.execute(),
         path_obstacles_output,
     )

--- a/crates/control/src/behavior/walk_to_kick_off.rs
+++ b/crates/control/src/behavior/walk_to_kick_off.rs
@@ -1,7 +1,10 @@
 use coordinate_systems::Field;
 use framework::AdditionalOutput;
-use linear_algebra::{Point2, Pose2};
-use types::{motion_command::MotionCommand, path_obstacles::PathObstacle, world_state::WorldState};
+use linear_algebra::{Orientation2, Pose2};
+use types::{
+    motion_command::MotionCommand, parameters::RolePositionsParameters,
+    path_obstacles::PathObstacle, world_state::WorldState,
+};
 
 use super::{head::LookAction, walk_to_pose::WalkAndStand};
 
@@ -10,11 +13,15 @@ pub fn execute(
     walk_and_stand: &WalkAndStand,
     look_action: &LookAction,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
-    striker_set_position: Point2<Field>,
+    role_positions: RolePositionsParameters,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     walk_and_stand.execute(
-        ground_to_field.inverse() * Pose2::from(striker_set_position),
+        ground_to_field.inverse()
+            * Pose2::<Field>::from_parts(
+                role_positions.striker_kickoff_position,
+                Orientation2::new(role_positions.striker_kickoff_orientation),
+            ),
         look_action.execute(),
         path_obstacles_output,
     )

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, Range};
 use std::{path::PathBuf, time::Duration};
 
 use coordinate_systems::{Field, Ground, NormalizedPixel};
-use linear_algebra::{Point2, Vector2};
+use linear_algebra::{Point2, Pose2, Vector2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -87,8 +87,7 @@ pub struct RolePositionsParameters {
     pub striker_supporter_minimum_x: f32,
     pub keeper_x_offset: f32,
     pub striker_distance_to_non_free_center_circle: f32,
-    pub striker_kickoff_position: Point2<Field>,
-    pub striker_kickoff_orientation: f32,
+    pub striker_kickoff_pose: Pose2<Field>,
 }
 
 #[derive(

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -87,7 +87,8 @@ pub struct RolePositionsParameters {
     pub striker_supporter_minimum_x: f32,
     pub keeper_x_offset: f32,
     pub striker_distance_to_non_free_center_circle: f32,
-    pub striker_set_position: Point2<Field>,
+    pub striker_kickoff_position: Point2<Field>,
+    pub striker_kickoff_orientation: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1113,7 +1113,7 @@
       "striker_distance_to_non_free_center_circle": 0.4,
       "striker_kickoff_pose": {
         "translation": [0.0, 0.3],
-        "rotation": [0.0007962742820382118, -0.9999997019767761]
+        "rotation": [0.0, -1.0]
       }
     },
     "dribbling": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1111,8 +1111,10 @@
       "striker_supporter_minimum_x": 2.0,
       "keeper_x_offset": 0.1,
       "striker_distance_to_non_free_center_circle": 0.4,
-      "striker_kickoff_position": [0.0, 0.3],
-      "striker_kickoff_orientation": -1.57
+      "striker_kickoff_pose": {
+        "translation": [0.0, 0.3],
+        "rotation": [0.0007962742820382118, -0.9999997019767761]
+      }
     },
     "dribbling": {
       "hybrid_align_distance": 0.5,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1111,7 +1111,8 @@
       "striker_supporter_minimum_x": 2.0,
       "keeper_x_offset": 0.1,
       "striker_distance_to_non_free_center_circle": 0.4,
-      "striker_set_position": [-0.3, 0.0]
+      "striker_kickoff_position": [0.0, 0.3],
+      "striker_kickoff_orientation": -1.57
     },
     "dribbling": {
       "hybrid_align_distance": 0.5,


### PR DESCRIPTION
## Why? What?

Make kickoff in the direction of the supporting striker easier by positioning differently in ready

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Kick off to left supporter if supporting striker is penalized? I.e. rotate 180 degrees about midpoint Z axis

## How to Test

Behavior sim or test game. Observe Striker position when HULKs are kicking team
