### PR TITLE
Mujoco walking with FSRs

### DIFF
--- a/tools/machine-learning/mujoco/model/nao.xml
+++ b/tools/machine-learning/mujoco/model/nao.xml
@@ -156,15 +156,10 @@
                   <inertial pos="0.02542 0.0033 -0.03239" mass="0.17184" fullinertia="269442.9e-9 644342.28e-9 525755.35e-9 -5696.02e-9 139379.2e-9 18741.43e-9"/>
                   <joint name="left_leg.ankle_roll" axis="1 0 0" range="-22.79 44.06" limited="true"/>
 
-
-                  <site name="force_sensitive_resistors.left.rear_right" pos="-0.035 0.028 -0.031" size="0.015"  type="sphere"/>
-                  <geom name="force_sensitive_resistors.left.rear_right" pos="-0.035 0.028 -0.031" size="0.015" type="sphere"/>
-                  <site name="force_sensitive_resistors.left.rear_left" pos="-0.035 -0.017 -0.031" size="0.015" type="sphere"/>
-                  <geom name="force_sensitive_resistors.left.rear_left" pos="-0.035 -0.017 -0.031" size="0.015" type="sphere" />
-                  <site name="force_sensitive_resistors.left.front_left" pos="0.075 0.0225 -0.031" size="0.015" type="sphere"/>
-                  <geom name="force_sensitive_resistors.left.front_left" pos="0.075 0.0225 -0.031" size="0.015" type="sphere" />
-                  <site name="force_sensitive_resistors.left.front_right" pos="0.075 -0.0225 -0.031" size="0.015" type="sphere"/>
-                  <geom name="force_sensitive_resistors.left.front_right" pos="0.075 -0.0225 -0.031" size="0.015" type="sphere" />
+                  <site name="force_sensitive_resistors.left.rear_right" pos="-0.02 0.025 -0.04519" size="0.04 0.025 0.005" type="box" rgba="1 0 0 0.3"/>
+                  <site name="force_sensitive_resistors.left.rear_left" pos="-0.02 -0.017 -0.04519" size="0.04 0.017 0.005" type="box" rgba="1 0 0 0.3"/>
+                  <site name="force_sensitive_resistors.left.front_right" pos="0.06 0.025 -0.04519" size="0.04 0.025 0.005" type="box" rgba="1 0 0 0.3"/>
+                  <site name="force_sensitive_resistors.left.front_left" pos="0.06 -0.017 -0.04519" size="0.04 0.017 0.005" type="box" rgba="1 0 0 0.3"/>
                 </body>
               </body>
             </body>
@@ -215,15 +210,10 @@
                   <inertial pos="0.02542 -0.0033 -0.03239" mass="0.17184" fullinertia="269303.1e-9 643474.47e-9 525034.16e-9 5874.62e-9 139133.06e-9 -18848.77e-9"/>
                   <joint name="right_leg.ankle_roll" axis="1 0 0" range="-44.06 22.8" limited="true"/>
 
-
-                  <site name="force_sensitive_resistors.right.rear_left" pos="-0.035 0.017 -0.031" size="0.015"  type="sphere"/>
-                  <geom name="force_sensitive_resistors.right.rear_left" pos="-0.035 0.017 -0.031" size="0.015" type="sphere"/>
-                  <site name="force_sensitive_resistors.right.rear_right" pos="-0.035 -0.028 -0.031" size="0.015" type="sphere"/>
-                  <geom name="force_sensitive_resistors.right.rear_right" pos="-0.035 -0.028 -0.031" size="0.015" type="sphere" />
-                  <site name="force_sensitive_resistors.right.front_left" pos="0.075 0.0225 -0.031" size="0.015" type="sphere"/>
-                  <geom name="force_sensitive_resistors.right.front_left" pos="0.075 0.0225 -0.031" size="0.015" type="sphere" />
-                  <site name="force_sensitive_resistors.right.front_right" pos="0.075 -0.0225 -0.031" size="0.015" type="sphere"/>
-                  <geom name="force_sensitive_resistors.right.front_right" pos="0.075 -0.0225 -0.031" size="0.015" type="sphere" />
+                  <site name="force_sensitive_resistors.right.rear_right" pos="-0.02 -0.025 -0.04519" size="0.04 0.025 0.005" type="box" rgba="1 0 0 0.3"/>
+                  <site name="force_sensitive_resistors.right.rear_left" pos="-0.02 0.017 -0.04519" size="0.04 0.017 0.005" type="box" rgba="1 0 0 0.3"/>
+                  <site name="force_sensitive_resistors.right.front_right" pos="0.06 -0.025 -0.04519" size="0.04 0.025 0.005" type="box" rgba="1 0 0 0.3"/>
+                  <site name="force_sensitive_resistors.right.front_left" pos="0.06 0.017 -0.04519" size="0.04 0.017 0.005" type="box" rgba="1 0 0 0.3"/>
                 </body>
               </body>
             </body>

--- a/tools/machine-learning/mujoco/scripts/mujoco-walking.py
+++ b/tools/machine-learning/mujoco/scripts/mujoco-walking.py
@@ -20,7 +20,7 @@ from walking_engine import (
 
 def default_parameters() -> Parameters:
     return Parameters(
-        sole_pressure_threshold=0.5,
+        sole_pressure_threshold=5.0,
         min_step_duration=0.25,
         step_duration=0.25,
         foot_lift_apex=0.015,
@@ -148,7 +148,6 @@ def main():
                     ).data
                     for pos in fsr_positions
                 )
-                / 10.0
             )
             left_pressure = (
                 sum(
@@ -157,7 +156,6 @@ def main():
                     ).data
                     for pos in fsr_positions
                 )
-                / 10.0
             )
             measurements = Measurements(left_pressure, right_pressure)
 


### PR DESCRIPTION
## Why? What?

Integrates FSR sensors into walking simulation. Based on #1545.
Unfortunately the FSR sensors from #1489 did not work since they changed the foot geometry. Therefore the FSR sensors have been changed so that each foot is divided into 4 box regions. All contact forces within the boxes region with the foot geom are included in the force calculation.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* `uv run scripts/mujoco-walking.py`
