### PR TITLE
Fix Sacrificial Nao

### DIFF
--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -78,7 +78,6 @@ impl RefereePoseDetectionFilter {
             detected_above_arm_poses_queue: VecDeque::with_capacity(
                 *context.referee_pose_queue_length,
             ),
-            motion_in_standby_count: 0,
         })
     }
 

--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -78,6 +78,7 @@ impl RefereePoseDetectionFilter {
             detected_above_arm_poses_queue: VecDeque::with_capacity(
                 *context.referee_pose_queue_length,
             ),
+            motion_in_standby_count: 0,
         })
     }
 

--- a/crates/control/src/sacrificial_lamb.rs
+++ b/crates/control/src/sacrificial_lamb.rs
@@ -12,7 +12,7 @@ use types::{cycle_time::CycleTime, messages::IncomingMessage, pose_detection::Vi
 
 #[derive(Deserialize, Serialize)]
 pub struct SacrificialLamb {
-    last_majority_vote: bool,
+    last_majority_vote_verdict: bool,
     visual_referee_state: VisualRefereeState,
     motion_in_standby_count: usize,
 }
@@ -47,7 +47,7 @@ pub struct MainOutputs {
 impl SacrificialLamb {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
-            last_majority_vote: false,
+            last_majority_vote_verdict: false,
             visual_referee_state: VisualRefereeState::WaitingForDetections,
             motion_in_standby_count: 0,
         })
@@ -81,9 +81,9 @@ impl SacrificialLamb {
             })
             .max();
 
-        let majority_vote_detected_now =
-            !self.last_majority_vote && *context.majority_vote_is_referee_ready_pose_detected;
-        self.last_majority_vote = *context.majority_vote_is_referee_ready_pose_detected;
+        let current_majority_vote_verdict = !self.last_majority_vote_verdict
+            && *context.majority_vote_is_referee_ready_pose_detected;
+        self.last_majority_vote_verdict = *context.majority_vote_is_referee_ready_pose_detected;
 
         let motion_in_standby =
             new_motion_in_standby_count.map_or(false, |new_motion_in_standby_count| {
@@ -94,7 +94,7 @@ impl SacrificialLamb {
 
         self.visual_referee_state = match (
             self.visual_referee_state,
-            majority_vote_detected_now,
+            current_majority_vote_verdict,
             motion_in_standby,
         ) {
             (VisualRefereeState::WaitingForDetections, true, motion_in_standby) => {


### PR DESCRIPTION
## Why? What?

The sacrificial lamb also changed to `Ready` when the opponent was penalized. This is fixed now.
Also removes unused variable `detection_times`.

Fixes #877 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
Check normal behaviour: correct detection, sacrificial lamb starts after 5s, rest of the team after another 15s.
Check penalizing opponent in first 5s after detection: no nao should move.
Check penalizing of sacrificial lamb after it starts moving: rest of the team should not start moving.
