### PR TITLE
Increase `foot_z_offset`

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -7,7 +7,7 @@
     "minimum_overall_keypoint_confidence": 0.5,
     "minimum_visual_referee_keypoint_confidence": 0.8,
     "minimum_shoulder_angle": 0.2,
-    "foot_z_offset": 0.05,
+    "foot_z_offset": 0.10,
     "referee_pose_queue_length": 8,
     "minimum_number_poses_before_message": 3
   },


### PR DESCRIPTION
## Why? What?

Increase `foot_z_offset` to improve visual referee position filtering.

Fixes #1311 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Setup visual referee and see where the referee pose in projected to field coordinates in twix map pose position panel.
