### PR TITLE
Historical Revisionism

### DIFF
--- a/crates/control/src/game_controller_filter.rs
+++ b/crates/control/src/game_controller_filter.rs
@@ -7,7 +7,7 @@ use std::{
 use color_eyre::Result;
 use context_attribute::context;
 use framework::{AdditionalOutput, MainOutput, PerceptionInput};
-use hardware::{SpeakerInterface, TimeInterface};
+use hardware::SpeakerInterface;
 use serde::{Deserialize, Serialize};
 use spl_network_messages::GameControllerStateMessage;
 use types::{
@@ -63,7 +63,7 @@ impl GameControllerFilter {
 
     pub fn cycle(
         &mut self,
-        mut context: CycleContext<impl TimeInterface + SpeakerInterface>,
+        mut context: CycleContext<impl SpeakerInterface>,
     ) -> Result<MainOutputs> {
         for (time, source_address, message) in context
             .network_message
@@ -123,7 +123,7 @@ impl GameControllerFilter {
 
     fn alert_if_multiple_game_controllers(
         &mut self,
-        context: &CycleContext<impl TimeInterface + SpeakerInterface>,
+        context: &CycleContext<impl SpeakerInterface>,
         source_address: SocketAddr,
         time: SystemTime,
     ) {

--- a/crates/hulk_replayer/src/main.rs
+++ b/crates/hulk_replayer/src/main.rs
@@ -8,12 +8,10 @@ mod timeline;
 mod window;
 mod worker_thread;
 
-use std::time::SystemTime;
-
 use color_eyre::{eyre::Result, install};
 use hardware::{
     ActuatorInterface, CameraInterface, IdInterface, MicrophoneInterface, NetworkInterface,
-    PathsInterface, RecordingInterface, SensorInterface, SpeakerInterface, TimeInterface,
+    PathsInterface, RecordingInterface, SensorInterface, SpeakerInterface,
 };
 use replayer::replayer;
 use types::{
@@ -38,7 +36,6 @@ pub trait HardwareInterface:
     + RecordingInterface
     + SensorInterface
     + SpeakerInterface
-    + TimeInterface
 {
 }
 
@@ -113,12 +110,6 @@ impl SensorInterface for ReplayerHardwareInterface {
 
 impl SpeakerInterface for ReplayerHardwareInterface {
     fn write_to_speakers(&self, _request: SpeakerRequest) {}
-}
-
-impl TimeInterface for ReplayerHardwareInterface {
-    fn get_now(&self) -> SystemTime {
-        panic!("replayer should not use replay host system time")
-    }
 }
 
 impl HardwareInterface for ReplayerHardwareInterface {}

--- a/crates/hulk_replayer/src/main.rs
+++ b/crates/hulk_replayer/src/main.rs
@@ -117,7 +117,7 @@ impl SpeakerInterface for ReplayerHardwareInterface {
 
 impl TimeInterface for ReplayerHardwareInterface {
     fn get_now(&self) -> SystemTime {
-        SystemTime::now()
+        panic!("replayer should not use replay host system time")
     }
 }
 

--- a/crates/vision/src/image_receiver.rs
+++ b/crates/vision/src/image_receiver.rs
@@ -15,9 +15,7 @@ pub struct ImageReceiver {
 }
 
 #[context]
-pub struct CreationContext {
-    hardware_interface: HardwareInterface,
-}
+pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
@@ -32,7 +30,7 @@ pub struct MainOutputs {
 }
 
 impl ImageReceiver {
-    pub fn new(_context: CreationContext<impl TimeInterface>) -> Result<Self> {
+    pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             last_cycle_start: SystemTime::UNIX_EPOCH,
         })

--- a/crates/vision/src/image_receiver.rs
+++ b/crates/vision/src/image_receiver.rs
@@ -32,9 +32,9 @@ pub struct MainOutputs {
 }
 
 impl ImageReceiver {
-    pub fn new(context: CreationContext<impl TimeInterface>) -> Result<Self> {
+    pub fn new(_context: CreationContext<impl TimeInterface>) -> Result<Self> {
         Ok(Self {
-            last_cycle_start: context.hardware_interface.get_now(),
+            last_cycle_start: SystemTime::UNIX_EPOCH,
         })
     }
 


### PR DESCRIPTION
## Why? What?

Historic inputs are currently bronek in replay because they are recorded at the beginning of a cycle along with the cross inputs.
However, when a historic input is passed to a node, it is augmented with data from the current cycle such that the BTreeMap contains data from previous cycles as well as from the current one.

This augmentation was also done during recording, but since it happened at the beginning of the cycle, for the "current" data it used whatever was last written to the database buffer slot (usually data from a couple cycles ago).

This PR removes the augmentation during replay and moves it to the cycle context construction.
However, there is one problem with clocks: 
In a normal hulk binary, the SystemTime used for inserting data from the current cycle into the historic input BTreeMap is taken from the hardware interface.
This is wrong in the replayer and I replaced the get_now in the replayer hardware interface with an explicit panic to prevent accidental misuse.
There currently is no clean way to get the current hula time in the generated code, so I'm reaching into the cycletime info in the own database. Not all cyclers have this but our sole realtime cycler does.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

- [ ] Make clocks a framework feature

## How to Test

The easiest way is probably to look at the goalpost obstacles in replay when the robot is turning.
On main, they jitter all over the place but on this branch remain fixed where they should be.