### PR TITLE
Look at the Ball in Stand for StrikerSupport

### DIFF
--- a/crates/control/src/behavior/stand.rs
+++ b/crates/control/src/behavior/stand.rs
@@ -89,6 +89,13 @@ pub fn execute(
                 ) => Some(MotionCommand::Stand {
                     head: HeadMotion::Center,
                 }),
+                (_, Role::StrikerSupporter, Some(ball)) => Some(MotionCommand::Stand {
+                    head: HeadMotion::LookAt {
+                        target: ball.ball_in_ground,
+                        image_region_target: Default::default(),
+                        camera: None,
+                    },
+                }),
                 _ => None,
             }
         }


### PR DESCRIPTION
## Why? What?
 
To see the ball coming, the StrikerSupport should look at the ball during stand

Fixes #