### PR TITLE
Run CI workflow on github runners

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -10,9 +10,7 @@ env:
 jobs:
   build:
     name: Build and Push CI Image
-    runs-on:
-      - self-hosted
-      - v3
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Why? What?

I did not get buildah running on our runners as they are inside an LXC container... This (as well as `meta-nao`) now moves the container building and releasing stuff to the github hosted runners