### PR TITLE
Use incremental profile for cargo test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -98,7 +98,7 @@ jobs:
           lfs: true
       - name: Test
         run: |
-          cargo test --all-features --workspace
+          cargo test --profile incremental --all-features --workspace
 
   build:
     name: Build


### PR DESCRIPTION
## Why? What?

The Test CI check has been one of the slowest for quite a while now, often taking ~40s even when almost nothing needs to be recompiled.

Using the incremental profile should speed up recompilation a bit but most significantly should speed up test execution.
Test execution times excluding compilation on my desktop (equivalent hardware to our CI runner):
```bash
$ cargo test --all-features --workspace 
183.09s user 4.22s system 510% cpu 36.704 total

$ cargo test --profile incremental --all-features --workspace
14.74s user 5.04s system 289% cpu 6.833 total
```

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

See CI