### PR TITLE
Warn if cycle takes too long

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -530,7 +530,8 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
                 #after_remaining_nodes
                 let recording_duration = recording_timestamp.elapsed().expect("time ran backwards");
 
-                if recording_duration.as_secs_f32() > 0.4 {
+                const EXECUTION_TIME_UPPER_BOUND: f32 = 0.4;
+                if recording_duration.as_secs_f32() > EXECUTION_TIME_UPPER_BOUND {
                     self
                         .hardware_interface
                         .write_to_speakers(types::audio::SpeakerRequest::PlaySound {

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -530,6 +530,14 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
                 #after_remaining_nodes
                 let recording_duration = recording_timestamp.elapsed().expect("time ran backwards");
 
+                if recording_duration.as_secs_f32() > 0.4 {
+                    self
+                        .hardware_interface
+                        .write_to_speakers(types::audio::SpeakerRequest::PlaySound {
+                            sound: types::audio::Sound::Donk,
+                        });
+                }
+
                 if enable_recording {
                     self.recording_sender.try_send(match instance {
                         #(#recording_variants)*

--- a/crates/hulk_behavior_simulator/src/interfake.rs
+++ b/crates/hulk_behavior_simulator/src/interfake.rs
@@ -8,8 +8,11 @@ use parking_lot::Mutex;
 
 use buffered_watch::{Receiver, Sender};
 use color_eyre::Result;
-use hardware::{NetworkInterface, RecordingInterface, TimeInterface};
-use types::messages::{IncomingMessage, OutgoingMessage};
+use hardware::{NetworkInterface, RecordingInterface, SpeakerInterface, TimeInterface};
+use types::{
+    audio::SpeakerRequest,
+    messages::{IncomingMessage, OutgoingMessage},
+};
 
 use crate::{cyclers::control::Database, HardwareInterface};
 
@@ -56,6 +59,10 @@ impl TimeInterface for Interfake {
     fn get_now(&self) -> SystemTime {
         self.time
     }
+}
+
+impl SpeakerInterface for Interfake {
+    fn write_to_speakers(&self, _request: SpeakerRequest) {}
 }
 
 pub trait FakeDataInterface {

--- a/crates/hulk_behavior_simulator/src/lib.rs
+++ b/crates/hulk_behavior_simulator/src/lib.rs
@@ -1,4 +1,4 @@
-use hardware::{NetworkInterface, RecordingInterface, TimeInterface};
+use hardware::{NetworkInterface, RecordingInterface, SpeakerInterface, TimeInterface};
 use interfake::FakeDataInterface;
 
 pub mod fake_data;
@@ -11,6 +11,6 @@ pub mod state;
 include!(concat!(env!("OUT_DIR"), "/generated_code.rs"));
 
 pub trait HardwareInterface:
-    TimeInterface + NetworkInterface + RecordingInterface + FakeDataInterface
+    TimeInterface + NetworkInterface + RecordingInterface + FakeDataInterface + SpeakerInterface
 {
 }


### PR DESCRIPTION
## Why? What?

Plays a sound if a cycler's node execution took too long.
Should help diagnose issues like we saw in yesterday's testgame.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

Use bound closer to the actual cycle bound of each cycle.

## How to Test

*Describe how to test your changes. (For the reviewer)*
