### PR TITLE
Look at the ball if close

### DIFF
--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -149,6 +149,7 @@ pub struct DribblingParameters {
     pub distance_to_be_aligned: f32,
     pub angle_to_approach_ball_from_threshold: f32,
     pub ignore_robot_when_near_ball_radius: f32,
+    pub distance_to_look_directly_at_the_ball: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1144,7 +1144,8 @@
       "hybrid_align_distance": 0.5,
       "distance_to_be_aligned": 0.1,
       "angle_to_approach_ball_from_threshold": 0.78,
-      "ignore_robot_when_near_ball_radius": 0.6
+      "ignore_robot_when_near_ball_radius": 0.6,
+      "distance_to_look_directly_at_the_ball": 1.0
     },
     "walk_and_stand": {
       "hysteresis": [0.1, 0.1],


### PR DESCRIPTION
## Why? What?

Look at the ball with the bottom camera when close. This reduces lag in the image and hopefully gives better ball detections.

Fixes #1290

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

let the striker walk towards the ball, it first should do look-around and then fix the ball with the bottom camera if it is close.