### PR TITLE
Slightly liquify again

### DIFF
--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -200,7 +200,7 @@ pub fn generate_replayer_struct(cyclers: &Cyclers, with_communication: bool) -> 
                     parameters::directory::deserialize(
                         parameters_directory,
                         &hardware_ids,
-                        false,
+                        true,
                     ).wrap_err("failed to parse initial parameters")?;
                 let initial_parameters = parameters_from_disk;
                 #[allow(unused)]


### PR DESCRIPTION
## Why? What?

#1237 broke the replayer, since it doesn't use the object detection cycler by default.
Now superfluous paramters are allowed in replayer but forbidden for other targets.

Fixes #1237 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Replay anything, should wörk