### PR TITLE
Better defender corner kick positioning

### DIFF
--- a/crates/control/src/behavior/defend.rs
+++ b/crates/control/src/behavior/defend.rs
@@ -154,65 +154,6 @@ impl<'cycle> Defend<'cycle> {
     }
 }
 
-fn defend_left_pose(
-    world_state: &WorldState,
-    field_dimensions: &FieldDimensions,
-    role_positions: &RolePositionsParameters,
-) -> Option<Pose2<Ground>> {
-    let ground_to_field = world_state.robot.ground_to_field?;
-    let ball = world_state
-        .rule_ball
-        .or(world_state.ball)
-        .unwrap_or_else(|| BallState::new_at_center(ground_to_field));
-
-    let position_to_defend = point![
-        -field_dimensions.length / 2.0,
-        role_positions.defender_y_offset
-    ];
-    let mut distance_to_target = if ball.field_side == Side::Left {
-        role_positions.defender_aggressive_ring_radius
-    } else {
-        role_positions.defender_passive_ring_radius
-    };
-    distance_to_target = penalty_kick_defender_radius(
-        distance_to_target,
-        world_state.filtered_game_controller_state,
-        field_dimensions,
-    );
-    let defend_pose = block_on_circle(ball.ball_in_field, position_to_defend, distance_to_target);
-    let field_to_ground = ground_to_field.inverse();
-    Some(field_to_ground * defend_pose)
-}
-
-fn defend_right_pose(
-    world_state: &WorldState,
-    field_dimensions: &FieldDimensions,
-    role_positions: &RolePositionsParameters,
-) -> Option<Pose2<Ground>> {
-    let ground_to_field = world_state.robot.ground_to_field?;
-    let ball = world_state
-        .rule_ball
-        .or(world_state.ball)
-        .unwrap_or_else(|| BallState::new_at_center(ground_to_field));
-
-    let position_to_defend = point![
-        -field_dimensions.length / 2.0,
-        -role_positions.defender_y_offset
-    ];
-    let mut distance_to_target = if ball.field_side == Side::Right {
-        role_positions.defender_aggressive_ring_radius
-    } else {
-        role_positions.defender_passive_ring_radius
-    };
-    distance_to_target = penalty_kick_defender_radius(
-        distance_to_target,
-        world_state.filtered_game_controller_state,
-        field_dimensions,
-    );
-    let defend_pose = block_on_circle(ball.ball_in_field, position_to_defend, distance_to_target);
-    Some(ground_to_field.inverse() * defend_pose)
-}
-
 fn defend_pose(
     world_state: &WorldState,
     field_dimensions: &FieldDimensions,

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -168,8 +168,22 @@ impl Behavior {
             .map(|filtered_game_controller_state| filtered_game_controller_state.game_state);
 
         match world_state.robot.role {
-            Role::DefenderLeft => actions.push(Action::DefendLeft),
-            Role::DefenderRight => actions.push(Action::DefendRight),
+            Role::DefenderLeft => match world_state.filtered_game_controller_state {
+                Some(FilteredGameControllerState {
+                    sub_state: Some(SubState::CornerKick),
+                    kicking_team: Team::Opponent,
+                    ..
+                }) => actions.push(Action::DefendOpponentCornerKick { side: Side::Left }),
+                _ => actions.push(Action::DefendLeft),
+            },
+            Role::DefenderRight => match world_state.filtered_game_controller_state {
+                Some(FilteredGameControllerState {
+                    sub_state: Some(SubState::CornerKick),
+                    kicking_team: Team::Opponent,
+                    ..
+                }) => actions.push(Action::DefendOpponentCornerKick { side: Side::Right }),
+                _ => actions.push(Action::DefendRight),
+            },
             Role::Keeper => match world_state.filtered_game_controller_state {
                 Some(FilteredGameControllerState {
                     game_phase: GamePhase::PenaltyShootout { .. },
@@ -307,6 +321,18 @@ impl Behavior {
                         &mut context.path_obstacles_output,
                         *context.defend_walk_speed,
                     ),
+                    Action::DefendOpponentCornerKick { side: Side::Left } => defend
+                        .opponent_corner_kick(
+                            &mut context.path_obstacles_output,
+                            *context.defend_walk_speed,
+                            Side::Left,
+                        ),
+                    Action::DefendOpponentCornerKick { side: Side::Right } => defend
+                        .opponent_corner_kick(
+                            &mut context.path_obstacles_output,
+                            *context.defend_walk_speed,
+                            Side::Right,
+                        ),
                     Action::Stand => stand::execute(
                         world_state,
                         context.field_dimensions,

--- a/crates/types/src/action.rs
+++ b/crates/types/src/action.rs
@@ -1,6 +1,8 @@
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
+use crate::field_dimensions::Side;
+
 #[derive(
     Debug, Clone, Copy, PathSerialize, PathDeserialize, PathIntrospect, Serialize, Deserialize,
 )]
@@ -12,6 +14,7 @@ pub enum Action {
     DefendLeft,
     DefendPenaltyKick,
     DefendRight,
+    DefendOpponentCornerKick { side: Side },
     Dribble,
     FallSafely,
     Initial,

--- a/tests/behavior/corner_kicks.lua
+++ b/tests/behavior/corner_kicks.lua
@@ -1,0 +1,128 @@
+local inspect = require 'inspect'
+print("Hello world from lua!")
+
+function spawn_robot(number)
+    table.insert(state.robots, create_robot(number))
+end
+
+spawn_robot(1)
+spawn_robot(2)
+spawn_robot(3)
+spawn_robot(4)
+spawn_robot(5)
+spawn_robot(6)
+spawn_robot(7)
+
+local game_end_time = 20000.0
+
+function on_goal()
+    print("Goal scored, resetting ball!")
+    print("Ball: " .. inspect(state.ball))
+    print("Ball was at x: " .. state.ball.position[1] .. " y: " .. state.ball.position[2])
+    state.ball = nil
+end
+
+function on_cycle()
+    if state.ball == nil and state.cycle_count % 1000 == 0 then
+        print(inspect(state))
+        state.ball = {
+            position = { 0.0, 0.0 },
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 100 then
+        state.game_controller_state.game_state = "Ready"
+    end
+
+    if state.cycle_count == 1600 then
+        state.game_controller_state.game_state = "Set"
+    end
+
+    if state.cycle_count == 1700 then
+        state.game_controller_state.game_state = "Playing"
+    end
+
+    if state.cycle_count == 2000 then
+        state.game_controller_state.sub_state = "CornerKick"
+        state.game_controller_state.kicking_team = "Opponent"
+    end
+
+    if state.cycle_count >= 2500 then
+        state.ball = {
+            position = { -4.5, 3.0},
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 5000 then
+        state.game_controller_state.sub_state = "CornerKick"
+        state.game_controller_state.kicking_team = "Opponent"
+    end
+
+    if state.cycle_count >= 5500 then
+        state.ball = {
+            position = { -4.5, -3.0},
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 8000 then
+        state.game_controller_state.sub_state = "CornerKick"
+        state.game_controller_state.kicking_team = "Hulks"
+    end
+
+    if state.cycle_count >= 8500 then
+        state.ball = {
+            position = { 4.5, -3.0},
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 11000 then
+        state.game_controller_state.sub_state = "CornerKick"
+        state.game_controller_state.kicking_team = "Hulks"
+    end
+
+    if state.cycle_count >= 11500 then
+        state.ball = {
+            position = { 4.5, 3.0},
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+
+    if state.cycle_count == 15000 then
+        state.game_controller_state.sub_state = "PenaltyKick"
+        state.game_controller_state.game_state = "Ready"
+        state.game_controller_state.kicking_team = "Opponent"
+    end
+
+    if state.cycle_count >= 15000 then
+        state.ball = {
+            position = { -3.2, 0.0},
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == 16500 then
+        state.game_controller_state.game_state = "Playing"
+    end
+
+    if state.cycle_count == 18000 then
+        state.game_controller_state.sub_state = "PenaltyKick"
+        state.game_controller_state.game_state = "Playing"
+        state.game_controller_state.kicking_team = "Hulks"
+    end
+
+    if state.cycle_count >= 18000 then
+        state.ball = {
+            position = { 3.2, 0.0},
+            velocity = { 0.0, 0.0 },
+        }
+    end
+
+    if state.cycle_count == game_end_time then
+        state.finished = true
+    end
+end


### PR DESCRIPTION
## Why? What?

Improves the defender positioning for opponent corner kicks. Previously, the defender would be clamped to the goal line. This positioning overlaps with the Striker and is thus not desirable. This offsets the defender x position in these situations.   

Depends on #1244 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- Serve the behavior simulator with the `corner_kicks.lua` test and confirm the defender position for the opponent corner kicks.  
