### PR TITLE
Add OS version to gammaray status message

### DIFF
--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -36,13 +36,16 @@ pub async fn gammaray(arguments: Arguments, repository: &Repository) -> Result<(
 
     let team_toml = &repository.parameters_root().join("team.toml");
 
+    // prevent moving String into async closure
+    let version = &version;
+
     ProgressIndicator::map_tasks(
         arguments.naos,
-        "Uploading image ...",
+        format!("Uploading image v{version}: ..."),
         |nao_address, progress_bar| async move {
             let nao = Nao::try_new_with_ping(nao_address.ip).await?;
             nao.flash_image(image_path, |msg| {
-                progress_bar.set_message(format!("Uploading image: {}", msg))
+                progress_bar.set_message(format!("Uploading image v{version}: {}", msg))
             })
             .await
             .wrap_err_with(|| format!("failed to flash image to {nao_address}"))?;

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -38,7 +38,7 @@ impl ProgressIndicator {
 
     pub async fn map_tasks<T, F, M>(
         items: impl IntoIterator<Item = T>,
-        message: &'static str,
+        message: impl Into<Cow<'static, str>> + Clone,
         task: impl Fn(T, ProgressBar) -> F,
     ) where
         T: ToString,
@@ -51,7 +51,7 @@ impl ProgressIndicator {
             .map(|item| (multi_progress.task(item.to_string()), item))
             .map(|(progress, item)| {
                 progress.enable_steady_tick();
-                progress.set_message(message);
+                progress.set_message(message.clone());
                 let future = task(item, progress.progress.clone());
                 async move { progress.finish_with(future.await) }
             })


### PR DESCRIPTION
## Why? What?

Having juggled a bunch of branches with different OS versions recently, I got tired of guessing which OS version gammaray was actually uploading, so I added it to the status messages.

Should™️  be conflict-free with #1486 

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Also print the currently installed version on each robot, i.e. `v10.5.42 -> v10.6.1`

## How to Test

Gammaray a NAO and watch the status messages.