### PR TITLE
Twix documentation

### DIFF
--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -102,5 +102,5 @@ This downloads and builds all dependencies for the workspace and displays the he
     ```
 
     Pepsi is subsequently installed at `~/.cargo/bin/pepsi`.
-    Don't forget to update it from time to time with `cargo update pepsi` to get the latest features and bugfixes. <br> <br>
+    Don't forget to update it from time to time by reinstalling it to get the latest features and bugfixes. <br> <br>
     The same can also be done for [twix](../tooling/twix.md), our debug tool.

--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -77,7 +77,7 @@ We use Git to manage all our software.
 git clone https://github.com/hulks/hulk.git
 ```
 
-## Build Pepsi
+## Build [Pepsi](../tooling/pepsi.md)
 
 Pepsi is our main tool to interact with the repository, configure NAOs, and upload the software to the robot.
 For a more in depth overview and introduction to Pepsi, consult [../tooling/pepsi.md].
@@ -95,10 +95,12 @@ This downloads and builds all dependencies for the workspace and displays the he
 
 !!! tip
 
-    You can also install Pepsi into your local system to conviniently use it without rebuilding:
+    You can also install Pepsi into your local system to conveniently use it without rebuilding:
 
     ```
     cargo install --path tools/pepsi
     ```
 
     Pepsi is subsequently installed at `~/.cargo/bin/pepsi`.
+    Don't forget to update it from time to time with `cargo update pepsi` to get the latest features and bugfixes. <br> <br>
+    The same can also be done for [twix](../tooling/twix.md), our debug tool.

--- a/docs/tooling/twix.md
+++ b/docs/tooling/twix.md
@@ -11,7 +11,7 @@ Twix is subsequently installed at `~/.cargo/bin/twix`. <br>
 
 !!! tip
 
-    Don't forget to update it from time to time with `cargo update twix` to get the latest features and bugfixes.
+    Don't forget to update it from time to time by reinstalling it to get the latest features and bugfixes.
 
 # Configuration
 

--- a/docs/tooling/twix.md
+++ b/docs/tooling/twix.md
@@ -1,13 +1,29 @@
+# Installation
+
+Twix doesn't have to be installed to be used, it can be directly run from the repository with `./twix` (just as pepsi).
+But you can also install it into your local system to conveniently use it without rebuilding:
+
+```
+cargo install --path tools/twix
+```
+
+Twix is subsequently installed at `~/.cargo/bin/twix`. <br>
+
+!!! tip
+
+    Don't forget to update it from time to time with `cargo update twix` to get the latest features and bugfixes.
+
 # Configuration
 
 Twix loads a user configuration file on startup. The location of the configuration file depends on your platform:
-- Linux: `/home/alice/.config/hulks/twix.toml`
-- Windows: `C:\Users\Alice\AppData\Roaming\hulks\twix.toml`
-- MacOS: `/Users/Alice/Library/Application Support/hulks/twix.toml`
+
+-   Linux: `/home/alice/.config/hulks/twix.toml`
+-   Windows: `C:\Users\Alice\AppData\Roaming\hulks\twix.toml`
+-   MacOS: `/Users/Alice/Library/Application Support/hulks/twix.toml`
 
 See the example config further down on this page for the general format.
 
-After loading the user configuration, it is merged with the default values, which are defined in `tools/twix/default.toml`.
+After loading the user configuration, it is merged with the default values, which are defined in `tools/twix/config_default.toml`.
 
 ## Keybindings
 
@@ -21,12 +37,15 @@ for a complete list of bindable keys.
 Possible modifiers are `A` (Alt), `C` (Ctrl), and `S` (Shift).
 When binding a single-letter key, it is also possible and preferred to specify "Shift" by capitalizing the letter, e.g. `C-T` for Ctrl+Shift+T.
 
-Example keybind triggers:
-- `C-t`: Ctrl + T
-- `C-T`: Ctrl + Shift + T
-- `A-S-Esc`: Alt + Shift + Escape
+!!! example "Example keybind triggers"
+
+    -   `C-t`: Ctrl + T
+    -   `C-T`: Ctrl + Shift + T
+    -   `A-S-Esc`: Alt + Shift + Escape
 
 Possible actions are:
+
+<!-- prettier-ignore -->
 | Action         | Description                                      |
 |----------------|--------------------------------------------------|
 |`close_tab`     | Close current tab                                |
@@ -41,18 +60,18 @@ Possible actions are:
 |`open_tab`      | Open a new tab in the current surface            |
 |`reconnect`     | Reestablish the connection to the NAO            |
 
-## Example configuration
+!!! example "Example configuration"
 
-```toml
-# Remap navigation keys for non-vim users
-[keys]
-C-h = "no_op"
-C-j = "no_op"
-C-k = "no_op"
-C-l = "no_op"
+    ```toml
+    # Remap navigation keys for non-vim users
+    [keys]
+    C-h = "no_op"
+    C-j = "no_op"
+    C-k = "no_op"
+    C-l = "no_op"
 
-C-Left = "focus_left"
-C-Down = "focus_below"
-C-Up = "focus_above"
-C-Right = "focus_right"
-```
+    C-Left = "focus_left"
+    C-Down = "focus_below"
+    C-Up = "focus_above"
+    C-Right = "focus_right"
+    ```


### PR DESCRIPTION
## Why? What?

- There was nothing about the installation
- There were opportunities to use more [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/)
- Update name of twix default config 

## How to Test

run `mkdocs serve`