### PR TITLE
Fix walk acceleration

### DIFF
--- a/crates/walking_engine/src/mode/walking.rs
+++ b/crates/walking_engine/src/mode/walking.rs
@@ -29,7 +29,11 @@ impl Walking {
         let (backward_acceleration, forward_acceleration) =
             if last_requested_step.forward.is_sign_positive() {
                 (
-                    -last_requested_step.forward,
+                    if last_requested_step.forward > 0.0 {
+                        -last_requested_step.forward
+                    } else {
+                        -context.parameters.max_forward_acceleration
+                    },
                     context.parameters.max_forward_acceleration,
                 )
             } else {

--- a/crates/walking_engine/src/mode/walking.rs
+++ b/crates/walking_engine/src/mode/walking.rs
@@ -1,4 +1,5 @@
 use super::{catching::Catching, kicking::Kicking, stopping::Stopping, Mode, WalkTransition};
+use nalgebra::RealField;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 use types::{
@@ -26,10 +27,23 @@ impl Walking {
         support_side: Side,
         last_requested_step: Step,
     ) -> Self {
+        let (backward_acceleration, forward_acceleration) =
+            if last_requested_step.forward.is_sign_positive() {
+                (
+                    -last_requested_step.forward,
+                    context.parameters.max_forward_acceleration,
+                )
+            } else {
+                (
+                    -context.parameters.max_forward_acceleration,
+                    last_requested_step.forward,
+                )
+            };
+
         let requested_step = Step {
             forward: last_requested_step.forward
                 + (requested_step.forward - last_requested_step.forward)
-                    .min(context.parameters.max_forward_acceleration),
+                    .clamp(backward_acceleration, forward_acceleration),
             left: requested_step.left,
             turn: requested_step.turn,
         };

--- a/crates/walking_engine/src/mode/walking.rs
+++ b/crates/walking_engine/src/mode/walking.rs
@@ -1,5 +1,4 @@
 use super::{catching::Catching, kicking::Kicking, stopping::Stopping, Mode, WalkTransition};
-use nalgebra::RealField;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 use types::{

--- a/crates/walking_engine/src/mode/walking.rs
+++ b/crates/walking_engine/src/mode/walking.rs
@@ -26,22 +26,22 @@ impl Walking {
         support_side: Side,
         last_requested_step: Step,
     ) -> Self {
-        let (backward_acceleration, forward_acceleration) =
-            if last_requested_step.forward.is_sign_positive() {
-                (
-                    if last_requested_step.forward > 0.0 {
-                        -last_requested_step.forward
-                    } else {
-                        -context.parameters.max_forward_acceleration
-                    },
-                    context.parameters.max_forward_acceleration,
-                )
-            } else {
-                (
-                    -context.parameters.max_forward_acceleration,
-                    last_requested_step.forward,
-                )
-            };
+        let (backward_acceleration, forward_acceleration) = if last_requested_step.forward > 0.0 {
+            (
+                -last_requested_step.forward,
+                context.parameters.max_forward_acceleration,
+            )
+        } else if last_requested_step.forward == 0.0 {
+            (
+                -context.parameters.max_forward_acceleration,
+                context.parameters.max_forward_acceleration,
+            )
+        } else {
+            (
+                -context.parameters.max_forward_acceleration,
+                -last_requested_step.forward,
+            )
+        };
 
         let requested_step = Step {
             forward: last_requested_step.forward

--- a/crates/walking_engine/src/parameters.rs
+++ b/crates/walking_engine/src/parameters.rs
@@ -18,6 +18,8 @@ pub struct Parameters {
     pub gyro_balancing: GyroBalancingParameters,
     pub max_forward_acceleration: f32,
     pub max_inside_turn: f32,
+    pub max_level_delta: f32,
+    pub max_rotation_speed: f32,
     pub max_step_duration: Duration,
     pub max_support_foot_lift_speed: f32,
     pub min_step_duration: Duration,
@@ -26,8 +28,6 @@ pub struct Parameters {
     pub step_midpoint: Step,
     pub stiffnesses: Stiffnesses,
     pub swinging_arms: SwingingArmsParameters,
-    pub max_level_delta: f32,
-    pub max_rotation_speed: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -400,8 +400,8 @@
     "injected_step": null,
     "max_step_size": {
       "forward": 0.045,
-      "left": 0.1,
-      "turn": 1.0
+      "left": 0.06,
+      "turn": 0.5
     },
     "step_size_delta_slow": {
       "forward": -0.025,
@@ -411,7 +411,7 @@
     "step_size_delta_fast": {
       "forward": 0.01,
       "left": 0.04,
-      "turn": 0.0
+      "turn": 0.2
     },
     "max_step_size_backwards": 0.04,
     "translation_exponent": 1.5,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -403,6 +403,7 @@
       "left": 0.06,
       "turn": 0.5
     },
+    "initial_side_bonus": 0.04,
     "step_size_delta_slow": {
       "forward": -0.025,
       "left": 0.0,


### PR DESCRIPTION
## Why? What?

- Now, also the backwards acceleration is limited
- It's always still possible to directly stop 
- Reduces turn speed
  - When this is too high, the robot falls forwards when the hip-yaw-pitch opens
- Reduces side-steps-size

## How to Test

Let it walk