### PR TITLE
Expose features flag to pepsi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -137,12 +137,17 @@ impl Repository {
         workspace: bool,
         profile: &str,
         target: &str,
+        features: &[String],
         passthrough_arguments: &[String],
     ) -> Result<()> {
         let use_docker = target == "nao" && OS_IS_NOT_LINUX;
 
         let cargo_command = format!("cargo {action} ")
             + format!("--profile {profile} ").as_str()
+            + {
+                let features_string = features.join(" ");
+                format!("--features {features_string} ").as_str()
+            }
             + if workspace {
                 "--workspace --all-features --all-targets ".to_string()
             } else {
@@ -204,6 +209,7 @@ impl Repository {
         workspace: bool,
         profile: &str,
         target: &str,
+        features: &[String],
         passthrough_arguments: &[String],
     ) -> Result<()> {
         self.cargo(
@@ -211,25 +217,41 @@ impl Repository {
             workspace,
             profile,
             target,
+            features,
             passthrough_arguments,
         )
         .await
     }
 
     pub async fn check(&self, workspace: bool, profile: &str, target: &str) -> Result<()> {
-        self.cargo(CargoAction::Check, workspace, profile, target, &[])
-            .await
+        self.cargo(
+            CargoAction::Check,
+            workspace,
+            profile,
+            target,
+            &["".to_string()],
+            &[],
+        )
+        .await
     }
 
     pub async fn clippy(&self, workspace: bool, profile: &str, target: &str) -> Result<()> {
-        self.cargo(CargoAction::Clippy, workspace, profile, target, &[])
-            .await
+        self.cargo(
+            CargoAction::Clippy,
+            workspace,
+            profile,
+            target,
+            &["".to_string()],
+            &[],
+        )
+        .await
     }
 
     pub async fn run(
         &self,
         profile: &str,
         target: &str,
+        features: &[String],
         passthrough_arguments: &[String],
     ) -> Result<()> {
         self.cargo(
@@ -237,6 +259,7 @@ impl Repository {
             false,
             profile,
             target,
+            features,
             passthrough_arguments,
         )
         .await

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -137,17 +137,19 @@ impl Repository {
         workspace: bool,
         profile: &str,
         target: &str,
-        features: &[String],
+        features: &str,
         passthrough_arguments: &[String],
     ) -> Result<()> {
         let use_docker = target == "nao" && OS_IS_NOT_LINUX;
 
         let cargo_command = format!("cargo {action} ")
             + format!("--profile {profile} ").as_str()
-            + {
-                let features_string = features.join(" ");
-                format!("--features {features_string} ").as_str()
+            + if !features.is_empty() {
+                format!("--features {features} ")
+            } else {
+                String::new()
             }
+            .as_str()
             + if workspace {
                 "--workspace --all-features --all-targets ".to_string()
             } else {
@@ -209,7 +211,7 @@ impl Repository {
         workspace: bool,
         profile: &str,
         target: &str,
-        features: &[String],
+        features: &str,
         passthrough_arguments: &[String],
     ) -> Result<()> {
         self.cargo(
@@ -224,34 +226,20 @@ impl Repository {
     }
 
     pub async fn check(&self, workspace: bool, profile: &str, target: &str) -> Result<()> {
-        self.cargo(
-            CargoAction::Check,
-            workspace,
-            profile,
-            target,
-            &["".to_string()],
-            &[],
-        )
-        .await
+        self.cargo(CargoAction::Check, workspace, profile, target, "", &[])
+            .await
     }
 
     pub async fn clippy(&self, workspace: bool, profile: &str, target: &str) -> Result<()> {
-        self.cargo(
-            CargoAction::Clippy,
-            workspace,
-            profile,
-            target,
-            &["".to_string()],
-            &[],
-        )
-        .await
+        self.cargo(CargoAction::Clippy, workspace, profile, target, "", &[])
+            .await
     }
 
     pub async fn run(
         &self,
         profile: &str,
         target: &str,
-        features: &[String],
+        features: &str,
         passthrough_arguments: &[String],
     ) -> Result<()> {
         self.cargo(

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -137,14 +137,15 @@ impl Repository {
         workspace: bool,
         profile: &str,
         target: &str,
-        features: &str,
+        features: Option<Vec<String>>,
         passthrough_arguments: &[String],
     ) -> Result<()> {
         let use_docker = target == "nao" && OS_IS_NOT_LINUX;
 
         let cargo_command = format!("cargo {action} ")
             + format!("--profile {profile} ").as_str()
-            + if !features.is_empty() {
+            + if let Some(features) = features {
+                let features = features.join(",");
                 format!("--features {features} ")
             } else {
                 String::new()
@@ -211,7 +212,7 @@ impl Repository {
         workspace: bool,
         profile: &str,
         target: &str,
-        features: &str,
+        features: Option<Vec<String>>,
         passthrough_arguments: &[String],
     ) -> Result<()> {
         self.cargo(
@@ -226,12 +227,12 @@ impl Repository {
     }
 
     pub async fn check(&self, workspace: bool, profile: &str, target: &str) -> Result<()> {
-        self.cargo(CargoAction::Check, workspace, profile, target, "", &[])
+        self.cargo(CargoAction::Check, workspace, profile, target, None, &[])
             .await
     }
 
     pub async fn clippy(&self, workspace: bool, profile: &str, target: &str) -> Result<()> {
-        self.cargo(CargoAction::Clippy, workspace, profile, target, "", &[])
+        self.cargo(CargoAction::Clippy, workspace, profile, target, None, &[])
             .await
     }
 
@@ -239,7 +240,7 @@ impl Repository {
         &self,
         profile: &str,
         target: &str,
-        features: &str,
+        features: Option<Vec<String>>,
         passthrough_arguments: &[String],
     ) -> Result<()> {
         self.cargo(

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.12.0"
+version = "3.13.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -19,6 +19,8 @@ pub struct Arguments {
     pub target: String,
     #[arg(long)]
     pub no_sdk_installation: bool,
+    #[arg(long)]
+    pub features: Vec<String>,
     /// Pass through arguments to cargo ... -- PASSTHROUGH_ARGUMENTS
     #[arg(last = true, value_parser)]
     pub passthrough_arguments: Vec<String>,
@@ -61,6 +63,7 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
                 arguments.workspace,
                 &arguments.profile,
                 &arguments.target,
+                &arguments.features,
                 &arguments.passthrough_arguments,
             )
             .await
@@ -81,6 +84,7 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
                 .run(
                     &arguments.profile,
                     &arguments.target,
+                    &arguments.features,
                     &arguments.passthrough_arguments,
                 )
                 .await

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -19,8 +19,8 @@ pub struct Arguments {
     pub target: String,
     #[arg(long)]
     pub no_sdk_installation: bool,
-    #[arg(long, default_value = "")]
-    pub features: String,
+    #[arg(long, default_value = None, num_args = 1..)]
+    pub features: Option<Vec<String>>,
     /// Pass through arguments to cargo ... -- PASSTHROUGH_ARGUMENTS
     #[arg(last = true, value_parser)]
     pub passthrough_arguments: Vec<String>,
@@ -63,7 +63,7 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
                 arguments.workspace,
                 &arguments.profile,
                 &arguments.target,
-                &arguments.features,
+                arguments.features,
                 &arguments.passthrough_arguments,
             )
             .await
@@ -84,7 +84,7 @@ pub async fn cargo(arguments: Arguments, repository: &Repository, command: Comma
                 .run(
                     &arguments.profile,
                     &arguments.target,
-                    &arguments.features,
+                    arguments.features,
                     &arguments.passthrough_arguments,
                 )
                 .await

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -19,8 +19,8 @@ pub struct Arguments {
     pub target: String,
     #[arg(long)]
     pub no_sdk_installation: bool,
-    #[arg(long)]
-    pub features: Vec<String>,
+    #[arg(long, default_value = "")]
+    pub features: String,
     /// Pass through arguments to cargo ... -- PASSTHROUGH_ARGUMENTS
     #[arg(last = true, value_parser)]
     pub passthrough_arguments: Vec<String>,

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -97,7 +97,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
                 profile: arguments.profile.clone(),
                 target: "nao".to_string(),
                 no_sdk_installation: arguments.no_sdk_installation,
-                features: Vec::new(),
+                features: "".to_string(),
                 passthrough_arguments: Vec::new(),
                 remote: arguments.remote,
             },

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -97,6 +97,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
                 profile: arguments.profile.clone(),
                 target: "nao".to_string(),
                 no_sdk_installation: arguments.no_sdk_installation,
+                features: Vec::new(),
                 passthrough_arguments: Vec::new(),
                 remote: arguments.remote,
             },

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -97,7 +97,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
                 profile: arguments.profile.clone(),
                 target: "nao".to_string(),
                 no_sdk_installation: arguments.no_sdk_installation,
-                features: "".to_string(),
+                features: None,
                 passthrough_arguments: Vec::new(),
                 remote: arguments.remote,
             },


### PR DESCRIPTION
## Why? What?

Exposes the `--features <features>` flag of cargo to pepsi. This flag is needed to enable the `ObjectDetectionCycler` when running the replayer.   

Fixes #1095

## How to Test

Run the command:
`$ pepsi run --target replayer --features with_object_detection -- <path to replay log>`
