### PR TITLE
Reduce visual referee threshold

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -5,7 +5,7 @@
     "maximum_distance_to_referee_position": 2.0,
     "minimum_bounding_box_confidence": 0.8,
     "minimum_overall_keypoint_confidence": 0.5,
-    "minimum_visual_referee_keypoint_confidence": 0.85,
+    "minimum_visual_referee_keypoint_confidence": 0.8,
     "minimum_shoulder_angle": 0.2,
     "foot_z_offset": 0.05,
     "referee_pose_queue_length": 8,


### PR DESCRIPTION
## Why? What?
Reduce `minimum_visual_referee_keypoint_confidence` to improve visual referee performance. 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

## How to Test
