### PR TITLE
add toggle between old calibration mode and new calibration mode

### DIFF
--- a/crates/control/src/behavior/calibrate.rs
+++ b/crates/control/src/behavior/calibrate.rs
@@ -5,9 +5,17 @@ use types::{
     world_state::WorldState,
 };
 
-pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
+pub fn execute(
+    world_state: &WorldState,
+    use_stand_head_unstiff_calibration: bool,
+) -> Option<MotionCommand> {
     if PrimaryState::Calibration != world_state.robot.primary_state {
         return None;
+    }
+    if use_stand_head_unstiff_calibration {
+        return Some(MotionCommand::Stand {
+            head: HeadMotion::Unstiff,
+        });
     }
 
     let head =

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -72,6 +72,8 @@ pub struct CycleContext {
     maximum_step_size: Parameter<Step, "step_planner.max_step_size">,
     enable_pose_detection: Parameter<bool, "pose_detection.enable">,
     wide_stance: Parameter<WideStanceParameters, "wide_stance">,
+    use_stand_head_unstiff_calibration:
+        Parameter<bool, "calibration_controller.use_stand_head_unstiff_calibration">,
 }
 
 #[context]
@@ -273,7 +275,9 @@ impl Behavior {
                         *context.intercept_ball_parameters,
                         *context.maximum_step_size,
                     ),
-                    Action::Calibrate => calibrate::execute(world_state),
+                    Action::Calibrate => {
+                        calibrate::execute(world_state, *context.use_stand_head_unstiff_calibration)
+                    }
                     Action::DefendGoal => defend.goal(&mut context.path_obstacles_output),
                     Action::DefendKickOff => defend.kick_off(&mut context.path_obstacles_output),
                     Action::DefendLeft => defend.left(&mut context.path_obstacles_output),

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1530,6 +1530,7 @@
     "look_at_dispatch_delay": {
       "nanos": 0,
       "secs": 1
-    }
+    },
+    "use_stand_head_unstiff_calibration": false
   }
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1531,6 +1531,6 @@
       "nanos": 0,
       "secs": 1
     },
-    "use_stand_head_unstiff_calibration": false
+    "use_stand_head_unstiff_calibration": true
   }
 }


### PR DESCRIPTION
## Why? What?

I think completely removing the old calibration mode this close to an event could prove fatal if the new one isn't full functional #1115 or if and when people want to do manual adjustments, either during an event, or in the future to manually break camera matrices on purpose as we have done before for testing.
This adds a simple boolean toggle between the old and new calibration.

Feel free to suggest better naming

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Setting the bool to false uses the new calibration which does (something) I guess?
Setting to true should make robot behave as before, i.e. stand up straight with the head stiffness at 0.