### PR TITLE
Detect orthogonal lines using RANSAC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,6 +3584,7 @@ dependencies = [
  "parameters",
  "path_serde",
  "projection",
+ "ransac",
  "serde",
  "serde_json",
  "source_analyzer",
@@ -3624,6 +3625,7 @@ dependencies = [
  "parameters",
  "path_serde",
  "projection",
+ "ransac",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3706,6 +3708,7 @@ dependencies = [
  "parameters",
  "path_serde",
  "projection",
+ "ransac",
  "serde",
  "serde_json",
  "source_analyzer",
@@ -5989,6 +5992,7 @@ dependencies = [
  "ordered-float",
  "rand",
  "rand_chacha",
+ "serde",
 ]
 
 [[package]]
@@ -7358,8 +7362,10 @@ dependencies = [
  "log",
  "mlua",
  "nalgebra",
+ "ordered-float",
  "parameters",
  "projection",
+ "ransac",
  "repository",
  "serde",
  "serde_json",

--- a/crates/geometry/src/corner.rs
+++ b/crates/geometry/src/corner.rs
@@ -1,0 +1,53 @@
+use linear_algebra::{distance_squared, Point2, Vector2};
+use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::{line::Line2, Distance};
+
+/// A corner given by a point and the directions of two outgoing rays.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    PathSerialize,
+    PathIntrospect,
+    PathDeserialize,
+)]
+pub struct Corner<Frame> {
+    pub point: Point2<Frame>,
+    pub direction1: Vector2<Frame>,
+    pub direction2: Vector2<Frame>,
+}
+
+impl<Frame> Corner<Frame> {
+    /// Creates an orthogonal corner from a line and a point outside the line.
+    pub fn from_line_and_point_orthogonal(line: Line2<Frame>, point: Point2<Frame>) -> Self {
+        let corner_point = line.closest_point(point);
+        let direction1 = line.direction;
+        let direction2 = point - corner_point;
+
+        Self {
+            point: corner_point,
+            direction1,
+            direction2,
+        }
+    }
+}
+
+impl<Frame> Distance<Point2<Frame>> for Corner<Frame> {
+    fn squared_distance_to(&self, point: Point2<Frame>) -> f32 {
+        let difference_to_point = point - self.point;
+
+        let projected_point1 = self.point
+            + (self.direction1 * self.direction1.dot(difference_to_point).max(0.0)
+                / self.direction1.norm_squared());
+        let projected_point2 = self.point
+            + (self.direction2 * self.direction2.dot(difference_to_point).max(0.0)
+                / self.direction2.norm_squared());
+
+        distance_squared(point, projected_point1).min(distance_squared(point, projected_point2))
+    }
+}

--- a/crates/geometry/src/corner.rs
+++ b/crates/geometry/src/corner.rs
@@ -11,6 +11,7 @@ use crate::{line::Line2, Distance};
     Debug,
     Default,
     Deserialize,
+    PartialEq,
     Serialize,
     PathSerialize,
     PathIntrospect,
@@ -24,7 +25,7 @@ pub struct Corner<Frame> {
 
 impl<Frame> Corner<Frame> {
     /// Creates an orthogonal corner from a line and a point outside the line.
-    pub fn from_line_and_point_orthogonal(line: Line2<Frame>, point: Point2<Frame>) -> Self {
+    pub fn from_line_and_point_orthogonal(line: &Line2<Frame>, point: Point2<Frame>) -> Self {
         let corner_point = line.closest_point(point);
         let direction1 = line.direction;
         let direction2 = point - corner_point;
@@ -39,15 +40,88 @@ impl<Frame> Corner<Frame> {
 
 impl<Frame> Distance<Point2<Frame>> for Corner<Frame> {
     fn squared_distance_to(&self, point: Point2<Frame>) -> f32 {
-        let difference_to_point = point - self.point;
+        let difference_to = point - self.point;
 
         let projected_point1 = self.point
-            + (self.direction1 * self.direction1.dot(difference_to_point).max(0.0)
+            + (self.direction1 * self.direction1.dot(difference_to).max(0.0)
                 / self.direction1.norm_squared());
         let projected_point2 = self.point
-            + (self.direction2 * self.direction2.dot(difference_to_point).max(0.0)
+            + (self.direction2 * self.direction2.dot(difference_to).max(0.0)
                 / self.direction2.norm_squared());
 
         distance_squared(point, projected_point1).min(distance_squared(point, projected_point2))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_relative_eq;
+    use linear_algebra::{distance, point, vector};
+
+    use crate::line::Line;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy)]
+    struct SomeFrame;
+
+    const CORNER: Corner<SomeFrame> = Corner {
+        point: point![5.0, 5.0],
+        direction1: vector![0.0, 3.0],
+        direction2: vector![-10.0, 0.0],
+    };
+
+    #[test]
+    fn is_orthogonal() {
+        let line: Line2<SomeFrame> = Line {
+            point: point![0.0, 0.0],
+            direction: vector![10.0, 0.0],
+        };
+        let point = point![15.0, 5.0];
+        let corner_point = point![15.0, 0.0];
+
+        let corner = Corner::from_line_and_point_orthogonal(&line, point);
+        assert_relative_eq!(corner.point, corner_point);
+        assert_relative_eq!(corner.direction1.dot(corner.direction2), 0.0);
+    }
+
+    #[test]
+    fn correct_distance_top_left() {
+        let point = point![0.0, 15.0];
+        let distance = 5.0;
+        let squared_distance = distance * distance;
+
+        assert_relative_eq!(CORNER.distance_to(point), distance);
+        assert_relative_eq!(CORNER.squared_distance_to(point), squared_distance);
+    }
+
+    #[test]
+    fn correct_distance_top_right() {
+        let point = point![15.0, 15.0];
+        let distance = 10.0;
+        let squared_distance = distance * distance;
+
+        assert_relative_eq!(CORNER.distance_to(point), distance);
+        assert_relative_eq!(CORNER.squared_distance_to(point), squared_distance);
+    }
+
+    #[test]
+    fn correct_distance_bottom_left() {
+        let point = point![0.0, 0.0];
+        let distance = 5.0;
+        let squared_distance = distance * distance;
+
+        assert_relative_eq!(CORNER.distance_to(point), distance);
+        assert_relative_eq!(CORNER.squared_distance_to(point), squared_distance);
+    }
+
+    #[test]
+    fn correct_distance_bottom_right() {
+        let point = point![10.0, -5.0];
+        let distance = distance(CORNER.point, point);
+        let squared_distance = distance * distance;
+
+        assert_relative_eq!(CORNER.distance_to(point), distance);
+        assert_relative_eq!(CORNER.squared_distance_to(point), squared_distance);
     }
 }

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -2,7 +2,6 @@ pub mod arc;
 pub mod circle;
 pub mod circle_tangents;
 pub mod convex_hull;
-pub mod corner;
 pub mod direction;
 pub mod is_inside_polygon;
 pub mod line;
@@ -10,6 +9,7 @@ pub mod line_segment;
 pub mod look_at;
 pub mod rectangle;
 pub mod two_line_segments;
+pub mod two_lines;
 
 pub trait Distance<T> {
     fn squared_distance_to(&self, other: T) -> f32;

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -2,6 +2,7 @@ pub mod arc;
 pub mod circle;
 pub mod circle_tangents;
 pub mod convex_hull;
+pub mod corner;
 pub mod direction;
 pub mod is_inside_polygon;
 pub mod line;

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -8,9 +8,7 @@ use approx::{AbsDiffEq, RelativeEq};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
-use linear_algebra::{
-    center, distance, distance_squared, vector, Point2, Rotation2, Transform, Vector2,
-};
+use linear_algebra::{center, distance, distance_squared, Point2, Rotation2, Transform, Vector2};
 
 use crate::{arc::Arc, direction::Direction, Distance};
 
@@ -128,7 +126,10 @@ impl<Frame> LineSegment<Frame> {
 
     pub fn get_direction(&self, point: Point2<Frame>) -> Direction {
         let direction_vector = self.1 - self.0;
-        let clockwise_normal_vector = vector![direction_vector.y(), -direction_vector.x()];
+        let clockwise_normal_vector = Direction::Clockwise
+            .rotate_vector_90_degrees(direction_vector)
+            .normalize();
+
         let directed_cathetus = clockwise_normal_vector.dot(&(point - self.0));
 
         match directed_cathetus {

--- a/crates/geometry/src/two_lines.rs
+++ b/crates/geometry/src/two_lines.rs
@@ -88,7 +88,7 @@ mod tests {
 
         let corner = TwoLines::from_line_and_point_orthogonal(&line, point);
         assert_relative_eq!(corner.intersection_point, corner_point);
-        assert_relative_eq!(corner.first_direction.dot(corner.second_direction), 0.0);
+        assert_relative_eq!(corner.first_direction.dot(&corner.second_direction), 0.0);
     }
 
     #[test]

--- a/crates/hulk/Cargo.toml
+++ b/crates/hulk/Cargo.toml
@@ -28,6 +28,7 @@ object_detection = { workspace = true }
 parameters = { workspace = true }
 path_serde = { workspace = true }
 projection = { workspace = true }
+ransac = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spl_network = { workspace = true }

--- a/crates/hulk_imagine/Cargo.toml
+++ b/crates/hulk_imagine/Cargo.toml
@@ -27,6 +27,7 @@ nalgebra = { workspace = true }
 parameters = { workspace = true }
 path_serde = { workspace = true }
 projection = { workspace = true }
+ransac = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hulk_replayer/Cargo.toml
+++ b/crates/hulk_replayer/Cargo.toml
@@ -31,6 +31,7 @@ object_detection = { workspace = true }
 parameters = { workspace = true }
 path_serde = { workspace = true }
 projection = { workspace = true }
+ransac = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spl_network = { workspace = true }

--- a/crates/ransac/Cargo.toml
+++ b/crates/ransac/Cargo.toml
@@ -13,3 +13,4 @@ nalgebra = { workspace = true }
 ordered-float = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+serde = { workspace = true }

--- a/crates/ransac/src/lib.rs
+++ b/crates/ransac/src/lib.rs
@@ -42,7 +42,7 @@ impl<Frame> RansacFeature<Frame> {
     {
         unused_points
             .into_iter()
-            .filter(|point| self.squared_distance_to(**point) <= maximum_score_distance_squared)
+            .filter(|&point| self.squared_distance_to(*point) <= maximum_score_distance_squared)
             .map(|point| 1.0 - self.distance_to(*point) / maximum_score_distance)
             .sum()
     }

--- a/crates/ransac/src/lib.rs
+++ b/crates/ransac/src/lib.rs
@@ -9,8 +9,9 @@ use geometry::{
 use linear_algebra::{Point2, Rotation2};
 use ordered_float::NotNan;
 use rand::{seq::SliceRandom, Rng};
+use serde::{Deserialize, Serialize};
 
-#[derive(Default, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub enum RansacFeature<Frame> {
     #[default]
     None,

--- a/crates/ransac/src/lib.rs
+++ b/crates/ransac/src/lib.rs
@@ -24,7 +24,7 @@ impl<Frame> RansacFeature<Frame> {
         let line = Line::from_points(point1, point2);
         let two_lines = TwoLines::from_line_and_point_orthogonal(&line, point3);
 
-        if two_lines.direction2.norm() > f32::EPSILON {
+        if two_lines.second_direction.norm() > f32::EPSILON {
             Self::TwoLines(two_lines)
         } else {
             Self::Line(line)
@@ -73,12 +73,14 @@ impl<Frame> IntoIterator for RansacResult<Frame> {
             }
             RansacFeature::TwoLines(two_lines) => {
                 let dividing_line1 = Line {
-                    point: two_lines.point,
-                    direction: two_lines.direction1.normalize() + two_lines.direction2.normalize(),
+                    point: two_lines.intersection_point,
+                    direction: two_lines.first_direction.normalize()
+                        + two_lines.second_direction.normalize(),
                 };
                 let dividing_line2 = Line {
-                    point: two_lines.point,
-                    direction: two_lines.direction1.normalize() - two_lines.direction2.normalize(),
+                    point: two_lines.intersection_point,
+                    direction: two_lines.first_direction.normalize()
+                        - two_lines.second_direction.normalize(),
                 };
 
                 let (used_points1, used_points2): (Vec<_>, Vec<_>) =
@@ -86,12 +88,12 @@ impl<Frame> IntoIterator for RansacResult<Frame> {
                         dividing_line1.is_above(*point) != dividing_line2.is_above(*point)
                     });
                 let line1 = Line {
-                    point: two_lines.point,
-                    direction: two_lines.direction1,
+                    point: two_lines.intersection_point,
+                    direction: two_lines.first_direction,
                 };
                 let line2 = Line {
-                    point: two_lines.point,
-                    direction: two_lines.direction2,
+                    point: two_lines.intersection_point,
+                    direction: two_lines.second_direction,
                 };
 
                 [

--- a/crates/vision/src/field_border_detection.rs
+++ b/crates/vision/src/field_border_detection.rs
@@ -113,6 +113,7 @@ fn find_border_lines(
     let result = ransac.next_feature(
         random_state,
         20,
+        false,
         first_line_association_distance,
         first_line_association_distance,
     );
@@ -126,6 +127,7 @@ fn find_border_lines(
     let result = ransac.next_feature(
         random_state,
         20,
+        false,
         second_line_association_distance,
         second_line_association_distance,
     );

--- a/crates/vision/src/field_border_detection.rs
+++ b/crates/vision/src/field_border_detection.rs
@@ -110,13 +110,15 @@ fn find_border_lines(
     second_line_association_distance: f32,
 ) -> Vec<LineSegment<Pixel>> {
     // first line
-    let result = ransac.next_feature(
+    let Some(result) = ransac.next_feature(
         random_state,
         20,
         false,
         first_line_association_distance,
         first_line_association_distance,
-    );
+    ) else {
+        return Vec::new();
+    };
     if !matches!(result.feature, RansacFeature::Line(_))
         || result.used_points.len() < min_points_per_line
     {
@@ -124,13 +126,15 @@ fn find_border_lines(
     }
     let first_line = best_fit_line(&result.used_points);
     // second line
-    let result = ransac.next_feature(
+    let Some(result) = ransac.next_feature(
         random_state,
         20,
         false,
         second_line_association_distance,
         second_line_association_distance,
-    );
+    ) else {
+        return Vec::new();
+    };
     if !matches!(result.feature, RansacFeature::Line(_))
         || result.used_points.len() < min_points_per_line
     {

--- a/crates/vision/src/field_border_detection.rs
+++ b/crates/vision/src/field_border_detection.rs
@@ -9,7 +9,7 @@ use coordinate_systems::Pixel;
 use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{point, Point2, Vector2};
 use projection::{camera_matrix::CameraMatrix, Projection};
-use ransac::Ransac;
+use ransac::{Ransac, RansacFeature};
 use types::{
     color::Intensity,
     field_border::FieldBorder,
@@ -110,24 +110,28 @@ fn find_border_lines(
     second_line_association_distance: f32,
 ) -> Vec<LineSegment<Pixel>> {
     // first line
-    let result = ransac.next_line(
+    let result = ransac.next_feature(
         random_state,
         20,
         first_line_association_distance,
         first_line_association_distance,
     );
-    if result.line.is_none() || result.used_points.len() < min_points_per_line {
+    if !matches!(result.feature, RansacFeature::Line(_))
+        || result.used_points.len() < min_points_per_line
+    {
         return Vec::new();
     }
     let first_line = best_fit_line(&result.used_points);
     // second line
-    let result = ransac.next_line(
+    let result = ransac.next_feature(
         random_state,
         20,
         second_line_association_distance,
         second_line_association_distance,
     );
-    if result.line.is_none() || result.used_points.len() < min_points_per_line {
+    if !matches!(result.feature, RansacFeature::Line(_))
+        || result.used_points.len() < min_points_per_line
+    {
         return vec![first_line];
     }
     let second_line = best_fit_line(&result.used_points);

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -250,22 +250,28 @@ impl LineDetection {
                             .unwrap(),
                     )),
                     RansacFeature::TwoLines(two_lines) => {
-                        let point = context
+                        let intersection_point = context
                             .camera_matrix
-                            .ground_to_pixel(two_lines.point)
+                            .ground_to_pixel(two_lines.intersection_point)
                             .unwrap();
                         RansacFeature::TwoLines(TwoLines {
-                            point,
-                            direction1: context
+                            intersection_point,
+                            first_direction: context
                                 .camera_matrix
-                                .ground_to_pixel(two_lines.point + two_lines.direction1.normalize())
-                                .unwrap_or(point)
-                                - point,
-                            direction2: context
+                                .ground_to_pixel(
+                                    two_lines.intersection_point
+                                        + two_lines.first_direction.normalize(),
+                                )
+                                .unwrap_or(intersection_point)
+                                - intersection_point,
+                            second_direction: context
                                 .camera_matrix
-                                .ground_to_pixel(two_lines.point + two_lines.direction2.normalize())
-                                .unwrap_or(point)
-                                - point,
+                                .ground_to_pixel(
+                                    two_lines.intersection_point
+                                        + two_lines.second_direction.normalize(),
+                                )
+                                .unwrap_or(intersection_point)
+                                - intersection_point,
                         })
                     }
                 })

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -171,13 +171,15 @@ impl LineDetection {
             if ransac.unused_points.len() < *context.minimum_number_of_points_on_line {
                 break;
             }
-            let ransac_result = ransac.next_feature(
+            let Some(ransac_result) = ransac.next_feature(
                 &mut self.random_state,
                 *context.ransac_iterations,
                 *context.ransac_fit_two_lines,
                 *context.maximum_fit_distance_in_ground,
                 *context.maximum_fit_distance_in_ground + *context.margin_for_point_inclusion,
-            );
+            ) else {
+                break;
+            };
             detected_features.push(ransac_result.feature.clone());
 
             for line_segment in ransac_result {
@@ -241,7 +243,6 @@ impl LineDetection {
             detected_features
                 .into_iter()
                 .map(|feature| match feature {
-                    RansacFeature::None => RansacFeature::None,
                     RansacFeature::Line(line) => RansacFeature::Line(Line::from_points(
                         context.camera_matrix.ground_to_pixel(line.point).unwrap(),
                         context

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -20,7 +20,7 @@ use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{distance, Point2};
 use ordered_float::NotNan;
 use projection::{camera_matrix::CameraMatrix, Projection};
-use ransac::{Ransac, RansacResult};
+use ransac::{Ransac, RansacFeature, RansacResult};
 use types::{
     filtered_segments::FilteredSegments,
     image_segments::GenericSegment,
@@ -168,16 +168,18 @@ impl LineDetection {
                 break;
             }
             let RansacResult {
-                line: ransac_line,
+                feature,
                 used_points,
-            } = ransac.next_line(
+            } = ransac.next_feature(
                 &mut self.random_state,
                 *context.ransac_iterations,
                 *context.maximum_fit_distance_in_ground,
                 *context.maximum_fit_distance_in_ground + *context.margin_for_point_inclusion,
             );
-            let ransac_line =
-                ransac_line.expect("Insufficient number of line points. Cannot fit line.");
+            let ransac_line = match feature {
+                RansacFeature::Line(line) => line,
+                _ => unimplemented!(),
+            };
             if used_points.len() < *context.minimum_number_of_points_on_line {
                 discarded_lines.push((ransac_line, LineDiscardReason::TooFewPoints));
                 break;

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -75,6 +75,7 @@ pub struct CycleContext {
     minimum_number_of_points_on_line:
         Parameter<usize, "line_detection.$cycler_instance.minimum_number_of_points_on_line">,
     ransac_iterations: Parameter<usize, "line_detection.$cycler_instance.ransac_iterations">,
+    ransac_fit_two_lines: Parameter<bool, "line_detection.$cycler_instance.ransac_fit_two_lines">,
 
     camera_matrix: RequiredInput<Option<CameraMatrix>, "camera_matrix?">,
     filtered_segments: Input<FilteredSegments, "filtered_segments">,
@@ -173,6 +174,7 @@ impl LineDetection {
             let ransac_result = ransac.next_feature(
                 &mut self.random_state,
                 *context.ransac_iterations,
+                *context.ransac_fit_two_lines,
                 *context.maximum_fit_distance_in_ground,
                 *context.maximum_fit_distance_in_ground + *context.margin_for_point_inclusion,
             );

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -159,7 +159,7 @@
         "end": 0.1
       },
       "minimum_number_of_points_on_line": 10,
-      "ransac_iterations": 20
+      "ransac_iterations": 50
     },
     "vision_bottom": {
       "use_horizontal_segments": true,
@@ -186,7 +186,7 @@
         "end": 0.1
       },
       "minimum_number_of_points_on_line": 10,
-      "ransac_iterations": 20
+      "ransac_iterations": 50
     }
   },
   "field_border_detection": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -153,7 +153,7 @@
       "maximum_fit_distance_in_ground": 0.05,
       "maximum_gap_on_line": 0.2,
       "maximum_merge_gap_in_pixels": 5,
-      "maximum_number_of_lines": 10,
+      "maximum_number_of_features": 10,
       "allowed_projected_segment_length": {
         "start": 0.02,
         "end": 0.1
@@ -180,7 +180,7 @@
       "maximum_fit_distance_in_ground": 0.05,
       "maximum_gap_on_line": 0.1,
       "maximum_merge_gap_in_pixels": 30,
-      "maximum_number_of_lines": 10,
+      "maximum_number_of_features": 10,
       "allowed_projected_segment_length": {
         "start": 0.02,
         "end": 0.1

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -159,7 +159,8 @@
         "end": 0.1
       },
       "minimum_number_of_points_on_line": 10,
-      "ransac_iterations": 50
+      "ransac_iterations": 50,
+      "ransac_fit_two_lines": false
     },
     "vision_bottom": {
       "use_horizontal_segments": true,
@@ -186,7 +187,8 @@
         "end": 0.1
       },
       "minimum_number_of_points_on_line": 10,
-      "ransac_iterations": 50
+      "ransac_iterations": 50,
+      "ransac_fit_two_lines": false
     }
   },
   "field_border_detection": {

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -34,8 +34,10 @@ linear_algebra = { workspace = true }
 log = { workspace = true }
 mlua = { workspace = true }
 nalgebra = { workspace = true }
+ordered-float = { workspace = true }
 parameters = { workspace = true }
 projection = { workspace = true }
+ransac = { workspace = true }
 repository = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -58,7 +58,6 @@ impl Overlay for LineDetection {
         };
         for feature in detected_features {
             match feature {
-                RansacFeature::None => {}
                 RansacFeature::Line(line) => {
                     painter.line(line.point, line.direction, Stroke::new(2.0, Color32::RED))
                 }

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -64,13 +64,13 @@ impl Overlay for LineDetection {
                 }
                 RansacFeature::TwoLines(two_lines) => {
                     painter.line(
-                        two_lines.point,
-                        two_lines.direction1,
+                        two_lines.intersection_point,
+                        two_lines.first_direction,
                         Stroke::new(2.0, Color32::GREEN),
                     );
                     painter.line(
-                        two_lines.point,
-                        two_lines.direction2,
+                        two_lines.intersection_point,
+                        two_lines.second_direction,
                         Stroke::new(2.0, Color32::GREEN),
                     );
                 }

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -3,6 +3,7 @@ use eframe::epaint::{Color32, Stroke};
 
 use coordinate_systems::Pixel;
 use geometry::line_segment::LineSegment;
+use ransac::RansacFeature;
 use types::{image_segments::GenericSegment, line_data::LineDiscardReason};
 
 use crate::{
@@ -17,6 +18,7 @@ use crate::{
 type DiscardedLines = Vec<(LineSegment<Pixel>, LineDiscardReason)>;
 
 pub struct LineDetection {
+    detected_features: BufferHandle<Option<Vec<RansacFeature<Pixel>>>>,
     lines_in_image: BufferHandle<Option<Vec<LineSegment<Pixel>>>>,
     discarded_lines: BufferHandle<Option<DiscardedLines>>,
     filtered_segments: BufferHandle<Option<Vec<GenericSegment>>>,
@@ -28,6 +30,9 @@ impl Overlay for LineDetection {
     fn new(nao: std::sync::Arc<crate::nao::Nao>, selected_cycler: VisionCycler) -> Self {
         let cycler_path = selected_cycler.as_path();
         Self {
+            detected_features: nao.subscribe_value(format!(
+                "{cycler_path}.additional_outputs.detected_features"
+            )),
             lines_in_image: nao
                 .subscribe_value(format!("{cycler_path}.additional_outputs.lines_in_image")),
             discarded_lines: nao
@@ -39,6 +44,9 @@ impl Overlay for LineDetection {
     }
 
     fn paint(&self, painter: &TwixPainter<Pixel>) -> Result<()> {
+        let Some(detected_features) = self.detected_features.get_last_value()?.flatten() else {
+            return Ok(());
+        };
         let Some(lines_in_image) = self.lines_in_image.get_last_value()?.flatten() else {
             return Ok(());
         };
@@ -48,6 +56,26 @@ impl Overlay for LineDetection {
         let Some(filtered_segments) = self.filtered_segments.get_last_value()?.flatten() else {
             return Ok(());
         };
+        for feature in detected_features {
+            match feature {
+                RansacFeature::None => {}
+                RansacFeature::Line(line) => {
+                    painter.line(line.point, line.direction, Stroke::new(2.0, Color32::RED))
+                }
+                RansacFeature::TwoLines(two_lines) => {
+                    painter.line(
+                        two_lines.point,
+                        two_lines.direction1,
+                        Stroke::new(2.0, Color32::GREEN),
+                    );
+                    painter.line(
+                        two_lines.point,
+                        two_lines.direction2,
+                        Stroke::new(2.0, Color32::GREEN),
+                    );
+                }
+            };
+        }
         for segment in filtered_segments {
             painter.line_segment(
                 segment.start.cast(),

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -287,6 +287,13 @@ impl<World> TwixPainter<World> {
         self.painter.line_segment([start, end], stroke);
     }
 
+    pub fn line(&self, point: Point2<World>, direction: Vector2<World>, stroke: Stroke) {
+        let start = self.transform_world_to_pixel(point - direction * 10000.0);
+        let end = self.transform_world_to_pixel(point + direction * 10000.0);
+        let stroke = self.transform_stroke(stroke);
+        self.painter.line_segment([start, end], stroke);
+    }
+
     pub fn rect_filled(&self, min: Point2<World>, max: Point2<World>, fill_color: Color32) {
         let right_bottom = point![max.x(), min.y()];
         let left_top = point![min.x(), max.y()];


### PR DESCRIPTION
## Why? What?

This PR implements detecting orthogonal lines in the field using RANSAC. This improves the placement of line segments near corners.

Depends on #1334.

Since our `image_to_ground` is currently resulting in orthogonal lines not always being orthogonal, it may currently result in worse line fittings.

This feature is currently gated behind the `ransac_fit_two_lines` parameter, which is false by default.

## ToDo / Known Issues

- [x] Evaluate line detection parameters, e.g. if `ransac_iterations` should be increased.

## Ideas for Next Iterations (Not This PR)

- Extract type of junction from orthogonal lines and use it directly within localization

## How to Test

Enable recording and upload to a NAO. Watch the replay and have a look at the image panel with the line detection overlay enabled. The green lines show the fitted orthogonal lines, the red ones the fitted lines. Note that only the blue lines are the extracted line segments used for localization.

