### PR TITLE
Actually score goals

### DIFF
--- a/crates/control/src/kick_selector.rs
+++ b/crates/control/src/kick_selector.rs
@@ -417,7 +417,7 @@ fn generate_decisions_for_instant_kicks(
                     kick_pose,
                     strength: parameters.kick_off_kick_strength,
                 })
-            } else if !is_own_kick_off && (is_inside_field || scores_goal) && is_strategic_target {
+            } else if !is_own_kick_off && (is_inside_field && is_strategic_target || scores_goal) {
                 let kick_pose = compute_kick_pose(ball_position, target, kick_info, kicking_side);
                 Some(KickDecision {
                     target,


### PR DESCRIPTION
## Why? What?

This change allows instant kick decisions if they are scoring goals. Previously they had to also be "strategic" that is "closer to the opponent goal"

Based on #1264 

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

when close to the goal, there should be red (instant) kick decisions in twix.

use replay of first half devils game on 34.