### PR TITLE
fix center circle violation

### DIFF
--- a/crates/control/src/rule_obstacle_composer.rs
+++ b/crates/control/src/rule_obstacle_composer.rs
@@ -132,6 +132,14 @@ impl RuleObstacleComposer {
                 FilteredGameControllerState {
                     game_state:
                         FilteredGameState::Ready {
+                            kicking_team_known: false,
+                        },
+                    sub_state: None,
+                    ..
+                }
+                | FilteredGameControllerState {
+                    game_state:
+                        FilteredGameState::Ready {
                             kicking_team_known: true,
                         },
                     sub_state: None,


### PR DESCRIPTION
## Why? What?

Fixes the robot walking through the center circle obstacle if the kicking team is unknown. Was a bug of #1427.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Let the robot score a goal and it doesnt walk through the center circle back to its pose
