### PR TITLE
Allow to disable instant kicks

### DIFF
--- a/crates/control/src/kick_selector.rs
+++ b/crates/control/src/kick_selector.rs
@@ -112,6 +112,11 @@ impl KickSelector {
             KickVariant::Turn => context.in_walk_kicks.turn.enabled,
             KickVariant::Side => context.in_walk_kicks.side.enabled,
         });
+        instant_kick_decisions.retain(|target| match target.variant {
+            KickVariant::Forward => context.in_walk_kicks.forward.enabled,
+            KickVariant::Turn => context.in_walk_kicks.turn.enabled,
+            KickVariant::Side => context.in_walk_kicks.side.enabled,
+        });
 
         kick_decisions.sort_by(|left, right| {
             compare_decisions(left, right, &context, *context.ground_to_upcoming_support)


### PR DESCRIPTION
## Why? What?

Only retain the enabled kick variants. This was done for "normal" kick decisions but the instant ones were not filtered.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

disable one variant of a kick (e.g. the turn kick) via the parameters and check that the robot is not doing this kick anymore. Or that no instant kick variants of this type are produced.