### PR TITLE
Wide stance improvements

### DIFF
--- a/crates/control/src/behavior/defend.rs
+++ b/crates/control/src/behavior/defend.rs
@@ -55,23 +55,25 @@ impl<'cycle> Defend<'cycle> {
         )
     }
 
-    pub fn wide_stance(
-        &self,
-        wide_stance_paramters: WideStanceParameters,
-    ) -> Option<MotionCommand> {
+    pub fn wide_stance(&self, parameters: WideStanceParameters) -> Option<MotionCommand> {
         let ball = self.world_state.ball?;
 
         let position = ball.ball_in_ground;
         let velocity = ball.ball_in_ground_velocity;
 
-        if velocity.x() >= wide_stance_paramters.minimum_velocity {
+        let ball_is_in_front_of_robot =
+            position.coords().norm() < parameters.maximum_ball_distance && position.x() > 0.0;
+        let ball_is_moving_towards_robot =
+            ball.ball_in_ground_velocity.x() < -parameters.minimum_ball_velocity;
+
+        if !ball_is_in_front_of_robot || !ball_is_moving_towards_robot {
             return None;
         }
 
         let horizontal_distance_to_intersection =
             position.y() - position.x() / velocity.x() * velocity.y();
 
-        if horizontal_distance_to_intersection.abs() < wide_stance_paramters.action_radius {
+        if horizontal_distance_to_intersection.abs() < parameters.action_radius {
             Some(MotionCommand::WideStance)
         } else {
             None

--- a/crates/control/src/behavior/head.rs
+++ b/crates/control/src/behavior/head.rs
@@ -1,5 +1,6 @@
 use types::{
     motion_command::{HeadMotion, ImageRegion},
+    roles::Role,
     world_state::WorldState,
 };
 
@@ -14,10 +15,26 @@ impl<'cycle> LookAction<'cycle> {
     }
 
     pub fn execute(&self) -> HeadMotion {
-        HeadMotion::LookAt {
-            target: self.world_state.position_of_interest,
-            image_region_target: ImageRegion::Center,
-            camera: None,
+        if self.world_state.robot.role == Role::Keeper {
+            if let Some(ball_position) = self.world_state.ball {
+                HeadMotion::LookAt {
+                    target: ball_position.ball_in_ground,
+                    image_region_target: ImageRegion::Center,
+                    camera: None,
+                }
+            } else {
+                HeadMotion::LookAt {
+                    target: self.world_state.position_of_interest,
+                    image_region_target: ImageRegion::Center,
+                    camera: None,
+                }
+            }
+        } else {
+            HeadMotion::LookAt {
+                target: self.world_state.position_of_interest,
+                image_region_target: ImageRegion::Center,
+                camera: None,
+            }
         }
     }
 }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -378,8 +378,9 @@ pub struct SearchSuggestorParameters {
     Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
 )]
 pub struct WideStanceParameters {
+    pub maximum_ball_distance: f32,
+    pub minimum_ball_velocity: f32,
     pub action_radius: f32,
-    pub minimum_velocity: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -515,8 +515,9 @@
     }
   },
   "wide_stance": {
-    "action_radius": 0.3,
-    "minimum_velocity": -0.5
+    "maximum_ball_distance": 1.5,
+    "minimum_ball_velocity": 0.6,
+    "action_radius": 0.25
   },
   "kick_steps": {
     "forward": [


### PR DESCRIPTION
## Why? What?

This PR improves the wide stance by adding an additional distance check, tuning parameters and adjusting active vision to let the keeper look more at the ball.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

- Make active vision dependent on position uncertainty (i.e. if the keeper knows exactly where it is, look at the corner less often).

## How to Test

Deploy a robot as keeper (player number one and two other robots in the game controller) and see how the keeper behaves.
