### PR TITLE
Use workspace fields for all crates

### DIFF
--- a/crates/argument_parsers/Cargo.toml
+++ b/crates/argument_parsers/Cargo.toml
@@ -5,8 +5,6 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 color-eyre = { workspace = true }
 regex = { workspace = true }

--- a/crates/coordinate_systems/Cargo.toml
+++ b/crates/coordinate_systems/Cargo.toml
@@ -5,8 +5,6 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 approx = { workspace = true }
 approx_derive = { workspace = true }

--- a/crates/hulk_behavior_simulator/Cargo.toml
+++ b/crates/hulk_behavior_simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hulk_behavior_simulator"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/linear_algebra/Cargo.toml
+++ b/crates/linear_algebra/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "linear_algebra"
-version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 approx = { workspace = true }

--- a/crates/object_detection/Cargo.toml
+++ b/crates/object_detection/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 color-eyre = { workspace = true }

--- a/crates/parameter_tester/Cargo.toml
+++ b/crates/parameter_tester/Cargo.toml
@@ -5,8 +5,6 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 color-eyre = { workspace = true }
 framework = { workspace = true }

--- a/tools/annotato/Cargo.toml
+++ b/tools/annotato/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "annotato"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 clap = { workspace = true}

--- a/tools/hula/Cargo.toml
+++ b/tools/hula/Cargo.toml
@@ -5,6 +5,11 @@ members = [
   "proxy",
 ]
 
+[workspace.package]
+edition = "2021"
+license = "GPL-3.0-only"
+homepage = "https://github.com/hulks/hulk"
+
 [workspace.dependencies]
 chrono = "0.4.23"
 clap = { version = "4.0.29", features = ["derive"] }

--- a/tools/hula/proxy/Cargo.toml
+++ b/tools/hula/proxy/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hula"
 version = "0.5.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 clap = { workspace = true }

--- a/tools/hula/types/Cargo.toml
+++ b/tools/hula/types/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hula-types"
 version = "0.1.0"
-edition = "2021"
-license = "GPL-3.0-only"
-homepage = "https://github.com/hulks/hulk"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 
 [dependencies]
 serde = { workspace = true }


### PR DESCRIPTION
## Why? What?

This PR cleans up the Cargo.toml files of all crates to use the workspace settings
This is done to unify the settings for all crates to obey the following structure:

```toml
[package]
name = "<package-name>"
version.workspace = true
edition.workspace = true
license.workspace = true
homepage.workspace = true
```

Note that for tools the version is still explicitely given and not set via the workspace.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Build it.
