### PR TITLE
refactor `kick_target_provider`, disable obstacle detection for kick off

### DIFF
--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -12,12 +12,26 @@ use types::{
     field_dimensions::FieldDimensions,
     filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState,
-    kick_target::{KickTarget, KickTargetWithKickVariants},
+    kick_target::{KickTarget, KickTargetWithKickVariants, PlayingSituation},
     motion_command::KickVariant,
     obstacles::Obstacle,
     parameters::FindKickTargetsParameters,
     world_state::BallState,
 };
+
+trait WithVariants {
+    fn with_variants(self, variants: &[KickVariant]) -> Vec<KickTargetWithKickVariants>;
+}
+impl WithVariants for Vec<KickTarget> {
+    fn with_variants(self, variants: &[KickVariant]) -> Vec<KickTargetWithKickVariants> {
+        self.into_iter()
+            .map(|kick_target| KickTargetWithKickVariants {
+                kick_target,
+                kick_variants: variants.to_vec(),
+            })
+            .collect()
+    }
+}
 
 #[derive(Deserialize, Serialize)]
 pub struct KickTargetProvider;
@@ -79,22 +93,17 @@ impl KickTargetProvider {
     }
 
     pub fn cycle(&self, context: CycleContext) -> Result<MainOutputs> {
-        let ball_position = context.ball_state.ball_in_ground;
+        let obstacle_circles = generate_obstacle_circles(
+            context.obstacles,
+            *context.ball_radius_for_kick_target_selection,
+        );
 
-        let obstacle_circles = match context.filtered_game_controller_state {
-            Some(FilteredGameControllerState {
-                game_phase: GamePhase::PenaltyShootout { .. },
-                ..
-            }) => vec![],
-            Some(FilteredGameControllerState {
-                sub_state: Some(SubState::PenaltyKick),
-                ..
-            }) => vec![],
-            _ => generate_obstacle_circles(
-                context.obstacles,
-                *context.ball_radius_for_kick_target_selection,
-            ),
-        };
+        let playing_situation = get_playing_situation(
+            context.filtered_game_controller_state,
+            context.ball_state.ball_in_field,
+            context.find_kick_targets_parameters,
+            context.field_dimensions,
+        );
 
         let collect_kick_targets_parameters = CollectKickTargetsParameter {
             find_kick_targets_parameter: context.find_kick_targets_parameters,
@@ -112,9 +121,9 @@ impl KickTargetProvider {
             *context.ground_to_field,
             context.field_dimensions,
             &obstacle_circles,
-            ball_position,
+            *context.ball_state,
             collect_kick_targets_parameters,
-            context.filtered_game_controller_state,
+            playing_situation,
         );
 
         Ok(MainOutputs {
@@ -146,188 +155,79 @@ fn collect_kick_targets(
     ground_to_field: Isometry2<Ground, Field>,
     field_dimensions: &FieldDimensions,
     obstacle_circles: &[Circle<Ground>],
-    ball_position: Point2<Ground>,
+    ball_state: BallState,
     collect_kick_targets_parameters: CollectKickTargetsParameter<'_>,
-    filtered_game_controller_state: Option<&FilteredGameControllerState>,
+    playing_situation: PlayingSituation,
 ) -> (Vec<KickTargetWithKickVariants>, bool) {
     let field_to_ground = ground_to_field.inverse();
 
-    let is_own_kick_off = matches!(
-        filtered_game_controller_state,
-        Some(FilteredGameControllerState {
-            game_state: FilteredGameState::Playing { kick_off: true, .. },
-            game_phase: GamePhase::Normal,
-            ..
-        })
-    );
-    let is_not_free_for_opponent = matches!(
-        filtered_game_controller_state,
-        Some(FilteredGameControllerState {
-            opponent_game_state: FilteredGameState::Playing {
-                ball_is_free: false,
-                ..
-            },
-            ..
-        })
-    );
-    let is_penalty_shot = matches!(
-        filtered_game_controller_state,
-        Some(FilteredGameControllerState {
-            game_phase: GamePhase::PenaltyShootout { .. },
-            kicking_team: Team::Hulks,
-            ..
-        }) | Some(FilteredGameControllerState {
-            sub_state: Some(SubState::PenaltyKick),
-            kicking_team: Team::Hulks,
-            ..
-        })
-    );
-
-    let (kick_opportunities, allow_instant_kicks): (Vec<_>, _) =
-        if is_own_kick_off && is_not_free_for_opponent {
-            (
+    let (mut kick_opportunities, allow_instant_kicks, respect_obstacles): (Vec<_>, _, _) =
+        match playing_situation {
+            PlayingSituation::KickOff => (
                 generate_kick_off_kick_targets(
                     field_dimensions,
                     field_to_ground,
                     collect_kick_targets_parameters.kick_off_kick_strength,
                 )
-                .into_iter()
-                .map(|kick_target| KickTargetWithKickVariants {
-                    kick_target,
-                    kick_variants: collect_kick_targets_parameters
-                        .kick_off_kick_variants
-                        .clone(),
-                })
-                .collect(),
+                .with_variants(&collect_kick_targets_parameters.kick_off_kick_variants),
                 true,
-            )
-        } else if is_ball_in_opponents_corners(
-            ball_position,
-            collect_kick_targets_parameters.find_kick_targets_parameter,
-            field_dimensions,
-            ground_to_field,
-        ) {
-            (
+                false,
+            ),
+            PlayingSituation::CornerKick => (
                 generate_corner_kick_targets(
                     collect_kick_targets_parameters.find_kick_targets_parameter,
                     field_dimensions,
                     field_to_ground,
                     collect_kick_targets_parameters.corner_kick_strength,
                 )
-                .into_iter()
-                .map(|kick_target| KickTargetWithKickVariants {
-                    kick_target,
-                    kick_variants: collect_kick_targets_parameters.corner_kick_variants.clone(),
-                })
-                .collect(),
+                .with_variants(&collect_kick_targets_parameters.corner_kick_variants),
                 true,
-            )
-        } else if is_penalty_shot {
-            (
+                true,
+            ),
+            PlayingSituation::PenaltyShot => (
                 generate_penalty_shot_kick_targets(
                     field_dimensions,
                     field_to_ground,
                     collect_kick_targets_parameters.penalty_shot_kick_strength,
                 )
-                .into_iter()
-                .map(|kick_target| KickTargetWithKickVariants {
-                    kick_target,
-                    kick_variants: collect_kick_targets_parameters
-                        .penalty_kick_kick_variants
-                        .clone(),
-                })
-                .collect(),
+                .with_variants(&collect_kick_targets_parameters.penalty_kick_kick_variants),
                 true,
-            )
-        } else {
-            (
+                false,
+            ),
+            PlayingSituation::Normal => (
                 generate_goal_line_kick_targets(field_dimensions, field_to_ground)
-                    .into_iter()
-                    .map(|kick_target| KickTargetWithKickVariants {
-                        kick_target,
-                        kick_variants: collect_kick_targets_parameters
-                            .goal_line_kick_variants
-                            .clone(),
-                    })
-                    .collect(),
+                    .with_variants(&collect_kick_targets_parameters.goal_line_kick_variants),
                 true,
-            )
+                true,
+            ),
         };
 
-    let obstacle_circles: Vec<_> = obstacle_circles
-        .iter()
-        .map(|circle| {
-            let ball_to_obstacle = circle.center - ball_position;
-            let safety_radius = circle.radius
-                / collect_kick_targets_parameters
-                    .max_kick_around_obstacle_angle
-                    .sin();
-            let distance_to_obstacle = ball_to_obstacle.norm();
-            let center = if distance_to_obstacle < safety_radius {
-                circle.center
-                    + ball_to_obstacle.normalize() * (safety_radius - distance_to_obstacle)
-            } else {
-                circle.center
-            };
-            Circle {
-                center,
-                radius: circle.radius,
-            }
-        })
-        .collect();
+    if respect_obstacles {
+        kick_opportunities = modify_with_obstacles(
+            kick_opportunities,
+            obstacle_circles,
+            collect_kick_targets_parameters,
+            ball_state,
+            field_dimensions,
+            ground_to_field,
+        );
+    }
 
-    let kick_opportunities = kick_opportunities
-        .iter()
-        .flat_map(|kick_opportunity| {
-            let ball_to_target = LineSegment(ball_position, kick_opportunity.kick_target.position);
-            let closest_intersecting_obstacle = obstacle_circles
-                .iter()
-                .filter(|circle| circle.intersects_line_segment(&ball_to_target))
-                .min_by_key(|circle| NotNan::new(circle.center.coords().norm()).unwrap());
-            let targets = match closest_intersecting_obstacle {
-                Some(circle) => {
-                    let TwoLineSegments(left_tangent, right_tangent) =
-                        circle.tangents_with_point(ball_position).unwrap();
-                    [left_tangent, right_tangent]
-                        .into_iter()
-                        .map(|tangent| {
-                            let kick_direction = (tangent.0 - ball_position).normalize();
-                            // TODO: drop this constant?
-                            ball_position + kick_direction * 2.0
-                        })
-                        .filter(|&position| {
-                            field_dimensions.is_inside_field(ground_to_field * position)
-                        })
-                        .map(KickTarget::new)
-                        .collect()
-                }
-                None => vec![kick_opportunity.kick_target],
-            };
-            targets
-                .into_iter()
-                .map(|target| KickTargetWithKickVariants {
-                    kick_target: target,
-                    kick_variants: kick_opportunity.kick_variants.clone(),
-                })
-        })
-        .collect();
     (kick_opportunities, allow_instant_kicks)
 }
 
 fn is_ball_in_opponents_corners(
-    ball_position: Point2<Ground>,
+    ball_position: Point2<Field>,
     parameters: &FindKickTargetsParameters,
     field_dimensions: &FieldDimensions,
-    ground_to_field: Isometry2<Ground, Field>,
 ) -> bool {
-    let ball_in_field = ground_to_field * ball_position;
     let left_opponent_corner = point![field_dimensions.length / 2.0, field_dimensions.width / 2.0];
     let right_opponent_corner =
         point![field_dimensions.length / 2.0, -field_dimensions.width / 2.0];
     let ball_near_left_opponent_corner =
-        distance(ball_in_field, left_opponent_corner) < parameters.distance_from_corner;
+        distance(ball_position, left_opponent_corner) < parameters.distance_from_corner;
     let ball_near_right_opponent_corner =
-        distance(ball_in_field, right_opponent_corner) < parameters.distance_from_corner;
+        distance(ball_position, right_opponent_corner) < parameters.distance_from_corner;
     ball_near_left_opponent_corner || ball_near_right_opponent_corner
 }
 
@@ -408,4 +308,110 @@ fn generate_penalty_shot_kick_targets(
         KickTarget::new_with_strength(left_kick_off_target, penalty_shot_kick_strength),
         KickTarget::new_with_strength(right_kick_off_target, penalty_shot_kick_strength),
     ]
+}
+
+fn get_playing_situation(
+    filtered_game_controller_state: Option<&FilteredGameControllerState>,
+    ball_position: Point2<Field>,
+    parameters: &FindKickTargetsParameters,
+    field_dimensions: &FieldDimensions,
+) -> PlayingSituation {
+    let is_ball_in_opponent_corner =
+        is_ball_in_opponents_corners(ball_position, parameters, field_dimensions);
+    match filtered_game_controller_state {
+        Some(FilteredGameControllerState {
+            game_state: FilteredGameState::Playing { kick_off: true, .. },
+            game_phase: GamePhase::Normal,
+            opponent_game_state:
+                FilteredGameState::Playing {
+                    ball_is_free: false,
+                    ..
+                },
+            ..
+        }) => PlayingSituation::KickOff,
+        Some(FilteredGameControllerState {
+            game_phase: GamePhase::PenaltyShootout { .. },
+            kicking_team: Team::Hulks,
+            ..
+        })
+        | Some(FilteredGameControllerState {
+            sub_state: Some(SubState::PenaltyKick),
+            kicking_team: Team::Hulks,
+            ..
+        }) => PlayingSituation::PenaltyShot,
+        _ if is_ball_in_opponent_corner => PlayingSituation::CornerKick,
+        _ => PlayingSituation::Normal,
+    }
+}
+
+fn modify_with_obstacles(
+    kick_opportunities: Vec<KickTargetWithKickVariants>,
+    obstacle_circles: &[Circle<Ground>],
+    collect_kick_targets_parameters: CollectKickTargetsParameter<'_>,
+    ball_state: BallState,
+    field_dimensions: &FieldDimensions,
+    ground_to_field: Isometry2<Ground, Field>,
+) -> Vec<KickTargetWithKickVariants> {
+    let obstacle_circles: Vec<_> = obstacle_circles
+        .iter()
+        .map(|circle| {
+            let ball_to_obstacle = circle.center - ball_state.ball_in_ground;
+            let safety_radius = circle.radius
+                / collect_kick_targets_parameters
+                    .max_kick_around_obstacle_angle
+                    .sin();
+            let distance_to_obstacle = ball_to_obstacle.norm();
+            let center = if distance_to_obstacle < safety_radius {
+                circle.center
+                    + ball_to_obstacle.normalize() * (safety_radius - distance_to_obstacle)
+            } else {
+                circle.center
+            };
+            Circle {
+                center,
+                radius: circle.radius,
+            }
+        })
+        .collect();
+
+    kick_opportunities
+        .iter()
+        .flat_map(|kick_opportunity| {
+            let ball_to_target = LineSegment(
+                ball_state.ball_in_ground,
+                kick_opportunity.kick_target.position,
+            );
+            let closest_intersecting_obstacle = obstacle_circles
+                .iter()
+                .filter(|circle| circle.intersects_line_segment(&ball_to_target))
+                .min_by_key(|circle| NotNan::new(circle.center.coords().norm()).unwrap());
+            let targets = match closest_intersecting_obstacle {
+                Some(circle) => {
+                    let TwoLineSegments(left_tangent, right_tangent) = circle
+                        .tangents_with_point(ball_state.ball_in_ground)
+                        .unwrap();
+                    [left_tangent, right_tangent]
+                        .into_iter()
+                        .map(|tangent| {
+                            let kick_direction =
+                                (tangent.0 - ball_state.ball_in_ground).normalize();
+                            // TODO: drop this constant?
+                            ball_state.ball_in_ground + kick_direction * 2.0
+                        })
+                        .filter(|&position| {
+                            field_dimensions.is_inside_field(ground_to_field * position)
+                        })
+                        .map(KickTarget::new)
+                        .collect()
+                }
+                None => vec![kick_opportunity.kick_target],
+            };
+            targets
+                .into_iter()
+                .map(|target| KickTargetWithKickVariants {
+                    kick_target: target,
+                    kick_variants: kick_opportunity.kick_variants.clone(),
+                })
+        })
+        .collect()
 }

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -166,46 +166,45 @@ fn collect_kick_targets(
 ) -> (Vec<KickTargetWithKickVariants>, bool) {
     let field_to_ground = ground_to_field.inverse();
 
-    let (mut kick_opportunities, allow_instant_kicks, respect_obstacles): (Vec<_>, _, _) =
-        match playing_situation {
-            PlayingSituation::KickOff => (
-                generate_kick_off_kick_targets(
-                    field_dimensions,
-                    field_to_ground,
-                    collect_kick_targets_parameters.kick_off_kick_strength,
-                )
-                .with_variants(&collect_kick_targets_parameters.kick_off_kick_variants),
-                true,
-                false,
-            ),
-            PlayingSituation::CornerKick => (
-                generate_corner_kick_targets(
-                    collect_kick_targets_parameters.find_kick_targets_parameter,
-                    field_dimensions,
-                    field_to_ground,
-                    collect_kick_targets_parameters.corner_kick_strength,
-                )
-                .with_variants(&collect_kick_targets_parameters.corner_kick_variants),
-                true,
-                true,
-            ),
-            PlayingSituation::PenaltyShot => (
-                generate_penalty_shot_kick_targets(
-                    field_dimensions,
-                    field_to_ground,
-                    collect_kick_targets_parameters.penalty_shot_kick_strength,
-                )
-                .with_variants(&collect_kick_targets_parameters.penalty_kick_kick_variants),
-                true,
-                false,
-            ),
-            PlayingSituation::Normal => (
-                generate_goal_line_kick_targets(field_dimensions, field_to_ground)
-                    .with_variants(&collect_kick_targets_parameters.goal_line_kick_variants),
-                true,
-                true,
-            ),
-        };
+    let (mut kick_opportunities, allow_instant_kicks, respect_obstacles) = match playing_situation {
+        PlayingSituation::KickOff => (
+            generate_kick_off_kick_targets(
+                field_dimensions,
+                field_to_ground,
+                collect_kick_targets_parameters.kick_off_kick_strength,
+            )
+            .with_variants(&collect_kick_targets_parameters.kick_off_kick_variants),
+            true,
+            false,
+        ),
+        PlayingSituation::CornerKick => (
+            generate_corner_kick_targets(
+                collect_kick_targets_parameters.find_kick_targets_parameter,
+                field_dimensions,
+                field_to_ground,
+                collect_kick_targets_parameters.corner_kick_strength,
+            )
+            .with_variants(&collect_kick_targets_parameters.corner_kick_variants),
+            true,
+            true,
+        ),
+        PlayingSituation::PenaltyShot => (
+            generate_penalty_shot_kick_targets(
+                field_dimensions,
+                field_to_ground,
+                collect_kick_targets_parameters.penalty_shot_kick_strength,
+            )
+            .with_variants(&collect_kick_targets_parameters.penalty_kick_kick_variants),
+            true,
+            false,
+        ),
+        PlayingSituation::Normal => (
+            generate_goal_line_kick_targets(field_dimensions, field_to_ground)
+                .with_variants(&collect_kick_targets_parameters.goal_line_kick_variants),
+            true,
+            true,
+        ),
+    };
 
     if respect_obstacles {
         kick_opportunities = modify_with_obstacles(

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -65,6 +65,7 @@ pub struct CycleContext {
         Parameter<Vec<KickVariant>, "kick_target_provider.penalty_kick_kick_variants">,
     goal_line_kick_variants:
         Parameter<Vec<KickVariant>, "kick_target_provider.goal_line_kick_variants">,
+    playing_situation: AdditionalOutput<PlayingSituation, "playing_situation">,
 }
 
 struct CollectKickTargetsParameter<'cycle> {
@@ -92,7 +93,7 @@ impl KickTargetProvider {
         Ok(Self {})
     }
 
-    pub fn cycle(&self, context: CycleContext) -> Result<MainOutputs> {
+    pub fn cycle(&self, mut context: CycleContext) -> Result<MainOutputs> {
         let obstacle_circles = generate_obstacle_circles(
             context.obstacles,
             *context.ball_radius_for_kick_target_selection,
@@ -104,6 +105,10 @@ impl KickTargetProvider {
             context.find_kick_targets_parameters,
             context.field_dimensions,
         );
+
+        context
+            .playing_situation
+            .fill_if_subscribed(|| playing_situation);
 
         let collect_kick_targets_parameters = CollectKickTargetsParameter {
             find_kick_targets_parameter: context.find_kick_targets_parameters,

--- a/crates/control/src/kick_target_provider.rs
+++ b/crates/control/src/kick_target_provider.rs
@@ -3,7 +3,7 @@ use ordered_float::NotNan;
 
 use context_attribute::context;
 use coordinate_systems::{Field, Ground};
-use framework::MainOutput;
+use framework::{AdditionalOutput, MainOutput};
 use geometry::{circle::Circle, line_segment::LineSegment, two_line_segments::TwoLineSegments};
 use linear_algebra::{distance, point, Isometry2, Point2};
 use serde::{Deserialize, Serialize};

--- a/crates/types/src/kick_target.rs
+++ b/crates/types/src/kick_target.rs
@@ -1,3 +1,4 @@
+use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
 use linear_algebra::Point2;
@@ -6,7 +7,17 @@ use coordinate_systems::Ground;
 
 use crate::motion_command::KickVariant;
 
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+)]
 pub enum PlayingSituation {
     KickOff,
     CornerKick,

--- a/crates/types/src/kick_target.rs
+++ b/crates/types/src/kick_target.rs
@@ -6,6 +6,15 @@ use coordinate_systems::Ground;
 
 use crate::motion_command::KickVariant;
 
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+pub enum PlayingSituation {
+    KickOff,
+    CornerKick,
+    PenaltyShot,
+    #[default]
+    Normal,
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct KickTarget {
     pub position: Point2<Ground>,


### PR DESCRIPTION
## Why? What?

In last test game the kick off targets were not placed as supposed, because they tried to avoid obstacles. We decided to ignore obstacles in kick off, as no opponent robot is allowed in the center circle. Only own team members are allowed until after the kick and this might also help with the indirect kick rule.

Fixes #

## ToDo / Known Issues

Issue from testgame 16.July.2024

## Ideas for Next Iterations (Not This PR)

none

## How to Test

With game controller test kick off situations and watch kick targets to be placed on the center line and no other kick targets should be changed.
