### PR TITLE
Add paths to nalgebra types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4538,6 +4538,7 @@ name = "path_serde"
 version = "0.1.0"
 dependencies = [
  "nalgebra",
+ "num-traits",
  "path_serde_derive",
  "serde",
  "thiserror",

--- a/crates/path_serde/Cargo.toml
+++ b/crates/path_serde/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 
 [dependencies]
 nalgebra = { workspace = true }
-serde = { workspace = true }
+num-traits = { workspace = true }
 path_serde_derive = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/path_serde/src/implementation.rs
+++ b/crates/path_serde/src/implementation.rs
@@ -519,6 +519,8 @@ impl<T> PathIntrospect for Isometry2<T> {
     fn extend_with_fields(fields: &mut BTreeSet<String>, prefix: &str) {
         fields.insert(format!("{prefix}translation"));
         fields.insert(format!("{prefix}rotation"));
+        Vector2::<T>::extend_with_fields(fields, &format!("{prefix}translation."));
+        UnitComplex::<T>::extend_with_fields(fields, &format!("{prefix}rotation."));
     }
 }
 
@@ -597,5 +599,7 @@ impl<T> PathIntrospect for Isometry3<T> {
     fn extend_with_fields(fields: &mut BTreeSet<String>, prefix: &str) {
         fields.insert(format!("{prefix}translation"));
         fields.insert(format!("{prefix}rotation"));
+        Vector3::<T>::extend_with_fields(fields, &format!("{prefix}translation."));
+        UnitQuaternion::<T>::extend_with_fields(fields, &format!("{prefix}rotation."));
     }
 }

--- a/crates/path_serde/src/not_supported.rs
+++ b/crates/path_serde/src/not_supported.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{deserialize, serialize, PathDeserialize, PathIntrospect, PathSerialize};
-use nalgebra::{DMatrix, Isometry2, Isometry3, Rotation3, SMatrix, UnitComplex};
+use nalgebra::{DMatrix, Rotation3, SMatrix};
 use serde::{Deserializer, Serializer};
 
 macro_rules! implement_as_not_supported {
@@ -94,12 +94,9 @@ implement_as_not_supported!(u64);
 implement_as_not_supported!(usize);
 // nalgebra
 implement_as_not_supported!(DMatrix<f32>);
-implement_as_not_supported!(Isometry2<f32>);
-implement_as_not_supported!(Isometry3<f32>);
 implement_as_not_supported!(Rotation3<f32>);
 implement_as_not_supported!(SMatrix<f32, 3, 3>);
 implement_as_not_supported!(SMatrix<f32, 3, 4>);
-implement_as_not_supported!(UnitComplex<f32>);
 // stdlib
 implement_as_not_supported!(Duration);
 implement_as_not_supported!(HashMap<K, V>, K, V);


### PR DESCRIPTION
## Why? What?

Adds paths to some nalgebra types to subscribe and write to via communication.
Allows something like `.rotation.deg` on an `Isometry2` to get the rotation in degree.

## ToDo / Known Issues

- [ ] Test it myself...

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Subscribe via twix to respective types
