### PR TITLE
Avoid singularity in testcase

### DIFF
--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -275,8 +275,8 @@ mod test {
             (-2.0, FRAC_PI_2),
             (FRAC_PI_2, FRAC_PI_2),
             (-FRAC_PI_2, FRAC_PI_2),
-            (PI, FRAC_PI_2),
-            (-PI, FRAC_PI_2),
+            (PI - f32::EPSILON, FRAC_PI_2),
+            (-PI + f32::EPSILON, FRAC_PI_2),
         ];
 
         for (input, angle_limit) in testcases {


### PR DESCRIPTION
## Why? What?

[Why?](https://github.com/HULKs/hulk/actions/runs/9812469696/job/27096599499?pr=1107#step:4:211)
What? There's a singularity at PI and -PI that apparently causes the test to fail when we unintentionally bump the nalgebra version.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

'ave a propaganda at the CI