### PR TITLE
Minimum Feet Width

### DIFF
--- a/crates/filtering/src/mean_clustering.rs
+++ b/crates/filtering/src/mean_clustering.rs
@@ -10,5 +10,10 @@ impl MeanClustering for CountedCluster {
     fn push(&mut self, other: Point2<Ground>) {
         self.mean = (self.mean * self.samples as f32 + other.coords()) / (self.samples + 1) as f32;
         self.samples += 1;
+        if other.x() < self.lefmost_point.x() {
+            self.lefmost_point = other;
+        } else if other.x() > self.rightmost_point.x() {
+            self.rightmost_point = other;
+        }
     }
 }

--- a/crates/filtering/src/mean_clustering.rs
+++ b/crates/filtering/src/mean_clustering.rs
@@ -10,8 +10,8 @@ impl MeanClustering for CountedCluster {
     fn push(&mut self, other: Point2<Ground>) {
         self.mean = (self.mean * self.samples as f32 + other.coords()) / (self.samples + 1) as f32;
         self.samples += 1;
-        if other.x() < self.lefmost_point.x() {
-            self.lefmost_point = other;
+        if other.x() < self.leftmost_point.x() {
+            self.leftmost_point = other;
         } else if other.x() > self.rightmost_point.x() {
             self.rightmost_point = other;
         }

--- a/crates/types/src/detected_feet.rs
+++ b/crates/types/src/detected_feet.rs
@@ -25,4 +25,6 @@ pub struct ClusterPoint {
 pub struct CountedCluster {
     pub mean: Point2<Ground>,
     pub samples: usize,
+    pub lefmost_point: Point2<Ground>,
+    pub rightmost_point: Point2<Ground>,
 }

--- a/crates/types/src/detected_feet.rs
+++ b/crates/types/src/detected_feet.rs
@@ -25,6 +25,6 @@ pub struct ClusterPoint {
 pub struct CountedCluster {
     pub mean: Point2<Ground>,
     pub samples: usize,
-    pub lefmost_point: Point2<Ground>,
+    pub leftmost_point: Point2<Ground>,
     pub rightmost_point: Point2<Ground>,
 }

--- a/crates/vision/src/feet_detection.rs
+++ b/crates/vision/src/feet_detection.rs
@@ -81,7 +81,7 @@ impl FeetDetection {
             .into_iter()
             .filter(|cluster| cluster.samples > *context.minimum_samples_per_cluster)
             .filter(|cluster| {
-                cluster.rightmost_point.y() - cluster.lefmost_point.y()
+                cluster.rightmost_point.y() - cluster.leftmost_point.y()
                     >= *context.minimum_feet_width
             })
             .collect();
@@ -203,7 +203,7 @@ fn cluster_scored_cluster_points(
             None => clusters.push(CountedCluster {
                 mean: point.position_in_ground,
                 samples: 1,
-                lefmost_point: point.position_in_ground,
+                leftmost_point: point.position_in_ground,
                 rightmost_point: point.position_in_ground,
             }),
         }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -17,14 +17,16 @@
       "maximum_cluster_distance": 0.2,
       "minimum_consecutive_segments": 7,
       "minimum_luminance_standard_deviation": 7,
-      "minimum_samples_per_cluster": 8
+      "minimum_samples_per_cluster": 8,
+      "minimum_feet_width": 0.06
     },
     "vision_bottom": {
       "enable": true,
       "maximum_cluster_distance": 0.2,
       "minimum_consecutive_segments": 7,
       "minimum_luminance_standard_deviation": 7,
-      "minimum_samples_per_cluster": 8
+      "minimum_samples_per_cluster": 8,
+      "minimum_feet_width": 0.06
     }
   },
   "whistle_detection": {


### PR DESCRIPTION


## Why? What?

- Filter feet obstacles, which are only a few pixels wide.
- Store leftmost and rightmost point in CountedClusters, filter clusterwidth

### Without:
![image](https://github.com/user-attachments/assets/685d0ecd-2bc5-450e-8416-b5c428cb44f5)

### With:
![image](https://github.com/user-attachments/assets/7498a316-09bc-4f6c-b14c-bd9d64b508df)


## Ideas for Next Iterations (Not This PR)

- Also check height -> @MeiiMoon @knoellle 

## How to Test

- Check false-positives in feet detection