### PR TITLE
Enforcing difference between Line and LineSegment and clean up related code

### DIFF
--- a/crates/calibration/src/goal_box/lines.rs
+++ b/crates/calibration/src/goal_box/lines.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::{Ground, Pixel};
-use geometry::line::{Line, Line2};
+use geometry::line_segment::LineSegment;
 use linear_algebra::Point2;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use projection::{camera_matrix::CameraMatrix, Projection};
@@ -10,9 +10,9 @@ use projection::{camera_matrix::CameraMatrix, Projection};
     Clone, Debug, Default, Serialize, Deserialize, PathSerialize, PathIntrospect, PathDeserialize,
 )]
 pub struct Lines<Frame> {
-    pub border_line: Line2<Frame>,
-    pub goal_box_line: Line2<Frame>,
-    pub connecting_line: Line2<Frame>,
+    pub border_line: LineSegment<Frame>,
+    pub goal_box_line: LineSegment<Frame>,
+    pub connecting_line: LineSegment<Frame>,
 }
 
 impl Lines<Pixel> {
@@ -40,10 +40,10 @@ pub enum LinesError {
 
 fn project_line_and_map_error(
     matrix: &CameraMatrix,
-    line: Line2<Pixel>,
+    line: LineSegment<Pixel>,
     which: &str,
-) -> Result<Line2<Ground>, LinesError> {
-    Ok(Line(
+) -> Result<LineSegment<Ground>, LinesError> {
+    Ok(LineSegment(
         project_point_and_map_error(matrix, line.0, format!("{which} point 0"))?,
         project_point_and_map_error(matrix, line.1, format!("{which} point 1"))?,
     ))

--- a/crates/control/src/camera_matrix_calculator.rs
+++ b/crates/control/src/camera_matrix_calculator.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use context_attribute::context;
 use coordinate_systems::{Camera, Ground, Head, Pixel, Robot};
 use framework::{AdditionalOutput, MainOutput};
-use geometry::line::{Line, Line2};
+use geometry::line_segment::LineSegment;
 use linear_algebra::{point, vector, IntoTransform, Isometry3, Vector3};
 use types::{
     field_dimensions::FieldDimensions, field_lines::ProjectedFieldLines,
@@ -105,7 +105,7 @@ impl CameraMatrixCalculator {
 fn project_penalty_area_on_images(
     field_dimensions: &FieldDimensions,
     camera_matrix: &CameraMatrix,
-) -> Option<Vec<Line2<Pixel>>> {
+) -> Option<Vec<LineSegment<Pixel>>> {
     let field_length = &field_dimensions.length;
     let field_width = &field_dimensions.width;
     let penalty_area_length = &field_dimensions.penalty_area_length;
@@ -137,11 +137,11 @@ fn project_penalty_area_on_images(
         .ok()?;
 
     Some(vec![
-        Line(penalty_top_left, penalty_top_right),
-        Line(penalty_bottom_left, penalty_bottom_right),
-        Line(penalty_bottom_left, penalty_top_left),
-        Line(penalty_bottom_right, penalty_top_right),
-        Line(corner_left, corner_right),
+        LineSegment(penalty_top_left, penalty_top_right),
+        LineSegment(penalty_bottom_left, penalty_bottom_right),
+        LineSegment(penalty_bottom_left, penalty_top_left),
+        LineSegment(penalty_bottom_right, penalty_top_right),
+        LineSegment(corner_left, corner_right),
     ])
 }
 

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -10,25 +10,10 @@ pub mod look_at;
 pub mod rectangle;
 pub mod two_line_segments;
 
-use std::f32::consts::{FRAC_PI_2, PI};
-
-use linear_algebra::{Rotation2, Vector2};
-
 pub trait Distance<T> {
     fn squared_distance_to(&self, other: T) -> f32;
 
     fn distance_to(&self, other: T) -> f32 {
         self.squared_distance_to(other).sqrt()
-    }
-}
-
-fn signed_acute_angle<Frame>(first: Vector2<Frame>, second: Vector2<Frame>) -> f32 {
-    let difference = Rotation2::rotation_between(first, second).angle();
-    if difference > FRAC_PI_2 {
-        difference - PI
-    } else if difference < -FRAC_PI_2 {
-        difference + PI
-    } else {
-        difference
     }
 }

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -10,10 +10,25 @@ pub mod look_at;
 pub mod rectangle;
 pub mod two_line_segments;
 
+use std::f32::consts::{FRAC_PI_2, PI};
+
+use linear_algebra::{Rotation2, Vector2};
+
 pub trait Distance<T> {
     fn squared_distance_to(&self, other: T) -> f32;
 
     fn distance_to(&self, other: T) -> f32 {
         self.squared_distance_to(other).sqrt()
+    }
+}
+
+fn signed_acute_angle<Frame>(first: Vector2<Frame>, second: Vector2<Frame>) -> f32 {
+    let difference = Rotation2::rotation_between(first, second).angle();
+    if difference > FRAC_PI_2 {
+        difference - PI
+    } else if difference < -FRAC_PI_2 {
+        difference + PI
+    } else {
+        difference
     }
 }

--- a/crates/geometry/src/line.rs
+++ b/crates/geometry/src/line.rs
@@ -1,17 +1,12 @@
-use std::{
-    f32::consts::{FRAC_PI_2, PI},
-    ops::Mul,
-};
+use std::ops::Mul;
 
 use approx::{AbsDiffEq, RelativeEq};
 use serde::{Deserialize, Serialize};
 
-use linear_algebra::{
-    center, distance, distance_squared, point, vector, Point, Point2, Rotation2, Transform, Vector2,
-};
+use linear_algebra::{distance_squared, point, vector, Point, Point2, Transform};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
-use crate::Distance;
+use crate::{line_segment::LineSegment, signed_acute_angle, Distance};
 
 #[derive(
     Copy,
@@ -106,17 +101,6 @@ impl<Frame> Line2<Frame> {
     }
 }
 
-fn signed_acute_angle<Frame>(first: Vector2<Frame>, second: Vector2<Frame>) -> f32 {
-    let difference = Rotation2::rotation_between(first, second).angle();
-    if difference > FRAC_PI_2 {
-        difference - PI
-    } else if difference < -FRAC_PI_2 {
-        difference + PI
-    } else {
-        difference
-    }
-}
-
 impl<Frame, const DIMENSION: usize> Line<Frame, DIMENSION> {
     pub fn closest_point(&self, point: Point<Frame, DIMENSION>) -> Point<Frame, DIMENSION> {
         let difference_on_line = self.1 - self.0;
@@ -124,14 +108,6 @@ impl<Frame, const DIMENSION: usize> Line<Frame, DIMENSION> {
         self.0
             + (difference_on_line * difference_on_line.dot(difference_to_point)
                 / difference_on_line.norm_squared())
-    }
-
-    pub fn length(&self) -> f32 {
-        distance(self.0, self.1)
-    }
-
-    pub fn center(&self) -> Point<Frame, DIMENSION> {
-        center(self.0, self.1)
     }
 }
 
@@ -185,6 +161,12 @@ impl<Frame, const DIMENSION: usize> RelativeEq for Line<Frame, DIMENSION> {
     ) -> bool {
         self.0.relative_eq(&other.0, epsilon, max_relative)
             && self.1.relative_eq(&other.1, epsilon, max_relative)
+    }
+}
+
+impl<Frame> From<LineSegment<Frame>> for Line2<Frame> {
+    fn from(line_segment: LineSegment<Frame>) -> Self {
+        Self(line_segment.0, line_segment.1)
     }
 }
 

--- a/crates/geometry/src/line.rs
+++ b/crates/geometry/src/line.rs
@@ -38,8 +38,7 @@ impl<Frame> Line2<Frame> {
     }
 
     pub fn is_above(&self, point: Point2<Frame>) -> bool {
-        let rise = (point.x() - self.0.x()) * self.slope();
-        point.y() >= rise + self.0.y()
+        self.signed_distance_to_point(point) >= 0.0
     }
 
     pub fn signed_distance_to_point(&self, point: Point2<Frame>) -> f32 {

--- a/crates/geometry/src/line.rs
+++ b/crates/geometry/src/line.rs
@@ -3,10 +3,10 @@ use std::ops::Mul;
 use approx::{AbsDiffEq, RelativeEq};
 use serde::{Deserialize, Serialize};
 
-use linear_algebra::{distance_squared, point, vector, Point, Point2, Transform};
+use linear_algebra::{distance_squared, point, Point, Point2, Transform};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
-use crate::{line_segment::LineSegment, Distance};
+use crate::{direction::Direction, line_segment::LineSegment, Distance};
 
 #[derive(
     Copy,
@@ -44,7 +44,9 @@ impl<Frame> Line2<Frame> {
 
     pub fn signed_distance_to_point(&self, point: Point2<Frame>) -> f32 {
         let line_vector = self.1 - self.0;
-        let normal_vector = vector![-line_vector.y(), line_vector.x()].normalize();
+        let normal_vector = Direction::Counterclockwise
+            .rotate_vector_90_degrees(line_vector)
+            .normalize();
         normal_vector.dot(point.coords()) - normal_vector.dot(self.0.coords())
     }
 

--- a/crates/geometry/src/line.rs
+++ b/crates/geometry/src/line.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use linear_algebra::{distance_squared, point, vector, Point, Point2, Transform};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
-use crate::{line_segment::LineSegment, signed_acute_angle, Distance};
+use crate::{line_segment::LineSegment, Distance};
 
 #[derive(
     Copy,
@@ -28,27 +28,6 @@ pub type Line2<Frame> = Line<Frame, 2>;
 pub type Line3<Frame> = Line<Frame, 3>;
 
 impl<Frame> Line2<Frame> {
-    pub fn signed_acute_angle(&self, other: Self) -> f32 {
-        let self_direction = self.1 - self.0;
-        let other_direction = other.1 - other.0;
-        signed_acute_angle(self_direction, other_direction)
-    }
-
-    pub fn angle(&self, other: Self) -> f32 {
-        (self.1 - self.0).angle(other.1 - other.0)
-    }
-
-    pub fn signed_acute_angle_to_orthogonal(&self, other: Self) -> f32 {
-        let self_direction = self.1 - self.0;
-        let other_direction = other.1 - other.0;
-        let orthogonal_other_direction = vector![other_direction.y(), -other_direction.x()];
-        signed_acute_angle(self_direction, orthogonal_other_direction)
-    }
-
-    pub fn is_orthogonal(&self, other: Self, epsilon: f32) -> bool {
-        self.signed_acute_angle_to_orthogonal(other).abs() < epsilon
-    }
-
     pub fn slope(&self) -> f32 {
         let difference = self.0 - self.1;
         difference.y() / difference.x()
@@ -67,19 +46,6 @@ impl<Frame> Line2<Frame> {
         let line_vector = self.1 - self.0;
         let normal_vector = vector![-line_vector.y(), line_vector.x()].normalize();
         normal_vector.dot(point.coords()) - normal_vector.dot(self.0.coords())
-    }
-
-    pub fn project_onto_segment(&self, point: Point2<Frame>) -> Point2<Frame> {
-        let difference_on_line = self.1 - self.0;
-        let difference_to_point = point - self.0;
-        let t = difference_to_point.dot(difference_on_line) / difference_on_line.norm_squared();
-        if t <= 0.0 {
-            self.0
-        } else if t >= 1.0 {
-            self.1
-        } else {
-            self.0 + difference_on_line * t
-        }
     }
 
     pub fn intersection(&self, other: &Line2<Frame>) -> Point2<Frame> {
@@ -167,135 +133,5 @@ impl<Frame, const DIMENSION: usize> RelativeEq for Line<Frame, DIMENSION> {
 impl<Frame> From<LineSegment<Frame>> for Line2<Frame> {
     fn from(line_segment: LineSegment<Frame>) -> Self {
         Self(line_segment.0, line_segment.1)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::f32::consts::FRAC_PI_4;
-
-    use approx::assert_relative_eq;
-
-    use super::*;
-
-    #[derive(Clone, Copy, Debug)]
-    struct SomeFrame;
-
-    #[test]
-    fn correct_acute_signed_angle() {
-        #[derive(Debug)]
-        struct Case {
-            self_line: Line2<SomeFrame>,
-            other_line: Line2<SomeFrame>,
-            expected_angle: f32,
-        }
-
-        let thirty_degree = 30.0_f32.to_radians();
-        let sixty_degree = 60.0_f32.to_radians();
-        let cases = [
-            Case {
-                self_line: Line(point![0.0, 0.0], point![42.0, 0.0]),
-                other_line: Line(point![0.0, 0.0], point![42.0, 0.0]),
-                expected_angle: 0.0,
-            },
-            Case {
-                self_line: Line(point![0.0, 0.0], point![42.0, 0.0]),
-                other_line: Line(point![0.0, 0.0], point![42.0, 42.0]),
-                expected_angle: FRAC_PI_4,
-            },
-            Case {
-                self_line: Line(point![0.0, 0.0], point![42.0, 42.0]),
-                other_line: Line(point![0.0, 0.0], point![42.0, 0.0]),
-                expected_angle: -FRAC_PI_4,
-            },
-            Case {
-                self_line: Line(point![0.0, 0.0], point![42.0, 0.0]),
-                other_line: Line(point![0.0, 0.0], point![42.0, -42.0]),
-                expected_angle: -FRAC_PI_4,
-            },
-            Case {
-                self_line: Line(point![0.0, 0.0], point![42.0, -42.0]),
-                other_line: Line(point![0.0, 0.0], point![42.0, 0.0]),
-                expected_angle: FRAC_PI_4,
-            },
-            Case {
-                self_line: Line(
-                    point![0.0, 0.0],
-                    point![(-thirty_degree).cos(), (-thirty_degree).sin()],
-                ),
-                other_line: Line(
-                    point![0.0, 0.0],
-                    point![thirty_degree.cos(), thirty_degree.sin()],
-                ),
-                expected_angle: sixty_degree,
-            },
-            Case {
-                self_line: Line(
-                    point![0.0, 0.0],
-                    point![thirty_degree.cos(), thirty_degree.sin()],
-                ),
-                other_line: Line(
-                    point![0.0, 0.0],
-                    point![(-thirty_degree).cos(), (-thirty_degree).sin()],
-                ),
-                expected_angle: -sixty_degree,
-            },
-            Case {
-                self_line: Line(
-                    point![0.0, 0.0],
-                    point![(-sixty_degree).cos(), (-sixty_degree).sin()],
-                ),
-                other_line: Line(
-                    point![0.0, 0.0],
-                    point![sixty_degree.cos(), sixty_degree.sin()],
-                ),
-                expected_angle: -sixty_degree,
-            },
-            Case {
-                self_line: Line(
-                    point![0.0, 0.0],
-                    point![sixty_degree.cos(), sixty_degree.sin()],
-                ),
-                other_line: Line(
-                    point![0.0, 0.0],
-                    point![(-sixty_degree).cos(), (-sixty_degree).sin()],
-                ),
-                expected_angle: sixty_degree,
-            },
-        ]
-        .into_iter()
-        .flat_map(|case| {
-            [
-                Case {
-                    self_line: case.self_line,
-                    other_line: case.other_line,
-                    expected_angle: case.expected_angle,
-                },
-                Case {
-                    self_line: Line(case.self_line.1, case.self_line.0),
-                    other_line: case.other_line,
-                    expected_angle: case.expected_angle,
-                },
-                Case {
-                    self_line: case.self_line,
-                    other_line: Line(case.other_line.1, case.other_line.0),
-                    expected_angle: case.expected_angle,
-                },
-                Case {
-                    self_line: Line(case.self_line.1, case.self_line.0),
-                    other_line: Line(case.other_line.1, case.other_line.0),
-                    expected_angle: case.expected_angle,
-                },
-            ]
-        });
-
-        for case in cases {
-            dbg!(&case);
-            assert_relative_eq!(
-                case.self_line.signed_acute_angle(case.other_line),
-                case.expected_angle,
-                epsilon = 0.000001,
-            );
-        }
     }
 }

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -50,7 +50,9 @@ impl<Frame> LineSegment<Frame> {
 
     pub fn signed_distance_to_point(&self, point: Point2<Frame>) -> f32 {
         let line_vector = self.1 - self.0;
-        let normal_vector = vector![-line_vector.y(), line_vector.x()].normalize();
+        let normal_vector = Direction::Counterclockwise
+            .rotate_vector_90_degrees(line_vector)
+            .normalize();
         normal_vector.dot(point.coords()) - normal_vector.dot(self.0.coords())
     }
 
@@ -67,7 +69,8 @@ impl<Frame> LineSegment<Frame> {
     pub fn signed_acute_angle_to_orthogonal(&self, other: Self) -> f32 {
         let self_direction = self.1 - self.0;
         let other_direction = other.1 - other.0;
-        let orthogonal_other_direction = vector![other_direction.y(), -other_direction.x()];
+        let orthogonal_other_direction =
+            Direction::Clockwise.rotate_vector_90_degrees(other_direction);
         signed_acute_angle(self_direction, orthogonal_other_direction)
     }
 

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -480,7 +480,6 @@ mod tests {
         });
 
         for case in cases {
-            dbg!(&case);
             assert_relative_eq!(
                 case.self_line.signed_acute_angle(case.other_line),
                 case.expected_angle,

--- a/crates/types/src/field_border.rs
+++ b/crates/types/src/field_border.rs
@@ -1,4 +1,4 @@
-use geometry::line::Line2;
+use geometry::{line::Line, line_segment::LineSegment};
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::Pixel;
@@ -9,11 +9,13 @@ use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
     Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
 )]
 pub struct FieldBorder {
-    pub border_lines: Vec<Line2<Pixel>>,
+    pub border_lines: Vec<LineSegment<Pixel>>,
 }
 
 impl FieldBorder {
     pub fn is_inside_field(&self, point: Point2<Pixel>) -> bool {
-        self.border_lines.iter().all(|line| line.is_above(point))
+        self.border_lines
+            .iter()
+            .all(|line_segment| Line::from(*line_segment).is_above(point))
     }
 }

--- a/crates/types/src/field_lines.rs
+++ b/crates/types/src/field_lines.rs
@@ -1,5 +1,5 @@
 use coordinate_systems::Pixel;
-use geometry::line::Line2;
+use geometry::line_segment::LineSegment;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -7,6 +7,6 @@ use serde::{Deserialize, Serialize};
     Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
 )]
 pub struct ProjectedFieldLines {
-    pub top: Vec<Line2<Pixel>>,
-    pub bottom: Vec<Line2<Pixel>>,
+    pub top: Vec<LineSegment<Pixel>>,
+    pub bottom: Vec<LineSegment<Pixel>>,
 }

--- a/crates/types/src/field_marks.rs
+++ b/crates/types/src/field_marks.rs
@@ -1,11 +1,11 @@
-use geometry::line_segment::LineSegment;
+use geometry::{direction::Direction as RotationDirection, line_segment::LineSegment};
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::Field;
 
 use crate::field_dimensions::FieldDimensions;
-use linear_algebra::{distance, point, vector, Point2, Vector2};
+use linear_algebra::{distance, point, Point2, Vector2};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum FieldMark {
@@ -116,9 +116,9 @@ impl FieldMark {
                 let measured_direction = (measured_line.0 - measured_line.1).normalize();
                 let center_vector =
                     (correspondence_0_reference - center) + (correspondence_1_reference - center);
-                let center_vector_rotated_by_90_degree =
-                    vector![-center_vector.y(), center_vector.x()];
-                let reference_direction = center_vector_rotated_by_90_degree.normalize();
+                let reference_direction = RotationDirection::Counterclockwise
+                    .rotate_vector_90_degrees(center_vector)
+                    .normalize();
 
                 Correspondences {
                     correspondence_points: (

--- a/crates/types/src/field_marks.rs
+++ b/crates/types/src/field_marks.rs
@@ -1,4 +1,4 @@
-use geometry::line::{Line, Line2};
+use geometry::line_segment::LineSegment;
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +10,7 @@ use linear_algebra::{distance, point, vector, Point2, Vector2};
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum FieldMark {
     Line {
-        line: Line2<Field>,
+        line: LineSegment<Field>,
         direction: Direction,
     },
     Circle {
@@ -26,7 +26,7 @@ pub enum Direction {
 }
 
 impl FieldMark {
-    pub fn to_correspondence_points(self, measured_line: Line2<Field>) -> Correspondences {
+    pub fn to_correspondence_points(self, measured_line: LineSegment<Field>) -> Correspondences {
         match self {
             FieldMark::Line {
                 line: reference_line,
@@ -44,7 +44,7 @@ impl FieldMark {
                 .unwrap()
                 .0
                 {
-                    1 | 2 => Line(measured_line.1, measured_line.0),
+                    1 | 2 => LineSegment(measured_line.1, measured_line.0),
                     _ => measured_line,
                 };
 
@@ -52,9 +52,9 @@ impl FieldMark {
                 let reference_direction = (reference_line.0 - reference_line.1).normalize();
 
                 let projected_point_on_measured_line =
-                    measured_line.project_onto_segment(reference_line.0);
+                    measured_line.closest_point(reference_line.0);
                 let projected_point_on_reference_line =
-                    reference_line.project_onto_segment(measured_line.0);
+                    reference_line.closest_point(measured_line.0);
 
                 let measured_distance =
                     distance(projected_point_on_measured_line, reference_line.0);
@@ -72,24 +72,20 @@ impl FieldMark {
                     }
                 };
 
-                let projected_point_on_measured_line =
-                    measured_line.project_onto_segment(reference_line.1);
-                let projected_point_on_reference_line =
-                    reference_line.project_onto_segment(measured_line.1);
+                let closest_point_on_measured_line = measured_line.closest_point(reference_line.1);
+                let closest_point_on_reference_line = reference_line.closest_point(measured_line.1);
 
-                let measured_distance =
-                    distance(projected_point_on_measured_line, reference_line.1);
-                let reference_distance =
-                    distance(measured_line.1, projected_point_on_reference_line);
+                let measured_distance = distance(closest_point_on_measured_line, reference_line.1);
+                let reference_distance = distance(measured_line.1, closest_point_on_reference_line);
                 let correspondence_1 = if measured_distance < reference_distance {
                     CorrespondencePoints {
-                        measured: projected_point_on_measured_line,
+                        measured: closest_point_on_measured_line,
                         reference: reference_line.1,
                     }
                 } else {
                     CorrespondencePoints {
                         measured: measured_line.1,
-                        reference: projected_point_on_reference_line,
+                        reference: closest_point_on_reference_line,
                     }
                 };
 
@@ -159,14 +155,14 @@ pub struct CorrespondencePoints {
 pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> Vec<FieldMark> {
     vec![
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![-field_dimensions.length / 2.0, field_dimensions.width / 2.0],
                 point![field_dimensions.length / 2.0, field_dimensions.width / 2.0],
             ),
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0,
                     -field_dimensions.width / 2.0
@@ -176,7 +172,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0,
                     -field_dimensions.width / 2.0
@@ -186,14 +182,14 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![field_dimensions.length / 2.0, -field_dimensions.width / 2.0],
                 point![field_dimensions.length / 2.0, field_dimensions.width / 2.0],
             ),
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0,
                     field_dimensions.penalty_area_width / 2.0
@@ -206,7 +202,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0,
                     -field_dimensions.penalty_area_width / 2.0
@@ -219,7 +215,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0 + field_dimensions.penalty_area_length,
                     -field_dimensions.penalty_area_width / 2.0
@@ -232,7 +228,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0,
                     field_dimensions.goal_box_area_width / 2.0
@@ -245,7 +241,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0,
                     -field_dimensions.goal_box_area_width / 2.0
@@ -258,7 +254,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0 + field_dimensions.goal_box_area_length,
                     -field_dimensions.goal_box_area_width / 2.0
@@ -271,7 +267,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.penalty_area_length,
                     field_dimensions.penalty_area_width / 2.0
@@ -284,7 +280,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.penalty_area_length,
                     -field_dimensions.penalty_area_width / 2.0
@@ -297,7 +293,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.penalty_area_length,
                     -field_dimensions.penalty_area_width / 2.0
@@ -310,7 +306,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.goal_box_area_length,
                     field_dimensions.goal_box_area_width / 2.0
@@ -323,7 +319,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.goal_box_area_length,
                     -field_dimensions.goal_box_area_width / 2.0
@@ -336,7 +332,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.goal_box_area_length,
                     -field_dimensions.goal_box_area_width / 2.0
@@ -349,7 +345,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![0.0, -field_dimensions.width / 2.0],
                 point![0.0, field_dimensions.width / 2.0],
             ),
@@ -360,7 +356,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             radius: field_dimensions.center_circle_diameter / 2.0,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0 + field_dimensions.penalty_marker_distance
                         - field_dimensions.penalty_marker_size / 2.0,
@@ -376,7 +372,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     -field_dimensions.length / 2.0 + field_dimensions.penalty_marker_distance,
                     -field_dimensions.penalty_marker_size / 2.0
@@ -389,7 +385,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveY,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0
                         - field_dimensions.penalty_marker_distance
@@ -405,7 +401,7 @@ pub fn field_marks_from_field_dimensions(field_dimensions: &FieldDimensions) -> 
             direction: Direction::PositiveX,
         },
         FieldMark::Line {
-            line: Line(
+            line: LineSegment(
                 point![
                     field_dimensions.length / 2.0 - field_dimensions.penalty_marker_distance,
                     -field_dimensions.penalty_marker_size / 2.0

--- a/crates/types/src/line_data.rs
+++ b/crates/types/src/line_data.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use coordinate_systems::{Ground, Pixel};
-use geometry::line::Line2;
+use geometry::line_segment::LineSegment;
 use linear_algebra::Point2;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
     Clone, Default, Debug, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect,
 )]
 pub struct LineData {
-    pub lines: Vec<Line2<Ground>>,
+    pub lines: Vec<LineSegment<Ground>>,
     pub used_segments: HashSet<Point2<Pixel, u16>>,
 }
 

--- a/crates/types/src/planned_path.rs
+++ b/crates/types/src/planned_path.rs
@@ -71,7 +71,7 @@ impl RelativeEq for PathSegment {
 impl PathSegment {
     pub fn length(&self) -> f32 {
         match self {
-            PathSegment::LineSegment(line_segment) => line_segment.norm(),
+            PathSegment::LineSegment(line_segment) => line_segment.length(),
             PathSegment::Arc(arc, direction) => arc.length(*direction),
         }
     }

--- a/crates/vision/src/calibration_measurement_provider.rs
+++ b/crates/vision/src/calibration_measurement_provider.rs
@@ -9,7 +9,7 @@ use calibration::goal_box::{lines::Lines, measurement::Measurement};
 use context_attribute::context;
 use coordinate_systems::{Ground, Pixel};
 use framework::MainOutput;
-use geometry::line::{Line, Line2};
+use geometry::line_segment::LineSegment;
 use linear_algebra::point;
 use projection::{camera_matrix::CameraMatrix, Projection};
 use types::{
@@ -89,8 +89,11 @@ fn get_measurement_from_image(
     get_fake_measurement(image, matrix, position, field_dimensions)
 }
 
-fn project_line_to_camera(matrix: &CameraMatrix, line: Line2<Ground>) -> Result<Line2<Pixel>> {
-    Ok(Line(
+fn project_line_to_camera(
+    matrix: &CameraMatrix,
+    line: LineSegment<Ground>,
+) -> Result<LineSegment<Pixel>> {
+    Ok(LineSegment(
         matrix.ground_to_pixel(line.0)?,
         matrix.ground_to_pixel(line.1)?,
     ))
@@ -104,13 +107,13 @@ fn get_fake_measurement(
 ) -> Result<Measurement> {
     // Minimal length lines representing the 3 lines to make sure they are in the camera's FOV
     // otherwise occlusions/ trimmed lines have to be handled
-    let border_line = Line(point![2.0, 0.0], point![3.0, 0.0]);
+    let border_line = LineSegment(point![2.0, 0.0], point![3.0, 0.0]);
     let goal_box_line = {
         let y = field_dimensions.goal_box_area_length + border_line.0.y();
         let bottom_x = border_line.0.x() + 0.5;
-        Line(point![bottom_x, y], point![bottom_x + 1.0, y])
+        LineSegment(point![bottom_x, y], point![bottom_x + 1.0, y])
     };
-    let connecting_line = Line(
+    let connecting_line = LineSegment(
         goal_box_line.0,
         point![goal_box_line.0.x(), border_line.0.y()],
     );

--- a/crates/vision/src/field_border_detection.rs
+++ b/crates/vision/src/field_border_detection.rs
@@ -1,5 +1,5 @@
 use color_eyre::Result;
-use geometry::line::{Line, Line2};
+use geometry::line_segment::LineSegment;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
@@ -108,7 +108,7 @@ fn find_border_lines(
     angle_threshold: f32,
     first_line_association_distance: f32,
     second_line_association_distance: f32,
-) -> Vec<Line2<Pixel>> {
+) -> Vec<LineSegment<Pixel>> {
     // first line
     let result = ransac.next_line(
         random_state,
@@ -137,11 +137,11 @@ fn find_border_lines(
     vec![first_line, second_line]
 }
 
-fn best_fit_line(points: &[Point2<Pixel>]) -> Line2<Pixel> {
+fn best_fit_line(points: &[Point2<Pixel>]) -> LineSegment<Pixel> {
     let half_size = points.len() / 2;
     let line_start = find_center_of_group(&points[0..half_size]);
     let line_end = find_center_of_group(&points[half_size..points.len()]);
-    Line(line_start, line_end)
+    LineSegment(line_start, line_end)
 }
 
 fn find_center_of_group(group: &[Point2<Pixel>]) -> Point2<Pixel> {
@@ -154,16 +154,16 @@ fn find_center_of_group(group: &[Point2<Pixel>]) -> Point2<Pixel> {
 }
 
 fn is_orthogonal(
-    lines: &[Line2<Pixel>; 2],
+    lines: &[LineSegment<Pixel>; 2],
     camera_matrix: &CameraMatrix,
     angle_threshold: f32,
 ) -> Result<bool> {
     let projected_lines = [
-        Line(
+        LineSegment(
             camera_matrix.pixel_to_ground(lines[0].0)?,
             camera_matrix.pixel_to_ground(lines[0].1)?,
         ),
-        Line(
+        LineSegment(
             camera_matrix.pixel_to_ground(lines[1].0)?,
             camera_matrix.pixel_to_ground(lines[1].1)?,
         ),

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, iter::Peekable, ops::Range};
 
 use color_eyre::Result;
-use geometry::line::{Line, Line2};
+use geometry::line_segment::LineSegment;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
@@ -30,8 +30,9 @@ pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
-    lines_in_image: AdditionalOutput<Vec<Line2<Pixel>>, "lines_in_image">,
-    discarded_lines: AdditionalOutput<Vec<(Line2<Pixel>, LineDiscardReason)>, "discarded_lines">,
+    lines_in_image: AdditionalOutput<Vec<LineSegment<Pixel>>, "lines_in_image">,
+    discarded_lines:
+        AdditionalOutput<Vec<(LineSegment<Pixel>, LineDiscardReason)>, "discarded_lines">,
     ransac_input: AdditionalOutput<Vec<Point2<Pixel>>, "ransac_input">,
 
     allowed_line_length_in_field:
@@ -158,7 +159,7 @@ impl LineDetection {
                 break;
             };
 
-            let line_in_ground = Line(start_point_in_robot, end_point_in_robot);
+            let line_in_ground = LineSegment(start_point_in_robot, end_point_in_robot);
             let line_length_in_robot = line_in_ground.length();
             let is_too_short = *context.check_line_length
                 && line_length_in_robot < context.allowed_line_length_in_field.start;
@@ -182,7 +183,7 @@ impl LineDetection {
 
             lines_in_ground.push(line_in_ground);
             if context.lines_in_image.is_subscribed() {
-                image_lines.push(Line(start_point_in_ground, end_point_in_ground));
+                image_lines.push(LineSegment(start_point_in_ground, end_point_in_ground));
             }
         }
         let line_data = LineData {
@@ -194,7 +195,7 @@ impl LineDetection {
             image_lines
                 .into_iter()
                 .map(|line| {
-                    Line(
+                    LineSegment(
                         context.camera_matrix.ground_to_pixel(line.0).unwrap(),
                         context.camera_matrix.ground_to_pixel(line.1).unwrap(),
                     )
@@ -206,7 +207,7 @@ impl LineDetection {
                 .into_iter()
                 .map(|(line, discard_reason)| {
                     (
-                        Line(
+                        LineSegment(
                             context.camera_matrix.ground_to_pixel(line.0).unwrap(),
                             context.camera_matrix.ground_to_pixel(line.1).unwrap(),
                         ),

--- a/tools/twix/src/panels/image/overlays/field_border.rs
+++ b/tools/twix/src/panels/image/overlays/field_border.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use color_eyre::Result;
 use coordinate_systems::Pixel;
 use eframe::epaint::{Color32, Stroke};
-use geometry::line::Line2;
+use geometry::line_segment::LineSegment;
 use linear_algebra::Point2;
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub struct FieldBorder {
-    border_lines: BufferHandle<Option<Vec<Line2<Pixel>>>>,
+    border_lines: BufferHandle<Option<Vec<LineSegment<Pixel>>>>,
     candidates: BufferHandle<Option<Vec<Point2<Pixel>>>>,
 }
 

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::Pixel;
-use geometry::line::Line2;
+use geometry::line_segment::LineSegment;
 use linear_algebra::Point2;
 use types::line_data::LineDiscardReason;
 
@@ -12,10 +12,10 @@ use crate::{
     value_buffer::BufferHandle,
 };
 
-type DiscardedLines = Vec<(Line2<Pixel>, LineDiscardReason)>;
+type DiscardedLines = Vec<(LineSegment<Pixel>, LineDiscardReason)>;
 
 pub struct LineDetection {
-    lines_in_image: BufferHandle<Option<Vec<Line2<Pixel>>>>,
+    lines_in_image: BufferHandle<Option<Vec<LineSegment<Pixel>>>>,
     discarded_lines: BufferHandle<Option<DiscardedLines>>,
     ransac_input: BufferHandle<Option<Vec<Point2<Pixel>>>>,
 }

--- a/tools/twix/src/panels/map/layers/line_correspondences.rs
+++ b/tools/twix/src/panels/map/layers/line_correspondences.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::Field;
-use geometry::line::Line2;
+use geometry::line_segment::LineSegment;
 use types::field_dimensions::FieldDimensions;
 
 use crate::{
@@ -12,8 +12,8 @@ use crate::{
 };
 
 pub struct LineCorrespondences {
-    correspondence_lines: BufferHandle<Option<Vec<Line2<Field>>>>,
-    lines_in_field: BufferHandle<Option<Vec<Line2<Field>>>>,
+    correspondence_lines: BufferHandle<Option<Vec<LineSegment<Field>>>>,
+    lines_in_field: BufferHandle<Option<Vec<LineSegment<Field>>>>,
 }
 
 impl Layer<Field> for LineCorrespondences {

--- a/tools/twix/src/panels/map/layers/lines.rs
+++ b/tools/twix/src/panels/map/layers/lines.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::{Ground, Pixel};
-use geometry::line::Line2;
+use geometry::line_segment::LineSegment;
 use projection::{camera_matrix::CameraMatrix, Projection};
 use types::field_dimensions::FieldDimensions;
 
@@ -13,9 +13,9 @@ use crate::{
 };
 
 pub struct Lines {
-    lines_in_image_top: BufferHandle<Option<Vec<Line2<Pixel>>>>,
+    lines_in_image_top: BufferHandle<Option<Vec<LineSegment<Pixel>>>>,
     camera_matrix_top: BufferHandle<Option<CameraMatrix>>,
-    lines_in_image_bottom: BufferHandle<Option<Vec<Line2<Pixel>>>>,
+    lines_in_image_bottom: BufferHandle<Option<Vec<LineSegment<Pixel>>>>,
     camera_matrix_bottom: BufferHandle<Option<CameraMatrix>>,
 }
 
@@ -62,7 +62,7 @@ impl Layer<Ground> for Lines {
 
 fn paint_lines(
     painter: &TwixPainter<Ground>,
-    lines_in_image: Option<Vec<Line2<Pixel>>>,
+    lines_in_image: Option<Vec<LineSegment<Pixel>>>,
     camera_matrix: Option<CameraMatrix>,
 ) -> Option<()> {
     let camera_matrix = camera_matrix?;


### PR DESCRIPTION
## Why? What?

This PR enforces the semantic difference between a Line (i.e. infinitely long, given by point and direction) and a LineSegment (finite in length, given by two points) in our code.

This ensures that something like `closet_point()` behaves as expected according to the type.
It additionally cleans up code regarding to the two geometry types.

Depends on #1246.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Build the code, have especially a look at which direction vector are rotated by 90 degrees.
