### PR TITLE
Add missing dependencies for fresh install

### DIFF
--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -32,7 +32,7 @@ Use your distribution's package manager to install the following dependencies:
 === "Fedora"
 
     ```sh
-    sudo dnf install git git-lfs clang python3 which zstd xz file rsync alsa-lib-devel
+    sudo dnf install git git-lfs clang cmake python3 which zstd xz file rsync alsa-lib-devel opusfile-devel hdf5-devel luajit-devel systemd-devel
     ```
 
 === "Ubuntu"

--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -16,29 +16,34 @@ Use your distribution's package manager to install the following dependencies:
 
 -   [Git](https://git-scm.com/), [Git LFS](https://git-lfs.com/)
 -   [clang](https://clang.llvm.org/)
+-   [cmake](https://cmake.org/)
 -   [python3](https://www.python.org/)
 -   [which](https://carlowood.github.io/which/)
 -   [zstd](http://www.zstd.net/)
 -   [xz](https://tukaani.org/xz/)
 -   [file](https://darwinsys.com/file/)
 -   [rsync](https://rsync.samba.org/)
+-   [opusfile](https://opus-codec.org/)
+-   [hdf5](https://www.hdfgroup.org/solutions/hdf5/)
+-   [luajit](https://luajit.org/)
+-   [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
 
 === "Arch Linux"
 
     ```sh
-    sudo pacman -S git git-lfs clang python3 which zstd xz file rsync
+    sudo pacman -S git git-lfs clang cmake python3 which zstd xz file rsync alsa-lib opusfile hdf5 luajit systemd-libs
     ```
 
 === "Fedora"
 
     ```sh
-    sudo dnf install git git-lfs clang cmake python3 which zstd xz file rsync alsa-lib-devel opusfile-devel hdf5-devel luajit-devel systemd-devel
+    sudo dnf install git git-lfs clang cmake python3 which zstd xz file rsync alsa-lib-devel opusfile-devel hdf5-devel systemd-devel luajit-devel
     ```
 
 === "Ubuntu"
 
     ```sh
-    sudo apt install git git-lfs clang python3 zstd xz-utils file rsync
+    sudo apt install git git-lfs clang cmake python3 zstd xz-utils file rsync libasound2-dev libopusfile-dev libhdf5-dev libsystemd-dev libluajit-5.1-dev
     ```
 
 ### OpenVino:tm: runtime for Neural Networks


### PR DESCRIPTION
## Why? What?

For some reason dependencies that were already listed in the docs (or I thought so) were removed at one point. But these are **required** for a fresh install (esp if you reinstall Fedora or you are a newbie).

~If someone else can test for Arch & Ubuntu, I can add cmake, etc to these two as well.~ - Referred `tools/ci/github-runners/Dockerfile`.

P.S. `systemd-devel` provides `udev`

Fixes #

FIxes rust-analyser and pepsi build errors caused by missing dependencies for Fedora.

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

1. All commands on each distro should run without an error
2. On a fresh install (i.e. a freshly pulled docker container), these instructions should get `./pepsi run` complete as the baseline.
3. The LSP (via VSCode, etc) - connected to the above mentioned docker container should index without any errors.
  - When something is missing, this will fail even if `pepsi run` works.
