### PR TITLE
clamped wrongly in opponent kickoff

### DIFF
--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -84,16 +84,14 @@ fn support_pose(
         .filtered_game_controller_state
         .map(|filtered_game_controller_state| filtered_game_controller_state.game_state);
     let mut clamped_x = match filtered_game_state {
-        Some(FilteredGameState::Ready { .. }) => supporting_position
-            .x()
-            .min(maximum_x_in_ready_and_when_ball_is_not_free),
-        Some(FilteredGameState::Playing {
+        Some(FilteredGameState::Ready { .. })
+        | Some(FilteredGameState::Playing {
             ball_is_free: false,
             kick_off: true,
             ..
         }) => supporting_position
             .x()
-            .clamp(maximum_x_in_ready_and_when_ball_is_not_free, maximum_x),
+            .min(maximum_x_in_ready_and_when_ball_is_not_free),
         _ => supporting_position.x().clamp(minimum_x, maximum_x),
     };
 


### PR DESCRIPTION
## Why? What?

In kickoff the positions for the midfielders were clamped to -1.5, 2.25, which allowed them to immediately walk into the opponent half. This now clamps them to -1.5 or their desired position, whichever is smaller.

Fixes #1287 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

*Describe how to test your changes. (For the reviewer)*
