### PR TITLE
Stop horizontal segments at uppermost limb segment

### DIFF
--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -5,7 +5,6 @@ use std::{
 
 use color_eyre::Result;
 use itertools::iproduct;
-use ordered_float::NotNan;
 use projection::{camera_matrix::CameraMatrix, horizon::Horizon, Projection};
 use serde::{Deserialize, Serialize};
 
@@ -161,9 +160,8 @@ fn new_grid(
         .iter()
         .flat_map(|limb| &limb.pixel_polygon)
         .filter(|point| (0.0..image.width() as f32).contains(&point.x()))
-        .filter_map(|point| NotNan::new(point.y()).ok())
-        .min()
-        .map(NotNan::into_inner)
+        .map(|point| point.y())
+        .min_by(f32::total_cmp)
         .unwrap_or(image.height() as f32)
         .clamp(0.0, image.height() as f32);
 

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -130,7 +130,7 @@
   },
   "line_detection": {
     "vision_top": {
-      "use_horizontal_segments": false,
+      "use_horizontal_segments": true,
       "use_vertical_segments": true,
       "allowed_line_length_in_field": {
         "start": 0.3,
@@ -150,13 +150,13 @@
       "maximum_number_of_lines": 10,
       "allowed_projected_segment_length": {
         "start": 0.02,
-        "end": 0.2
+        "end": 0.1
       },
       "minimum_number_of_points_on_line": 10,
       "ransac_iterations": 20
     },
     "vision_bottom": {
-      "use_horizontal_segments": false,
+      "use_horizontal_segments": true,
       "use_vertical_segments": true,
       "allowed_line_length_in_field": {
         "start": 0.15,
@@ -176,7 +176,7 @@
       "maximum_number_of_lines": 10,
       "allowed_projected_segment_length": {
         "start": 0.02,
-        "end": 0.2
+        "end": 0.1
       },
       "minimum_number_of_points_on_line": 10,
       "ransac_iterations": 20


### PR DESCRIPTION
## Why? What?

what the title says (almost). This is needed for horizontal segments to be used in line detection, as otherwise we would detect our own feet/knees as lines.

## ToDo / Known Issues

This implementation is not entirely correct. Ideally, we should clip the line segments to the image rectangle, and then get the minimum over the clipped endpoints. This PR achieves 80% of that, using 20% of the effort. I'm working on a follow-up with a better implementation.

## Ideas for Next Iterations (Not This PR)

see above

## How to Test

twix
