### PR TITLE
ignore failing notification in `buffered_watch::Sender`

### DIFF
--- a/crates/buffered_watch/src/sender.rs
+++ b/crates/buffered_watch/src/sender.rs
@@ -90,6 +90,6 @@ impl<'lock, T> Drop for SenderGuard<'lock, T> {
                 }
             }
         }
-        self.notifier.send(()).unwrap();
+        let _ = self.notifier.send(());
     }
 }


### PR DESCRIPTION
## Why? What?

Failing to notify receivers if there are none anymore, it is not an error.
This ignores the error.

Fixes #1127

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Not used in this fashion in `main` at the moment. But you can create a test case as described in #1127
