### PR TITLE
Localization motion in standby

### DIFF
--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -166,7 +166,7 @@ impl Localization {
         penalty: &Option<Penalty>,
     ) {
         match (self.last_primary_state, primary_state, game_phase) {
-            (PrimaryState::Standby, PrimaryState::Ready, _) => {
+            (PrimaryState::Standby | PrimaryState::Initial, PrimaryState::Ready, _) => {
                 let initial_pose = generate_initial_pose(
                     &context.initial_poses[*context.player_number],
                     context.field_dimensions,


### PR DESCRIPTION
## Why? What?

Due to the problem related filtered game state filter, it caused the problem for the robot to skip standby between initial and ready, and the robot goes straight from Initial to Ready. 

In the correct order, the robot goes from Initial -> Standby -> Ready, and from Standby -> Ready, the robot does "generate_initial_pose", which is the correct pose. On the other hand, when the Standby is skipped, robot goes from Initial->Ready, and during Initial, the robot get unstiffed. When the robot is unstiffed, it does the 'generate_penalized_poses', therefore this caused the delocalization.

To fix the root of this issue, see issue #1333. What this PR does is though, we add PrimaryState:Initial -> PrimaryState:Ready transition, in case a robot ever skips Standby again, the delocalization due to "skipped Standby" will be prevented. 


Fixes #1270 


## How to Test



