### PR TITLE
Fix Enum plot tooltip

### DIFF
--- a/tools/twix/src/panels/enum_plot.rs
+++ b/tools/twix/src/panels/enum_plot.rs
@@ -9,8 +9,8 @@ use std::{
 
 use eframe::{
     egui::{
-        show_tooltip_at_pointer, Align2, Button, ComboBox, FontId, Response, RichText, Sense,
-        TextStyle, Ui, Widget, WidgetText,
+        show_tooltip_at_pointer, widgets::Label, Align2, Button, ComboBox, FontId, Response,
+        RichText, Sense, TextStyle, TextWrapMode, Ui, Widget, WidgetText,
     },
     emath::{remap, Rangef, RectTransform},
     epaint::{Color32, Rect, Rounding, Shape, Stroke, TextShape, Vec2},
@@ -102,7 +102,7 @@ impl Segment {
         if ui.rect_contains_pointer(screenspace_rect) {
             if let Some(tooltip) = self.tooltip() {
                 show_tooltip_at_pointer(ui.ctx(), ui.layer_id(), "Fridolin".into(), |ui| {
-                    ui.label(tooltip)
+                    ui.add(Label::new(tooltip).wrap_mode(TextWrapMode::Extend));
                 });
             }
         }


### PR DESCRIPTION
## Why? What?

Fixes the enum plot tooltip becoming small after hovering over an enum variant which does not have a lot of text.

Fixes #

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* subscribe fall_state and fall_direction for example and do some hovering. should look normal
