### PR TITLE
Factor out distance_to_* methods to own trait

### DIFF
--- a/crates/calibration/src/goal_box/residuals.rs
+++ b/crates/calibration/src/goal_box/residuals.rs
@@ -1,3 +1,4 @@
+use geometry::Distance;
 use types::field_dimensions::FieldDimensions;
 
 use crate::{
@@ -40,13 +41,13 @@ impl CalculateResiduals for GoalBoxResiduals {
             .signed_acute_angle_to_orthogonal(projected_lines.connecting_line);
         let distance_between_parallel_line_start_points = projected_lines
             .border_line
-            .distance_to_point(projected_lines.goal_box_line.0);
+            .distance_to(projected_lines.goal_box_line.0);
         let distance_between_parallel_line_center_points = projected_lines
             .border_line
-            .distance_to_point(projected_lines.goal_box_line.center());
+            .distance_to(projected_lines.goal_box_line.center());
         let distance_between_parallel_line_end_points = projected_lines
             .border_line
-            .distance_to_point(projected_lines.goal_box_line.1);
+            .distance_to(projected_lines.goal_box_line.1);
 
         Ok(GoalBoxResiduals {
             border_to_connecting_angle,

--- a/crates/control/src/behavior/intercept_ball.rs
+++ b/crates/control/src/behavior/intercept_ball.rs
@@ -67,7 +67,7 @@ pub fn execute(
                 ball.ball_in_ground,
                 ball.ball_in_ground + ball.ball_in_ground_velocity,
             );
-            let interception_point = ball_line.project_point(Point::origin());
+            let interception_point = ball_line.closest_point(Point::origin());
 
             if interception_point.coords().norm() > parameters.maximum_intercept_distance {
                 return None;

--- a/crates/geometry/src/circle.rs
+++ b/crates/geometry/src/circle.rs
@@ -8,7 +8,7 @@ use linear_algebra::{distance, vector, Point2};
 
 use crate::{
     arc::Arc, circle_tangents::CircleTangents, direction::Direction, line_segment::LineSegment,
-    rectangle::Rectangle, two_line_segments::TwoLineSegments,
+    rectangle::Rectangle, two_line_segments::TwoLineSegments, Distance,
 };
 
 #[derive(
@@ -88,7 +88,7 @@ where
     }
 
     pub fn intersects_line_segment(&self, line_segment: &LineSegment<Frame>) -> bool {
-        line_segment.shortest_distance_to_point(self.center) <= self.radius
+        line_segment.distance_to(self.center) <= self.radius
     }
 
     pub fn overlaps_arc(&self, arc: Arc<Frame>, orientation: Direction) -> bool {

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -9,3 +9,11 @@ pub mod line_segment;
 pub mod look_at;
 pub mod rectangle;
 pub mod two_line_segments;
+
+pub trait Distance<T> {
+    fn squared_distance_to(&self, other: T) -> f32;
+
+    fn distance_to(&self, other: T) -> f32 {
+        self.squared_distance_to(other).sqrt()
+    }
+}

--- a/crates/geometry/src/line.rs
+++ b/crates/geometry/src/line.rs
@@ -11,6 +11,8 @@ use linear_algebra::{
 };
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
+use crate::Distance;
+
 #[derive(
     Copy,
     Clone,
@@ -116,34 +118,12 @@ fn signed_acute_angle<Frame>(first: Vector2<Frame>, second: Vector2<Frame>) -> f
 }
 
 impl<Frame, const DIMENSION: usize> Line<Frame, DIMENSION> {
-    pub fn project_point(&self, point: Point<Frame, DIMENSION>) -> Point<Frame, DIMENSION> {
+    pub fn closest_point(&self, point: Point<Frame, DIMENSION>) -> Point<Frame, DIMENSION> {
         let difference_on_line = self.1 - self.0;
         let difference_to_point = point - self.0;
         self.0
             + (difference_on_line * difference_on_line.dot(difference_to_point)
                 / difference_on_line.norm_squared())
-    }
-
-    pub fn squared_distance_to_segment(&self, point: Point<Frame, DIMENSION>) -> f32 {
-        let difference_on_line = self.1 - self.0;
-        let difference_to_point = point - self.0;
-        let t = difference_to_point.dot(difference_on_line) / difference_on_line.norm_squared();
-        if t <= 0.0 {
-            (point - self.0).norm_squared()
-        } else if t >= 1.0 {
-            (point - self.1).norm_squared()
-        } else {
-            (point - (self.0 + difference_on_line * t)).norm_squared()
-        }
-    }
-
-    pub fn squared_distance_to_point(&self, point: Point<Frame, DIMENSION>) -> f32 {
-        let closest_point = self.project_point(point);
-        distance_squared(closest_point, point)
-    }
-
-    pub fn distance_to_point(&self, point: Point<Frame, DIMENSION>) -> f32 {
-        self.squared_distance_to_point(point).sqrt()
     }
 
     pub fn length(&self) -> f32 {
@@ -152,6 +132,13 @@ impl<Frame, const DIMENSION: usize> Line<Frame, DIMENSION> {
 
     pub fn center(&self) -> Point<Frame, DIMENSION> {
         center(self.0, self.1)
+    }
+}
+
+impl<Frame, const DIMENSION: usize> Distance<Point<Frame, DIMENSION>> for Line<Frame, DIMENSION> {
+    fn squared_distance_to(&self, point: Point<Frame, DIMENSION>) -> f32 {
+        let closest_point = self.closest_point(point);
+        distance_squared(closest_point, point)
     }
 }
 

--- a/crates/ransac/src/lib.rs
+++ b/crates/ransac/src/lib.rs
@@ -1,4 +1,7 @@
-use geometry::line::{Line, Line2};
+use geometry::{
+    line::{Line, Line2},
+    Distance,
+};
 use linear_algebra::Point2;
 use ordered_float::NotNan;
 use rand::{seq::SliceRandom, Rng};
@@ -47,9 +50,9 @@ impl<Frame> Ransac<Frame> {
                     .unused_points
                     .iter()
                     .filter(|&point| {
-                        line.squared_distance_to_point(*point) <= maximum_score_distance_squared
+                        line.squared_distance_to(*point) <= maximum_score_distance_squared
                     })
-                    .map(|point| 1.0 - line.distance_to_point(*point) / maximum_score_distance)
+                    .map(|point| 1.0 - line.distance_to(*point) / maximum_score_distance)
                     .sum();
                 (line, score)
             })
@@ -57,7 +60,7 @@ impl<Frame> Ransac<Frame> {
             .expect("max_by_key erroneously returned no result")
             .0;
         let (used_points, unused_points) = self.unused_points.iter().partition(|point| {
-            best_line.squared_distance_to_point(**point) <= maximum_inclusion_distance_squared
+            best_line.squared_distance_to(**point) <= maximum_inclusion_distance_squared
         });
         self.unused_points = unused_points;
         RansacResult {

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -124,7 +124,7 @@ impl LineDetection {
             }
             let mut points_with_projection_onto_line: Vec<_> = used_points
                 .iter()
-                .map(|&point| (point, ransac_line.project_point(point)))
+                .map(|&point| (point, ransac_line.closest_point(point)))
                 .collect();
             points_with_projection_onto_line.sort_by_key(|(_point, projected_point)| {
                 NotNan::new(projected_point.x()).expect("Tried to compare NaN")


### PR DESCRIPTION
## Why? What?

This PR is a refactor of the distance_to_* methods factoring them out to their own trait.
This is done to make the behavior and naming of Line and LineSegment functions more consistent and the code more readable.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

See if it builds.
