### PR TITLE
Upload source distribution

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -311,9 +311,14 @@ impl Nao {
         let mut command = self.rsync_with_nao()?;
         command
             .arg("--mkpath")
-            .arg("--keep-dirlinks")
+            .arg("--copy-dirlinks")
             .arg("--copy-links")
             .arg("--info=progress2")
+            .arg("--exclude=.git")
+            .arg("--exclude=webots")
+            .arg("--exclude=tools/machine-learning")
+            .arg("--exclude=tools/charging-box")
+            .arg("--filter=dir-merge,- .gitignore")
             .arg(format!("{}/", local_directory.as_ref().display()))
             .arg(format!(
                 "{}:{}/",

--- a/crates/repository/src/upload.rs
+++ b/crates/repository/src/upload.rs
@@ -1,13 +1,7 @@
-use std::{ffi::OsString, path::Path};
+use std::path::Path;
 
-use color_eyre::{
-    eyre::{bail, Context},
-    Result,
-};
-use tokio::{
-    fs::{create_dir_all, symlink},
-    process::Command,
-};
+use color_eyre::{eyre::Context, Result};
+use tokio::fs::{create_dir_all, symlink};
 
 use crate::Repository;
 
@@ -37,24 +31,9 @@ impl Repository {
             .await
             .wrap_err("failed to create directory for logs")?;
 
-        let source_file = upload_directory.join("logs/source.tar.gz");
-
-        let mut archive_command = OsString::from("cd ");
-        archive_command.push(&self.root);
-        archive_command.push(" && git ls-files --cached --others --exclude-standard | tar Tczf - ");
-        archive_command.push(source_file);
-
-        let mut command = Command::new("sh");
-        command.arg("-c").arg(archive_command);
-
-        let status = command
-            .status()
+        symlink(&self.root, upload_directory.join("logs/source"))
             .await
-            .wrap_err("failed to run archive command")?;
-
-        if !status.success() {
-            bail!("archive command failed with {status}")
-        }
+            .wrap_err("failed to link source directory")?;
 
         Ok(())
     }

--- a/crates/repository/src/upload.rs
+++ b/crates/repository/src/upload.rs
@@ -1,7 +1,13 @@
-use std::path::Path;
+use std::{ffi::OsString, path::Path};
 
-use color_eyre::{eyre::Context, Result};
-use tokio::fs::{create_dir_all, symlink};
+use color_eyre::{
+    eyre::{bail, Context},
+    Result,
+};
+use tokio::{
+    fs::{create_dir_all, symlink},
+    process::Command,
+};
 
 use crate::Repository;
 
@@ -26,6 +32,29 @@ impl Repository {
         )
         .await
         .wrap_err("failed to link executable")?;
+
+        create_dir_all(upload_directory.join("logs"))
+            .await
+            .wrap_err("failed to create directory for logs")?;
+
+        let source_file = upload_directory.join("logs/source.tar.gz");
+
+        let mut archive_command = OsString::from("cd ");
+        archive_command.push(&self.root);
+        archive_command.push(" && git ls-files --cached --others --exclude-standard | tar Tczf - ");
+        archive_command.push(source_file);
+
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(archive_command);
+
+        let status = command
+            .status()
+            .await
+            .wrap_err("failed to run archive command")?;
+
+        if !status.success() {
+            bail!("archive command failed with {status}")
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Why? What?

This PR adds also uploading the source code when uploading to a NAO to allow for reproducible build of e.g. the replayer at a later stage.

Blocked on #1486.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

Currently the whole repository except the `webots` folder is uploaded. We should consider whether we want to exclude other subfolders like e.g. `tools`.


## How to Test

Upload to a NAO, connect to it and observe the source code in the `hulk/logs/source` subfolder.
