### PR TITLE
disallow instant kicks in penalty shootout and penalty kick

### DIFF
--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -7,7 +7,7 @@ use framework::MainOutput;
 use geometry::{circle::Circle, line_segment::LineSegment, two_line_segments::TwoLineSegments};
 use linear_algebra::{distance, point, Isometry2, Point2};
 use serde::{Deserialize, Serialize};
-use spl_network_messages::GamePhase;
+use spl_network_messages::{GamePhase, SubState};
 use types::{
     field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
@@ -154,6 +154,20 @@ fn collect_kick_targets(
         })
     );
 
+    let is_penalty_shoot = matches!(
+        filtered_game_controller_state,
+        Some(FilteredGameControllerState {
+            game_phase: GamePhase::PenaltyShootout { .. },
+            ..
+        })
+    ) || matches!(
+        filtered_game_controller_state,
+        Some(FilteredGameControllerState {
+            sub_state: Some(SubState::PenaltyKick),
+            ..
+        })
+    );
+
     let (kick_opportunities, allow_instant_kicks): (Vec<_>, _) =
         if is_own_kick_off && is_not_free_for_opponent {
             (
@@ -204,7 +218,7 @@ fn collect_kick_targets(
                             .clone(),
                     })
                     .collect(),
-                true,
+                !is_penalty_shoot,
             )
         };
 


### PR DESCRIPTION
## Why? What?

Tests for penalty shootout looked better without instant kicks. In my opinion a little jockeling is fine in this phase.
More small changes to addresses #546.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*
- [ ] should be tested again on the field

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test
Use GameController in Penalty Shootout with a HULKs striker and compare main against this.