### PR TITLE
Mujoco: compute arm joints for base policy

### DIFF
--- a/tools/machine-learning/mujoco/packages/kinematics/src/kinematics/inverse_kinematics.py
+++ b/tools/machine-learning/mujoco/packages/kinematics/src/kinematics/inverse_kinematics.py
@@ -20,6 +20,26 @@ from transforms import (
 
 
 @dataclass
+class ArmJoints:
+    shoulder_pitch: float = 0.0
+    shoulder_roll: float = 0.0
+    elbow_yaw: float = 0.0
+    elbow_roll: float = 0.0
+    wrist_yaw: float = 0.0
+
+    def to_numpy(self) -> NDArray[np.float64]:
+        return np.array(
+            [
+                self.shoulder_pitch,
+                self.shoulder_roll,
+                self.elbow_yaw,
+                self.elbow_roll,
+                self.wrist_yaw,
+            ],
+        )
+
+
+@dataclass
 class LegJoints:
     hip_yaw_pitch: float
     hip_roll: float

--- a/tools/machine-learning/mujoco/packages/nao_env/src/nao_env/nao_walking.py
+++ b/tools/machine-learning/mujoco/packages/nao_env/src/nao_env/nao_walking.py
@@ -156,6 +156,7 @@ class NaoWalking(MujocoEnv, utils.EzPickle):
             foot_offset_right=-0.052,
             walk_height=0.23,
             torso_tilt=0.055,
+            arm_pitch_factor=1.0,
         )
         self.state = initial_state(self.parameters)
 
@@ -327,6 +328,7 @@ def apply_walking(
     left_arm, right_arm = walking_engine.compute_arm_joints(
         left_sole,
         right_sole,
+        pitch_factor=parameters.arm_pitch_factor,
     )
 
     nao.actuators.left_leg.ankle_pitch += lower_body_joints.left.ankle_pitch

--- a/tools/machine-learning/mujoco/packages/nao_env/src/nao_env/nao_walking.py
+++ b/tools/machine-learning/mujoco/packages/nao_env/src/nao_env/nao_walking.py
@@ -324,6 +324,10 @@ def apply_walking(
         left_lift,
         right_lift,
     )
+    left_arm, right_arm = walking_engine.compute_arm_joints(
+        left_sole,
+        right_sole,
+    )
 
     nao.actuators.left_leg.ankle_pitch += lower_body_joints.left.ankle_pitch
     nao.actuators.left_leg.ankle_roll += lower_body_joints.left.ankle_roll
@@ -341,3 +345,15 @@ def apply_walking(
         lower_body_joints.right.hip_pitch - parameters.torso_tilt
     )
     nao.actuators.right_leg.hip_roll += lower_body_joints.right.hip_roll
+
+    nao.actuators.left_arm.shoulder_pitch += left_arm.shoulder_pitch
+    nao.actuators.left_arm.shoulder_roll += left_arm.shoulder_roll
+    nao.actuators.left_arm.elbow_yaw += left_arm.elbow_yaw
+    nao.actuators.left_arm.elbow_roll += left_arm.elbow_roll
+    nao.actuators.left_arm.wrist_yaw += left_arm.wrist_yaw
+
+    nao.actuators.right_arm.shoulder_pitch += right_arm.shoulder_pitch
+    nao.actuators.right_arm.shoulder_roll += right_arm.shoulder_roll
+    nao.actuators.right_arm.elbow_yaw += right_arm.elbow_yaw
+    nao.actuators.right_arm.elbow_roll += right_arm.elbow_roll
+    nao.actuators.right_arm.wrist_yaw += right_arm.wrist_yaw

--- a/tools/machine-learning/mujoco/packages/walking_engine/src/walking_engine/__init__.py
+++ b/tools/machine-learning/mujoco/packages/walking_engine/src/walking_engine/__init__.py
@@ -1,4 +1,4 @@
-from .joint_command import compute_lower_body_joints
+from .joint_command import compute_arm_joints, compute_lower_body_joints
 from .walking import (
     step,
 )
@@ -11,6 +11,7 @@ __all__ = [
     "Parameters",
     "Side",
     "State",
+    "compute_arm_joints",
     "compute_lower_body_joints",
     "step",
 ]

--- a/tools/machine-learning/mujoco/packages/walking_engine/src/walking_engine/joint_command.py
+++ b/tools/machine-learning/mujoco/packages/walking_engine/src/walking_engine/joint_command.py
@@ -1,6 +1,6 @@
 import numpy as np
 from kinematics import LowerBodyJoints, foot_to_isometry
-from kinematics.inverse_kinematics import leg_angles
+from kinematics.inverse_kinematics import ArmJoints, leg_angles
 from robot_dimensions import ANKLE_TO_SOLE
 from transforms import Pose2
 from transforms.transforms import isometry_from_translation
@@ -25,3 +25,18 @@ def compute_lower_body_joints(
         walk_to_robot @ left_foot_in_walk,
         walk_to_robot @ right_foot_in_walk,
     )
+
+
+def compute_arm_joints(
+    left_sole: Pose2,
+    right_sole: Pose2,
+    *,
+    pitch_factor: float = 8.0,
+) -> tuple[ArmJoints, ArmJoints]:
+    left_arm = ArmJoints()
+    left_arm.shoulder_pitch = -pitch_factor * right_sole.x
+
+    right_arm = ArmJoints()
+    right_arm.shoulder_pitch = -pitch_factor * left_sole.x
+
+    return left_arm, right_arm

--- a/tools/machine-learning/mujoco/packages/walking_engine/src/walking_engine/walking_types.py
+++ b/tools/machine-learning/mujoco/packages/walking_engine/src/walking_engine/walking_types.py
@@ -15,6 +15,7 @@ class Parameters:
     foot_lift_apex: float
     foot_offset_left: float
     foot_offset_right: float
+    arm_pitch_factor: float
 
 
 @dataclass


### PR DESCRIPTION
## Why? What?

Adds the basic arm swing movement to the base policy in the mujoco walking engine.

Based on #??? Ole's walking branch (`im-gonna-walk-a-100-miles`)

Fixes #1601

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

run `uv run scripts/mujoco-walking.py` -> The arms move
