### PR TITLE
Cleanup motion safe exits

### DIFF
--- a/crates/control/src/motion/arms_up_squat.rs
+++ b/crates/control/src/motion/arms_up_squat.rs
@@ -47,10 +47,11 @@ impl ArmsUpSquat {
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
         let motion_selection = context.motion_selection;
+        let condition_input = context.condition_input;
 
         if motion_selection.current_motion == MotionType::ArmsUpSquat {
             self.interpolator
-                .advance_by(last_cycle_duration, context.condition_input);
+                .advance_by(last_cycle_duration, condition_input);
         } else {
             self.interpolator.reset();
         }

--- a/crates/control/src/motion/arms_up_stand.rs
+++ b/crates/control/src/motion/arms_up_stand.rs
@@ -47,10 +47,11 @@ impl ArmsUpstand {
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
         let motion_selection = context.motion_selection;
+        let condition_input = context.condition_input;
 
         if motion_selection.current_motion == MotionType::ArmsUpStand {
             self.interpolator
-                .advance_by(last_cycle_duration, context.condition_input);
+                .advance_by(last_cycle_duration, condition_input);
         } else {
             self.interpolator.reset();
         }

--- a/crates/control/src/motion/center_jump.rs
+++ b/crates/control/src/motion/center_jump.rs
@@ -47,9 +47,11 @@ impl CenterJump {
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
+        let condition_input = context.condition_input;
+
         if context.motion_selection.current_motion == MotionType::CenterJump {
             self.interpolator
-                .advance_by(last_cycle_duration, context.condition_input);
+                .advance_by(last_cycle_duration, condition_input);
         } else {
             self.interpolator.reset();
         }

--- a/crates/control/src/motion/center_jump.rs
+++ b/crates/control/src/motion/center_jump.rs
@@ -55,7 +55,6 @@ impl CenterJump {
         } else {
             self.interpolator.reset();
         }
-
         context.motion_safe_exits[MotionType::CenterJump] = self.interpolator.is_finished();
 
         Ok(MainOutputs {

--- a/crates/control/src/motion/jump_left.rs
+++ b/crates/control/src/motion/jump_left.rs
@@ -48,9 +48,11 @@ impl JumpLeft {
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
+        let condition_input = context.condition_input;
+
         if context.motion_selection.current_motion == MotionType::JumpLeft {
             self.interpolator
-                .advance_by(last_cycle_duration, context.condition_input);
+                .advance_by(last_cycle_duration, condition_input);
         } else {
             self.interpolator.reset();
         }

--- a/crates/control/src/motion/jump_left.rs
+++ b/crates/control/src/motion/jump_left.rs
@@ -56,7 +56,6 @@ impl JumpLeft {
         } else {
             self.interpolator.reset();
         }
-
         context.motion_safe_exits[MotionType::JumpLeft] = self.interpolator.is_finished();
 
         Ok(MainOutputs {

--- a/crates/control/src/motion/jump_right.rs
+++ b/crates/control/src/motion/jump_right.rs
@@ -56,7 +56,6 @@ impl JumpRight {
         } else {
             self.interpolator.reset();
         }
-
         context.motion_safe_exits[MotionType::JumpRight] = self.interpolator.is_finished();
 
         Ok(MainOutputs {

--- a/crates/control/src/motion/jump_right.rs
+++ b/crates/control/src/motion/jump_right.rs
@@ -48,9 +48,11 @@ impl JumpRight {
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
+        let condition_input = context.condition_input;
+
         if context.motion_selection.current_motion == MotionType::JumpRight {
             self.interpolator
-                .advance_by(last_cycle_duration, context.condition_input);
+                .advance_by(last_cycle_duration, condition_input);
         } else {
             self.interpolator.reset();
         }

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -65,8 +65,6 @@ impl StandUpBack {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
         let condition_input = context.condition_input;
 
-        context.motion_safe_exits[MotionType::StandUpBack] = false;
-
         self.interpolator
             .advance_by(last_cycle_duration, condition_input);
 

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -61,25 +61,22 @@ impl StandUpBack {
         })
     }
 
-    pub fn advance_interpolator(&mut self, context: &mut CycleContext) {
-        let last_cycle_duration = context.cycle_time.last_cycle_duration;
-        let condition_input = context.condition_input;
-
-        self.interpolator
-            .advance_by(last_cycle_duration, condition_input);
-
-        context.motion_safe_exits[MotionType::StandUpBack] = self.interpolator.is_finished();
-    }
-
-    pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let stand_up_back_estimated_remaining_duration =
             if let MotionType::StandUpBack = context.motion_selection.current_motion {
-                self.advance_interpolator(&mut context);
+                let last_cycle_duration = context.cycle_time.last_cycle_duration;
+                let condition_input = context.condition_input;
+
+                self.interpolator
+                    .advance_by(last_cycle_duration, condition_input);
+
                 Some(self.interpolator.estimated_remaining_duration())
             } else {
                 self.interpolator.reset();
                 None
             };
+        context.motion_safe_exits[MotionType::StandUpBack] = self.interpolator.is_finished();
+
         self.filtered_gyro.update(context.angular_velocity.inner);
         let gyro = self.filtered_gyro.state();
 

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -65,8 +65,6 @@ impl StandUpFront {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
         let condition_input = context.condition_input;
 
-        context.motion_safe_exits[MotionType::StandUpFront] = false;
-
         self.interpolator
             .advance_by(last_cycle_duration, condition_input);
 

--- a/crates/control/src/motion/stand_up_front.rs
+++ b/crates/control/src/motion/stand_up_front.rs
@@ -87,7 +87,7 @@ impl StandUpFront {
         positions.right_leg.ankle_roll += context.leg_balancing_factor.x * gyro.x;
 
         Ok(MainOutputs {
-            stand_up_front_positions: self.interpolator.value().into(),
+            stand_up_front_positions: positions.into(),
             stand_up_front_estimated_remaining_duration:
                 stand_up_front_estimated_remaining_duration.into(),
         })

--- a/crates/control/src/motion/stand_up_sitting.rs
+++ b/crates/control/src/motion/stand_up_sitting.rs
@@ -66,8 +66,6 @@ impl StandUpSitting {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
         let condition_input = context.condition_input;
 
-        context.motion_safe_exits[MotionType::StandUpSitting] = false;
-
         self.interpolator
             .advance_by(last_cycle_duration, condition_input);
 

--- a/crates/control/src/motion/stand_up_sitting.rs
+++ b/crates/control/src/motion/stand_up_sitting.rs
@@ -88,7 +88,7 @@ impl StandUpSitting {
         positions.right_leg.ankle_roll += context.leg_balancing_factor.x * gyro.x;
 
         Ok(MainOutputs {
-            stand_up_sitting_positions: self.interpolator.value().into(),
+            stand_up_sitting_positions: positions.into(),
             stand_up_sitting_estimated_remaining_duration: estimated_remaining_duration.into(),
         })
     }

--- a/crates/control/src/motion/stand_up_sitting.rs
+++ b/crates/control/src/motion/stand_up_sitting.rs
@@ -62,25 +62,22 @@ impl StandUpSitting {
         })
     }
 
-    pub fn advance_interpolator(&mut self, context: &mut CycleContext) {
-        let last_cycle_duration = context.cycle_time.last_cycle_duration;
-        let condition_input = context.condition_input;
-
-        self.interpolator
-            .advance_by(last_cycle_duration, condition_input);
-
-        context.motion_safe_exits[MotionType::StandUpSitting] = self.interpolator.is_finished();
-    }
-
-    pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let estimated_remaining_duration =
             if let MotionType::StandUpSitting = context.motion_selection.current_motion {
-                self.advance_interpolator(&mut context);
+                let last_cycle_duration = context.cycle_time.last_cycle_duration;
+                let condition_input = context.condition_input;
+
+                self.interpolator
+                    .advance_by(last_cycle_duration, condition_input);
+
                 Some(self.interpolator.estimated_remaining_duration())
             } else {
                 self.interpolator.reset();
                 None
             };
+        context.motion_safe_exits[MotionType::StandUpSitting] = self.interpolator.is_finished();
+
         self.filtered_gyro.update(context.angular_velocity.inner);
         let gyro = self.filtered_gyro.state();
 

--- a/crates/control/src/motion/wide_stance.rs
+++ b/crates/control/src/motion/wide_stance.rs
@@ -51,8 +51,6 @@ impl WideStance {
         let last_cycle_duration = context.cycle_time.last_cycle_duration;
         let condition_input = context.condition_input;
 
-        context.motion_safe_exits[MotionType::WideStance] = false;
-
         self.interpolator
             .advance_by(last_cycle_duration, condition_input);
 

--- a/crates/control/src/motion/wide_stance.rs
+++ b/crates/control/src/motion/wide_stance.rs
@@ -47,25 +47,22 @@ impl WideStance {
         })
     }
 
-    pub fn advance_interpolator(&mut self, context: CycleContext) {
-        let last_cycle_duration = context.cycle_time.last_cycle_duration;
-        let condition_input = context.condition_input;
-
-        self.interpolator
-            .advance_by(last_cycle_duration, condition_input);
-
-        context.motion_safe_exits[MotionType::WideStance] = self.interpolator.is_finished();
-    }
-
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
         let wide_stance_estimated_remaining_duration =
             if let MotionType::WideStance = context.motion_selection.current_motion {
-                self.advance_interpolator(context);
+                let last_cycle_duration = context.cycle_time.last_cycle_duration;
+                let condition_input = context.condition_input;
+
+                self.interpolator
+                    .advance_by(last_cycle_duration, condition_input);
+
                 Some(self.interpolator.estimated_remaining_duration())
             } else {
                 self.interpolator.reset();
                 None
             };
+        context.motion_safe_exits[MotionType::WideStance] = self.interpolator.is_finished();
+
         Ok(MainOutputs {
             wide_stance_positions: self.interpolator.value().into(),
             wide_stance_estimated_remaining_duration: wide_stance_estimated_remaining_duration


### PR DESCRIPTION
## Why? What?

- Stabilization for `stand_up_front` and `..._sitting` was never used 🙃
- Various motion files did the same but hat different formatting
- Various motions were not able to set `motion_safe_exits` when resetting

## How to Test

- Shouldn't modify anything
- Let it stand-up