### PR TITLE
Walk Slow/Normal/Fast

### DIFF
--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -2,7 +2,7 @@ use coordinate_systems::Ground;
 use geometry::look_at::LookAt;
 use linear_algebra::{Point, Pose2};
 use types::{
-    motion_command::{ArmMotion, HeadMotion, MotionCommand, OrientationMode},
+    motion_command::{ArmMotion, HeadMotion, MotionCommand, OrientationMode, WalkSpeed},
     parameters::{DribblingParameters, InWalkKickInfoParameters, InWalkKicksParameters},
     planned_path::PathSegment,
     world_state::WorldState,
@@ -64,9 +64,12 @@ pub fn execute(
         orientation_mode => orientation_mode,
     };
     match dribble_path {
-        Some(path) => {
-            Some(walk_path_planner.walk_with_obstacle_avoiding_arms(head, orientation_mode, path))
-        }
+        Some(path) => Some(walk_path_planner.walk_with_obstacle_avoiding_arms(
+            head,
+            orientation_mode,
+            path,
+            WalkSpeed::Fast,
+        )),
         None => Some(MotionCommand::Stand { head }),
     }
 }

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -6,7 +6,7 @@ use spl_network_messages::{GamePhase, SubState};
 use types::{
     filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState,
-    motion_command::{HeadMotion, ImageRegion, MotionCommand, OrientationMode},
+    motion_command::{HeadMotion, ImageRegion, MotionCommand, OrientationMode, WalkSpeed},
     parameters::InterceptBallParameters,
     planned_path::PathSegment,
     step_plan::Step,
@@ -87,6 +87,7 @@ pub fn execute(
                 left_arm: types::motion_command::ArmMotion::Swing,
                 right_arm: types::motion_command::ArmMotion::Swing,
                 orientation_mode: OrientationMode::Override(Orientation2::identity()),
+                speed: WalkSpeed::Fast,
             })
         }
         _ => None,

--- a/crates/control/src/behavior/lost_ball.rs
+++ b/crates/control/src/behavior/lost_ball.rs
@@ -3,8 +3,7 @@ use framework::AdditionalOutput;
 use geometry::look_at::LookAt;
 use linear_algebra::Point2;
 use types::{
-    motion_command::HeadMotion,
-    motion_command::{MotionCommand, OrientationMode},
+    motion_command::{HeadMotion, MotionCommand, OrientationMode, WalkSpeed},
     parameters::LostBallParameters,
     path_obstacles::PathObstacle,
     world_state::WorldState,
@@ -39,5 +38,6 @@ pub fn execute(
         HeadMotion::SearchForLostBall,
         OrientationMode::Override(orientation),
         path,
+        WalkSpeed::Normal,
     ))
 }

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -3,7 +3,7 @@ use framework::AdditionalOutput;
 use linear_algebra::{point, Isometry2, Orientation2, Point2, Pose2};
 use types::{
     field_dimensions::FieldDimensions,
-    motion_command::{HeadMotion, MotionCommand, OrientationMode},
+    motion_command::{HeadMotion, MotionCommand, OrientationMode, WalkSpeed},
     parameters::SearchParameters,
     path_obstacles::PathObstacle,
     roles::Role,
@@ -117,7 +117,12 @@ pub fn execute(
         } else {
             OrientationMode::AlignWithPath
         };
-        Some(walk_path_planner.walk_with_obstacle_avoiding_arms(head, orientation_mode, path))
+        Some(walk_path_planner.walk_with_obstacle_avoiding_arms(
+            head,
+            orientation_mode,
+            path,
+            WalkSpeed::Normal,
+        ))
     }
 }
 

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -6,9 +6,7 @@ use framework::AdditionalOutput;
 use linear_algebra::{point, Isometry2, Orientation2, Point, Point2, Pose2};
 use types::{
     field_dimensions::FieldDimensions,
-    motion_command::ArmMotion,
-    motion_command::MotionCommand,
-    motion_command::{HeadMotion, OrientationMode},
+    motion_command::{ArmMotion, HeadMotion, MotionCommand, OrientationMode, WalkSpeed},
     obstacles::Obstacle,
     parameters::{PathPlanningParameters, WalkAndStandParameters},
     path_obstacles::PathObstacle,
@@ -105,13 +103,15 @@ impl<'cycle> WalkPathPlanner<'cycle> {
         head: HeadMotion,
         orientation_mode: OrientationMode,
         path: Vec<PathSegment>,
+        speed: WalkSpeed,
     ) -> MotionCommand {
         MotionCommand::Walk {
             head,
-            orientation_mode,
             path,
             left_arm: self.arm_motion_with_obstacles(Side::Left),
             right_arm: self.arm_motion_with_obstacles(Side::Right),
+            orientation_mode,
+            speed,
         }
     }
 
@@ -198,6 +198,7 @@ impl<'cycle> WalkAndStand<'cycle> {
                 head,
                 orientation_mode,
                 path,
+                WalkSpeed::Normal,
             ))
         }
     }

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -12,6 +12,13 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum WalkSpeed {
+    Slow,
+    Normal,
+    Fast,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum OrientationMode {
     AlignWithPath,
     Override(Orientation2<Ground>),
@@ -54,6 +61,7 @@ pub enum MotionCommand {
         left_arm: ArmMotion,
         right_arm: ArmMotion,
         orientation_mode: OrientationMode,
+        speed: WalkSpeed,
     },
     InWalkKick {
         head: HeadMotion,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -441,9 +441,19 @@
   "step_planner": {
     "injected_step": null,
     "max_step_size": {
-      "forward": 0.06,
-      "left": 0.13,
+      "forward": 0.055,
+      "left": 0.1,
       "turn": 1.0
+    },
+    "step_size_delta_slow": {
+      "forward": -0.01,
+      "left": 0.0,
+      "turn": 0.0
+    },
+    "step_size_delta_fast": {
+      "forward": 0.01,
+      "left": 0.04,
+      "turn": 0.0
     },
     "max_step_size_backwards": 0.04,
     "translation_exponent": 1.5,


### PR DESCRIPTION
## Why? What?

Adds `*_delta` parameters for slower and faster walk by adjusting the maximum step size when planning steps. Behavior must select between `WalkSpeed::{Slow|Normal|Fast}`.
This allows to change the speed in e.g. striking situations.
Slow is currently unused.

Fixes #1098 

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Normal striking/loosing behavior. The striker walks faster than the searcher/looser.