### PR TITLE
Twix panel to save automatic calibration values to the repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8801,6 +8801,7 @@ dependencies = [
  "ball_filter",
  "bincode",
  "buffered_watch",
+ "calibration",
  "chrono",
  "clap 4.5.31",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8794,7 +8794,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -77,7 +77,6 @@
     }
   },
   "camera_matrix_parameters": {
-    "robot_rotation": [0.0, 0.0, 0.0],
     "vision_top": {
       "camera_pitch": -1.2,
       "extrinsic_rotations": [0, 0, 0],

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -77,6 +77,7 @@
     }
   },
   "camera_matrix_parameters": {
+    "robot_rotation": [0.0, 0.0, 0.0],
     "vision_top": {
       "camera_pitch": -1.2,
       "extrinsic_rotations": [0, 0, 0],

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -11,6 +11,7 @@ argument_parsers = { workspace = true }
 ball_filter = { workspace = true }
 bincode = { workspace = true }
 buffered_watch = { workspace = true }
+calibration = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.9.4"
+version = "0.9.5"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -34,10 +34,9 @@ use log::{error, warn};
 use nao::Nao;
 use panel::Panel;
 use panels::{
-    CameraCalibrationExportPanel, BallCandidatePanel, BehaviorSimulatorPanel,
-    EnumPlotPanel, ImageColorSelectPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel,
-    ManualCalibrationPanel, MapPanel, ParameterPanel, PlotPanel, RemotePanel, TextPanel,
-    VisionTunerPanel,
+    BallCandidatePanel, BehaviorSimulatorPanel, CameraCalibrationExportPanel, EnumPlotPanel,
+    ImageColorSelectPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel, ManualCalibrationPanel,
+    MapPanel, ParameterPanel, PlotPanel, RemotePanel, TextPanel, VisionTunerPanel,
 };
 use reachable_naos::ReachableNaos;
 use repository::{inspect_version::check_for_update, Repository};

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -34,7 +34,7 @@ use log::{error, warn};
 use nao::Nao;
 use panel::Panel;
 use panels::{
-    AutomaticCameraCalibrationExportPanel, BallCandidatePanel, BehaviorSimulatorPanel,
+    CameraCalibrationExportPanel, BallCandidatePanel, BehaviorSimulatorPanel,
     EnumPlotPanel, ImageColorSelectPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel,
     ManualCalibrationPanel, MapPanel, ParameterPanel, PlotPanel, RemotePanel, TextPanel,
     VisionTunerPanel,
@@ -138,7 +138,7 @@ impl_selectable_panel!(
     ImageSegmentsPanel,
     LookAtPanel,
     ManualCalibrationPanel,
-    AutomaticCameraCalibrationExportPanel,
+    CameraCalibrationExportPanel,
     MapPanel,
     ParameterPanel,
     PlotPanel,

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -34,9 +34,10 @@ use log::{error, warn};
 use nao::Nao;
 use panel::Panel;
 use panels::{
-    BallCandidatePanel, BehaviorSimulatorPanel, EnumPlotPanel, ImageColorSelectPanel, ImagePanel,
-    ImageSegmentsPanel, LookAtPanel, ManualCalibrationPanel, MapPanel, ParameterPanel, PlotPanel,
-    RemotePanel, TextPanel, VisionTunerPanel,
+    AutomaticCameraCalibrationExportPanel, BallCandidatePanel, BehaviorSimulatorPanel,
+    EnumPlotPanel, ImageColorSelectPanel, ImagePanel, ImageSegmentsPanel, LookAtPanel,
+    ManualCalibrationPanel, MapPanel, ParameterPanel, PlotPanel, RemotePanel, TextPanel,
+    VisionTunerPanel,
 };
 use reachable_naos::ReachableNaos;
 use repository::{inspect_version::check_for_update, Repository};
@@ -137,6 +138,7 @@ impl_selectable_panel!(
     ImageSegmentsPanel,
     LookAtPanel,
     ManualCalibrationPanel,
+    AutomaticCameraCalibrationExportPanel,
     MapPanel,
     ParameterPanel,
     PlotPanel,

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use eframe::egui::{Response, Ui, Widget};
+use log::error;
+use nalgebra::Vector3;
+use serde_json::Value;
+
+use calibration::corrections::Corrections;
+use communication::messages::TextOrBinary;
+use parameters::directory::Scope;
+
+use crate::{log_error::LogError, nao::Nao, panel::Panel, value_buffer::BufferHandle};
+
+pub const TOP_CAMERA_EXTRINSICS_PATH: &str =
+    "camera_matrix_parameters.vision_top.extrinsic_rotations";
+pub const BOTTOM_CAMERA_EXTRINSICS_PATH: &str =
+    "camera_matrix_parameters.vision_bottom.extrinsic_rotations";
+pub struct AutomaticCameraCalibrationExportPanel {
+    nao: Arc<Nao>,
+    top_camera: BufferHandle<Vector3<f32>>,
+    bottom_camera: BufferHandle<Vector3<f32>>,
+    calibration_corrections: BufferHandle<Value>,
+}
+
+impl Panel for AutomaticCameraCalibrationExportPanel {
+    const NAME: &'static str = "Automatic Calibration";
+
+    fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
+        let top_camera = nao.subscribe_value(format!("parameters.{TOP_CAMERA_EXTRINSICS_PATH}"));
+        let bottom_camera =
+            nao.subscribe_value(format!("parameters.{BOTTOM_CAMERA_EXTRINSICS_PATH}"));
+        let calibration_corrections =
+            nao.subscribe_json("Control.additional_outputs.last_calibration_corrections");
+
+        Self {
+            nao,
+            top_camera,
+            bottom_camera,
+            calibration_corrections,
+        }
+    }
+}
+
+impl Widget for &mut AutomaticCameraCalibrationExportPanel {
+    fn ui(self, ui: &mut Ui) -> Response {
+        ui.style_mut().spacing.slider_width = ui.available_size().x - 250.0;
+        ui.vertical(|ui| {
+            if let Some(value) = self
+                .calibration_corrections
+                .get_last_value()
+                .ok()
+                .flatten()
+                .and_then(|value| serde_json::from_value::<Corrections>(value).ok())
+            {
+                let top_angles = value.correction_in_camera_top.clone().euler_angles();
+                let bottom_angles = value.correction_in_camera_bottom.euler_angles();
+                let body_angles = value.correction_in_robot.euler_angles();
+
+                draw_group(ui, "Top", top_angles, &self.nao, TOP_CAMERA_EXTRINSICS_PATH);
+                draw_angles_from_buffer(ui, &self.top_camera);
+                ui.separator();
+
+                draw_group(
+                    ui,
+                    "Bottom",
+                    bottom_angles,
+                    &self.nao,
+                    BOTTOM_CAMERA_EXTRINSICS_PATH,
+                );
+                draw_angles_from_buffer(ui, &self.bottom_camera);
+                ui.separator();
+
+                draw_group(
+                    ui,
+                    "Body",
+                    body_angles,
+                    &self.nao,
+                    "camera_matrix_parameters.robot_rotation",
+                );
+                draw_angles(ui, body_angles, "Calibrated");
+            } else {
+                ui.label("Not yet calibrated");
+            }
+        })
+        .response
+    }
+}
+
+fn serialize_and_call<V: serde::Serialize, T: FnOnce(serde_json::Value)>(data: V, callback: T) {
+    match serde_json::to_value(data) {
+        Ok(value) => {
+            callback(value);
+        }
+        Err(error) => error!("failed to serialize parameter value: {error:#?}"),
+    }
+}
+
+fn draw_group(ui: &mut Ui, label: &str, rotations: (f32, f32, f32), nao: &Nao, path: &str) {
+    ui.horizontal(|ui| {
+        ui.label(label);
+        if ui.button("Save to repo").clicked() {
+            serialize_and_call(rotations, |value| {
+                nao.store_parameters(path, value, Scope::default_head())
+                    .log_err();
+            });
+        }
+        if ui.button("Set in Nao").clicked() {
+            serialize_and_call(rotations, |value| {
+                nao.write(format!("parameters.{path}"), TextOrBinary::Text(value));
+            });
+        }
+    });
+    draw_angles(ui, rotations, "Calibrated");
+}
+
+fn draw_angles_from_buffer(ui: &mut Ui, current_values: &BufferHandle<Vector3<f32>>) {
+    if let Some(value) = current_values.get_last_value().ok().flatten() {
+        draw_angles(ui, (value.x, value.y, value.z), "Current");
+    }
+}
+fn draw_angles(ui: &mut Ui, rotations: (f32, f32, f32), sublabel: &str) {
+    ui.label(format!(
+        "{sublabel}: [{0:.2}°, {1:.2}°, {2:.2}°]",
+        rotations.0.to_degrees(),
+        rotations.1.to_degrees(),
+        rotations.2.to_degrees()
+    ));
+}

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -19,7 +19,7 @@ pub const BOTTOM_CAMERA_EXTRINSICS_PATH: &str =
 pub const ROBOT_BODY_ROTATION_PATH: &str =
     "camera_matrix_parameters.calibration.correction_in_robot";
 
-pub struct AutomaticCameraCalibrationExportPanel {
+pub struct CameraCalibrationExportPanel {
     nao: Arc<Nao>,
     top_camera: BufferHandle<Vector3<f32>>,
     bottom_camera: BufferHandle<Vector3<f32>>,
@@ -29,7 +29,7 @@ pub struct AutomaticCameraCalibrationExportPanel {
     primary_state: BufferHandle<PrimaryState>,
 }
 
-impl Panel for AutomaticCameraCalibrationExportPanel {
+impl Panel for CameraCalibrationExportPanel {
     const NAME: &'static str = "Automatic Calibration";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
@@ -55,7 +55,7 @@ impl Panel for AutomaticCameraCalibrationExportPanel {
     }
 }
 
-impl Widget for &mut AutomaticCameraCalibrationExportPanel {
+impl Widget for &mut CameraCalibrationExportPanel {
     fn ui(self, ui: &mut Ui) -> Response {
         ui.style_mut().spacing.slider_width = ui.available_size().x - 250.0;
         ui.vertical(|ui| {

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -30,7 +30,7 @@ pub struct CameraCalibrationExportPanel {
 }
 
 impl Panel for CameraCalibrationExportPanel {
-    const NAME: &'static str = "Automatic Calibration";
+    const NAME: &'static str = "Camera Calibration";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         let top_camera = nao.subscribe_value(format!("parameters.{TOP_CAMERA_EXTRINSICS_PATH}"));

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -30,7 +30,7 @@ pub struct CameraCalibrationExportPanel {
 }
 
 impl Panel for CameraCalibrationExportPanel {
-    const NAME: &'static str = "Camera Calibration";
+    const NAME: &'static str = "Camera Calibration Export";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
         let top_camera = nao.subscribe_value(format!("parameters.{TOP_CAMERA_EXTRINSICS_PATH}"));

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -17,6 +17,7 @@ pub const TOP_CAMERA_EXTRINSICS_PATH: &str =
 pub const BOTTOM_CAMERA_EXTRINSICS_PATH: &str =
     "camera_matrix_parameters.vision_bottom.extrinsic_rotations";
 pub const ROBOT_BODY_ROTATION_PATH: &str = "camera_matrix_parameters.robot_rotation";
+
 pub struct AutomaticCameraCalibrationExportPanel {
     nao: Arc<Nao>,
     top_camera: BufferHandle<Vector3<f32>>,
@@ -64,9 +65,9 @@ impl Widget for &mut AutomaticCameraCalibrationExportPanel {
                 .flatten()
                 .and_then(|value| serde_json::from_value::<Corrections>(value).ok())
             {
-                let top_angles = value.correction_in_camera_top.inner.euler_angles();
-                let bottom_angles = value.correction_in_camera_bottom.inner.euler_angles();
-                let body_angles = value.correction_in_robot.inner.euler_angles();
+                let top_angles = value.correction_in_camera_top.euler_angles();
+                let bottom_angles = value.correction_in_camera_bottom.euler_angles();
+                let body_angles = value.correction_in_robot.euler_angles();
 
                 draw_group(ui, "Top", top_angles, &self.nao, TOP_CAMERA_EXTRINSICS_PATH);
                 draw_angles_from_buffer(ui, &self.top_camera);

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use calibration::corrections::Corrections;
 use communication::messages::TextOrBinary;
 use parameters::directory::Scope;
+use types::primary_state::PrimaryState;
 
 use crate::{log_error::LogError, nao::Nao, panel::Panel, value_buffer::BufferHandle};
 
@@ -15,11 +16,15 @@ pub const TOP_CAMERA_EXTRINSICS_PATH: &str =
     "camera_matrix_parameters.vision_top.extrinsic_rotations";
 pub const BOTTOM_CAMERA_EXTRINSICS_PATH: &str =
     "camera_matrix_parameters.vision_bottom.extrinsic_rotations";
+pub const ROBOT_BODY_ROTATION_PATH: &str = "camera_matrix_parameters.robot_rotation";
 pub struct AutomaticCameraCalibrationExportPanel {
     nao: Arc<Nao>,
     top_camera: BufferHandle<Vector3<f32>>,
     bottom_camera: BufferHandle<Vector3<f32>>,
+    robot_body_rotations: BufferHandle<Vector3<f32>>,
     calibration_corrections: BufferHandle<Value>,
+    calibration_measurements: BufferHandle<Value>,
+    primary_state: BufferHandle<PrimaryState>,
 }
 
 impl Panel for AutomaticCameraCalibrationExportPanel {
@@ -29,14 +34,21 @@ impl Panel for AutomaticCameraCalibrationExportPanel {
         let top_camera = nao.subscribe_value(format!("parameters.{TOP_CAMERA_EXTRINSICS_PATH}"));
         let bottom_camera =
             nao.subscribe_value(format!("parameters.{BOTTOM_CAMERA_EXTRINSICS_PATH}"));
-        let calibration_corrections =
-            nao.subscribe_json("Control.additional_outputs.last_calibration_corrections");
+        let body_rotations = nao.subscribe_value(format!("parameters.{ROBOT_BODY_ROTATION_PATH}"));
+        let calibration_corrections = nao
+            .subscribe_json("Control.additional_outputs.calibration_controller.last_corrections");
+        let calibration_measurements = nao
+            .subscribe_json("Control.additional_outputs.calibration_controller.last_measurements");
+        let primary_state = nao.subscribe_value("Control.main_outputs.primary_state");
 
         Self {
             nao,
             top_camera,
             bottom_camera,
+            robot_body_rotations: body_rotations,
             calibration_corrections,
+            calibration_measurements,
+            primary_state,
         }
     }
 }
@@ -52,9 +64,9 @@ impl Widget for &mut AutomaticCameraCalibrationExportPanel {
                 .flatten()
                 .and_then(|value| serde_json::from_value::<Corrections>(value).ok())
             {
-                let top_angles = value.correction_in_camera_top.clone().euler_angles();
-                let bottom_angles = value.correction_in_camera_bottom.euler_angles();
-                let body_angles = value.correction_in_robot.euler_angles();
+                let top_angles = value.correction_in_camera_top.inner.euler_angles();
+                let bottom_angles = value.correction_in_camera_bottom.inner.euler_angles();
+                let body_angles = value.correction_in_robot.inner.euler_angles();
 
                 draw_group(ui, "Top", top_angles, &self.nao, TOP_CAMERA_EXTRINSICS_PATH);
                 draw_angles_from_buffer(ui, &self.top_camera);
@@ -70,16 +82,37 @@ impl Widget for &mut AutomaticCameraCalibrationExportPanel {
                 draw_angles_from_buffer(ui, &self.bottom_camera);
                 ui.separator();
 
-                draw_group(
-                    ui,
-                    "Body",
-                    body_angles,
-                    &self.nao,
-                    "camera_matrix_parameters.robot_rotation",
-                );
-                draw_angles(ui, body_angles, "Calibrated");
+                draw_group(ui, "Body", body_angles, &self.nao, ROBOT_BODY_ROTATION_PATH);
+                draw_angles_from_buffer(ui, &self.robot_body_rotations);
+
+                if let Some(measurements_value) = self
+                    .calibration_measurements
+                    .get_last_value()
+                    .ok()
+                    .flatten()
+                {
+                    ui.separator();
+                    ui.label("Measurements");
+                    if ui.button("Download").clicked() {
+                        // save measurement to disk as json
+                        let json = serde_json::to_string_pretty(&measurements_value).unwrap();
+                        let path = "measurements.json";
+
+                        std::fs::write(path, json).unwrap();
+                    }
+                }
             } else {
-                ui.label("Not yet calibrated");
+                self.primary_state
+                    .get_last_value()
+                    .ok()
+                    .flatten()
+                    .map(|primary_state| match primary_state {
+                        PrimaryState::Calibration => ui.label("Calibration in progress"),
+                        _ => ui.label(format!(
+                            "Not yet calibrated, primary state: {:?}",
+                            primary_state
+                        )),
+                    });
             }
         })
         .response
@@ -95,34 +128,38 @@ fn serialize_and_call<V: serde::Serialize, T: FnOnce(serde_json::Value)>(data: V
     }
 }
 
-fn draw_group(ui: &mut Ui, label: &str, rotations: (f32, f32, f32), nao: &Nao, path: &str) {
+fn draw_group(ui: &mut Ui, label: &str, rotations_radians: (f32, f32, f32), nao: &Nao, path: &str) {
+    let rotations_degrees = [
+        rotations_radians.0,
+        rotations_radians.1,
+        rotations_radians.2,
+    ]
+    .map(|radians: f32| radians.to_degrees());
     ui.horizontal(|ui| {
         ui.label(label);
         if ui.button("Save to repo").clicked() {
-            serialize_and_call(rotations, |value| {
+            serialize_and_call(rotations_degrees, |value| {
                 nao.store_parameters(path, value, Scope::default_head())
                     .log_err();
             });
         }
         if ui.button("Set in Nao").clicked() {
-            serialize_and_call(rotations, |value| {
+            serialize_and_call(rotations_degrees, |value| {
                 nao.write(format!("parameters.{path}"), TextOrBinary::Text(value));
             });
         }
     });
-    draw_angles(ui, rotations, "Calibrated");
+    draw_angles(ui, &rotations_degrees, "Calibrated");
 }
 
 fn draw_angles_from_buffer(ui: &mut Ui, current_values: &BufferHandle<Vector3<f32>>) {
     if let Some(value) = current_values.get_last_value().ok().flatten() {
-        draw_angles(ui, (value.x, value.y, value.z), "Current");
+        draw_angles(ui, &[value.x, value.y, value.z], "Current");
     }
 }
-fn draw_angles(ui: &mut Ui, rotations: (f32, f32, f32), sublabel: &str) {
+fn draw_angles(ui: &mut Ui, rotations_degrees: &[f32; 3], sublabel: &str) {
     ui.label(format!(
         "{sublabel}: [{0:.2}°, {1:.2}°, {2:.2}°]",
-        rotations.0.to_degrees(),
-        rotations.1.to_degrees(),
-        rotations.2.to_degrees()
+        rotations_degrees[0], rotations_degrees[1], rotations_degrees[2]
     ));
 }

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -16,7 +16,8 @@ pub const TOP_CAMERA_EXTRINSICS_PATH: &str =
     "camera_matrix_parameters.vision_top.extrinsic_rotations";
 pub const BOTTOM_CAMERA_EXTRINSICS_PATH: &str =
     "camera_matrix_parameters.vision_bottom.extrinsic_rotations";
-pub const ROBOT_BODY_ROTATION_PATH: &str = "camera_matrix_parameters.robot_rotation";
+pub const ROBOT_BODY_ROTATION_PATH: &str =
+    "camera_matrix_parameters.calibration.correction_in_robot";
 
 pub struct AutomaticCameraCalibrationExportPanel {
     nao: Arc<Nao>,

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -23,7 +23,7 @@ pub struct CameraCalibrationExportPanel {
     nao: Arc<Nao>,
     top_camera: BufferHandle<Vector3<f32>>,
     bottom_camera: BufferHandle<Vector3<f32>>,
-    robot_body_rotations: BufferHandle<Vector3<f32>>,
+    body_rotations: BufferHandle<Vector3<f32>>,
     calibration_corrections: BufferHandle<Value>,
     calibration_measurements: BufferHandle<Value>,
     primary_state: BufferHandle<PrimaryState>,
@@ -37,17 +37,17 @@ impl Panel for CameraCalibrationExportPanel {
         let bottom_camera =
             nao.subscribe_value(format!("parameters.{BOTTOM_CAMERA_EXTRINSICS_PATH}"));
         let body_rotations = nao.subscribe_value(format!("parameters.{ROBOT_BODY_ROTATION_PATH}"));
-        let calibration_corrections = nao
-            .subscribe_json("Control.additional_outputs.calibration_controller.last_corrections");
-        let calibration_measurements = nao
-            .subscribe_json("Control.additional_outputs.calibration_controller.last_measurements");
+        let calibration_corrections =
+            nao.subscribe_json("Control.additional_outputs.last_corrections");
+        let calibration_measurements =
+            nao.subscribe_json("Control.additional_outputs.last_measurements");
         let primary_state = nao.subscribe_value("Control.main_outputs.primary_state");
 
         Self {
             nao,
             top_camera,
             bottom_camera,
-            robot_body_rotations: body_rotations,
+            body_rotations: body_rotations,
             calibration_corrections,
             calibration_measurements,
             primary_state,
@@ -85,7 +85,7 @@ impl Widget for &mut CameraCalibrationExportPanel {
                 ui.separator();
 
                 draw_group(ui, "Body", body_angles, &self.nao, ROBOT_BODY_ROTATION_PATH);
-                draw_angles_from_buffer(ui, &self.robot_body_rotations);
+                draw_angles_from_buffer(ui, &self.body_rotations);
 
                 if let Some(measurements_value) = self
                     .calibration_measurements
@@ -159,6 +159,7 @@ fn draw_angles_from_buffer(ui: &mut Ui, current_values: &BufferHandle<Vector3<f3
         draw_angles(ui, &[value.x, value.y, value.z], "Current");
     }
 }
+
 fn draw_angles(ui: &mut Ui, rotations_degrees: &[f32; 3], sublabel: &str) {
     ui.label(format!(
         "{sublabel}: [{0:.2}°, {1:.2}°, {2:.2}°]",

--- a/tools/twix/src/panels/automatic_camera_calibration_export.rs
+++ b/tools/twix/src/panels/automatic_camera_calibration_export.rs
@@ -47,7 +47,7 @@ impl Panel for CameraCalibrationExportPanel {
             nao,
             top_camera,
             bottom_camera,
-            body_rotations: body_rotations,
+            body_rotations,
             calibration_corrections,
             calibration_measurements,
             primary_state,

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -7,7 +7,13 @@ use nalgebra::Vector3;
 use parameters::directory::Scope;
 use serde_json::Value;
 
-use crate::{log_error::LogError, nao::Nao, panel::Panel, value_buffer::BufferHandle};
+use crate::{
+    log_error::LogError,
+    nao::Nao,
+    panel::Panel,
+    panels::{BOTTOM_CAMERA_EXTRINSICS_PATH, TOP_CAMERA_EXTRINSICS_PATH},
+    value_buffer::BufferHandle,
+};
 
 pub struct ManualCalibrationPanel {
     nao: Arc<Nao>,
@@ -19,12 +25,9 @@ impl Panel for ManualCalibrationPanel {
     const NAME: &'static str = "Manual Calibration";
 
     fn new(nao: Arc<Nao>, _value: Option<&Value>) -> Self {
-        let top_camera = nao.subscribe_value(
-            "parameters.camera_matrix_parameters.vision_top.extrinsic_rotations".to_string(),
-        );
-        let bottom_camera = nao.subscribe_value(
-            "parameters.camera_matrix_parameters.vision_bottom.extrinsic_rotations".to_string(),
-        );
+        let top_camera = nao.subscribe_value(format!("parameters.{TOP_CAMERA_EXTRINSICS_PATH}"));
+        let bottom_camera =
+            nao.subscribe_value(format!("parameters.{BOTTOM_CAMERA_EXTRINSICS_PATH}"));
 
         Self {
             nao,
@@ -44,7 +47,7 @@ impl Widget for &mut ManualCalibrationPanel {
                     "Top Camera",
                     value,
                     &self.nao,
-                    "camera_matrix_parameters.vision_top.extrinsic_rotations",
+                    TOP_CAMERA_EXTRINSICS_PATH,
                 );
             }
             ui.separator();
@@ -54,7 +57,7 @@ impl Widget for &mut ManualCalibrationPanel {
                     "Bottom Camera",
                     value,
                     &self.nao,
-                    "camera_matrix_parameters.vision_bottom.extrinsic_rotations",
+                    BOTTOM_CAMERA_EXTRINSICS_PATH,
                 );
             }
         })
@@ -82,8 +85,15 @@ fn draw_calibration_ui(
             }
         }
     });
+
+    // DO NOT REMOVE THIS.
+    // In order to save user's sanity, roll, pitch, yaw are swapped to the actual way an airplane fly
+    // rotations.{x,y,z} are in OpenCV convention (z to robot front)
+    // roll -> z
+    // pitch -> x
+    // yaw -> y
     let range = -15.0..=15.0;
-    let mut roll = rotations.x;
+    let mut roll = rotations.z; // See above
     let response = ui.add(
         Slider::new(&mut roll, range.clone())
             .text("Roll")
@@ -91,11 +101,11 @@ fn draw_calibration_ui(
     );
     if response.changed() {
         nao.write(
-            format!("parameters.{path}.x"),
+            format!("parameters.{path}.z"),
             TextOrBinary::Text(serde_json::to_value(roll).unwrap()),
         );
     }
-    let mut pitch = rotations.y;
+    let mut pitch = rotations.x; // See above
     let response = ui.add(
         Slider::new(&mut pitch, range.clone())
             .text("Pitch")
@@ -103,15 +113,15 @@ fn draw_calibration_ui(
     );
     if response.changed() {
         nao.write(
-            format!("parameters.{path}.y"),
+            format!("parameters.{path}.x"),
             TextOrBinary::Text(serde_json::to_value(pitch).unwrap()),
         );
     }
-    let mut yaw = rotations.z;
+    let mut yaw = rotations.y; // See above
     let response = ui.add(Slider::new(&mut yaw, range).text("Yaw").smart_aim(false));
     if response.changed() {
         nao.write(
-            format!("parameters.{path}.z"),
+            format!("parameters.{path}.y"),
             TextOrBinary::Text(serde_json::to_value(yaw).unwrap()),
         );
     }

--- a/tools/twix/src/panels/manual_camera_calibration.rs
+++ b/tools/twix/src/panels/manual_camera_calibration.rs
@@ -86,14 +86,9 @@ fn draw_calibration_ui(
         }
     });
 
-    // DO NOT REMOVE THIS.
-    // In order to save user's sanity, roll, pitch, yaw are swapped to the actual way an airplane fly
-    // rotations.{x,y,z} are in OpenCV convention (z to robot front)
-    // roll -> z
-    // pitch -> x
-    // yaw -> y
+    // Note: Roll, pitch, yaw are swapped to the actual way an airplane fly in the following section for the UI
     let range = -15.0..=15.0;
-    let mut roll = rotations.z; // See above
+    let mut roll = rotations.z;
     let response = ui.add(
         Slider::new(&mut roll, range.clone())
             .text("Roll")
@@ -105,7 +100,7 @@ fn draw_calibration_ui(
             TextOrBinary::Text(serde_json::to_value(roll).unwrap()),
         );
     }
-    let mut pitch = rotations.x; // See above
+    let mut pitch = rotations.x;
     let response = ui.add(
         Slider::new(&mut pitch, range.clone())
             .text("Pitch")
@@ -117,7 +112,7 @@ fn draw_calibration_ui(
             TextOrBinary::Text(serde_json::to_value(pitch).unwrap()),
         );
     }
-    let mut yaw = rotations.y; // See above
+    let mut yaw = rotations.y;
     let response = ui.add(Slider::new(&mut yaw, range).text("Yaw").smart_aim(false));
     if response.changed() {
         nao.write(

--- a/tools/twix/src/panels/mod.rs
+++ b/tools/twix/src/panels/mod.rs
@@ -1,3 +1,4 @@
+mod automatic_camera_calibration_export;
 mod ball_candidates;
 mod behavior_simulator;
 mod enum_plot;
@@ -13,6 +14,10 @@ mod remote;
 mod text;
 mod vision_tuner;
 
+pub use automatic_camera_calibration_export::{
+    AutomaticCameraCalibrationExportPanel, BOTTOM_CAMERA_EXTRINSICS_PATH,
+    TOP_CAMERA_EXTRINSICS_PATH,
+};
 pub use ball_candidates::BallCandidatePanel;
 pub use behavior_simulator::BehaviorSimulatorPanel;
 pub use enum_plot::EnumPlotPanel;

--- a/tools/twix/src/panels/mod.rs
+++ b/tools/twix/src/panels/mod.rs
@@ -15,8 +15,7 @@ mod text;
 mod vision_tuner;
 
 pub use automatic_camera_calibration_export::{
-    CameraCalibrationExportPanel, BOTTOM_CAMERA_EXTRINSICS_PATH,
-    TOP_CAMERA_EXTRINSICS_PATH,
+    CameraCalibrationExportPanel, BOTTOM_CAMERA_EXTRINSICS_PATH, TOP_CAMERA_EXTRINSICS_PATH,
 };
 pub use ball_candidates::BallCandidatePanel;
 pub use behavior_simulator::BehaviorSimulatorPanel;

--- a/tools/twix/src/panels/mod.rs
+++ b/tools/twix/src/panels/mod.rs
@@ -15,7 +15,7 @@ mod text;
 mod vision_tuner;
 
 pub use automatic_camera_calibration_export::{
-    AutomaticCameraCalibrationExportPanel, BOTTOM_CAMERA_EXTRINSICS_PATH,
+    CameraCalibrationExportPanel, BOTTOM_CAMERA_EXTRINSICS_PATH,
     TOP_CAMERA_EXTRINSICS_PATH,
 };
 pub use ball_candidates::BallCandidatePanel;


### PR DESCRIPTION
## Why? What?

Similar functionality to the Manual Calibration panel, subscribes to the additional output from calibration controller and re-use the "save to head" button used elsewhere :) + set-in-nao
- Also fixed the Roll-Pitch-Yaw labels in the manual panel so that the human doing the tuning can do it as before without getting their brain tangled :P 

Left hand side shows the result from calibration and when "set in Nao" is clicked it is synced to the nao (as seen on manual calibration panel) and save to repo will automagically update the right JSON file ;)

![image](https://github.com/user-attachments/assets/f0e4694c-ecf6-442a-a656-58d3d0ebc5f0)

Fixes #

https://github.com/HULKs/hulk/issues/1115

## TODO/ Known Issues

- [x] ~For unknown reasons, I had to use `subscribe_json` for `Control.additional_outputs.last_calibration_corrections`, otherwise the deserialized values were garbage!~ -> #1448

## Ideas for Next Iterations (Not This PR)

* Add statistics, metrics (i.e. RMSE - root mean square error), etc to the panel (after implementing)
    * Helps to decide if a calibration run is good.

## How to Test

Launch twix and open "Automatic camera calibration..." panel. Once calibratiopn process is completed, it should display the values.