### PR TITLE
Prevent zero measurement noise

### DIFF
--- a/crates/control/src/obstacle_filter.rs
+++ b/crates/control/src/obstacle_filter.rs
@@ -289,7 +289,7 @@ impl ObstacleFilter {
             hypothesis.state.update(
                 Matrix2::identity(),
                 detected_position.inner.coords,
-                measurement_noise * detected_position.coords().norm_squared(),
+                measurement_noise * (detected_position.coords().norm_squared() + f32::EPSILON),
             );
             hypothesis.obstacle_kind = match hypothesis.obstacle_kind {
                 ObstacleKind::Robot => hypothesis.obstacle_kind,


### PR DESCRIPTION
## Why? What?

See issue for details, adding epsilon to the measurement distance in all obstacle filter updates to prevent crashes.

Fixes #1039 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

#1113 fixes #1039 symtomatically, making it hard to reproduce this bug.