### PR TITLE
draw team ball in map panel

### DIFF
--- a/tools/twix/src/panels/map/layers/ball_measurements.rs
+++ b/tools/twix/src/panels/map/layers/ball_measurements.rs
@@ -51,7 +51,7 @@ impl Layer<Ground> for BallMeasurement {
                 stroke,
                 Color32::YELLOW.gamma_multiply(0.5),
             );
-            painter.ball(position, 0.07);
+            painter.ball(position, 0.07, Color32::WHITE);
         }
 
         Ok(())

--- a/tools/twix/src/panels/map/layers/behavior_simulator.rs
+++ b/tools/twix/src/panels/map/layers/behavior_simulator.rs
@@ -120,7 +120,7 @@ impl Layer<Field> for BehaviorSimulator {
         }
 
         if let Some(ball_state) = self.ball.get_last_value().wrap_err("ball state")?.flatten() {
-            painter.ball(ball_state.position, 0.05);
+            painter.ball(ball_state.position, 0.05, Color32::WHITE);
         }
 
         Ok(())

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -192,11 +192,11 @@ impl<World> TwixPainter<World> {
             .add(Shape::Path(PathShape::line(points, stroke)));
     }
 
-    pub fn ball(&self, position: Point2<World>, radius: f32) {
+    pub fn ball(&self, position: Point2<World>, radius: f32, color: Color32) {
         self.circle(
             position,
             radius,
-            Color32::WHITE,
+            color,
             Stroke {
                 width: radius / 8.0,
                 color: Color32::BLACK,


### PR DESCRIPTION
## Why? What?

What it says, makes replay debugging a lot easier.
Team Ball is read, own ball white

![image](https://github.com/user-attachments/assets/f43cb0ba-8d88-4a29-aa84-40941e908c99)
