### PR TITLE
default opponent goalkeeper number when above 7

### DIFF
--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -180,10 +180,13 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
                     5 => PlayerNumber::Five,
                     6 => PlayerNumber::Six,
                     7 => PlayerNumber::Seven,
-                    _ => bail!(
-                        "unexpected goal keeper player number {}",
-                        message.teams[opponent_team_index].goalkeeper
-                    ),
+                    _ => {
+                        eprintln!(
+                            "unexpected goal keeper player number {}, defaulting to PlayerNumber::One",
+                            message.teams[opponent_team_index].goalkeeper
+                        );
+                        PlayerNumber::One
+                    }
                 },
                 score: message.teams[opponent_team_index].score,
                 penalty_shoot_index: message.teams[opponent_team_index].penaltyShot,


### PR DESCRIPTION
## Why? What?

If the opponent uses a playernumber above 7 for the goalkeeper the message filter bails and we discard the message aka we don't receive any information from the game controller and don't go into the standby phase and __cannot play at all!__
This defaults it to `PlayerNumber::One`.

To the reviewer, the `One` is sort of arbitrary, I could just do `default()` but either way that information is inaccurate.
Let me know what you think.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

#1021 

## How to Test

Use current main:
Before going into `standby`, substitute the opponent goalkeeper with a number higher than 7.
Then click standby button and observe that we don't do anything.
Also the error logs can be looked at.

Now use the new code and repeat the procedure and oh wow now it works.
