### PR TITLE
Add pepsi wireless scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,7 +4577,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -317,6 +317,24 @@ impl Nao {
         String::from_utf8(output.stdout).wrap_err("failed to decode UTF-8")
     }
 
+    pub async fn scan_networks(&self) -> Result<()> {
+        let output = self
+            .ssh_to_nao()
+            .arg("iwctl")
+            .arg("station")
+            .arg("wlan0")
+            .arg("scan")
+            .output()
+            .await
+            .wrap_err("failed to execute iwctl ssh command")?;
+
+        if !output.status.success() {
+            bail!("iwctl ssh command exited with {}", output.status);
+        }
+
+        Ok(())
+    }
+
     pub async fn set_network(&self, network: Network) -> Result<()> {
         let command_string = [
             Network::SplA,

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "3.15.0"
+version = "3.16.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -96,11 +96,11 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
     .await
     .wrap_err("failed to set player numbers")?;
 
-    wireless(WirelessArguments::Scan { naos: naos.clone() })
-        .await
-        .wrap_err("failed to scan for networks")?;
-
     if !arguments.prepare {
+        wireless(WirelessArguments::Scan { naos: naos.clone() })
+            .await
+            .wrap_err("failed to scan for networks")?;
+
         wireless(WirelessArguments::Set {
             network: arguments.network,
             naos: naos.clone(),

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -96,6 +96,10 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
     .await
     .wrap_err("failed to set player numbers")?;
 
+    wireless(WirelessArguments::Scan { naos: naos.clone() })
+        .await
+        .wrap_err("failed to scan for networks")?;
+
     if !arguments.prepare {
         wireless(WirelessArguments::Set {
             network: arguments.network,


### PR DESCRIPTION
## Why? What?

This PR adds a `pepsi wireless scan` subcommand to allow for scanning for networks.

This was done since robots are often unable to set the network since wifi autoconnect is broken (see #435).

It also adds this scanning step to the `pregame` subcommand.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
pepsi wireless scan 41
```
