### PR TITLE
Remove `Uncertain` kind from Team type

### DIFF
--- a/crates/control/src/ball_state_composer.rs
+++ b/crates/control/src/ball_state_composer.rs
@@ -100,8 +100,6 @@ impl BallStateComposer {
                 let side_factor = match kicking_team {
                     Team::Opponent => -1.0,
                     Team::Hulks => 1.0,
-                    // If uncertain get ready to defend own goal
-                    Team::Uncertain => -1.0,
                 };
                 let penalty_spot_x = context.field_dimensions.length / 2.0
                     - context.field_dimensions.penalty_marker_distance;

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -216,7 +216,7 @@ impl Behavior {
                     actions.push(Action::Dribble);
                 }
                 Some(FilteredGameState::Ready {
-                    kicking_team: Team::Hulks,
+                    kicking_team: Some(Team::Hulks),
                 }) => match world_state.filtered_game_controller_state {
                     Some(FilteredGameControllerState {
                         sub_state: Some(SubState::PenaltyKick),

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -165,11 +165,6 @@ impl Behavior {
         }
         actions.push(Action::InterceptBall);
 
-        let filtered_game_state = world_state
-            .filtered_game_controller_state
-            .as_ref()
-            .map(|filtered_game_controller_state| filtered_game_controller_state.game_state);
-
         match world_state.robot.role {
             Role::DefenderLeft => match world_state.filtered_game_controller_state {
                 Some(FilteredGameControllerState {
@@ -208,32 +203,36 @@ impl Behavior {
             Role::MidfielderRight => actions.push(Action::SupportRight),
             Role::ReplacementKeeper => actions.push(Action::DefendGoal),
             Role::Searcher => actions.push(Action::Search),
-            Role::Striker => match filtered_game_state {
+            Role::Striker => match world_state.filtered_game_controller_state {
                 None
-                | Some(FilteredGameState::Playing {
-                    ball_is_free: true, ..
+                | Some(FilteredGameControllerState {
+                    game_state:
+                        FilteredGameState::Playing {
+                            ball_is_free: true, ..
+                        },
+                    ..
                 }) => {
                     actions.push(Action::Dribble);
                 }
-                Some(FilteredGameState::Ready {
-                    kicking_team: Some(Team::Hulks),
-                }) => match world_state.filtered_game_controller_state {
-                    Some(FilteredGameControllerState {
-                        sub_state: Some(SubState::PenaltyKick),
-                        ..
-                    }) => actions.push(Action::WalkToPenaltyKick),
+                Some(FilteredGameControllerState {
+                    game_state:
+                        FilteredGameState::Ready {
+                            kicking_team_known: true,
+                        },
+                    kicking_team: Team::Hulks,
+                    sub_state,
+                    ..
+                }) => match sub_state {
+                    Some(SubState::PenaltyKick) => actions.push(Action::WalkToPenaltyKick),
                     _ => actions.push(Action::WalkToKickOff),
                 },
-                _ => match world_state.filtered_game_controller_state {
-                    Some(FilteredGameControllerState {
-                        game_state:
-                            FilteredGameState::Ready { .. } | FilteredGameState::Playing { .. },
-                        sub_state: Some(SubState::PenaltyKick),
-                        kicking_team: Team::Opponent,
-                        ..
-                    }) => actions.push(Action::DefendPenaltyKick),
-                    _ => actions.push(Action::DefendKickOff),
-                },
+                Some(FilteredGameControllerState {
+                    game_state: FilteredGameState::Ready { .. } | FilteredGameState::Playing { .. },
+                    sub_state: Some(SubState::PenaltyKick),
+                    kicking_team: Team::Opponent,
+                    ..
+                }) => actions.push(Action::DefendPenaltyKick),
+                _ => actions.push(Action::DefendKickOff),
             },
             Role::StrikerSupporter => actions.push(Action::SupportStriker),
         };

--- a/crates/control/src/game_controller_state_filter.rs
+++ b/crates/control/src/game_controller_state_filter.rs
@@ -418,14 +418,14 @@ impl State {
             State::Standby => {
                 if visual_referee_proceed_to_ready {
                     FilteredGameState::Ready {
-                        kicking_team: game_controller_state.kicking_team,
+                        kicking_team: Some(game_controller_state.kicking_team),
                     }
                 } else {
                     FilteredGameState::Standby
                 }
             }
             State::Ready => FilteredGameState::Ready {
-                kicking_team: game_controller_state.kicking_team,
+                kicking_team: Some(game_controller_state.kicking_team),
             },
             State::Set => FilteredGameState::Set,
             State::WhistleInSet {
@@ -450,9 +450,7 @@ impl State {
                 ball_is_free: !(is_in_sub_state && opponent_is_kicking_team),
                 kick_off: false,
             },
-            State::WhistleInPlaying { .. } => FilteredGameState::Ready {
-                kicking_team: Team::Uncertain,
-            },
+            State::WhistleInPlaying { .. } => FilteredGameState::Ready { kicking_team: None },
             State::Finished => match game_controller_state.game_phase {
                 GamePhase::PenaltyShootout { .. } => FilteredGameState::Set,
                 _ => FilteredGameState::Finished,

--- a/crates/control/src/game_controller_state_filter.rs
+++ b/crates/control/src/game_controller_state_filter.rs
@@ -418,14 +418,14 @@ impl State {
             State::Standby => {
                 if visual_referee_proceed_to_ready {
                     FilteredGameState::Ready {
-                        kicking_team: Some(game_controller_state.kicking_team),
+                        kicking_team_known: true,
                     }
                 } else {
                     FilteredGameState::Standby
                 }
             }
             State::Ready => FilteredGameState::Ready {
-                kicking_team: Some(game_controller_state.kicking_team),
+                kicking_team_known: true,
             },
             State::Set => FilteredGameState::Set,
             State::WhistleInSet {
@@ -450,7 +450,9 @@ impl State {
                 ball_is_free: !(is_in_sub_state && opponent_is_kicking_team),
                 kick_off: false,
             },
-            State::WhistleInPlaying { .. } => FilteredGameState::Ready { kicking_team: None },
+            State::WhistleInPlaying { .. } => FilteredGameState::Ready {
+                kicking_team_known: false,
+            },
             State::Finished => match game_controller_state.game_phase {
                 GamePhase::PenaltyShootout { .. } => FilteredGameState::Set,
                 _ => FilteredGameState::Finished,

--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -55,7 +55,7 @@ impl RuleObstacleComposer {
                             | SubState::GoalKick
                             | SubState::PushingFreeKick,
                         ),
-                    kicking_team: Team::Opponent | Team::Uncertain,
+                    kicking_team: Team::Opponent,
                     game_state: FilteredGameState::Playing { .. },
                     ..
                 },
@@ -113,7 +113,7 @@ impl RuleObstacleComposer {
                 FilteredGameControllerState {
                     game_state:
                         FilteredGameState::Ready {
-                            kicking_team: Team::Hulks,
+                            kicking_team: Some(Team::Hulks),
                         },
                     sub_state: None,
                     ..
@@ -131,7 +131,7 @@ impl RuleObstacleComposer {
                 FilteredGameControllerState {
                     game_state:
                         FilteredGameState::Ready {
-                            kicking_team: Team::Opponent | Team::Uncertain,
+                            kicking_team: Some(Team::Opponent),
                         },
                     sub_state: None,
                     ..
@@ -163,8 +163,6 @@ pub fn create_penalty_box(
     let side_factor: f32 = match kicking_team {
         Team::Hulks => 1.0,
         Team::Opponent => -1.0,
-        // Striker may still enter opponent penalty box so this doesn't stop us from defending our own goal
-        Team::Uncertain => 1.0,
     };
     let half_field_length = field_dimensions.length / 2.0;
     let half_penalty_area_length = field_dimensions.penalty_area_length / 2.0;

--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -113,9 +113,10 @@ impl RuleObstacleComposer {
                 FilteredGameControllerState {
                     game_state:
                         FilteredGameState::Ready {
-                            kicking_team: Some(Team::Hulks),
+                            kicking_team_known: true,
                         },
                     sub_state: None,
+                    kicking_team: Team::Hulks,
                     ..
                 },
                 _,
@@ -131,9 +132,10 @@ impl RuleObstacleComposer {
                 FilteredGameControllerState {
                     game_state:
                         FilteredGameState::Ready {
-                            kicking_team: Some(Team::Opponent),
+                            kicking_team_known: true,
                         },
                     sub_state: None,
+                    kicking_team: Team::Opponent,
                     ..
                 },
                 _,

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -167,8 +167,7 @@ fn get_rule_hypotheses(
     filtered_game_controller_state: &FilteredGameControllerState,
     field_dimensions: FieldDimensions,
 ) -> Vec<Point2<Field>> {
-    let kicking_team_half =
-        conservative_kicking_team_half(filtered_game_controller_state.kicking_team);
+    let kicking_team_half = kicking_team_half(filtered_game_controller_state.kicking_team);
 
     match (primary_state, filtered_game_controller_state.sub_state) {
         (PrimaryState::Ready, Some(SubState::PenaltyKick)) => {
@@ -195,11 +194,9 @@ fn get_rule_hypotheses(
     }
 }
 
-fn conservative_kicking_team_half(kicking_team: Team) -> Half {
+fn kicking_team_half(kicking_team: Team) -> Half {
     match kicking_team {
         Team::Opponent => Half::Opponent,
         Team::Hulks => Half::Own,
-        // If uncertain, assume opponent is kicking
-        Team::Uncertain => Half::Opponent,
     }
 }

--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -128,6 +128,7 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
                 message.teams[opponent_team_index].players[player_index as usize].try_into()
             })
             .collect::<Result<Vec<_>>>()?;
+
         Ok(GameControllerStateMessage {
             competition_phase: CompetitionPhase::try_from(message.competitionPhase)?,
             competition_type: CompetitionType::try_from(message.competitionType)?,
@@ -311,7 +312,6 @@ impl GameState {
 }
 
 #[derive(
-    Default,
     Clone,
     Copy,
     Debug,
@@ -326,8 +326,6 @@ impl GameState {
 pub enum Team {
     Hulks,
     Opponent,
-    #[default]
-    Uncertain,
 }
 
 impl Team {

--- a/crates/types/src/filtered_game_controller_state.rs
+++ b/crates/types/src/filtered_game_controller_state.rs
@@ -6,9 +6,7 @@ use spl_network_messages::{GamePhase, Penalty, PlayerNumber, SubState, Team};
 
 use crate::{filtered_game_state::FilteredGameState, players::Players};
 
-#[derive(
-    Default, Clone, Debug, Serialize, Deserialize, PathSerialize, PathIntrospect, PartialEq,
-)]
+#[derive(Clone, Debug, Serialize, Deserialize, PathSerialize, PathIntrospect, PartialEq)]
 
 pub struct FilteredGameControllerState {
     pub game_state: FilteredGameState,
@@ -22,4 +20,21 @@ pub struct FilteredGameControllerState {
 
     pub new_own_penalties_last_cycle: HashMap<PlayerNumber, Penalty>,
     pub new_opponent_penalties_last_cycle: HashMap<PlayerNumber, Penalty>,
+}
+
+impl Default for FilteredGameControllerState {
+    fn default() -> Self {
+        Self {
+            game_state: Default::default(),
+            opponent_game_state: Default::default(),
+            game_phase: Default::default(),
+            kicking_team: Team::Opponent,
+            penalties: Default::default(),
+            remaining_number_of_messages: Default::default(),
+            sub_state: Default::default(),
+            own_team_is_home_after_coin_toss: Default::default(),
+            new_own_penalties_last_cycle: Default::default(),
+            new_opponent_penalties_last_cycle: Default::default(),
+        }
+    }
 }

--- a/crates/types/src/filtered_game_state.rs
+++ b/crates/types/src/filtered_game_state.rs
@@ -19,7 +19,7 @@ pub enum FilteredGameState {
     #[default]
     Initial,
     Ready {
-        kicking_team: Team,
+        kicking_team: Option<Team>,
     },
     Set,
     Playing {

--- a/crates/types/src/filtered_game_state.rs
+++ b/crates/types/src/filtered_game_state.rs
@@ -1,6 +1,5 @@
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
-use spl_network_messages::Team;
 
 #[derive(
     Clone,
@@ -19,7 +18,7 @@ pub enum FilteredGameState {
     #[default]
     Initial,
     Ready {
-        kicking_team: Option<Team>,
+        kicking_team_known: bool,
     },
     Set,
     Playing {

--- a/tests/behavior/demonstration.lua
+++ b/tests/behavior/demonstration.lua
@@ -41,7 +41,7 @@ function on_cycle()
 
   if state.cycle_count == 5000 then
     state.game_controller_state.sub_state = nil
-    state.game_controller_state.kicking_team = "Uncertain"
+    state.game_controller_state.kicking_team = "Hulks"
     set_robot_pose(1, { 3.0, 2.5 }, 0.0)
   end
 


### PR DESCRIPTION
## Why? What?

~~`Team::Uncertain` is removed and wrapped with in `Option` where applicable (only in `FilteredGameState::Ready`)~~
**Update**: there is now only one kicking team in the `GameControllerState` and the `Playing` state contains a flag whether the kicking_team sent by the game controller is trustworthy.

This resolves the necessity to match the uncertain Team kind in places where it is always either Hulks or Opponent anyways.
This was especially annoying with the new behavior simulator but I wanted to make this a separate PR.

### Background

The FilteredGameControllerState contains a `kicking_team` field as well as two fields of type `FilteredGameState`, one for each team.
The `FilteredGameState::Ready` kind is the only place in our code where the `Team` could be `Uncertain` and if it wasn't uncertain, then the kicking team inside this kind was equal to the kicking team in the `FilteredGameState`.


Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Everything should work as before, there are no functional changes.