### PR TITLE
save all opponent penalties

### DIFF
--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -123,7 +123,7 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
                 message.teams[hulks_team_index].players[player_index as usize].try_into()
             })
             .collect::<Result<Vec<_>>>()?;
-        let opponent_players = (0..message.playersPerTeam)
+        let opponent_players = (0..MAX_NUM_PLAYERS)
             .map(|player_index| {
                 message.teams[opponent_team_index].players[player_index as usize].try_into()
             })


### PR DESCRIPTION
## Why? What?

If the opponent uses player numbers higher than 7 then using those penalties to determine anything won't work.
Right now this means the if they have a sacrificial lamb for the visual referee that has a jersey number higher than 7 we won't see it.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

#1021 

## How to Test

Test standby/ready with opponent team having player numbers higher than 7. MotionInStandby those players. In the current main will not wait to send in our sacrificial NAO.
In the new one we do. 