### PR TITLE
swap sides for stiffnesses instead of mirroring them

### DIFF
--- a/crates/types/src/joints.rs
+++ b/crates/types/src/joints.rs
@@ -11,6 +11,7 @@ use std::{
     ops::{Add, Div, Index, IndexMut, Mul, Sub},
 };
 
+use mirror::SwapSides;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 use splines::impl_Interpolate;
@@ -359,6 +360,18 @@ impl Mirror for Joints<f32> {
             right_arm: self.left_arm.mirrored(),
             left_leg: self.right_leg.mirrored(),
             right_leg: self.left_leg.mirrored(),
+        }
+    }
+}
+
+impl SwapSides for Joints<f32> {
+    fn swapped_sides(self) -> Self {
+        Self {
+            head: self.head,
+            left_arm: self.right_arm,
+            right_arm: self.left_arm,
+            left_leg: self.right_leg,
+            right_leg: self.left_leg,
         }
     }
 }

--- a/crates/types/src/joints/mirror.rs
+++ b/crates/types/src/joints/mirror.rs
@@ -1,3 +1,7 @@
 pub trait Mirror {
     fn mirrored(self) -> Self;
 }
+
+pub trait SwapSides {
+    fn swapped_sides(self) -> Self;
+}

--- a/crates/types/src/motor_commands.rs
+++ b/crates/types/src/motor_commands.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::joints::{
     body::{BodyJoints, LowerBodyJoints, UpperBodyJoints},
-    mirror::Mirror,
+    mirror::{Mirror, SwapSides},
     Joints,
 };
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
@@ -34,12 +34,12 @@ impl_Interpolate!(f32, MotorCommands<Joints<f32>>, PI);
 
 impl<T> Mirror for MotorCommands<T>
 where
-    T: Mirror,
+    T: Mirror + SwapSides,
 {
     fn mirrored(self) -> Self {
         Self {
             positions: T::mirrored(self.positions),
-            stiffnesses: T::mirrored(self.stiffnesses),
+            stiffnesses: T::swapped_sides(self.stiffnesses),
         }
     }
 }


### PR DESCRIPTION
## Why? What?

mirror was meant for angles not for stiffnesses, when mirroring motions with individual stiffnesses, we should only flip the sides without special care for signs etc.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

?
