### PR TITLE
only Forward kicks as penalty kicks

### DIFF
--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -219,28 +219,21 @@ fn collect_kick_targets(
                 .collect(),
                 true,
             )
-        } else if is_penalty_shot {
-            (
-                generate_goal_line_kick_targets(field_dimensions, field_to_ground)
-                    .into_iter()
-                    .map(|kick_target| KickTargetWithKickVariants {
-                        kick_target,
-                        kick_variants: collect_kick_targets_parameters
-                            .penalty_kick_kick_variants
-                            .clone(),
-                    })
-                    .collect(),
-                true,
-            )
         } else {
             (
                 generate_goal_line_kick_targets(field_dimensions, field_to_ground)
                     .into_iter()
                     .map(|kick_target| KickTargetWithKickVariants {
                         kick_target,
-                        kick_variants: collect_kick_targets_parameters
-                            .goal_line_kick_variants
-                            .clone(),
+                        kick_variants: if is_penalty_shot {
+                            collect_kick_targets_parameters
+                                .penalty_kick_kick_variants
+                                .clone()
+                        } else {
+                            collect_kick_targets_parameters
+                                .goal_line_kick_variants
+                                .clone()
+                        },
                     })
                     .collect(),
                 true,

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -7,7 +7,7 @@ use framework::MainOutput;
 use geometry::{circle::Circle, line_segment::LineSegment, two_line_segments::TwoLineSegments};
 use linear_algebra::{distance, point, Isometry2, Point2};
 use serde::{Deserialize, Serialize};
-use spl_network_messages::{GamePhase, SubState};
+use spl_network_messages::{GamePhase, SubState, Team};
 use types::{
     field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
@@ -167,13 +167,15 @@ fn collect_kick_targets(
             ..
         })
     );
-    let is_penalty_shoot = matches!(
+    let is_penalty_shot = matches!(
         filtered_game_controller_state,
         Some(FilteredGameControllerState {
             game_phase: GamePhase::PenaltyShootout { .. },
+            kicking_team: Team::Hulks,
             ..
         }) | Some(FilteredGameControllerState {
             sub_state: Some(SubState::PenaltyKick),
+            kicking_team: Team::Hulks,
             ..
         })
     );
@@ -217,7 +219,7 @@ fn collect_kick_targets(
                 .collect(),
                 true,
             )
-        } else if is_penalty_shoot {
+        } else if is_penalty_shot {
             (
                 generate_goal_line_kick_targets(field_dimensions, field_to_ground)
                     .into_iter()

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1088,6 +1088,7 @@
     "kick_off_kick_strength": 0.25,
     "kick_off_kick_variants": ["Forward", "Side"],
     "corner_kick_variants": ["Forward", "Side", "Turn"],
+    "penalty_kick_kick_variants": ["Forward"],
     "goal_line_kick_variants": ["Forward", "Side", "Turn"]
   },
   "role_assignment": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1086,6 +1086,7 @@
     "max_kick_around_obstacle_angle": 0.8,
     "corner_kick_strength": 0.25,
     "kick_off_kick_strength": 0.25,
+    "penalty_shot_kick_strength": 2.0,
     "kick_off_kick_variants": ["Forward", "Side"],
     "corner_kick_variants": ["Forward", "Side", "Turn"],
     "penalty_kick_kick_variants": ["Forward"],


### PR DESCRIPTION
## Why? What?

@pejotejo and me decided it is best to only allow Forward kicks in the penalty situation, as they are most precise and also strike a goal. 
Also increases the kick strength for penalty kicks to 2.

More improvement for #546.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Test in Penalty Shootout or Penalty Kick, and see only Forward kicks. Can also be tested with other kicks if want clearer difference.
