### PR TITLE
Remove Hypotheses if no ground contact

### DIFF
--- a/crates/ball_filter/src/lib.rs
+++ b/crates/ball_filter/src/lib.rs
@@ -60,6 +60,10 @@ impl BallFilter {
         }
     }
 
+    pub fn reset(&mut self) {
+        self.hypotheses.clear()
+    }
+
     pub fn update(
         &mut self,
         detection_time: SystemTime,


### PR DESCRIPTION
## Why? What?

The ball filter adds velocity to balls when falling. To mitigate the effects, this PR removes all hypotheses whenever the robot loses ground contact.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Check ball output in map panel, when lifting the robot, the ball disappears
