### PR TITLE
Add `secsf32` and `millis` path_serde path to `Duration`

### DIFF
--- a/crates/path_serde/src/implementation.rs
+++ b/crates/path_serde/src/implementation.rs
@@ -748,7 +748,7 @@ impl PathDeserialize for Duration {
 
 impl PathIntrospect for Duration {
     fn extend_with_fields(fields: &mut HashSet<String>, prefix: &str) {
-        fields.insert(format!("{prefix}nanos"));
-        fields.insert(format!("{prefix}secs"));
+        fields.insert(format!("{prefix}secsf32"));
+        fields.insert(format!("{prefix}millis"));
     }
 }

--- a/crates/path_serde/src/implementation.rs
+++ b/crates/path_serde/src/implementation.rs
@@ -702,7 +702,7 @@ impl PathSerialize for Duration {
         S: Serializer,
     {
         match path {
-            "secsf32" => self
+            "secs_f32" => self
                 .as_secs_f32()
                 .serialize(serializer)
                 .map_err(serialize::Error::SerializationFailed),
@@ -727,10 +727,10 @@ impl PathDeserialize for Duration {
         D: Deserializer<'de>,
     {
         match path {
-            "secsf32" => {
-                let secsf32 = f32::deserialize(deserializer)
+            "secs_f32" => {
+                let secs_f32 = f32::deserialize(deserializer)
                     .map_err(deserialize::Error::DeserializationFailed)?;
-                *self = Duration::from_secs_f32(secsf32);
+                *self = Duration::from_secs_f32(secs_f32);
                 Ok(())
             }
             "millis" => {
@@ -748,7 +748,7 @@ impl PathDeserialize for Duration {
 
 impl PathIntrospect for Duration {
     fn extend_with_fields(fields: &mut HashSet<String>, prefix: &str) {
-        fields.insert(format!("{prefix}secsf32"));
+        fields.insert(format!("{prefix}secs_f32"));
         fields.insert(format!("{prefix}millis"));
     }
 }

--- a/crates/path_serde/src/not_supported.rs
+++ b/crates/path_serde/src/not_supported.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::SocketAddr,
     path::PathBuf,
-    time::{Duration, SystemTime},
+    time::SystemTime,
 };
 
 use crate::{deserialize, serialize, PathDeserialize, PathIntrospect, PathSerialize};
@@ -98,7 +98,6 @@ implement_as_not_supported!(Rotation3<f32>);
 implement_as_not_supported!(SMatrix<f32, 3, 3>);
 implement_as_not_supported!(SMatrix<f32, 3, 4>);
 // stdlib
-implement_as_not_supported!(Duration);
 implement_as_not_supported!(HashMap<K, V>, K, V);
 implement_as_not_supported!(HashSet<T>, T);
 implement_as_not_supported!(PathBuf);


### PR DESCRIPTION
## Why? What?

It was annoying to read the `Duration` in twix. 265314121 ns is just not as legible as 265 ms. 
Adds a `.millis` and `.secs_f32` path implementation to `Duration` path_serde. 
In twix one can now for example subscribe the text `ObjectDetectionTop.additional_outputs.inference_duration.millis` to see the `Duration` milliseconds. 

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- Subscribe to any Duration in twix with `.millis` and `.secs_f32` appended
