### PR TITLE
Include `direction` field in `Arc`

### DIFF
--- a/crates/bevyhavior_simulator/src/robot.rs
+++ b/crates/bevyhavior_simulator/src/robot.rs
@@ -234,9 +234,9 @@ pub fn move_robots(mut robots: Query<&mut Robot>, mut ball: ResMut<BallResource>
 
                 let target = match path[0] {
                     PathSegment::LineSegment(LineSegment(_start, end)) => end.coords(),
-                    PathSegment::Arc(arc, direction) => {
-                        direction.rotate_vector_90_degrees(arc.start - arc.circle.center)
-                    }
+                    PathSegment::Arc(arc) => arc
+                        .direction
+                        .rotate_vector_90_degrees(arc.start - arc.circle.center),
                 };
 
                 let orientation = match orientation_mode {

--- a/crates/control/src/motion/step_planner.rs
+++ b/crates/control/src/motion/step_planner.rs
@@ -99,8 +99,10 @@ impl StepPlanner {
                 };
                 Pose2::from_parts(line_segment.1, rotation)
             }
-            PathSegment::Arc(arc, orientation) => {
-                let direction = orientation.rotate_vector_90_degrees(arc.start - arc.circle.center);
+            PathSegment::Arc(arc) => {
+                let direction = arc
+                    .direction
+                    .rotate_vector_90_degrees(arc.start - arc.circle.center);
                 Pose2::from_parts(
                     arc.start + direction * 1.0,
                     Orientation2::from_vector(direction),

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -56,7 +56,7 @@ impl TimeToReachKickPosition {
                             PathSegment::LineSegment(_) => {
                                 length / context.configuration.path_planning.line_walking_speed
                             }
-                            PathSegment::Arc(_, _) => {
+                            PathSegment::Arc(_) => {
                                 length / context.configuration.path_planning.arc_walking_speed
                             }
                         }

--- a/crates/geometry/src/circle.rs
+++ b/crates/geometry/src/circle.rs
@@ -91,7 +91,7 @@ where
         line_segment.distance_to(self.center) <= self.radius
     }
 
-    pub fn overlaps_arc(&self, arc: Arc<Frame>, orientation: Direction) -> bool {
+    pub fn overlaps_arc(&self, arc: Arc<Frame>) -> bool {
         let distance = (arc.circle.center - self.center).norm_squared();
         if distance > (self.radius + arc.circle.radius).powi(2) {
             return false;
@@ -115,7 +115,7 @@ where
             angle_start_to_end += TAU;
         }
 
-        (angle_start_to_obstacle < angle_start_to_end) ^ (orientation == Direction::Clockwise)
+        (angle_start_to_obstacle < angle_start_to_end) ^ (arc.direction == Direction::Clockwise)
     }
 
     pub fn tangents_with_point(&self, other: Point2<Frame>) -> Option<TwoLineSegments<Frame>> {

--- a/crates/geometry/src/direction.rs
+++ b/crates/geometry/src/direction.rs
@@ -1,8 +1,20 @@
+use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
 use linear_algebra::{vector, Vector2};
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Serialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+)]
 pub enum Direction {
     Clockwise,
     Counterclockwise,

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -139,7 +139,7 @@ impl<Frame> LineSegment<Frame> {
         }
     }
 
-    pub fn overlaps_arc(&self, arc: Arc<Frame>, orientation: Direction) -> bool {
+    pub fn overlaps_arc(&self, arc: Arc<Frame>) -> bool {
         if self.distance_to(arc.circle.center) >= arc.circle.radius {
             return false;
         }
@@ -187,7 +187,7 @@ impl<Frame> LineSegment<Frame> {
             }
 
             if (angle_start_to_obstacle < angle_start_to_end)
-                ^ (orientation == Direction::Clockwise)
+                ^ (arc.direction == Direction::Clockwise)
             {
                 return true;
             }

--- a/crates/types/src/path_obstacles.rs
+++ b/crates/types/src/path_obstacles.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use geometry::{arc::Arc, circle::Circle, direction::Direction, line_segment::LineSegment};
+use geometry::{arc::Arc, circle::Circle, line_segment::LineSegment};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -24,12 +24,10 @@ impl PathObstacleShape {
         }
     }
 
-    pub fn overlaps_arc(&self, arc: Arc<Ground>, orientation: Direction) -> bool {
+    pub fn overlaps_arc(&self, arc: Arc<Ground>) -> bool {
         match self {
-            PathObstacleShape::Circle(circle) => circle.overlaps_arc(arc, orientation),
-            PathObstacleShape::LineSegment(line_segment) => {
-                line_segment.overlaps_arc(arc, orientation)
-            }
+            PathObstacleShape::Circle(circle) => circle.overlaps_arc(arc),
+            PathObstacleShape::LineSegment(line_segment) => line_segment.overlaps_arc(arc),
         }
     }
 

--- a/crates/types/src/planned_path.rs
+++ b/crates/types/src/planned_path.rs
@@ -1,17 +1,17 @@
 use approx::{AbsDiffEq, RelativeEq};
-use geometry::{arc::Arc, direction::Direction, line_segment::LineSegment};
-use linear_algebra::Point2;
-use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::Ground;
+use geometry::{arc::Arc, line_segment::LineSegment};
+use linear_algebra::Point2;
+use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
 #[derive(
     Clone, Debug, Serialize, Deserialize, PartialEq, PathSerialize, PathDeserialize, PathIntrospect,
 )]
 pub enum PathSegment {
     LineSegment(LineSegment<Ground>),
-    Arc(Arc<Ground>, Direction),
+    Arc(Arc<Ground>),
 }
 
 pub fn direct_path(start: Point2<Ground>, destination: Point2<Ground>) -> Vec<PathSegment> {
@@ -31,10 +31,9 @@ impl AbsDiffEq for PathSegment {
                 PathSegment::LineSegment(line_segment_self),
                 PathSegment::LineSegment(line_segment_other),
             ) => line_segment_self.abs_diff_eq(line_segment_other, epsilon),
-            (
-                PathSegment::Arc(arc_self, direction_self),
-                PathSegment::Arc(arc_other, direction_other),
-            ) => direction_self == direction_other && arc_self.abs_diff_eq(arc_other, epsilon),
+            (PathSegment::Arc(arc_self), PathSegment::Arc(arc_other)) => {
+                arc_self.abs_diff_eq(arc_other, epsilon)
+            }
             _ => false,
         }
     }
@@ -56,12 +55,8 @@ impl RelativeEq for PathSegment {
                 PathSegment::LineSegment(line_segment_self),
                 PathSegment::LineSegment(line_segment_other),
             ) => line_segment_self.relative_eq(line_segment_other, epsilon, max_relative),
-            (
-                PathSegment::Arc(arc_self, direction_self),
-                PathSegment::Arc(arc_other, direction_other),
-            ) => {
-                direction_self == direction_other
-                    && arc_self.relative_eq(arc_other, epsilon, max_relative)
+            (PathSegment::Arc(arc_self), PathSegment::Arc(arc_other)) => {
+                arc_self.relative_eq(arc_other, epsilon, max_relative)
             }
             _ => false,
         }
@@ -72,7 +67,7 @@ impl PathSegment {
     pub fn length(&self) -> f32 {
         match self {
             PathSegment::LineSegment(line_segment) => line_segment.length(),
-            PathSegment::Arc(arc, direction) => arc.length(*direction),
+            PathSegment::Arc(arc) => arc.length(),
         }
     }
 }

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -149,11 +149,12 @@ impl<World> TwixPainter<World> {
         self.world_to_pixel.inner.scaling()
     }
 
-    pub fn arc(&self, arc: Arc<World>, orientation: Direction, stroke: Stroke) {
+    pub fn arc(&self, arc: Arc<World>, stroke: Stroke) {
         let Arc {
             circle: Circle { center, radius },
             start,
             end,
+            direction,
         } = arc;
         let start_relative = start - center;
         let end_relative = end - center;
@@ -168,7 +169,7 @@ impl<World> TwixPainter<World> {
             angle_difference
         };
 
-        let signed_angle_difference = match orientation {
+        let signed_angle_difference = match direction {
             Direction::Clockwise => -TAU + counterclockwise_angle_difference,
             Direction::Counterclockwise => counterclockwise_angle_difference,
             Direction::Colinear => 0.0,
@@ -463,9 +464,8 @@ impl TwixPainter<Ground> {
                         color: line_color,
                     },
                 ),
-                PathSegment::Arc(arc, orientation) => self.arc(
+                PathSegment::Arc(arc) => self.arc(
                     arc,
-                    orientation,
                     Stroke {
                         width,
                         color: arc_color,


### PR DESCRIPTION
## Why? What?

With the way `Arc`s are currently defined/used, they need a `Direction` to be fully defined.
Also, every occurrence of an `Arc` seems to currently be accompanied by a `Direction`, for example as a second argument.

This PR moves this direction into the `Arc`.

In theory, one could also have a fully defined Arc without specifying the direction (e.g. by defining the direction as clockwise, and then switching start/end point to switch "direction").
This makes Arcs with an explicit direction slightly over-defined. I would argue this is fine,
especially since `Arc`s are commonly used where an explicit direction is needed (as in the case of a path segment, for example)

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

It's perfect

## How to Test

Stare at the code