### PR TITLE
Fixed WideStance falsePositiv

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -158,7 +158,9 @@ impl Behavior {
             }
         }
 
-        if matches!(world_state.robot.player_number, PlayerNumber::One) {
+        if matches!(world_state.robot.player_number, PlayerNumber::One)
+            && matches!(world_state.robot.role, Role::Keeper)
+        {
             actions.push(Action::WideStance);
         }
         actions.push(Action::InterceptBall);


### PR DESCRIPTION
## Why? What?
When we are runnig as playernumber one to the ball we doing the wideStance



*Describe here why you created this PR and what it does*
I added the condition that the player has to be keepr to do the WideStance 
We will do not the Wide Stance in the role Striker

Fixes #1289 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

uplaod it and look if the striker with playernumber one is doing the WideStance 
hopefully not 
