### PR TITLE
Disbale obstacles in penalty shootout

### DIFF
--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -7,7 +7,7 @@ use framework::MainOutput;
 use geometry::{circle::Circle, line_segment::LineSegment, two_line_segments::TwoLineSegments};
 use linear_algebra::{distance, point, Isometry2, Point2};
 use serde::{Deserialize, Serialize};
-use spl_network_messages::GamePhase;
+use spl_network_messages::{GamePhase, SubState};
 use types::{
     field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
@@ -79,6 +79,10 @@ impl KickTargetProvider {
         let obstacle_circles = match context.filtered_game_controller_state {
             Some(FilteredGameControllerState {
                 game_phase: GamePhase::PenaltyShootout { .. },
+                ..
+            }) => vec![],
+            Some(FilteredGameControllerState {
+                sub_state: Some(SubState::PenaltyKick),
                 ..
             }) => vec![],
             _ => generate_obstacle_circles(

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -76,19 +76,15 @@ impl KickTargetProvider {
     pub fn cycle(&self, context: CycleContext) -> Result<MainOutputs> {
         let ball_position = context.ball_state.ball_in_ground;
 
-        let obstacle_circles = if matches!(
-            context.filtered_game_controller_state,
+        let obstacle_circles = match context.filtered_game_controller_state {
             Some(FilteredGameControllerState {
                 game_phase: GamePhase::PenaltyShootout { .. },
                 ..
-            })
-        ) {
-            vec![]
-        } else {
-            generate_obstacle_circles(
+            }) => vec![],
+            _ => generate_obstacle_circles(
                 context.obstacles,
                 *context.ball_radius_for_kick_target_selection,
-            )
+            ),
         };
 
         let collect_kick_targets_parameters = CollectKickTargetsParameter {

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -76,10 +76,20 @@ impl KickTargetProvider {
     pub fn cycle(&self, context: CycleContext) -> Result<MainOutputs> {
         let ball_position = context.ball_state.ball_in_ground;
 
-        let obstacle_circles = generate_obstacle_circles(
-            context.obstacles,
-            *context.ball_radius_for_kick_target_selection,
-        );
+        let obstacle_circles = if matches!(
+            context.filtered_game_controller_state,
+            Some(FilteredGameControllerState {
+                game_phase: GamePhase::PenaltyShootout { .. },
+                ..
+            })
+        ) {
+            vec![]
+        } else {
+            generate_obstacle_circles(
+                context.obstacles,
+                *context.ball_radius_for_kick_target_selection,
+            )
+        };
 
         let collect_kick_targets_parameters = CollectKickTargetsParameter {
             find_kick_targets_parameter: context.find_kick_targets_parameters,


### PR DESCRIPTION
## Why? What?

Sometimes the robot falsely sees obstacles right in front of it during the penalty shootout phase and then kicks the ball around them (and not in the goal). Therefore they are disabled now during the penalty shoothot, but still drawn in twix.

One fix to improve penalty shootout #546.

Fixes #

## ToDo / Known Issues

- [x] disable also for Penalty Kick substate

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Test normal behavior in normal game phases and also test behavior in penalty shootout with obstacles. Should kick through obstacles. 
