### PR TITLE
Ball Filter - Throw out by validity

### DIFF
--- a/crates/control/src/ball_filter.rs
+++ b/crates/control/src/ball_filter.rs
@@ -157,7 +157,10 @@ impl BallFilter {
                 .start_time
                 .duration_since(ball.last_seen)
                 .expect("time ran backwards");
+            let validity_high_enough =
+                hypothesis.validity >= filter_parameters.validity_discard_threshold;
             is_ball_inside_field(ball, field_dimensions)
+                && validity_high_enough
                 && duration_since_last_observation < filter_parameters.hypothesis_timeout
         };
 


### PR DESCRIPTION
## Why? What?

In the refactor of the ball filter I forgot to throw out hypotheses by validity criterium. This PR reintroduces the check.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Check hypotheses are removed from the filter if their validity drops low
