### PR TITLE
Penalty kick behavioral fixes

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -226,7 +226,8 @@ impl Behavior {
                 },
                 _ => match world_state.filtered_game_controller_state {
                     Some(FilteredGameControllerState {
-                        game_state: FilteredGameState::Ready { .. },
+                        game_state:
+                            FilteredGameState::Ready { .. } | FilteredGameState::Playing { .. },
                         sub_state: Some(SubState::PenaltyKick),
                         kicking_team: Team::Opponent,
                         ..

--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -86,13 +86,22 @@ fn support_pose(
         .filtered_game_controller_state
         .as_ref()
         .map(|filtered_game_controller_state| filtered_game_controller_state.game_state);
-    let mut clamped_x = match filtered_game_state {
-        Some(FilteredGameState::Ready { .. })
-        | Some(FilteredGameState::Playing {
-            ball_is_free: false,
-            kick_off: true,
-            ..
-        }) => supporting_position
+    let sub_state = world_state
+        .filtered_game_controller_state
+        .map(|filtered_game_controller_state| filtered_game_controller_state.sub_state);
+    let mut clamped_x = match (filtered_game_state, sub_state) {
+        (Some(FilteredGameState::Ready { .. }), Some(Some(SubState::PenaltyKick))) => {
+            supporting_position.x().max(field_dimensions.length / 4.0)
+        }
+        (Some(FilteredGameState::Ready { .. }), _)
+        | (
+            Some(FilteredGameState::Playing {
+                ball_is_free: false,
+                kick_off: true,
+                ..
+            }),
+            _,
+        ) => supporting_position
             .x()
             .min(maximum_x_in_ready_and_when_ball_is_not_free),
         _ => supporting_position.x().clamp(minimum_x, maximum_x),

--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -88,6 +88,7 @@ fn support_pose(
         .map(|filtered_game_controller_state| filtered_game_controller_state.game_state);
     let sub_state = world_state
         .filtered_game_controller_state
+        .as_ref()
         .map(|filtered_game_controller_state| filtered_game_controller_state.sub_state);
     let mut clamped_x = match (filtered_game_state, sub_state) {
         (Some(FilteredGameState::Ready { .. }), Some(Some(SubState::PenaltyKick))) => {

--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -211,7 +211,14 @@ impl RoleAssignment {
 
         let mut team_ball = self.team_ball;
 
-        if spl_striker_message_timeout {
+        let is_in_penalty_kick = matches!(
+            context.filtered_game_controller_state,
+            Some(FilteredGameControllerState {
+                sub_state: Some(SubState::PenaltyKick),
+                ..
+            })
+        );
+        if spl_striker_message_timeout && !is_in_penalty_kick {
             match new_role {
                 Role::Keeper => {
                     team_ball = None;


### PR DESCRIPTION
## Why? What?

- Ignore striker message timeout to prevent roles from becoming looser and searcher in penalty kick as these seem to violate obstacles
- Keep striker in specific position for penalty kick because he would ignore the penalty box obstacle due to #1051 
- Clamp midfielders to opponent half to prevent them from walking back to own half during penalty kick

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Try it in game or merge #1309 to test in behavior simulator