### PR TITLE
Flush Control Frames to LoLA

### DIFF
--- a/tools/hula/Cargo.lock
+++ b/tools/hula/Cargo.lock
@@ -556,7 +556,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hula"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/tools/hula/proxy/Cargo.toml
+++ b/tools/hula/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hula"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "GPL-3.0-only"
 homepage = "https://github.com/hulks/hulk"

--- a/tools/hula/proxy/src/proxy.rs
+++ b/tools/hula/proxy/src/proxy.rs
@@ -224,6 +224,7 @@ fn handle_connection_event(
             };
             let lola_message = control_frame.into_lola(skull);
             write_named(writer, &lola_message).wrap_err("failed to serialize control message")?;
+            writer.flush().wrap_err("failed to flush control message")?;
             connection.is_sending_control_frames = true;
         }
         None => warn!(


### PR DESCRIPTION
## Why? What?

Flushes control frames to LoLA every time we want to send one.
This may reduce a delay in the output stream, if there ever was one. If not, this does not change anything, but also does not hurt.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Testgame?