### PR TITLE
Kick-Decision anticipation

### DIFF
--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -1,4 +1,4 @@
-use coordinate_systems::Ground;
+use coordinate_systems::{Ground, UpcomingSupport};
 use geometry::look_at::LookAt;
 use linear_algebra::{Isometry2, Point, Pose2};
 use types::{
@@ -33,7 +33,7 @@ pub fn execute(
             is_kick_pose_reached(
                 decision.kick_pose,
                 &in_walk_kicks[decision.variant],
-                world_state.robot.walk_return_offset,
+                world_state.robot.ground_to_upcoming_support,
             )
         });
     if let Some(kick) = available_kick {
@@ -82,9 +82,9 @@ pub fn execute(
 fn is_kick_pose_reached(
     kick_pose: Pose2<Ground>,
     kick_info: &InWalkKickInfoParameters,
-    walk_return_offset: Isometry2<Ground, Ground>,
+    ground_to_upcoming_support: Isometry2<Ground, UpcomingSupport>,
 ) -> bool {
-    let upcoming_kick_pose = walk_return_offset.inverse() * kick_pose;
+    let upcoming_kick_pose = ground_to_upcoming_support * kick_pose;
     let is_x_reached = upcoming_kick_pose.position().x().abs() < kick_info.reached_thresholds.x;
     let is_y_reached = upcoming_kick_pose.position().y().abs() < kick_info.reached_thresholds.y;
     let is_orientation_reached =

--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -1,6 +1,6 @@
 use coordinate_systems::Ground;
 use geometry::look_at::LookAt;
-use linear_algebra::{Point, Pose2};
+use linear_algebra::{Isometry2, Point, Pose2};
 use types::{
     motion_command::{ArmMotion, HeadMotion, MotionCommand, OrientationMode, WalkSpeed},
     parameters::{DribblingParameters, InWalkKickInfoParameters, InWalkKicksParameters},
@@ -30,7 +30,11 @@ pub fn execute(
         .iter()
         .chain(instant_kick_decisions.iter())
         .find(|decision| {
-            is_kick_pose_reached(decision.kick_pose, &in_walk_kicks[decision.variant])
+            is_kick_pose_reached(
+                decision.kick_pose,
+                &in_walk_kicks[decision.variant],
+                world_state.robot.walk_return_offset,
+            )
         });
     if let Some(kick) = available_kick {
         let command = MotionCommand::InWalkKick {
@@ -76,12 +80,14 @@ pub fn execute(
 }
 
 fn is_kick_pose_reached(
-    kick_pose_to_robot: Pose2<Ground>,
+    kick_pose: Pose2<Ground>,
     kick_info: &InWalkKickInfoParameters,
+    walk_return_offset: Isometry2<Ground, Ground>,
 ) -> bool {
-    let is_x_reached = kick_pose_to_robot.position().x().abs() < kick_info.reached_thresholds.x;
-    let is_y_reached = kick_pose_to_robot.position().y().abs() < kick_info.reached_thresholds.y;
+    let upcoming_kick_pose = walk_return_offset.inverse() * kick_pose;
+    let is_x_reached = upcoming_kick_pose.position().x().abs() < kick_info.reached_thresholds.x;
+    let is_y_reached = upcoming_kick_pose.position().y().abs() < kick_info.reached_thresholds.y;
     let is_orientation_reached =
-        kick_pose_to_robot.orientation().angle().abs() < kick_info.reached_thresholds.z;
+        upcoming_kick_pose.orientation().angle().abs() < kick_info.reached_thresholds.z;
     is_x_reached && is_y_reached && is_orientation_reached
 }

--- a/crates/control/src/obstacle_filter.rs
+++ b/crates/control/src/obstacle_filter.rs
@@ -40,10 +40,11 @@ pub struct CycleContext {
     network_robot_obstacles: HistoricInput<Vec<Point2<Ground>>, "network_robot_obstacles">,
     ground_to_field: HistoricInput<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
     sonar_obstacles: HistoricInput<Vec<SonarObstacle>, "sonar_obstacles">,
-
     foot_bumper_obstacles: HistoricInput<Vec<FootBumperObstacle>, "foot_bumper_obstacle">,
+
     cycle_time: Input<CycleTime, "cycle_time">,
     primary_state: Input<PrimaryState, "primary_state">,
+    current_ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
 
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
     goal_post_obstacle_radius: Parameter<f32, "obstacle_filter.goal_post_obstacle_radius">,
@@ -225,9 +226,10 @@ impl ObstacleFilter {
                 }
             })
             .collect::<Vec<_>>();
-        let current_ground_to_field = context.ground_to_field.get(&cycle_start_time);
-        let goal_posts =
-            calculate_goal_post_positions(current_ground_to_field.copied(), field_dimensions);
+        let goal_posts = calculate_goal_post_positions(
+            context.current_ground_to_field.copied(),
+            field_dimensions,
+        );
         let goal_post_obstacles = goal_posts
             .into_iter()
             .map(|goal_post| Obstacle::goal_post(goal_post, *context.goal_post_obstacle_radius));

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use context_attribute::context;
 use coordinate_systems::{Field, Ground};
 use framework::MainOutput;
-use linear_algebra::{Isometry2, Point2};
+use linear_algebra::{vector, Isometry2, Point2};
 use spl_network_messages::PlayerNumber;
 use types::{
     ball_position::HypotheticalBallPosition,
@@ -16,6 +16,7 @@ use types::{
     primary_state::PrimaryState,
     roles::Role,
     rule_obstacles::RuleObstacle,
+    step_plan::Step,
     world_state::{BallState, RobotState, WorldState},
 };
 
@@ -37,6 +38,7 @@ pub struct CycleContext {
     suggested_search_position: Input<Option<Point2<Field>>, "suggested_search_position?">,
     kick_decisions: Input<Option<Vec<KickDecision>>, "kick_decisions?">,
     instant_kick_decisions: Input<Option<Vec<KickDecision>>, "instant_kick_decisions?">,
+    walk_return_offset: CyclerState<Step, "walk_return_offset">,
 
     player_number: Parameter<PlayerNumber, "player_number">,
 
@@ -69,6 +71,13 @@ impl WorldStateComposer {
             fall_state: *context.fall_state,
             has_ground_contact: *context.has_ground_contact,
             player_number: *context.player_number,
+            walk_return_offset: Isometry2::from_parts(
+                vector![
+                    context.walk_return_offset.forward,
+                    context.walk_return_offset.left
+                ],
+                context.walk_return_offset.turn,
+            ),
         };
 
         let world_state = WorldState {

--- a/crates/control/src/world_state_composer.rs
+++ b/crates/control/src/world_state_composer.rs
@@ -2,9 +2,9 @@ use color_eyre::Result;
 use serde::{Deserialize, Serialize};
 
 use context_attribute::context;
-use coordinate_systems::{Field, Ground};
+use coordinate_systems::{Field, Ground, UpcomingSupport};
 use framework::MainOutput;
-use linear_algebra::{vector, Isometry2, Point2};
+use linear_algebra::{Isometry2, Point2};
 use spl_network_messages::PlayerNumber;
 use types::{
     ball_position::HypotheticalBallPosition,
@@ -16,7 +16,6 @@ use types::{
     primary_state::PrimaryState,
     roles::Role,
     rule_obstacles::RuleObstacle,
-    step_plan::Step,
     world_state::{BallState, RobotState, WorldState},
 };
 
@@ -38,7 +37,8 @@ pub struct CycleContext {
     suggested_search_position: Input<Option<Point2<Field>>, "suggested_search_position?">,
     kick_decisions: Input<Option<Vec<KickDecision>>, "kick_decisions?">,
     instant_kick_decisions: Input<Option<Vec<KickDecision>>, "instant_kick_decisions?">,
-    walk_return_offset: CyclerState<Step, "walk_return_offset">,
+    ground_to_upcoming_support:
+        CyclerState<Isometry2<Ground, UpcomingSupport>, "ground_to_upcoming_support">,
 
     player_number: Parameter<PlayerNumber, "player_number">,
 
@@ -71,13 +71,7 @@ impl WorldStateComposer {
             fall_state: *context.fall_state,
             has_ground_contact: *context.has_ground_contact,
             player_number: *context.player_number,
-            walk_return_offset: Isometry2::from_parts(
-                vector![
-                    context.walk_return_offset.forward,
-                    context.walk_return_offset.left
-                ],
-                context.walk_return_offset.turn,
-            ),
+            ground_to_upcoming_support: *context.ground_to_upcoming_support,
         };
 
         let world_state = WorldState {

--- a/crates/coordinate_systems/src/lib.rs
+++ b/crates/coordinate_systems/src/lib.rs
@@ -46,6 +46,22 @@ generate_coordinate_system!(
     /// X axis pointing forward
     /// Y axis pointing left
     Walk,
+    /// Represents the coordinate system of the ground frame next to the upcoming support foot.
+    ///
+    /// The UpcomingSupport frame helps the robot to anticipate and plan the placement of its foot
+    /// for the next step.
+    ///
+    /// This frame is used by the walking engine to plan steps. Its origin is located at the point
+    /// where the ground will be once the current step is completed and walking were to stop in the
+    /// following step (zero-step). In other words, it is the coordinate frame equal to the ground
+    /// frame where the current swing foot is, assuming it becoming support foot this control frame.
+    /// Planning always assumes that the current step is ending this very frame to be able to plan
+    /// the next, if walking determines that it actually ended this frame.
+    ///
+    /// Note:
+    /// - "Upcoming support foot" refers to the foot that will become the new support foot after
+    ///   the current swing foot lands.
+    UpcomingSupport,
     /// 2D coordinate system centered on the field,
     ///
     /// Origin: center of the field

--- a/crates/types/src/world_state.rs
+++ b/crates/types/src/world_state.rs
@@ -2,7 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use coordinate_systems::{Field, Ground};
+use coordinate_systems::{Field, Ground, UpcomingSupport};
 use linear_algebra::{Isometry2, Point2, Vector2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use spl_network_messages::PlayerNumber;
@@ -78,5 +78,5 @@ pub struct RobotState {
     pub fall_state: FallState,
     pub has_ground_contact: bool,
     pub player_number: PlayerNumber,
-    pub walk_return_offset: Isometry2<Ground, Ground>,
+    pub ground_to_upcoming_support: Isometry2<Ground, UpcomingSupport>,
 }

--- a/crates/types/src/world_state.rs
+++ b/crates/types/src/world_state.rs
@@ -78,4 +78,5 @@ pub struct RobotState {
     pub fall_state: FallState,
     pub has_ground_contact: bool,
     pub player_number: PlayerNumber,
+    pub walk_return_offset: Isometry2<Ground, Ground>,
 }

--- a/tools/twix/src/panels/map/layers/kick_decisions.rs
+++ b/tools/twix/src/panels/map/layers/kick_decisions.rs
@@ -58,7 +58,7 @@ impl KickDecisions {
             return Ok(());
         };
         let best_kick_decision = kick_decisions.first();
-        draw_kick_pose(
+        draw_kick_poses(
             painter,
             &kick_decisions,
             Stroke {
@@ -66,7 +66,7 @@ impl KickDecisions {
                 color: Color32::BLACK,
             },
         );
-        draw_kick_pose(
+        draw_kick_poses(
             painter,
             best_kick_decision.cloned().as_slice(),
             Stroke {
@@ -82,7 +82,7 @@ impl KickDecisions {
         else {
             return Ok(());
         };
-        draw_kick_pose(
+        draw_kick_poses(
             painter,
             &instant_kick_decisions,
             Stroke {
@@ -118,7 +118,7 @@ impl KickDecisions {
     }
 }
 
-fn draw_kick_pose(painter: &TwixPainter<Ground>, kick_decisions: &[KickDecision], stroke: Stroke) {
+fn draw_kick_poses(painter: &TwixPainter<Ground>, kick_decisions: &[KickDecision], stroke: Stroke) {
     for kick_decision in kick_decisions {
         painter.pose(
             kick_decision.kick_pose,


### PR DESCRIPTION
## Why? What?

Walking plans and acts in the matter of "steps". That means, new decisions are discrete and a new step can only start as soon as the current step ends. The next step is then planned in the idea of starting from zero. That means, if we request a zero step, and the current (just ended) step was not a zero step, then the ground frame travels at least the distance to the zero state.

What does that mean for deciding for kicks:
If we want to now whether we can kick the ball or even decide on a kick, we have to anticipate, that in the instant of deciding, the ground frame is still behind the support foot (assuming forward travel) and is going to travel some distance anyway. That is, we have to decide on the kick relative to the support foot.

To fix this issue, step planning uses the formerly called `walk_return_offset` which describes the distance ground will travel up until the zero step. I refactored this to a properly tagged framed transform called `Isometry2<Ground, UpcomingSupport>`. Step planning and also all kick decisions now use this transform to decide for kicks.

Additionally, I think there was a bug of subtracting the `walk_return_offset` in the step planner, as a mere component-wise subtraction does not care for rotating to the `From` frame correctly.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Look at step planning and kick decision output in a replay of a robot dribbling the ball. There currently is no other way than just debugging it manually... ...