### PR TITLE
Use hybrid AlignWithPath in Dribble

### DIFF
--- a/crates/control/src/behavior/dribble.rs
+++ b/crates/control/src/behavior/dribble.rs
@@ -1,13 +1,10 @@
 use coordinate_systems::{Ground, UpcomingSupport};
-use geometry::look_at::LookAt;
-use linear_algebra::{Isometry2, Point, Pose2};
+use linear_algebra::{Isometry2, Pose2};
 use spl_network_messages::GamePhase;
 use types::{
     camera_position::CameraPosition,
     filtered_game_controller_state::FilteredGameControllerState,
-    motion_command::{
-        ArmMotion, HeadMotion, ImageRegion, MotionCommand, OrientationMode, WalkSpeed,
-    },
+    motion_command::{ArmMotion, HeadMotion, ImageRegion, MotionCommand, WalkSpeed},
     parameters::{DribblingParameters, InWalkKickInfoParameters, InWalkKicksParameters},
     planned_path::PathSegment,
     world_state::WorldState,
@@ -69,19 +66,11 @@ pub fn execute(
 
     let best_pose = best_kick_decision.kick_pose;
 
-    let hybrid_orientation_mode = hybrid_alignment(
+    let orientation_mode = hybrid_alignment(
         best_pose,
         parameters.hybrid_align_distance,
         parameters.distance_to_be_aligned,
     );
-    let orientation_mode = match hybrid_orientation_mode {
-        types::motion_command::OrientationMode::AlignWithPath
-            if ball_position.coords().norm() > 0.0 =>
-        {
-            OrientationMode::Override(Point::origin().look_at(&ball_position))
-        }
-        orientation_mode => orientation_mode,
-    };
 
     if let Some(FilteredGameControllerState {
         game_phase: GamePhase::PenaltyShootout { .. },

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1139,8 +1139,8 @@
       }
     },
     "dribbling": {
-      "hybrid_align_distance": 0.5,
-      "distance_to_be_aligned": 0.1,
+      "hybrid_align_distance": 1.0,
+      "distance_to_be_aligned": 0.15,
       "angle_to_approach_ball_from_threshold": 0.78,
       "ignore_robot_when_near_ball_radius": 0.6,
       "distance_to_look_directly_at_the_ball": 1.0


### PR DESCRIPTION
## Why? What?

Instead of facing the ball, the striker uses proper hybrid alignment in dribble. This somewhat mitigates the problem of drifting towards the ball... but this also changes behavior on how to approach the ball, we should test whether this looks good.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Let the robot walk around the ball... Look at its alignment and path/step planning