### PR TITLE
Print warning when cycle takes too long

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,6 +2936,7 @@ dependencies = [
  "ittapi",
  "libc",
  "linear_algebra",
+ "log",
  "nalgebra",
  "object_detection",
  "path_serde",

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -532,6 +532,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
 
                 const EXECUTION_TIME_UPPER_BOUND: f32 = 0.4;
                 if recording_duration.as_secs_f32() > EXECUTION_TIME_UPPER_BOUND {
+                    log::warn!("Cycle took {}s!", recording_duration.as_secs_f32());
                     self
                         .hardware_interface
                         .write_to_speakers(types::audio::SpeakerRequest::PlaySound {

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -22,6 +22,7 @@ hardware = { workspace = true }
 ittapi = { workspace = true }
 libc = { workspace = true, optional = true }
 linear_algebra = { workspace = true }
+log = { workspace = true }
 nalgebra = { workspace = true }
 object_detection = { workspace = true }
 path_serde = { workspace = true }


### PR DESCRIPTION
## Why? What?

Followup for #1136 to leave a trace in the log files even if recording isn't on or that particular cycler isn't being recorded.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Add a sleep somewhere, look at the logs.