### PR TITLE
Change visual referee paramalams to fix false negatives

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1233,7 +1233,7 @@
       "nanos": 0,
       "secs": 3
     },
-    "minimum_above_head_arms_detections": 2
+    "minimum_above_head_arms_detections": 1
   },
   "sacrificial_lamb": {
     "wait_for_opponent_penalties_period": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -9,7 +9,7 @@
     "minimum_shoulder_angle": 0.2,
     "foot_z_offset": 0.05,
     "referee_pose_queue_length": 8,
-    "minimum_number_poses_before_message": 5
+    "minimum_number_poses_before_message": 3
   },
   "feet_detection": {
     "vision_top": {


### PR DESCRIPTION
## Why? What?

In the game against Nao Devils, we had too many false negatives in both game halves. We did however have percepts, so reducing the queue length would result in a true positive detection. Additionally only one Nao had this issue, meaning if only one Nao would be required to trigger a true positive detection, this would have been a true positive detection.     
- Decreases `minimum_number_poses_before_message`
- Decrease `minimum_above_head_arms_detections`

Fixes #1284 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test
