### PR TITLE
Fix changed interface name

### DIFF
--- a/tools/aliveness/src/main.rs
+++ b/tools/aliveness/src/main.rs
@@ -242,7 +242,7 @@ async fn handle_beacon(
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let interface_name = args().nth(1).unwrap_or_else(|| "enp4s0".to_owned());
+    let interface_name = args().nth(1).unwrap_or_else(|| "eth0".to_owned());
 
     listen_for_network_change(interface_name).await
 }


### PR DESCRIPTION
## Why? What?

This PR fixes the aliveness service not starting due to interface name having changed in HULKs OS 8.0.0.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Build aliveness service and copy binary to a NAO, e.g. using an installed pepsi max with

```sh
pepsi build aliveness
scp tools/aliveness/target/x86_64-aldebaran-linux-gnu/debug/aliveness-service nao@10.1.24.33:
```

Log into NAO and run aliveness service using
```sh
pepsi shell 33
./aliveness-service
```

Run `pepsi aliveness` in a separate terminal and observe output.
