### PR TITLE
Draw segment edges in image segmenter overlay

### DIFF
--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 use types::{
     camera_position::CameraPosition,
     color::{Hsv, RgChromaticity, Rgb},
-    image_segments::{Direction, ImageSegments, Segment},
+    image_segments::{Direction, EdgeType, ImageSegments, Segment},
 };
 
 use crate::{
@@ -269,11 +269,27 @@ impl ImageSegmentsPanel {
                 Color32::from_gray(((1.0 - chromaticity.red - chromaticity.green) * 255.0) as u8)
             }
         };
-        painter.line_segment(start, end, Stroke::new(4.0, visualized_color));
+        const SEGMENT_WIDTH: f32 = 4.0;
+        const END_MARKER_WIDTH: f32 = 0.25;
+        painter.line_segment(start, end, Stroke::new(SEGMENT_WIDTH, visualized_color));
         painter.line_segment(
-            start - vector![1.0, 0.0],
-            start + vector![1.0, 0.0],
-            Stroke::new(1.0, Color32::from_rgb(0, 0, 255)),
+            start + vector![0.0, END_MARKER_WIDTH] - vector![SEGMENT_WIDTH / 4.0, 0.0],
+            start + vector![0.0, END_MARKER_WIDTH] + vector![SEGMENT_WIDTH / 4.0, 0.0],
+            Stroke::new(1.0, edge_type_to_color(segment.start_edge_type)),
         );
+        painter.line_segment(
+            end - vector![0.0, END_MARKER_WIDTH] - vector![SEGMENT_WIDTH / 4.0, 0.0],
+            end - vector![0.0, END_MARKER_WIDTH] + vector![SEGMENT_WIDTH / 4.0, 0.0],
+            Stroke::new(1.0, edge_type_to_color(segment.end_edge_type)),
+        );
+    }
+}
+
+fn edge_type_to_color(edge_type: EdgeType) -> Color32 {
+    match edge_type {
+        EdgeType::Rising => Color32::RED,
+        EdgeType::Falling => Color32::BLUE,
+        EdgeType::ImageBorder => Color32::GOLD,
+        EdgeType::LimbBorder => Color32::BLACK,
     }
 }

--- a/tools/twix/src/panels/image_segments.rs
+++ b/tools/twix/src/panels/image_segments.rs
@@ -4,7 +4,7 @@ use eframe::{
     egui::{ComboBox, Response, Ui, Widget},
     epaint::{Color32, Stroke},
 };
-use linear_algebra::{point, vector};
+use linear_algebra::{point, vector, Vector2};
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::Pixel;
@@ -269,18 +269,32 @@ impl ImageSegmentsPanel {
                 Color32::from_gray(((1.0 - chromaticity.red - chromaticity.green) * 255.0) as u8)
             }
         };
+
         const SEGMENT_WIDTH: f32 = 4.0;
         const END_MARKER_WIDTH: f32 = 0.25;
+
+        let (main_axis, other_axis) = match direction {
+            Direction::Horizontal => (Vector2::x_axis(), Vector2::y_axis()),
+            Direction::Vertical => (Vector2::y_axis(), Vector2::x_axis()),
+        };
+
+        let main_axis_offset = main_axis * END_MARKER_WIDTH / 2.0;
+        let other_axis_offset = other_axis * SEGMENT_WIDTH / 3.0;
+
         painter.line_segment(start, end, Stroke::new(SEGMENT_WIDTH, visualized_color));
+
         painter.line_segment(
-            start + vector![0.0, END_MARKER_WIDTH] - vector![SEGMENT_WIDTH / 4.0, 0.0],
-            start + vector![0.0, END_MARKER_WIDTH] + vector![SEGMENT_WIDTH / 4.0, 0.0],
-            Stroke::new(1.0, edge_type_to_color(segment.start_edge_type)),
+            start + main_axis_offset + other_axis_offset,
+            start + main_axis_offset - other_axis_offset,
+            Stroke::new(
+                END_MARKER_WIDTH,
+                edge_type_to_color(segment.start_edge_type),
+            ),
         );
         painter.line_segment(
-            end - vector![0.0, END_MARKER_WIDTH] - vector![SEGMENT_WIDTH / 4.0, 0.0],
-            end - vector![0.0, END_MARKER_WIDTH] + vector![SEGMENT_WIDTH / 4.0, 0.0],
-            Stroke::new(1.0, edge_type_to_color(segment.end_edge_type)),
+            end - main_axis_offset + other_axis_offset,
+            end - main_axis_offset - other_axis_offset,
+            Stroke::new(END_MARKER_WIDTH, edge_type_to_color(segment.end_edge_type)),
         );
     }
 }


### PR DESCRIPTION
## Why? What?

Sometimes we want to know which edges the segments have to debug or analyze the image segmenter. This PR color codes them in Twix image segmenter overlay:

![image](https://github.com/user-attachments/assets/16653d68-ffe7-4ddc-8b24-3aa575177db8)

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Deploy, look through Image Segmenter overlay, ... profit :tada: