### PR TITLE
Detect edges on saturation

### DIFF
--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -281,6 +281,8 @@ pub enum EdgeDetectionSourceParameters {
     #[default]
     Luminance,
     GreenChromaticity,
+    Saturation,
+    SaturationYhs2,
 }
 
 #[derive(

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -13,11 +13,10 @@ use coordinate_systems::{Field, Ground, Pixel};
 use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{point, Isometry2, Point2, Transform, Vector2};
 use types::{
-    color::{Hsv, Intensity, RgChromaticity, Rgb, YCbCr444},
+    color::{Hsv, Intensity, RgChromaticity, Rgb, YCbCr444, Yhs2},
     field_color::FieldColorParameters,
     image_segments::{Direction, EdgeType, ImageSegments, ScanGrid, ScanLine, Segment},
-    limb::project_onto_limbs,
-    limb::{Limb, ProjectedLimbs},
+    limb::{project_onto_limbs, Limb, ProjectedLimbs},
     parameters::{EdgeDetectionSourceParameters, MedianModeParameters},
     ycbcr422_image::YCbCr422Image,
 };
@@ -477,6 +476,15 @@ fn pixel_to_edge_detection_value(
             let rgb = Rgb::from(pixel);
             let chromaticity = RgChromaticity::from(rgb);
             (chromaticity.green * 255.0) as u8
+        }
+        EdgeDetectionSourceParameters::Saturation => {
+            let rgb = Rgb::from(pixel);
+            let hsv = Hsv::from(rgb);
+            hsv.saturation
+        }
+        EdgeDetectionSourceParameters::SaturationYhs2 => {
+            let yhs2 = Yhs2::from(pixel);
+            yhs2.saturation
         }
     }
 }


### PR DESCRIPTION
## Why? What?

We wanted to try more color channels like HSV for image segmenter edge detection.

TL;DR: It is not promising, see images below. But let's add it anyway, maybe we will use it at some event.

# Y (as before)

![](https://github.com/user-attachments/assets/6c530181-221e-4aa5-bbda-0a793c91b512)

# Saturation (new)

![](https://github.com/user-attachments/assets/2e1a9f8a-622b-428a-9413-4eb97631efc9)
![](https://github.com/user-attachments/assets/c67a2878-575f-40b8-a55b-abe1c63f88d8)

# Saturation YHS2 (new)

![](https://github.com/user-attachments/assets/5fe4366f-7af1-4d19-a2d2-b7f752926dc1)
![](https://github.com/user-attachments/assets/b069f8af-3a6e-4b62-81e9-d075fee81824)

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Deploy, look through Twix (select different image sources in image segmenter panel and set parameter `edge_detection_source` and tune the `edge_detection_threshold`)