### PR TITLE
Separate Messages

### DIFF
--- a/crates/control/src/referee_pose_detection_filter.rs
+++ b/crates/control/src/referee_pose_detection_filter.rs
@@ -118,9 +118,7 @@ impl RefereePoseDetectionFilter {
             unpack_message_tree(&context.network_message.persistent);
 
         for (time, message) in time_tagged_persistent_messages {
-            if message.is_referee_ready_signal_detected {
-                self.detection_times[message.player_number] = Some(time);
-            }
+            self.detection_times[message.player_number] = Some(time);
         }
         let own_detected_pose_times =
             unpack_own_detection_tree(&context.detected_referee_pose_kind.persistent);
@@ -220,9 +218,6 @@ fn send_own_detection_message<T: NetworkInterface>(
     player_number: PlayerNumber,
 ) -> Result<()> {
     hardware_interface.write_to_network(OutgoingMessage::Spl(HulkMessage::VisualReferee(
-        VisualRefereeMessage {
-            player_number,
-            is_referee_ready_signal_detected: true,
-        },
+        VisualRefereeMessage { player_number },
     )))
 }

--- a/crates/control/src/visual_referee_filter.rs
+++ b/crates/control/src/visual_referee_filter.rs
@@ -10,7 +10,9 @@ use color_eyre::{eyre::Context, Result};
 use context_attribute::context;
 use hardware::NetworkInterface;
 use serde::{Deserialize, Serialize};
-use spl_network_messages::{PlayerNumber, SubState, VisualRefereeDecision, VisualRefereeMessage};
+use spl_network_messages::{
+    GestureVisualRefereeDecision, GestureVisualRefereeMessage, PlayerNumber, SubState,
+};
 use types::{
     cycle_time::CycleTime, filtered_whistle::FilteredWhistle,
     game_controller_state::GameControllerState, messages::OutgoingMessage,
@@ -97,12 +99,13 @@ impl VisualRefereeFilter {
 
             // Initially a random visual referee decision
             let gesture =
-                VisualRefereeDecision::from_u32(self.random_state.gen_range(1..=13)).unwrap();
+                GestureVisualRefereeDecision::from_u32(self.random_state.gen_range(1..=13))
+                    .unwrap();
 
             if let Some(address) = context.game_controller_address {
                 let message = OutgoingMessage::VisualReferee(
                     *address,
-                    VisualRefereeMessage {
+                    GestureVisualRefereeMessage {
                         player_number: *context.player_number,
                         gesture,
                         whistle_age: duration_since_last_whistle,

--- a/crates/spl_network/src/message_filter.rs
+++ b/crates/spl_network/src/message_filter.rs
@@ -2,7 +2,7 @@ use color_eyre::{eyre::Ok, Result};
 use context_attribute::context;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
-use spl_network_messages::PlayerNumber;
+use spl_network_messages::{HulkMessage, PlayerNumber, StrikerMessage, VisualRefereeMessage};
 use types::messages::IncomingMessage;
 
 #[derive(Deserialize, Serialize)]
@@ -32,9 +32,10 @@ impl MessageFilter {
             IncomingMessage::GameController(source_address, message) => Some(
                 IncomingMessage::GameController(*source_address, message.clone()),
             ),
-            IncomingMessage::Spl(message) if message.player_number != *context.player_number => {
-                Some(IncomingMessage::Spl(*message))
-            }
+            IncomingMessage::Spl(
+                message @ HulkMessage::Striker(StrikerMessage { player_number, .. })
+                | message @ HulkMessage::VisualReferee(VisualRefereeMessage { player_number, .. }),
+            ) if player_number != context.player_number => Some(IncomingMessage::Spl(*message)),
             _ => None,
         };
         Ok(MainOutputs {

--- a/crates/spl_network/src/message_filter.rs
+++ b/crates/spl_network/src/message_filter.rs
@@ -33,8 +33,10 @@ impl MessageFilter {
                 IncomingMessage::GameController(*source_address, message.clone()),
             ),
             IncomingMessage::Spl(
-                message @ HulkMessage::Striker(StrikerMessage { player_number, .. })
-                | message @ HulkMessage::VisualReferee(VisualRefereeMessage { player_number, .. }),
+                message @ (HulkMessage::Striker(StrikerMessage { player_number, .. })
+                | HulkMessage::VisualReferee(VisualRefereeMessage {
+                    player_number, ..
+                })),
             ) if player_number != context.player_number => Some(IncomingMessage::Spl(*message)),
             _ => None,
         };

--- a/crates/spl_network_messages/src/lib.rs
+++ b/crates/spl_network_messages/src/lib.rs
@@ -43,7 +43,6 @@ pub struct StrikerMessage {
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct VisualRefereeMessage {
     pub player_number: PlayerNumber,
-    pub is_referee_ready_signal_detected: bool,
 }
 
 #[derive(
@@ -133,7 +132,6 @@ mod tests {
     fn hulk_visual_referee_message_size() {
         let test_message = HulkMessage::VisualReferee(VisualRefereeMessage {
             player_number: PlayerNumber::Four,
-            is_referee_ready_signal_detected: true,
         });
         assert!(bincode::serialize(&test_message).unwrap().len() <= 128)
     }

--- a/crates/spl_network_messages/src/visual_referee_message.rs
+++ b/crates/spl_network_messages/src/visual_referee_message.rs
@@ -40,7 +40,7 @@ use crate::{
     PathIntrospect,
 )]
 #[repr(u8)]
-pub enum VisualRefereeDecision {
+pub enum GestureVisualRefereeDecision {
     #[default]
     KickInBlueTeam = GAMECONTROLLER_RETURN_STRUCT_VRC_GESTURE_KICK_IN_BLUE_TEAM,
     KickInRedTeam = GAMECONTROLLER_RETURN_STRUCT_VRC_GESTURE_KICK_IN_RED_TEAM,
@@ -58,14 +58,14 @@ pub enum VisualRefereeDecision {
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct VisualRefereeMessage {
+pub struct GestureVisualRefereeMessage {
     pub player_number: PlayerNumber,
-    pub gesture: VisualRefereeDecision,
+    pub gesture: GestureVisualRefereeDecision,
     pub whistle_age: Duration,
 }
 
-impl From<VisualRefereeMessage> for Vec<u8> {
-    fn from(message: VisualRefereeMessage) -> Self {
+impl From<GestureVisualRefereeMessage> for Vec<u8> {
+    fn from(message: GestureVisualRefereeMessage) -> Self {
         let message = message.into();
         unsafe {
             from_raw_parts(
@@ -77,8 +77,8 @@ impl From<VisualRefereeMessage> for Vec<u8> {
     }
 }
 
-impl From<VisualRefereeMessage> for RoboCupGameControlReturnData {
-    fn from(message: VisualRefereeMessage) -> Self {
+impl From<GestureVisualRefereeMessage> for RoboCupGameControlReturnData {
+    fn from(message: GestureVisualRefereeMessage) -> Self {
         let (ball_position, ball_age) = ([0.0; 2], message.whistle_age.as_secs_f32());
         RoboCupGameControlReturnData {
             header: [

--- a/crates/types/src/messages.rs
+++ b/crates/types/src/messages.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use spl_network_messages::{
-    GameControllerReturnMessage, GameControllerStateMessage, HulkMessage, VisualRefereeMessage,
+    GameControllerReturnMessage, GameControllerStateMessage, GestureVisualRefereeMessage,
+    HulkMessage,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
@@ -23,7 +24,7 @@ impl Default for IncomingMessage {
 pub enum OutgoingMessage {
     GameController(SocketAddr, GameControllerReturnMessage),
     Spl(HulkMessage),
-    VisualReferee(SocketAddr, VisualRefereeMessage),
+    VisualReferee(SocketAddr, GestureVisualRefereeMessage),
 }
 
 impl Default for OutgoingMessage {


### PR DESCRIPTION
## Why? What?

Many of the fields for the VisualRefereeMessage are not used in StrikerMessages and vice versa. This PR separates the messages into two distinct types.

Note to reviewer: The player number check in role_assignment was removed since the message filter already takes care of that.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Everything should work as before
