### PR TITLE
fix kick off kick targets

### DIFF
--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -7,6 +7,7 @@ use framework::MainOutput;
 use geometry::{circle::Circle, line_segment::LineSegment, two_line_segments::TwoLineSegments};
 use linear_algebra::{distance, point, Isometry2, Point2};
 use serde::{Deserialize, Serialize};
+use spl_network_messages::GamePhase;
 use types::{
     field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
@@ -135,8 +136,11 @@ fn collect_kick_targets(
     let field_to_ground = ground_to_field.inverse();
 
     let is_own_kick_off = matches!(
-        filtered_game_controller_state.map(|x| x.game_state),
-        Some(FilteredGameState::Playing { kick_off: true, .. })
+        filtered_game_controller_state.map(|x| (x.game_state, x.game_phase)),
+        Some((
+            FilteredGameState::Playing { kick_off: true, .. },
+            GamePhase::Normal
+        ))
     );
     let is_not_free_for_opponent = matches!(
         filtered_game_controller_state.map(|x| x.opponent_game_state),

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -136,16 +136,20 @@ fn collect_kick_targets(
     let field_to_ground = ground_to_field.inverse();
 
     let is_own_kick_off = matches!(
-        filtered_game_controller_state.map(|x| (x.game_state, x.game_phase)),
-        Some((
-            FilteredGameState::Playing { kick_off: true, .. },
-            GamePhase::Normal
-        ))
+        filtered_game_controller_state,
+        Some(FilteredGameControllerState {
+            game_state: FilteredGameState::Playing { kick_off: true, .. },
+            game_phase: GamePhase::Normal,
+            ..
+        })
     );
     let is_not_free_for_opponent = matches!(
-        filtered_game_controller_state.map(|x| x.opponent_game_state),
-        Some(FilteredGameState::Playing {
-            ball_is_free: false,
+        filtered_game_controller_state,
+        Some(FilteredGameControllerState {
+            opponent_game_state: FilteredGameState::Playing {
+                ball_is_free: false,
+                ..
+            },
             ..
         })
     );


### PR DESCRIPTION
## Why? What?

While testing the penalty shootout the NAO wanted to kick to the targets at the middle line from the kick-off. Now there is an extra check for the game phase

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
Test kick-off behavior, nothing should be changed. Then check behavior for penalty shootout, it should be as expected kick to the goal.
