### PR TITLE
print full backtrace if available

### DIFF
--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -34,6 +34,7 @@ pub fn generate_run_function(cyclers: &Cyclers) -> TokenStream {
             {
                 let keep_running = keep_running.clone();
                 std::panic::set_hook(Box::new(move |panic_info| {
+                    eprintln!("Full backtrace: {:#?}", std::backtrace::Backtrace::capture());
                     keep_running.cancel();
                     eprintln!("{panic_info}");
                 }));


### PR DESCRIPTION
## Why? What?

If something crashes due to an except we have no idea where this happened.
This prints this full backtrace if the `RUST_BACKTRACE` environment variable is set

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Cause an exception or panic, `hulk.err` should show where it happened
