### PR TITLE
Cleanup

### DIFF
--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -267,6 +267,8 @@ mod tests {
     use approx::assert_relative_eq;
     use linear_algebra::point;
 
+    use crate::circle::Circle;
+
     use super::*;
 
     #[derive(Debug, Clone, Copy)]
@@ -483,5 +485,41 @@ mod tests {
                 epsilon = 0.000001,
             );
         }
+    }
+
+    #[test]
+    fn arc_intersections() {
+        let arc: Arc<SomeFrame> = Arc {
+            circle: Circle {
+                center: point![1.0, 1.0],
+                radius: 1.0,
+            },
+            start: point![2.0, 1.0],
+            end: point![1.0, 2.0],
+            direction: Direction::Counterclockwise,
+        };
+
+        assert!(!LineSegment(point![0.0, 2.0], point![2.0, 0.0]).overlaps_arc(arc));
+        assert!(!LineSegment(point![2.0, 2.0], point![3.0, 3.0]).overlaps_arc(arc));
+        assert!(!LineSegment(point![0.0, 1.0], point![3.0, 0.0]).overlaps_arc(arc));
+        assert!(LineSegment(point![0.0, 1.0], point![3.0, 2.0]).overlaps_arc(arc));
+        assert!(LineSegment(point![0.0, 0.0], point![2.0, 2.0]).overlaps_arc(arc));
+
+        let arc: Arc<SomeFrame> = Arc {
+            circle: Circle {
+                center: point![1.0, 1.0],
+                radius: 1.0,
+            },
+            start: point![2.0, 1.0],
+            end: point![1.0, 2.0],
+            direction: Direction::Clockwise,
+        };
+
+        assert!(!LineSegment(point![1.0, 1.0], point![3.0, 3.0]).overlaps_arc(arc));
+        assert!(!LineSegment(point![0.5, 1.0], point![1.5, 1.0]).overlaps_arc(arc));
+        assert!(!LineSegment(point![0.0, 3.0], point![2.0, 3.0]).overlaps_arc(arc));
+        assert!(LineSegment(point![0.0, 2.0], point![2.0, 0.0]).overlaps_arc(arc));
+        assert!(LineSegment(point![0.0, 0.0], point![2.0, 2.0]).overlaps_arc(arc));
+        assert!(LineSegment(point![-1.0, 1.0], point![2.0, 0.0]).overlaps_arc(arc));
     }
 }

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -144,21 +144,19 @@ impl<Frame> LineSegment<Frame> {
             return false;
         }
 
-        let projection = (arc.circle.center - self.0).dot(&(self.1 - self.0));
+        let direction = self.1 - self.0;
+        let normed_direction = direction.normalize();
+
+        let projection = (arc.circle.center - self.0).dot(&direction);
         let projected_point_relative_contribution = projection / self.length_squared();
-        let base_point = self.0 + (self.1 - self.0) * projected_point_relative_contribution;
+        let base_point = self.0 + direction * projected_point_relative_contribution;
 
         let center_to_base_length = (base_point - arc.circle.center).norm();
         let base_to_intersection_length =
             f32::sqrt(arc.circle.radius.powi(2) - center_to_base_length.powi(2));
 
-        let direction_vector = vector![self.1.x() - self.0.x(), self.1.y() - self.0.y()];
-        let normed_direction_vector = direction_vector.normalize();
-
-        let intersection_point1 =
-            base_point + normed_direction_vector * base_to_intersection_length;
-        let intersection_point2 =
-            base_point - normed_direction_vector * base_to_intersection_length;
+        let intersection_point1 = base_point + normed_direction * base_to_intersection_length;
+        let intersection_point2 = base_point - normed_direction * base_to_intersection_length;
 
         let mut intersection_points: Vec<_> = Vec::new();
         if (0.0..1.0).contains(&self.projection_factor(intersection_point1)) {

--- a/crates/geometry/src/line_segment.rs
+++ b/crates/geometry/src/line_segment.rs
@@ -147,9 +147,8 @@ impl<Frame> LineSegment<Frame> {
         let direction = self.1 - self.0;
         let normed_direction = direction.normalize();
 
-        let projection = (arc.circle.center - self.0).dot(&direction);
-        let projected_point_relative_contribution = projection / self.length_squared();
-        let base_point = self.0 + direction * projected_point_relative_contribution;
+        let projection = (arc.circle.center - self.0).dot(&normed_direction);
+        let base_point = self.0 + normed_direction * projection;
 
         let center_to_base_length = (base_point - arc.circle.center).norm();
         let base_to_intersection_length =


### PR DESCRIPTION
Very minor cleanup, to make the diff of upcoming PRs more legible.

The direction was computed three times in a row, and once in a very convoluted way.