### PR TITLE
Throw error if main output isn't public

### DIFF
--- a/crates/context_attribute/src/lib.rs
+++ b/crates/context_attribute/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{
     token::Mut,
     AngleBracketedGenericArguments, Expr, ExprLit, GenericArgument, GenericParam, ItemStruct,
     Lifetime, LifetimeParam, Lit, Path, PathArguments, PathSegment, Type, TypeParam, TypePath,
-    TypeReference,
+    TypeReference, Visibility,
 };
 
 #[proc_macro_attribute]
@@ -121,7 +121,10 @@ pub fn context(_attributes: TokenStream, input: TokenStream) -> TokenStream {
                             _ => abort!(first_segment, "expected exactly two generic parameters"),
                         }
                     }
-                    "MainOutput" => {}
+                    "MainOutput" => match &field.vis {
+                        Visibility::Public(_) => {}
+                        _ => abort!(field, "fields of type MainOutput must be `pub`lic"),
+                    },
                     "HardwareInterface" => {
                         requires_lifetime_parameter = true;
                         requires_hardware_interface_parameter = true;


### PR DESCRIPTION
## Why? What?

I forgot to make a main output public.
I got an error from the compiler but no lint in my editor pointing to the line because the error the compiler sees is in the output of our code generation.
This PR remedies that.

![image](https://github.com/user-attachments/assets/f8d5aa6a-4b2a-4e32-b8f3-62c975e271b2)


Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

Sadly additional diagnostics such as quickfix/code actions are currently not possible from proc-macros...

## How to Test

Make a field of type `MainOutput` in a `#[context]` struct non-public.