### PR TITLE
Dependency cycle errors

### DIFF
--- a/crates/source_analyzer/src/cyclers.rs
+++ b/crates/source_analyzer/src/cyclers.rs
@@ -226,17 +226,17 @@ fn sort_nodes(
     {
         Ok(node_indices) => Ok({
             node_indices
-                .iter()
-                .map(|node_index| nodes[*node_index].clone())
+                .into_iter()
+                .map(|node_index| nodes[node_index].clone())
                 .collect()
         }),
         Err(cycles) => Err(Error::CircularDependency(
             cycles
-                .iter()
+                .into_iter()
                 .map(|cycle| {
                     cycle
-                        .iter()
-                        .map(|node_index| nodes[*node_index].name.clone())
+                        .into_iter()
+                        .map(|node_index| nodes[node_index].name.clone())
                         .collect()
                 })
                 .collect(),

--- a/crates/source_analyzer/src/error.rs
+++ b/crates/source_analyzer/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("`{node}` requires output `{output}`, but it is never produced")]
     MissingOutput { node: String, output: String },
     #[error("failed to sort nodes, circular dependency detected")]
-    CircularDependency,
+    CircularDependency(Vec<Vec<String>>),
 }
 
 #[derive(Debug, Error)]

--- a/crates/source_analyzer/src/error.rs
+++ b/crates/source_analyzer/src/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
     InvalidModulePath,
     #[error("`{node}` requires output `{output}`, but it is never produced")]
     MissingOutput { node: String, output: String },
-    #[error("failed to sort nodes, circular dependency detected")]
+    #[error("failed to sort nodes, circular dependencies detected: {}", .0.first().map(|cycle| cycle.join(", ")).unwrap_or("failed to determine loop".to_string()))]
     CircularDependency(Vec<Vec<String>>),
 }
 


### PR DESCRIPTION
## Why? What?

On main, when there is a dependency cycle, it only says "CircularDependency" with no additional information.
However, the library we are using for topological sorting also supports finding strongly connected components in the dependency graph.
This PR uses that to put the node names of dependency cycles into the error kind.

Fixes #

## ToDo / Known Issues

With some loops the library fails to sort but also outputs an empty vec of cycles.
Not sure what to do about it.

## Ideas for Next Iterations (Not This PR)

- ~~automatically resolve the cycle~~

## How to Test

- Create a dependency cycle, e.g. add `accepted_human_poses: Input<Vec<HumanPose>, "accepted_human_poses">,` in `pose_detection.rs`
- Enjoy improved error message.