### PR TITLE
Fix ignoring no_disconnect flag in post game

### DIFF
--- a/tools/pepsi/src/post_game.rs
+++ b/tools/pepsi/src/post_game.rs
@@ -32,10 +32,12 @@ pub async fn post_game(arguments: Arguments) -> Result<()> {
                 .await
                 .wrap_err_with(|| format!("failed to execute systemctl hulk on {nao_address}"))?;
 
-            progress_bar.set_message("Disconnecting from WiFi...");
-            nao.set_wifi(Network::None)
-                .await
-                .wrap_err_with(|| format!("failed to set network on {nao_address}"))?;
+            if !arguments.no_disconnect {
+                progress_bar.set_message("Disconnecting from WiFi...");
+                nao.set_wifi(Network::None)
+                    .await
+                    .wrap_err_with(|| format!("failed to set network on {nao_address}"))?;
+            }
 
             progress_bar.set_message("Downloading logs...");
             let log_directory = arguments.log_directory.join(nao_address.to_string());


### PR DESCRIPTION
## Why? What?

What it says.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
pepsi wifi set SPL_A 42
pepsi postgame --no-disconnect 42
pepsi wifi status 42
```

The NAO should still be connected to SPL_A.
