### PR TITLE
Add `defender_distance_to_be_aligned`

### DIFF
--- a/crates/control/src/behavior/defend.rs
+++ b/crates/control/src/behavior/defend.rs
@@ -46,12 +46,14 @@ impl<'cycle> Defend<'cycle> {
         pose: Pose2<Ground>,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         self.walk_and_stand.execute(
             pose,
             self.look_action.execute(),
             path_obstacles_output,
             walk_speed,
+            distance_to_be_aligned,
         )
     }
 
@@ -84,6 +86,7 @@ impl<'cycle> Defend<'cycle> {
         &self,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let pose = defend_pose(
             self.world_state,
@@ -92,13 +95,19 @@ impl<'cycle> Defend<'cycle> {
             -self.field_dimensions.length / 2.0,
             Side::Left,
         )?;
-        self.with_pose(pose, path_obstacles_output, walk_speed)
+        self.with_pose(
+            pose,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     }
 
     pub fn right(
         &self,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let pose = defend_pose(
             self.world_state,
@@ -107,7 +116,12 @@ impl<'cycle> Defend<'cycle> {
             -self.field_dimensions.length / 2.0,
             Side::Right,
         )?;
-        self.with_pose(pose, path_obstacles_output, walk_speed)
+        self.with_pose(
+            pose,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     }
 
     pub fn opponent_corner_kick(
@@ -115,6 +129,7 @@ impl<'cycle> Defend<'cycle> {
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
         field_side: Side,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let pose = defend_pose(
             self.world_state,
@@ -123,36 +138,59 @@ impl<'cycle> Defend<'cycle> {
             -self.field_dimensions.length / 2.0 + self.field_dimensions.goal_box_area_length * 2.0,
             field_side,
         )?;
-        self.with_pose(pose, path_obstacles_output, walk_speed)
+        self.with_pose(
+            pose,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     }
 
     pub fn penalty_kick(
         &self,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let pose =
             defend_penalty_kick(self.world_state, self.field_dimensions, self.role_positions)?;
-        self.with_pose(pose, path_obstacles_output, walk_speed)
+        self.with_pose(
+            pose,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     }
 
     pub fn goal(
         &self,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let pose = defend_goal_pose(self.world_state, self.field_dimensions, self.role_positions)?;
-        self.with_pose(pose, path_obstacles_output, walk_speed)
+        self.with_pose(
+            pose,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     }
 
     pub fn kick_off(
         &self,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let pose =
             defend_kick_off_pose(self.world_state, self.field_dimensions, self.role_positions)?;
-        self.with_pose(pose, path_obstacles_output, walk_speed)
+        self.with_pose(
+            pose,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     }
 }
 

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -307,34 +307,62 @@ impl Behavior {
                     Action::DefendGoal => defend.goal(
                         &mut context.path_obstacles_output,
                         *context.defend_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .defender_distance_to_be_aligned,
                     ),
                     Action::DefendKickOff => defend.kick_off(
                         &mut context.path_obstacles_output,
                         *context.defend_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .defender_distance_to_be_aligned,
                     ),
                     Action::DefendLeft => defend.left(
                         &mut context.path_obstacles_output,
                         *context.defend_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .defender_distance_to_be_aligned,
                     ),
                     Action::DefendRight => defend.right(
                         &mut context.path_obstacles_output,
                         *context.defend_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .defender_distance_to_be_aligned,
                     ),
                     Action::DefendPenaltyKick => defend.penalty_kick(
                         &mut context.path_obstacles_output,
                         *context.defend_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .defender_distance_to_be_aligned,
                     ),
                     Action::DefendOpponentCornerKick { side: Side::Left } => defend
                         .opponent_corner_kick(
                             &mut context.path_obstacles_output,
                             *context.defend_walk_speed,
                             Side::Left,
+                            context
+                                .parameters
+                                .walk_and_stand
+                                .defender_distance_to_be_aligned,
                         ),
                     Action::DefendOpponentCornerKick { side: Side::Right } => defend
                         .opponent_corner_kick(
                             &mut context.path_obstacles_output,
                             *context.defend_walk_speed,
                             Side::Right,
+                            context
+                                .parameters
+                                .walk_and_stand
+                                .defender_distance_to_be_aligned,
                         ),
                     Action::Stand => stand::execute(
                         world_state,
@@ -360,6 +388,10 @@ impl Behavior {
                         &mut context.path_obstacles_output,
                         self.previous_role,
                         *context.search_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .normal_distance_to_be_aligned,
                     ),
                     Action::SearchForLostBall => lost_ball::execute(
                         world_state,
@@ -386,6 +418,10 @@ impl Behavior {
                         &look_action,
                         &mut context.path_obstacles_output,
                         *context.support_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .normal_distance_to_be_aligned,
                     ),
                     Action::SupportRight => support::execute(
                         world_state,
@@ -404,6 +440,10 @@ impl Behavior {
                         &look_action,
                         &mut context.path_obstacles_output,
                         *context.support_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .normal_distance_to_be_aligned,
                     ),
                     Action::SupportStriker => support::execute(
                         world_state,
@@ -425,6 +465,10 @@ impl Behavior {
                         &look_action,
                         &mut context.path_obstacles_output,
                         *context.support_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .normal_distance_to_be_aligned,
                     ),
                     Action::WalkToKickOff => walk_to_kick_off::execute(
                         world_state,
@@ -433,6 +477,10 @@ impl Behavior {
                         &mut context.path_obstacles_output,
                         context.parameters.role_positions.striker_kickoff_pose,
                         *context.walk_to_kickoff_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .normal_distance_to_be_aligned,
                     ),
                     Action::WalkToPenaltyKick => walk_to_penalty_kick::execute(
                         world_state,
@@ -441,6 +489,10 @@ impl Behavior {
                         &mut context.path_obstacles_output,
                         context.field_dimensions,
                         *context.walk_to_penalty_kick_walk_speed,
+                        context
+                            .parameters
+                            .walk_and_stand
+                            .normal_distance_to_be_aligned,
                     ),
                 }?;
                 Some((action, motion_command))

--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -74,6 +74,7 @@ pub fn execute(
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     previous_role: Role,
     walk_speed: WalkSpeed,
+    distance_to_be_aligned: f32,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let search_role = assign_search_role(world_state);
@@ -101,7 +102,13 @@ pub fn execute(
     };
     if let Some(SearchRole::Goal) = search_role {
         let goal_pose = Pose2::from(search_position);
-        walk_and_stand.execute(goal_pose, head, path_obstacles_output, walk_speed)
+        walk_and_stand.execute(
+            goal_pose,
+            head,
+            path_obstacles_output,
+            walk_speed,
+            distance_to_be_aligned,
+        )
     } else {
         let path = walk_path_planner.plan(
             search_position,

--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -28,6 +28,7 @@ pub fn execute(
     look_action: &LookAction,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     walk_speed: WalkSpeed,
+    distance_to_be_aligned: f32,
 ) -> Option<MotionCommand> {
     let pose = support_pose(
         world_state,
@@ -42,6 +43,7 @@ pub fn execute(
         look_action.execute(),
         path_obstacles_output,
         walk_speed,
+        distance_to_be_aligned,
     )
 }
 

--- a/crates/control/src/behavior/walk_to_kick_off.rs
+++ b/crates/control/src/behavior/walk_to_kick_off.rs
@@ -16,6 +16,7 @@ pub fn execute(
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     striker_kickoff_pose: Pose2<Field>,
     walk_speed: WalkSpeed,
+    distance_to_be_aligned: f32,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     walk_and_stand.execute(
@@ -23,5 +24,6 @@ pub fn execute(
         look_action.execute(),
         path_obstacles_output,
         walk_speed,
+        distance_to_be_aligned,
     )
 }

--- a/crates/control/src/behavior/walk_to_penalty_kick.rs
+++ b/crates/control/src/behavior/walk_to_penalty_kick.rs
@@ -16,6 +16,7 @@ pub fn execute(
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     field_dimensions: &FieldDimensions,
     walk_speed: WalkSpeed,
+    distance_to_be_aligned: f32,
 ) -> Option<MotionCommand> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let kick_off_pose = Pose2::from(point![
@@ -29,5 +30,6 @@ pub fn execute(
         look_action.execute(),
         path_obstacles_output,
         walk_speed,
+        distance_to_be_aligned,
     )
 }

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -160,6 +160,7 @@ impl<'cycle> WalkAndStand<'cycle> {
         head: HeadMotion,
         path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
         walk_speed: WalkSpeed,
+        distance_to_be_aligned: f32,
     ) -> Option<MotionCommand> {
         let ground_to_field = self.world_state.robot.ground_to_field?;
         let distance_to_walk = target_pose.position().coords().norm();
@@ -180,7 +181,7 @@ impl<'cycle> WalkAndStand<'cycle> {
         let orientation_mode = hybrid_alignment(
             target_pose,
             self.parameters.hybrid_align_distance,
-            self.parameters.distance_to_be_aligned,
+            distance_to_be_aligned,
         );
 
         if is_reached {
@@ -210,14 +211,15 @@ pub fn hybrid_alignment(
     hybrid_align_distance: f32,
     distance_to_be_aligned: f32,
 ) -> OrientationMode {
-    assert!(hybrid_align_distance > distance_to_be_aligned);
+    assert!(hybrid_align_distance > 0.0);
+    assert!(distance_to_be_aligned > 0.0);
+
     let distance_to_target = target_pose.position().coords().norm();
-    if distance_to_target >= hybrid_align_distance {
+    if distance_to_target > distance_to_be_aligned + hybrid_align_distance {
         return OrientationMode::AlignWithPath;
     }
 
-    let angle_limit = ((distance_to_target - distance_to_be_aligned)
-        / (hybrid_align_distance - distance_to_be_aligned))
+    let angle_limit = ((distance_to_target - distance_to_be_aligned) / (hybrid_align_distance))
         .clamp(0.0, 1.0)
         * PI;
 

--- a/crates/control/src/behavior/walk_to_pose.rs
+++ b/crates/control/src/behavior/walk_to_pose.rs
@@ -219,7 +219,7 @@ pub fn hybrid_alignment(
         return OrientationMode::AlignWithPath;
     }
 
-    let angle_limit = ((distance_to_target - distance_to_be_aligned) / (hybrid_align_distance))
+    let angle_limit = ((distance_to_target - distance_to_be_aligned) / hybrid_align_distance)
         .clamp(0.0, 1.0)
         * PI;
 

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -151,7 +151,8 @@ pub struct WalkAndStandParameters {
     pub hysteresis: nalgebra::Vector2<f32>,
     pub target_reached_thresholds: nalgebra::Vector2<f32>,
     pub hybrid_align_distance: f32,
-    pub distance_to_be_aligned: f32,
+    pub normal_distance_to_be_aligned: f32,
+    pub defender_distance_to_be_aligned: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1142,7 +1142,7 @@
       }
     },
     "dribbling": {
-      "hybrid_align_distance": 0.5,
+      "hybrid_align_distance": 0.4,
       "distance_to_be_aligned": 0.1,
       "angle_to_approach_ball_from_threshold": 0.78,
       "ignore_robot_when_near_ball_radius": 0.6,
@@ -1151,8 +1151,9 @@
     "walk_and_stand": {
       "hysteresis": [0.1, 0.1],
       "target_reached_thresholds": [0.02, 0.05],
-      "hybrid_align_distance": 1.0,
-      "distance_to_be_aligned": 0.05
+      "hybrid_align_distance": 0.95,
+      "normal_distance_to_be_aligned": 0.05,
+      "defender_distance_to_be_aligned": 1.05
     },
     "lost_ball": {
       "offset_to_last_ball_location": [1.0, 0.0]


### PR DESCRIPTION
## Why? What?

Adds a new parameter to differentiate the distance to be aligned by hybrid alignment between defender actions and all other actions. 
The motivation behind this is to make defenders turn around earlier when walking back to their position to face the ball and perhaps do intercepting steps.   

Fixes #1277 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Use behavior simulator to check the orientation of defenders when walking back. 
