### PR TITLE
Fix striker becoming searcher

### DIFF
--- a/crates/control/src/role_assignment.rs
+++ b/crates/control/src/role_assignment.rs
@@ -224,6 +224,9 @@ impl RoleAssignment {
                     team_ball = None;
                     new_role = Role::Loser;
                 }
+                Role::Loser if *context.player_number == PlayerNumber::One => {
+                    new_role = Role::Keeper;
+                }
                 _ => {
                     send_spl_striker_message = false;
                     team_ball = None;


### PR DESCRIPTION
## Why? What?

This PR fixes the striker becoming searcher (and never leaving it without network messages).

Fixes #1372.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

- #1381

## How to Test

```sh
pepsi run --target replayer -- logs/2024-07-20-HULKs-vs-RoboEireann/second-half/10.1.24.41/2024-07-20_07:17:27/
```

See how the the role of the keeper after losing the ball is set to `Keeper` instead of `Searcher` (for only one cycle, since the values for the next cycles are retrieved from the replay without the fix)
