### PR TITLE
Less activations to activate foot bumper obstacles

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -87,7 +87,7 @@
     }
   },
   "foot_bumper_filter": {
-    "activations_needed": 2,
+    "activations_needed": 1,
     "acceptance_duration": { "nanos": 0, "secs": 1 },
     "buffer_size": 25,
     "number_of_detections_in_buffer_for_defective_declaration": 22,


### PR DESCRIPTION
## Why? What?

Have less activation / touches per Foot bumper needed to spawn an obstacle.
