### PR TITLE
Add parameter to force enable pose_detection

### DIFF
--- a/crates/object_detection/src/pose_detection.rs
+++ b/crates/object_detection/src/pose_detection.rs
@@ -60,6 +60,7 @@ pub struct CycleContext {
         Parameter<f32, "pose_detection.maximum_intersection_over_union">,
     minimum_bounding_box_confidence:
         Parameter<f32, "pose_detection.minimum_bounding_box_confidence">,
+    override_pose_detection: Parameter<bool, "pose_detection.override_pose_detection">,
 }
 
 #[context]
@@ -117,7 +118,7 @@ impl PoseDetection {
                 ..
             }
         );
-        if !behavior_requests_pose_detection {
+        if !behavior_requests_pose_detection && !context.override_pose_detection {
             return Ok(MainOutputs::default());
         };
 

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -9,7 +9,8 @@
     "minimum_shoulder_angle": 0.2,
     "foot_z_offset": 0.025,
     "referee_pose_queue_length": 8,
-    "minimum_number_poses_before_message": 3
+    "minimum_number_poses_before_message": 3,
+    "override_pose_detection": false
   },
   "feet_detection": {
     "vision_top": {


### PR DESCRIPTION
## Why? What?

It's annoying to always setup a visual referee scenario, when simply wanting to test the pose detection.
This adds a simple parameter called `override_pose_detection`, that overrides the enable condition for the `pose_detection.rs` module.   

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Upload to NAO with `override_pose_detection = true` in the `default.json`
- In twix, enable the `Pose Detection` overlay in an image tab and see if pose detection is running 
