### PR TITLE
Ball detection fixes

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -53,7 +53,7 @@
       "correction_proximity_merge_factor": 1.0,
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
-      "ball_radius_enlargement_factor": 2.0,
+      "ball_radius_enlargement_factor": 1.5,
       "detection_noise": [4.0, 4.0]
     },
     "vision_bottom": {
@@ -68,7 +68,7 @@
       "correction_proximity_merge_factor": 1.0,
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
-      "ball_radius_enlargement_factor": 2.0,
+      "ball_radius_enlargement_factor": 1.5,
       "detection_noise": [4.0, 4.0]
     }
   },


### PR DESCRIPTION
## Why? What?

Somehow the ball detection sample enlargement factor got increased from 1.5 to 2.0. The neural networks of the ball detection were trained with a factor of 1.5 and the positioner seems to perform worse with a factor of 2.0: Positions of detected balls are often too large and not at the correct center position. This PR decreases the factor back to 1.5.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

Change the parameter in Twix and observe the positions in the ball detection image overlay and ball candidates panel.