### PR TITLE
Fix CI (hopefully)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
     name: Build and Push CI Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/tools/ci/github-runners/Containerfile
+++ b/tools/ci/github-runners/Containerfile
@@ -22,4 +22,6 @@ RUN apt-get update && apt-get install --no-install-recommends --yes \
   && rm --recursive --force /var/lib/apt/lists/*
 
 RUN rustup component add clippy rustfmt
-RUN cargo install --locked taplo-cli
+
+RUN --mount=type=cache,target=/cargo_home \
+    CARGO_HOME=/cargo_home cargo install --locked taplo-cli --root /usr/local


### PR DESCRIPTION
## Why? What?

CI was broken because the `cargo install` build step created a cargo cache owned by root.

## How to Test

Pray :pray: