### PR TITLE
Fix referee position overlay

### DIFF
--- a/tools/twix/src/panels/map/layers/referee_position.rs
+++ b/tools/twix/src/panels/map/layers/referee_position.rs
@@ -20,9 +20,8 @@ impl Layer<Field> for RefereePosition {
     fn new(nao: Arc<Nao>) -> Self {
         let expected_referee_position =
             nao.subscribe_value("Control.main_outputs.expected_referee_position");
-        let maximum_distance_to_referee_position = nao.subscribe_value(
-            "parameters.object_detection.object_detection_top.distance_to_referee_position_threshold",
-        );
+        let maximum_distance_to_referee_position =
+            nao.subscribe_value("parameters.pose_detection.maximum_distance_to_referee_position");
         Self {
             expected_referee_position,
             maximum_distance_to_referee_position,


### PR DESCRIPTION
## Why? What?

Fixes a broken import in the referee position overlay in twix. 

Fixes #1227 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Open twix and enable the referee position overlay.  
