### PR TITLE
Higher ball candidates

### DIFF
--- a/crates/vision/src/perspective_grid_candidates_provider.rs
+++ b/crates/vision/src/perspective_grid_candidates_provider.rs
@@ -93,7 +93,7 @@ fn generate_rows(
             break;
         };
 
-        if radius < minimum_radius || row_vertical_center < 0.0 {
+        if radius < minimum_radius || row_vertical_center + radius < 0.0 {
             break;
         }
 


### PR DESCRIPTION
## Why? What?

We noticed with the new kick striker positioning that it has a really hard time seeing the ball.
The ball was at the top of the bottom image, partially cut off.
However, there were no perspective grid candidates there because the generator stops as soon as the center of the circles would be above the upper image border.

With this change, the generator stops once the candidate row is completely outside the image.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Read above