### PR TITLE
Add dependencies

### DIFF
--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -1,6 +1,5 @@
 # Setup Development Environment
 
-
 This section will guide you through the setup of your development environment to build software for the NAO robot and test your algorithms using our various tools.
 
 ## Installing Rust
@@ -15,14 +14,14 @@ Most of these dependencies are needed for the compilation of local tools.
 All dependencies needed for a cross-compilation for the NAO are included in the NAO SDK.
 Use your distribution's package manager to install the following dependencies:
 
-- [Git](https://git-scm.com/), [Git LFS](https://git-lfs.com/)
-- [clang](https://clang.llvm.org/)
-- [python3](https://www.python.org/)
-- [which](https://carlowood.github.io/which/)
-- [zstd](http://www.zstd.net/)
-- [xz](https://tukaani.org/xz/)
-- [file](https://darwinsys.com/file/)
-- [rsync](https://rsync.samba.org/)
+-   [Git](https://git-scm.com/), [Git LFS](https://git-lfs.com/)
+-   [clang](https://clang.llvm.org/)
+-   [python3](https://www.python.org/)
+-   [which](https://carlowood.github.io/which/)
+-   [zstd](http://www.zstd.net/)
+-   [xz](https://tukaani.org/xz/)
+-   [file](https://darwinsys.com/file/)
+-   [rsync](https://rsync.samba.org/)
 
 === "Arch Linux"
 
@@ -33,7 +32,7 @@ Use your distribution's package manager to install the following dependencies:
 === "Fedora"
 
     ```sh
-    sudo dnf install git git-lfs clang python3 which zstd xz file rsync
+    sudo dnf install git git-lfs clang python3 which zstd xz file rsync alsa-lib-devel
     ```
 
 === "Ubuntu"
@@ -41,10 +40,12 @@ Use your distribution's package manager to install the following dependencies:
     ```sh
     sudo apt install git git-lfs clang python3 zstd xz-utils file rsync
     ```
+
 ### OpenVino:tm: runtime for Neural Networks
 
 You will also need to install the OpenVino:tm: runtime for Webots. The HULKs SDK already contains the runtime for use with the NAOs.
-- [Installation Instructions (Linux)](https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-linux.html)
+
+-   [Installation Instructions (Linux)](https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-linux.html)
 
 If you are using a non-linux operating system (e.g. macOS or Windows), you additionally have to install [docker](https://docs.docker.com/engine/install/).
 


### PR DESCRIPTION
## Why? What?

Add Fedora dependency `alsa-lib-devel` 
Because it was removed

## Fixes

```
error: failed to run custom build command for `alsa-sys v0.3.1`

Caused by:
  process didn't exit successfully: `/home/schluis/worktree/hulk/target/debug/build/alsa-sys-021fd277984b93d0/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=ALSA_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=ALSA_STATIC
  cargo:rerun-if-env-changed=ALSA_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at /home/schluis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/alsa-sys-0.3.1/build.rs:13:18:

  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags alsa

  The system library `alsa` required by crate `alsa-sys` was not found.
  The file `alsa.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  The PKG_CONFIG_PATH environment variable is not set.

  HINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `alsa.pc`.

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

## Ideas for Next Iterations (Not This PR)

- Keep it, don't remove it

## How to Test

Hope for the best
Or deploy it locally using mkdocs
