### PR TITLE
Add taplo to CI image

### DIFF
--- a/tools/ci/github-runners/Containerfile
+++ b/tools/ci/github-runners/Containerfile
@@ -22,3 +22,4 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
   && rm --recursive --force /var/lib/apt/lists/*
 
 RUN rustup component add clippy rustfmt
+RUN cargo install --locked taplo-cli


### PR DESCRIPTION
## Why? What?

[Taplo](https://taplo.tamasfe.dev/) is a TOML toolkit written in Rust.
I plan to add a check to the CI to enforce consistent formatting of all our TOML files.

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

- Add check to CI
- Update documentation

## How to Test

We test in production :sunglasses: