### PR TITLE
remove impl for default when #[default] is enough

### DIFF
--- a/crates/types/src/initial_look_around.rs
+++ b/crates/types/src/initial_look_around.rs
@@ -17,7 +17,7 @@ pub enum BallSearchLookAround {
 impl Default for BallSearchLookAround {
     fn default() -> Self {
         Self::Center {
-            moving_towards: Side::Left,
+            moving_towards: Side::default(),
         }
     }
 }
@@ -38,17 +38,20 @@ pub struct QuickLookAround {
 }
 
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect,
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
 )]
 pub enum InitialLookAround {
+    #[default]
     Left,
     Right,
-}
-
-impl Default for InitialLookAround {
-    fn default() -> Self {
-        Self::Left
-    }
 }
 
 #[derive(

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -15,6 +15,7 @@ pub struct MotionSelection {
     Clone,
     Copy,
     Debug,
+    Default,
     Deserialize,
     Eq,
     PartialEq,
@@ -40,15 +41,10 @@ pub enum MotionType {
     StandUpBack,
     StandUpFront,
     StandUpSitting,
+    #[default]
     Unstiff,
     Walk,
     WideStance,
-}
-
-impl Default for MotionType {
-    fn default() -> Self {
-        Self::Unstiff
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]

--- a/crates/types/src/support_foot.rs
+++ b/crates/types/src/support_foot.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
     Clone,
     Copy,
     Debug,
+    Default,
     Deserialize,
     Eq,
     PartialEq,
@@ -14,6 +15,7 @@ use serde::{Deserialize, Serialize};
     PathIntrospect,
 )]
 pub enum Side {
+    #[default]
     Left,
     Right,
 }
@@ -24,12 +26,6 @@ impl Side {
             Side::Left => Self::Right,
             Side::Right => Self::Left,
         }
-    }
-}
-
-impl Default for Side {
-    fn default() -> Self {
-        Self::Left
     }
 }
 


### PR DESCRIPTION
## Why? What?

We have a few spots where we custom implement default() even though it is unnecessary.
This cleans that up.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test
