### PR TITLE
prefix with docker.io

### DIFF
--- a/tools/ci/github-runners/Containerfile
+++ b/tools/ci/github-runners/Containerfile
@@ -1,6 +1,7 @@
-FROM rust:1.78.0
+FROM docker.io/rust:1.78.0
 
 RUN apt-get update && apt-get install --no-install-recommends --yes \
+  buildah \
   clang \
   cmake \
   git-lfs \


### PR DESCRIPTION
## Why? What?
```
Error: creating build container: short-name "rust:1.78.0" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```