### PR TITLE
Fix uninitialized cycler databases

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -561,6 +561,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
             let itt_domain = ittapi::Domain::new(&instance_name);
 
             let (own_database_timestamp, own_database) = &mut *self.own_sender.borrow_mut();
+            *own_database = Default::default();
 
             #pre_setup
 


### PR DESCRIPTION
## Why? What?

While working with replay, we noticed wrong behavior regarding additional outputs due to an uninitialized database. This PR fixes the problem by initializing the databases before use.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Watch a replay, search for a situation with no camera matrix and observe, how there are no longer spurious additional outputs in the image panel.
