### PR TITLE
Bump egui to 0.28.1, egui_dock to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
  "egui_extras",
  "egui_plot",
  "glob",
- "image",
+ "image 0.24.9",
  "once_cell",
  "reqwest",
  "serde",
@@ -962,6 +962,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,36 +1202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics",
- "foreign-types 0.5.0",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "core-foundation",
- "core-graphics-types",
- "libc",
- "objc",
 ]
 
 [[package]]
@@ -1679,13 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
+name = "directories"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1707,17 +1682,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1762,23 +1726,24 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
+checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
 dependencies = [
  "bytemuck",
+ "emath",
  "serde",
 ]
 
 [[package]]
 name = "eframe"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020e2ccef6bbcec71dbc542f7eed64a5846fc3076727f5746da8fd307c91bab2"
+checksum = "6490ef800b2e41ee129b1f32f9ac15f713233fe3bc18e241a1afe1e4fb6811e0"
 dependencies = [
+ "ahash",
  "bytemuck",
- "cocoa",
- "directories-next",
+ "directories",
  "document-features",
  "egui",
  "egui-wgpu",
@@ -1787,10 +1752,12 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
- "image",
+ "image 0.25.2",
  "js-sys",
  "log",
- "objc",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "parking_lot",
  "percent-encoding",
  "raw-window-handle 0.5.2",
@@ -1798,7 +1765,6 @@ dependencies = [
  "ron",
  "serde",
  "static_assertions",
- "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1809,12 +1775,13 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
+checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
 dependencies = [
  "accesskit",
  "ahash",
+ "emath",
  "epaint",
  "log",
  "nohash-hasher",
@@ -1824,10 +1791,11 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469ff65843f88a702b731a1532b7d03b0e8e96d283e70f3a22b0e06c46cb9b37"
+checksum = "47c7a7c707877c3362a321ebb4f32be811c0b91f7aebf345fb162405c0218b4c"
 dependencies = [
+ "ahash",
  "bytemuck",
  "document-features",
  "egui",
@@ -1842,11 +1810,12 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
+checksum = "fac4e066af341bf92559f60dbdf2020b2a03c963415349af5f3f8d79ff7a4926"
 dependencies = [
  "accesskit_winit",
+ "ahash",
  "arboard",
  "egui",
  "log",
@@ -1860,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "egui_dock"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b8d9a54c0ed60f2670ad387c269663b4771431f090fa586906cf5f0bc586f4"
+checksum = "629a8b0e440d69996795669ceacc0dd839a997843489273600d31d16c9cb3500"
 dependencies = [
  "duplicate",
  "egui",
@@ -1872,13 +1841,14 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b78779f35ded1a853786c9ce0b43fe1053e10a21ea3b23ebea411805ce41593"
+checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
 dependencies = [
+ "ahash",
  "egui",
  "enum-map",
- "image",
+ "image 0.25.2",
  "log",
  "mime_guess2",
  "serde",
@@ -1886,10 +1856,11 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e5d975f3c86edc3d35b1db88bb27c15dde7c55d3b5af164968ab5ede3f44ca"
+checksum = "4e2bdc8b38cfa17cc712c4ae079e30c71c00cd4c2763c9e16dc7860a02769103"
 dependencies = [
+ "ahash",
  "bytemuck",
  "egui",
  "glow",
@@ -1902,11 +1873,13 @@ dependencies = [
 
 [[package]]
 name = "egui_plot"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7854b86dc1c2d352c5270db3d600011daa913d6b554141a03939761323288a1"
+checksum = "c7acc4fe778c41b91d57e04c1a2cf5765b3dc977f9f8384d2bb2eb4254855365"
 dependencies = [
+ "ahash",
  "egui",
+ "emath",
 ]
 
 [[package]]
@@ -1917,9 +1890,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
+checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2114,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b381f8b149657a4acf837095351839f32cd5c4aec1817fc4df84e18d76334176"
+checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2717,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.6.0",
  "gpu-descriptor-types",
@@ -2728,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3258,6 +3231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
  "bitflags 2.6.0",
  "block",
@@ -3806,10 +3791,11 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
  "bit-set",
  "bitflags 2.6.0",
  "codespan-reporting",
@@ -4120,7 +4106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -4262,15 +4247,6 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-foundation",
  "objc2-metal",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6109,7 +6085,7 @@ dependencies = [
  "fuzzy-matcher",
  "geometry",
  "gilrs",
- "image",
+ "image 0.24.9",
  "itertools 0.10.5",
  "kinematics",
  "linear_algebra",
@@ -6153,7 +6129,7 @@ dependencies = [
  "coordinate_systems",
  "enum-iterator",
  "geometry",
- "image",
+ "image 0.24.9",
  "linear_algebra",
  "nalgebra",
  "ordered-float",
@@ -6561,17 +6537,18 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
+checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
 dependencies = [
+ "block2 0.5.1",
  "core-foundation",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc",
- "raw-window-handle 0.5.2",
+ "objc2 0.5.2",
+ "objc2-foundation",
  "url",
  "web-sys",
 ]
@@ -6604,13 +6581,14 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.19.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
+checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "cfg_aliases 0.1.1",
+ "document-features",
  "js-sys",
  "log",
  "parking_lot",
@@ -6628,15 +6606,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
+ "document-features",
  "indexmap 2.2.6",
  "log",
  "naga",
@@ -6654,9 +6633,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1a4924366df7ab41a5d8546d6534f1f33231aa5b3f72b9930e300f254e39c3"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6695,9 +6674,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,10 +98,10 @@ coordinate_systems = { path = "crates/coordinate_systems" }
 ctrlc = { version = "3.2.3", features = ["termination"] }
 derive_more = "0.99.17"
 dirs = "5.0.1"
-eframe = { version = "0.27.2", features = ["persistence"] }
-egui_dock = { version = "0.12.0", features = ["serde"] }
-egui_extras = { version = "0.27.2", features = ["image"] }
-egui_plot = "0.27.2"
+eframe = { version = "0.28.1", features = ["persistence"] }
+egui_dock = { version = "0.13.0", features = ["serde"] }
+egui_extras = { version = "0.28.1", features = ["image"] }
+egui_plot = "0.28.1"
 energy_optimization = { path = "crates/energy_optimization" }
 enum-iterator = "1.4.1"
 enum_dispatch = "0.3.11"

--- a/crates/hulk_replayer/src/labels.rs
+++ b/crates/hulk_replayer/src/labels.rs
@@ -43,7 +43,7 @@ impl<'state> Widget for Labels<'state> {
                 left_top,
                 pos2(ui.max_rect().right(), left_top.y + row_height),
             );
-            let mut child_ui = ui.child_ui(child_rect, Layout::top_down(Align::Min));
+            let mut child_ui = ui.child_ui(child_rect, Layout::top_down(Align::Min), None);
             child_ui.set_height(row_height);
             child_ui.label(RichText::new(label_content.name).strong());
             let text_height = ui.style().text_styles.get(&TextStyle::Body).unwrap().size;

--- a/crates/hulk_replayer/src/replayer.rs
+++ b/crates/hulk_replayer/src/replayer.rs
@@ -81,7 +81,7 @@ pub fn replayer() -> Result<()> {
             spawn_workers(replayer, time_sender.clone(), move || {
                 context.request_repaint();
             });
-            Box::new(Window::new(indices, time_sender))
+            Ok(Box::new(Window::new(indices, time_sender)))
         }),
     )
     .map_err(|error| Report::msg(error.to_string()))

--- a/crates/hulk_replayer/src/timeline.rs
+++ b/crates/hulk_replayer/src/timeline.rs
@@ -43,7 +43,8 @@ impl<'state> Widget for Timeline<'state> {
                 ui.max_rect().left_top(),
                 vec2(ui.available_width(), ticks_height(ui)),
             );
-            let mut ticks_ui = ui.child_ui(ticks_rect, Layout::top_down_justified(Align::Min));
+            let mut ticks_ui =
+                ui.child_ui(ticks_rect, Layout::top_down_justified(Align::Min), None);
             ui.advance_cursor_after_rect(ticks_rect);
 
             let response = ui.add(Frames::new(

--- a/tools/annotato/src/main.rs
+++ b/tools/annotato/src/main.rs
@@ -74,10 +74,10 @@ fn start_labelling_ui(
 
             let context = &cc.egui_ctx;
             apply_theme(context, MOCHA);
-            Box::new(
-                AnnotatorApp::try_new(cc, image_folder, annotation_json, skip_introduction)
-                    .expect("failed to start annotato-rs"),
-            )
+
+            let app = AnnotatorApp::try_new(cc, image_folder, annotation_json, skip_introduction)?;
+
+            Ok(Box::new(app))
         }),
     )
 }

--- a/tools/annotato/src/widgets/path_row.rs
+++ b/tools/annotato/src/widgets/path_row.rs
@@ -1,5 +1,5 @@
 use eframe::{
-    egui::{Response, RichText, Sense, TextStyle, Ui, Widget, WidgetText},
+    egui::{Response, RichText, Sense, TextStyle, TextWrapMode, Ui, Widget, WidgetText},
     epaint::{Color32, Vec2},
 };
 
@@ -36,9 +36,18 @@ impl<'a> Widget for Row<'a> {
             RichText::new("❌").color(Color32::RED)
         }
         .into();
-        let text = text.into_galley(ui, Some(false), ui.available_width(), TextStyle::Button);
-        let check_mark =
-            check_mark.into_galley(ui, Some(false), ui.available_width(), TextStyle::Button);
+        let text = text.into_galley(
+            ui,
+            Some(TextWrapMode::Truncate),
+            ui.available_width(),
+            TextStyle::Button,
+        );
+        let check_mark = check_mark.into_galley(
+            ui,
+            Some(TextWrapMode::Extend),
+            ui.available_width(),
+            TextStyle::Button,
+        );
 
         let desired_size = Vec2::new(
             text.size().x + 40.0 + check_mark.size().x + 20.0,

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -101,13 +101,16 @@ fn main() -> Result<(), eframe::Error> {
     let configuration = Configuration::load()
         .unwrap_or_else(|error| panic!("failed to load configuration: {error}"));
 
-    let options = NativeOptions::default();
     run_native(
         "Twix",
-        options,
+        NativeOptions::default(),
         Box::new(|creation_context| {
             egui_extras::install_image_loaders(&creation_context.egui_ctx);
-            Box::new(TwixApp::create(creation_context, arguments, configuration))
+            Ok(Box::new(TwixApp::create(
+                creation_context,
+                arguments,
+                configuration,
+            )))
         }),
     )
 }

--- a/tools/twix/src/panels/enum_plot.rs
+++ b/tools/twix/src/panels/enum_plot.rs
@@ -100,7 +100,9 @@ impl Segment {
 
         if ui.rect_contains_pointer(screenspace_rect) {
             if let Some(tooltip) = self.tooltip() {
-                show_tooltip_at_pointer(ui.ctx(), "Fridolin".into(), |ui| ui.label(tooltip));
+                show_tooltip_at_pointer(ui.ctx(), ui.layer_id(), "Fridolin".into(), |ui| {
+                    ui.label(tooltip)
+                });
             }
         }
 
@@ -119,7 +121,7 @@ impl Segment {
 
         let text = WidgetText::from(&self.name()).into_galley(
             ui,
-            Some(false),
+            Some(eframe::egui::TextWrapMode::Truncate),
             available_text_rect.width(),
             TextStyle::Body,
         );

--- a/tools/twix/src/panels/plot.rs
+++ b/tools/twix/src/panels/plot.rs
@@ -261,7 +261,7 @@ impl PlotPanel {
         ui.horizontal(|ui| {
             let mut history_in_seconds = self.buffer_history.as_secs_f64();
             let widget = DragValue::new(&mut history_in_seconds)
-                .clamp_range(0.0..=600.0)
+                .range(0.0..=600.0)
                 .prefix("History [s]:");
             if ui.add(widget).changed() {
                 self.buffer_history = Duration::from_secs_f64(history_in_seconds);


### PR DESCRIPTION
## Why? What?

What the title would suggest. I want the latest egui version to take advantage of new features in a tool Ole and I are developing, and bumping the version should not be part of that PR.

## ToDo / Known Issues

It's perfect

## How to Test

use twix/annotato, there should not be any visible changes