### PR TITLE
Fix directed cathesis is not a real number

### DIFF
--- a/crates/control/src/path_planner.rs
+++ b/crates/control/src/path_planner.rs
@@ -278,8 +278,10 @@ impl PathPlanner {
             .min_by_key(|circle| NotNan::new(circle.center.coords().norm_squared()).unwrap());
         if let Some(circle) = closest_circle {
             let to_destination = destination - circle.center;
-            let safety_radius = circle.radius * 1.1;
-            destination += to_destination.normalize() * (safety_radius - to_destination.norm());
+            if to_destination.norm_squared() >= f32::EPSILON {
+                let safety_radius = circle.radius * 1.1;
+                destination += to_destination.normalize() * (safety_radius - to_destination.norm());
+            }
         }
 
         for circle in self

--- a/crates/control/src/path_planner.rs
+++ b/crates/control/src/path_planner.rs
@@ -278,9 +278,9 @@ impl PathPlanner {
             .min_by_key(|circle| NotNan::new(circle.center.coords().norm_squared()).unwrap());
         if let Some(circle) = closest_circle {
             let to_destination = destination - circle.center;
-            if to_destination.norm_squared() >= f32::EPSILON {
+            if let Some(to_destination_normalized) = to_destination.try_normalize(f32::EPSILON) {
                 let safety_radius = circle.radius * 1.1;
-                destination += to_destination.normalize() * (safety_radius - to_destination.norm());
+                destination += to_destination_normalized * (safety_radius - to_destination.norm());
             }
         }
 


### PR DESCRIPTION
## Why? What?

This PR ensures that destinations exactly in the center of an obstacle are not moved since the movement direction in this case is zero.

Fixes #1038.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

Investigate further why behavior request a destination in exactly the center of an obstacle.

## How to Test

Switch to `thagonduarte/directed-cathesis-in-behavior-sim`, run the behavior simulator and observe the panic.

```
pepsi run --target behavior_simulator -- run tests/behavior/ball_intercept.lua
```

Cherry pick the commit of this PR and observe how the panic is fixed.
