### PR TITLE
Fix a panic for the replayer when no frames exist to replay

### DIFF
--- a/crates/hulk_replayer/src/coordinate_systems.rs
+++ b/crates/hulk_replayer/src/coordinate_systems.rs
@@ -214,6 +214,8 @@ impl ViewportRange {
     }
 
     pub fn from_frame_range(frame_range: &FrameRange) -> Self {
+        const MINIMUM_WIDTH: f32 = 0.001;
+
         Self::new(
             RelativeTime::new(0.0),
             RelativeTime::new(
@@ -222,7 +224,8 @@ impl ViewportRange {
                     .inner()
                     .duration_since(frame_range.start().inner())
                     .expect("time ran backwards")
-                    .as_secs_f32(),
+                    .as_secs_f32()
+                    .max(MINIMUM_WIDTH),
             ),
         )
     }


### PR DESCRIPTION
## Why? What?

This PR fixes the replayer panicking when no frames exist to replay.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Upload to a NAO and download the logs before recording anything:

```sh
pepsi upload 33
pepsi logs download ./logs 33
```

Run the replayer and see that there is no panic (and no frames):

```sh
pepsi run replayeyr -- logs/10.1.24.33/[...]
```
