### PR TITLE
Add --prepare flag for pepsi upload and pregame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,7 +4575,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.13.4"
+version = "3.14.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.13.4"
+version = "3.14.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -133,7 +133,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
     let multi_progress = ProgressIndicator::new();
 
     if arguments.prepare {
-        println!("WARNING: This upload was only prepared, no actual upload was performed!")
+        eprintln!("WARNING: This upload was only prepared, no actual upload was performed!")
     } else {
         arguments
             .naos


### PR DESCRIPTION
## Why? What?

This PR adds a --prepare flag for pepsi upload and pregame. If the flag is set, no actual upload (and wireless set for pregame) is performed.

This allows for building the code and setting the player numbers before performing the actual deployment for a game.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
./pepsi pregame rc24a SPL_HULKs 37:1 --prepare
./pepsi upload 37 --prepare
```
