### PR TITLE
Adjust `Framed` vector API to match upstream nalgebra

### DIFF
--- a/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
@@ -76,7 +76,7 @@ fn update(
             && ball_in_ground
                 .coords()
                 .normalize()
-                .dot(velocity_in_ground.normalize())
+                .dot(&velocity_in_ground.normalize())
                 < -0.3
         {
             ball.velocity = Vector::zeros();

--- a/crates/bevyhavior_simulator/src/bin/penalty_shootout_defending.rs
+++ b/crates/bevyhavior_simulator/src/bin/penalty_shootout_defending.rs
@@ -77,7 +77,7 @@ fn update(
                     && ball_in_ground
                         .coords()
                         .normalize()
-                        .dot(velocity_in_ground.normalize())
+                        .dot(&velocity_in_ground.normalize())
                         < -0.3
                 {
                     ball.velocity = vector!(0.2, 0.0);

--- a/crates/bevyhavior_simulator/src/robot.rs
+++ b/crates/bevyhavior_simulator/src/robot.rs
@@ -312,7 +312,7 @@ pub fn move_robots(mut robots: Query<&mut Robot>, mut ball: ResMut<BallResource>
             HeadMotion::LookAt { target, .. } => Orientation2::from_vector(target.coords()).angle(),
             HeadMotion::LookLeftAndRightOf { target } => {
                 let glance_factor = 0.0; //self.time_elapsed.as_secs_f32().sin();
-                target.coords().angle(Vector2::x_axis())
+                target.coords().angle(&Vector2::x_axis())
                     + glance_factor * robot.parameters.look_at.glance_angle
             }
             HeadMotion::Unstiff => 0.0,
@@ -362,7 +362,7 @@ pub fn cycle_robots(
                 Rotation2::new(robot.database.main_outputs.sensor_data.positions.head.yaw);
             let ball_in_head: Point2<Head> = head_to_ground.inverse() * ball_in_ground;
             let field_of_view = robot.field_of_view();
-            let angle_to_ball = ball_in_head.coords().angle(Vector2::x_axis());
+            let angle_to_ball = ball_in_head.coords().angle(&Vector2::x_axis());
 
             angle_to_ball.abs() < field_of_view / 2.0 && ball_in_head.coords().norm() < 3.0
         });

--- a/crates/control/src/active_vision.rs
+++ b/crates/control/src/active_vision.rs
@@ -124,7 +124,7 @@ impl ActiveVision {
 }
 
 fn is_position_visible(position: Point2<Ground>, parameters: LookActionParameters) -> bool {
-    Vector2::x_axis().angle(position.coords()).abs() < parameters.angle_threshold
+    Vector2::x_axis().angle(&position.coords()).abs() < parameters.angle_threshold
         && position.coords().norm() < parameters.distance_threshold
 }
 

--- a/crates/control/src/dribble_path_planner.rs
+++ b/crates/control/src/dribble_path_planner.rs
@@ -25,7 +25,8 @@ pub fn plan(
     let robot_to_ball = ball_position_in_ground.coords();
     let dribble_pose_to_ball = ball_position_in_ground - best_pose.position();
 
-    let angle = robot_to_ball.angle(dribble_pose_to_ball);
+    let angle = robot_to_ball.angle(&dribble_pose_to_ball);
+
     let should_avoid_ball = angle > dribbling_parameters.angle_to_approach_ball_from_threshold;
     let ball_obstacle = should_avoid_ball.then_some(ball_position_in_ground);
 

--- a/crates/control/src/localization.rs
+++ b/crates/control/src/localization.rs
@@ -884,7 +884,7 @@ fn get_field_mark_correspondence(
                         );
                         let angle_weight = correspondences
                             .measured_direction
-                            .dot(correspondences.reference_direction)
+                            .dot(&correspondences.reference_direction)
                             .abs()
                             + measured_line_length / field_mark_length;
                         assert!(field_mark_length != 0.0);

--- a/crates/control/src/odometry.rs
+++ b/crates/control/src/odometry.rs
@@ -65,7 +65,7 @@ impl Odometry {
         );
         self.last_left_sole_to_right_sole = left_sole_to_right_sole;
         let corrected_offset_to_last_position =
-            offset_to_last_position.component_mul(*context.odometry_scale_factor);
+            offset_to_last_position.component_mul(context.odometry_scale_factor);
 
         let (_, _, yaw) = context.robot_orientation.inner.euler_angles();
         let orientation = Orientation2::new(yaw);

--- a/crates/control/src/time_to_reach_kick_position.rs
+++ b/crates/control/src/time_to_reach_kick_position.rs
@@ -73,7 +73,7 @@ impl TimeToReachKickPosition {
                 let turning_angle_towards_path = match context.dribble_path {
                     Some(path) => match path.first() {
                         Some(PathSegment::LineSegment(line_segment)) => {
-                            Some(line_segment.1.coords().angle(Vector2::x_axis()).abs())
+                            Some(line_segment.1.coords().angle(&Vector2::x_axis()).abs())
                         }
                         _ => None,
                     },

--- a/crates/geometry/src/line.rs
+++ b/crates/geometry/src/line.rs
@@ -36,7 +36,7 @@ impl<Frame> Line2<Frame> {
         let normal_vector = Direction::Counterclockwise
             .rotate_vector_90_degrees(self.direction)
             .normalize();
-        normal_vector.dot(point - self.point)
+        normal_vector.dot(&(point - self.point))
     }
 
     pub fn intersection(&self, other: &Line2<Frame>) -> Point2<Frame> {
@@ -65,7 +65,7 @@ impl<Frame, const DIMENSION: usize> Line<Frame, DIMENSION> {
 
     pub fn closest_point(&self, point: Point<Frame, DIMENSION>) -> Point<Frame, DIMENSION> {
         self.point
-            + (self.direction * self.direction.dot(point - self.point)
+            + (self.direction * self.direction.dot(&(point - self.point))
                 / self.direction.norm_squared())
     }
 }

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -63,7 +63,7 @@ impl<Frame> LineSegment<Frame> {
     }
 
     pub fn angle(&self, other: Self) -> f32 {
-        (self.1 - self.0).angle(other.1 - other.0)
+        (self.1 - self.0).angle(&(other.1 - other.0))
     }
 
     pub fn signed_acute_angle_to_orthogonal(&self, other: Self) -> f32 {

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -53,7 +53,7 @@ impl<Frame> LineSegment<Frame> {
         let normal_vector = Direction::Counterclockwise
             .rotate_vector_90_degrees(line_vector)
             .normalize();
-        normal_vector.dot(point.coords()) - normal_vector.dot(self.0.coords())
+        normal_vector.dot(&point.coords()) - normal_vector.dot(&self.0.coords())
     }
 
     pub fn signed_acute_angle(&self, other: Self) -> f32 {
@@ -79,7 +79,7 @@ impl<Frame> LineSegment<Frame> {
     }
 
     pub fn projection_factor(&self, point: Point2<Frame>) -> f32 {
-        let projection = (point - self.0).dot(self.1 - self.0);
+        let projection = (point - self.0).dot(&(self.1 - self.0));
 
         projection / self.length_squared()
     }
@@ -129,7 +129,7 @@ impl<Frame> LineSegment<Frame> {
     pub fn get_direction(&self, point: Point2<Frame>) -> Direction {
         let direction_vector = self.1 - self.0;
         let clockwise_normal_vector = vector![direction_vector.y(), -direction_vector.x()];
-        let directed_cathetus = clockwise_normal_vector.dot(point - self.0);
+        let directed_cathetus = clockwise_normal_vector.dot(&(point - self.0));
 
         match directed_cathetus {
             f if f == 0.0 => Direction::Colinear,
@@ -144,7 +144,7 @@ impl<Frame> LineSegment<Frame> {
             return false;
         }
 
-        let projection = (arc.circle.center - self.0).dot(self.1 - self.0);
+        let projection = (arc.circle.center - self.0).dot(&(self.1 - self.0));
         let projected_point_relative_contribution = projection / self.length_squared();
         let base_point = self.0 + (self.1 - self.0) * projected_point_relative_contribution;
 

--- a/crates/linear_algebra/src/vector.rs
+++ b/crates/linear_algebra/src/vector.rs
@@ -88,7 +88,7 @@ impl<Frame, const DIMENSION: usize, T> Framed<Frame, SVector<T, DIMENSION>> {
         self.inner.angle(&rhs.inner)
     }
 
-    pub fn component_mul(&self, rhs: Self) -> Self
+    pub fn component_mul(&self, rhs: &Self) -> Self
     where
         T: Scalar + ClosedMul,
     {

--- a/crates/linear_algebra/src/vector.rs
+++ b/crates/linear_algebra/src/vector.rs
@@ -81,7 +81,7 @@ impl<Frame, const DIMENSION: usize, T> Framed<Frame, SVector<T, DIMENSION>> {
         self.inner.dot(&rhs.inner)
     }
 
-    pub fn angle(&self, rhs: Self) -> T::SimdRealField
+    pub fn angle(&self, rhs: &Self) -> T::SimdRealField
     where
         T: SimdComplexField,
     {

--- a/crates/linear_algebra/src/vector.rs
+++ b/crates/linear_algebra/src/vector.rs
@@ -74,7 +74,7 @@ impl<Frame, const DIMENSION: usize, T> Framed<Frame, SVector<T, DIMENSION>> {
         self.inner.norm_squared()
     }
 
-    pub fn dot(&self, rhs: Self) -> T
+    pub fn dot(&self, rhs: &Self) -> T
     where
         T: Scalar + Zero + ClosedAdd + ClosedMul,
     {

--- a/crates/vision/src/line_detection/checks.rs
+++ b/crates/vision/src/line_detection/checks.rs
@@ -40,7 +40,7 @@ pub fn has_opposite_gradients(
     // gradients (approximately) point in opposite directions if their dot product is (close to) -1
     let gradient_at_start = get_gradient(image, segment.start, gradient_sobel_stride);
     let gradient_at_end = get_gradient(image, segment.end, gradient_sobel_stride);
-    gradient_at_start.dot(gradient_at_end) < gradient_alignment
+    gradient_at_start.dot(&gradient_at_end) < gradient_alignment
 }
 
 fn get_gradient(

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -158,7 +158,7 @@ impl<World> TwixPainter<World> {
         } = arc;
         let start_relative = start - center;
         let end_relative = end - center;
-        let angle_difference = start_relative.angle(end_relative);
+        let angle_difference = start_relative.angle(&end_relative);
         let end_right_of_start = Direction::Counterclockwise
             .rotate_vector_90_degrees(start_relative)
             .dot(&end_relative)

--- a/tools/twix/src/twix_painter.rs
+++ b/tools/twix/src/twix_painter.rs
@@ -161,7 +161,7 @@ impl<World> TwixPainter<World> {
         let angle_difference = start_relative.angle(end_relative);
         let end_right_of_start = Direction::Counterclockwise
             .rotate_vector_90_degrees(start_relative)
-            .dot(end_relative)
+            .dot(&end_relative)
             < 0.0;
         let counterclockwise_angle_difference = if end_right_of_start {
             TAU - angle_difference


### PR DESCRIPTION
## Why? What?

What the title says.
This only changes the signature of some functions to take a reference to `rhs`, just like the functions they are wrapping.

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

It's perfect

## How to Test

Stare at the code