### PR TITLE
Add `pepsi gamebranch` subcommand to create a game branch from a `deploy.toml` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ rust-toolchain.toml
 
 site/
 
+deploy.toml
 logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6749,7 +6749,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,6 @@ dependencies = [
  "color-eyre",
  "nao",
  "regex",
- "serde",
  "spl_network_messages",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6754,6 +6754,7 @@ dependencies = [
  "aliveness",
  "argument_parsers",
  "bat",
+ "chrono",
  "clap 4.5.29",
  "clap_complete",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "color-eyre",
  "nao",
  "regex",
+ "serde",
  "spl_network_messages",
 ]
 

--- a/crates/argument_parsers/Cargo.toml
+++ b/crates/argument_parsers/Cargo.toml
@@ -9,4 +9,5 @@ homepage.workspace = true
 color-eyre = { workspace = true }
 nao = { workspace = true }
 regex = { workspace = true }
+serde = { workspace = true }
 spl_network_messages = { workspace = true }

--- a/crates/argument_parsers/Cargo.toml
+++ b/crates/argument_parsers/Cargo.toml
@@ -9,5 +9,4 @@ homepage.workspace = true
 color-eyre = { workspace = true }
 nao = { workspace = true }
 regex = { workspace = true }
-serde = { workspace = true }
 spl_network_messages = { workspace = true }

--- a/deploy.toml.example
+++ b/deploy.toml.example
@@ -9,3 +9,12 @@ branches = [
 assignments = [
   "33:1",
 ]
+with_communication = false
+
+[recording_intervals]
+Control = 1
+VisionTop = 30
+VisionBottom = 30
+SplNetwork = 1
+# ObjectDetectionTop = 1
+# Audio = 1

--- a/deploy.toml.example
+++ b/deploy.toml.example
@@ -1,0 +1,11 @@
+# opponent = "B-Human"
+# phase = "second-half"
+location = "smd"
+wifi = "SPL_A"
+base = "main"
+branches = [
+  "julianschuler/example-branch",
+]
+assignments = [
+  "33:1",
+]

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+print_help() {
+    cat <<-__helpText__
+Usage: $0 <remote> <branch>
+
+Deploys a branch from a given remote by merge-squashing it to the current one.
+__helpText__
+}
+
+if [ $# -lt 2 ]; then
+  print_help
+  exit
+fi
+
+remote="$1"
+branch="$2"
+
+# ignore errors from the deploy remote not being present
+git remote remove deploy 2> /dev/null
+
+# exit on error for the following commands
+set -e
+
+git remote add deploy "https://github.com/$remote/hulk.git"
+git fetch deploy $branch
+git merge --squash "$remote/$branch"
+git commit -m "$remote/$branch"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -24,4 +24,4 @@ set -e
 
 git remote add deploy "https://github.com/$remote/hulk.git"
 git fetch deploy $branch
-git merge --squash "$remote/$branch"
+git merge --squash "deploy/$branch"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -25,4 +25,3 @@ set -e
 git remote add deploy "https://github.com/$remote/hulk.git"
 git fetch deploy $branch
 git merge --squash "$remote/$branch"
-git commit -m "$remote/$branch"

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 aliveness = { workspace = true }
 argument_parsers = { workspace = true }
 bat = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 color-eyre = { workspace = true }

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "4.0.0"
+version = "4.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -104,13 +104,10 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 }
             }
 
-            const ASSIGNEMNT_COMPLETION_SUBCOMMANDS: [&str; 2] = ["playernumber", "pregame"];
-            for subcommand in ASSIGNEMNT_COMPLETION_SUBCOMMANDS {
-                println!(
-                    "complete -c pepsi -n \"__fish_seen_subcommand_from {subcommand}\" \
-                         -f -a \"({assignement_completion_command})\""
-                );
-            }
+            println!(
+                "complete -c pepsi -n \"__fish_seen_subcommand_from playernumber\" \
+                     -f -a \"({assignement_completion_command})\""
+            );
         }
         Shell::Zsh => {
             let re = Regex::new("(:naos? -- .*):").unwrap();

--- a/tools/pepsi/src/deploy_config.rs
+++ b/tools/pepsi/src/deploy_config.rs
@@ -1,0 +1,107 @@
+use std::str::FromStr;
+
+use chrono::Utc;
+use color_eyre::{eyre::WrapErr, Result};
+use serde::{de::Error as DeserializeError, Deserialize, Deserializer};
+use tokio::fs::read_to_string;
+use toml::from_str;
+
+use argument_parsers::{parse_network, NaoAddress, NaoAddressPlayerAssignment};
+use nao::Network;
+use repository::Repository;
+
+#[derive(Deserialize)]
+pub struct DeployConfig {
+    pub opponent: Option<String>,
+    pub phase: Option<String>,
+    pub location: String,
+    #[serde(deserialize_with = "deserialize_network")]
+    pub wifi: Network,
+    pub base: String,
+    pub branches: Vec<Branch>,
+    #[serde(deserialize_with = "deserialize_assignments")]
+    pub assignments: Vec<NaoAddressPlayerAssignment>,
+}
+
+impl DeployConfig {
+    pub async fn read_from_file(repository: &Repository) -> Result<Self> {
+        let deploy_config = read_to_string(repository.root.join("deploy.toml"))
+            .await
+            .wrap_err("failed to read deploy.toml")?;
+
+        from_str(&deploy_config).wrap_err("could not deserialize config from deploy.toml")
+    }
+
+    pub fn branch_name(&self) -> String {
+        let date = Utc::now().date_naive();
+
+        let mut branch_name = if let Some(opponent) = &self.opponent {
+            format!("{date}-HULKs-vs-{opponent}")
+        } else {
+            format!("{date}-testgame")
+        };
+
+        if let Some(phase) = &self.phase {
+            branch_name.push('-');
+            branch_name.push_str(phase);
+        }
+
+        branch_name
+    }
+
+    pub fn naos(&self) -> Vec<NaoAddress> {
+        self.assignments
+            .iter()
+            .map(|assignment| assignment.nao_address)
+            .collect()
+    }
+}
+
+fn deserialize_network<'de, D, E>(deserializer: D) -> Result<Network, E>
+where
+    D: Deserializer<'de>,
+    E: DeserializeError + From<D::Error>,
+{
+    let network = String::deserialize(deserializer)?;
+
+    parse_network(&network).map_err(|error| E::custom(format!("{error:?}")))
+}
+
+fn deserialize_assignments<'de, D, E>(deserializer: D) -> Result<Vec<NaoAddressPlayerAssignment>, E>
+where
+    D: Deserializer<'de>,
+    E: DeserializeError + From<D::Error>,
+{
+    let assignments: Vec<String> = Vec::deserialize(deserializer)?;
+
+    assignments
+        .into_iter()
+        .map(|assignment| {
+            NaoAddressPlayerAssignment::from_str(&assignment)
+                .map_err(|error| E::custom(format!("{error:?}")))
+        })
+        .collect()
+}
+
+pub struct Branch {
+    pub remote: String,
+    pub branch: String,
+}
+
+impl<'de> Deserialize<'de> for Branch {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let branch = String::deserialize(deserializer)?;
+
+        let (remote, branch) = branch.split_once("/").ok_or_else(|| {
+            D::Error::custom("deploy target has to follow the format 'remote/branch'")
+        })?;
+
+        Ok(Self {
+            remote: remote.to_owned(),
+            branch: branch.to_owned(),
+        })
+    }
+}

--- a/tools/pepsi/src/deploy_config.rs
+++ b/tools/pepsi/src/deploy_config.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
 use chrono::Utc;
 use color_eyre::{eyre::WrapErr, Result};
@@ -21,6 +21,8 @@ pub struct DeployConfig {
     pub branches: Vec<Branch>,
     #[serde(deserialize_with = "deserialize_assignments")]
     pub assignments: Vec<NaoAddressPlayerAssignment>,
+    pub with_communication: bool,
+    pub recording_intervals: HashMap<String, usize>,
 }
 
 impl DeployConfig {

--- a/tools/pepsi/src/game_branch.rs
+++ b/tools/pepsi/src/game_branch.rs
@@ -1,0 +1,98 @@
+use clap::Args;
+use color_eyre::{eyre::WrapErr, Result};
+use repository::Repository;
+use tokio::{
+    io::{stdin, AsyncBufReadExt, BufReader},
+    process::Command,
+};
+
+use crate::{
+    deploy_config::{Branch, DeployConfig},
+    git::{create_and_switch_to_branch, create_commit, reset_to_head},
+};
+
+#[derive(Args)]
+pub struct Arguments {
+    /// Create the game branch even if it already exists
+    #[arg(short, long)]
+    force: bool,
+}
+
+pub async fn game_branch(arguments: Arguments, repository: &Repository) -> Result<()> {
+    let config = DeployConfig::read_from_file(repository)
+        .await
+        .wrap_err("failed to read deploy config from file")?;
+
+    let branch_name = config.branch_name();
+
+    create_and_switch_to_branch(&branch_name, &config.base, arguments.force)
+        .await
+        .wrap_err("failed to create and switch to branch")?;
+
+    'branches: for Branch { remote, branch } in &config.branches {
+        let status = Command::new(repository.root.join("scripts/deploy"))
+            .arg(remote)
+            .arg(branch)
+            .status()
+            .await
+            .wrap_err("failed to execute deploy script")?;
+
+        if !status.success() {
+            eprintln!("Automatic merge failed.");
+            let skip_prompt = format!("Do you want to skip deploying '{remote}/{branch}'?");
+
+            loop {
+                let skip = confirmation_prompt(&skip_prompt)
+                    .await
+                    .wrap_err("failed to create confirmation prompt")?;
+
+                if skip {
+                    reset_to_head()
+                        .await
+                        .wrap_err("failed to reset repository to HEAD")?;
+
+                    continue 'branches;
+                } else {
+                    eprintln!("Please resolve all conflicts now.");
+
+                    let conflicts_resolved =
+                        confirmation_prompt("Were you able to resolve the conflicts?")
+                            .await
+                            .wrap_err("failed to create confirmation prompt")?;
+
+                    if conflicts_resolved {
+                        break;
+                    }
+                }
+            }
+        }
+
+        create_commit(&format!("{remote}/{branch}"))
+            .await
+            .wrap_err("failed to create commit")?;
+    }
+
+    Ok(())
+}
+
+async fn confirmation_prompt(message: &str) -> Result<bool> {
+    let reader = BufReader::new(stdin());
+
+    let mut lines = reader.lines();
+
+    loop {
+        eprint!("{message} [y/n] ");
+
+        if let Some(line) = lines
+            .next_line()
+            .await
+            .wrap_err("failed to get next line")?
+        {
+            match line {
+                line if line == "y" => return Ok(true),
+                line if line == "n" => return Ok(false),
+                _ => {}
+            }
+        }
+    }
+}

--- a/tools/pepsi/src/game_branch.rs
+++ b/tools/pepsi/src/game_branch.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use clap::Args;
 use color_eyre::{eyre::WrapErr, Result};
 use repository::Repository;
@@ -12,23 +10,10 @@ use crate::{
     deploy_config::{Branch, DeployConfig},
     git::{create_and_switch_to_branch, create_commit, reset_to_head},
     player_number::{player_number, Arguments as PlayerNumberArguments},
-    recording::parse_key_value,
 };
 
 #[derive(Args)]
 pub struct Arguments {
-    /// Enable communication, communication is disabled by default
-    #[arg(long)]
-    pub with_communication: bool,
-    /// Intervals between cycle recordings, e.g. Control=1,VisionTop=30 to record every cycle in Control
-    /// and one out of every 30 in VisionTop. Set to 0 or don't specify to disable recording for a cycler.
-    #[arg(
-        long,
-        value_delimiter=',',
-        value_parser = parse_key_value::<String, usize>,
-        default_value = "Control=1,VisionTop=30,VisionBottom=30,SplNetwork=1",
-    )]
-    pub recording_intervals: Vec<(String, usize)>,
     /// Create the game branch even if it already exists
     #[arg(short, long)]
     pub force: bool,
@@ -43,11 +28,6 @@ pub async fn game_branch(arguments: Arguments, repository: &Repository) -> Resul
     create_and_switch_to_branch(&branch_name, &config.base, arguments.force)
         .await
         .wrap_err("failed to create and switch to branch")?;
-
-    configure_repository(repository, arguments, &config).await?;
-    create_commit("Add player number assigments and framework config")
-        .await
-        .wrap_err("failed to create commit")?;
 
     'branches: for Branch { remote, branch } in &config.branches {
         let status = Command::new(repository.root.join("scripts/deploy"))
@@ -92,16 +72,17 @@ pub async fn game_branch(arguments: Arguments, repository: &Repository) -> Resul
             .wrap_err("failed to create commit")?;
     }
 
+    configure_repository(repository, config).await?;
+    create_commit("Add player number assigments and framework config")
+        .await
+        .wrap_err("failed to create commit")?;
+
     Ok(())
 }
 
-async fn configure_repository(
-    repository: &Repository,
-    arguments: Arguments,
-    config: &DeployConfig,
-) -> Result<()> {
+async fn configure_repository(repository: &Repository, config: DeployConfig) -> Result<()> {
     repository
-        .configure_recording_intervals(HashMap::from_iter(arguments.recording_intervals))
+        .configure_recording_intervals(config.recording_intervals)
         .await
         .wrap_err("failed to apply recording settings")?;
 
@@ -111,7 +92,7 @@ async fn configure_repository(
         .wrap_err_with(|| format!("failed to set location for nao to {}", config.location))?;
 
     repository
-        .configure_communication(arguments.with_communication)
+        .configure_communication(config.with_communication)
         .await
         .wrap_err("failed to set communication")?;
 
@@ -128,6 +109,7 @@ async fn configure_repository(
     )
     .await
     .wrap_err("failed to set player numbers")?;
+
     Ok(())
 }
 

--- a/tools/pepsi/src/git.rs
+++ b/tools/pepsi/src/git.rs
@@ -1,0 +1,60 @@
+use std::ffi::OsStr;
+
+use color_eyre::{
+    eyre::{bail, Context},
+    Result,
+};
+use tokio::process::Command;
+
+pub struct GitCommand {
+    inner: Command,
+}
+
+impl GitCommand {
+    fn new(subcommand: impl AsRef<OsStr>) -> Self {
+        let mut inner = Command::new("git");
+        inner.arg(subcommand);
+
+        Self { inner }
+    }
+
+    fn arg(mut self, arg: impl AsRef<OsStr>) -> Self {
+        self.inner.arg(arg);
+        self
+    }
+
+    async fn run(mut self) -> Result<()> {
+        let status = self.inner.status().await.wrap_err("failed to run git")?;
+
+        if !status.success() {
+            bail!("git failed with {status}");
+        }
+
+        Ok(())
+    }
+}
+
+pub async fn create_and_switch_to_branch(name: &str, base: &str) -> Result<()> {
+    GitCommand::new("switch")
+        .arg("-c")
+        .arg(name)
+        .arg(base)
+        .run()
+        .await
+}
+
+pub async fn switch_to_branch(name: &str) -> Result<()> {
+    GitCommand::new("switch").arg(name).run().await
+}
+
+pub async fn create_commit(message: &str) -> Result<()> {
+    GitCommand::new("commit").arg("-m").arg(message).run().await
+}
+
+pub async fn reset_to_head() -> Result<()> {
+    GitCommand::new("reset")
+        .arg("--hard")
+        .arg("HEAD")
+        .run()
+        .await
+}

--- a/tools/pepsi/src/git.rs
+++ b/tools/pepsi/src/git.rs
@@ -1,7 +1,4 @@
-use std::{
-    ffi::OsStr,
-    process::{ExitStatus, Stdio},
-};
+use std::{ffi::OsStr, process::ExitStatus};
 
 use color_eyre::{
     eyre::{bail, Context},
@@ -26,11 +23,6 @@ impl GitCommand {
         self
     }
 
-    fn suppress_output(mut self) -> Self {
-        self.inner.stdout(Stdio::null()).stderr(Stdio::null());
-        self
-    }
-
     async fn status(mut self) -> Result<ExitStatus> {
         self.inner.status().await.wrap_err("failed to run git")
     }
@@ -46,15 +38,6 @@ impl GitCommand {
     }
 }
 
-pub async fn branch_exists(name: &str) -> Result<bool> {
-    Ok(GitCommand::new("show-branch")
-        .arg(name)
-        .suppress_output()
-        .status()
-        .await?
-        .success())
-}
-
 pub async fn create_and_switch_to_branch(name: &str, base: &str, force: bool) -> Result<()> {
     let create_flag = if force { "--force-create" } else { "--create" };
 
@@ -66,14 +49,11 @@ pub async fn create_and_switch_to_branch(name: &str, base: &str, force: bool) ->
         .await
 }
 
-pub async fn switch_to_branch(name: &str) -> Result<()> {
-    GitCommand::new("switch").arg(name).run().await
-}
-
 pub async fn create_commit(message: &str) -> Result<()> {
     GitCommand::new("commit")
-        .arg("-a")
-        .arg("-m")
+        .arg("--all")
+        .arg("--allow-empty")
+        .arg("--message")
         .arg(message)
         .run()
         .await

--- a/tools/pepsi/src/git.rs
+++ b/tools/pepsi/src/git.rs
@@ -55,9 +55,11 @@ pub async fn branch_exists(name: &str) -> Result<bool> {
         .success())
 }
 
-pub async fn create_and_switch_to_branch(name: &str, base: &str) -> Result<()> {
+pub async fn create_and_switch_to_branch(name: &str, base: &str, force: bool) -> Result<()> {
+    let create_flag = if force { "--force-create" } else { "--create" };
+
     GitCommand::new("switch")
-        .arg("-c")
+        .arg(create_flag)
         .arg(name)
         .arg(base)
         .run()

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -36,6 +36,7 @@ mod cargo;
 mod communication;
 mod completions;
 mod gammaray;
+mod git;
 mod hulk;
 mod location;
 mod logs;

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -13,6 +13,7 @@ use analyze::analyze;
 use cargo::{build, cargo, check, clippy, install, run, test};
 use communication::communication;
 use completions::completions;
+use game_branch::game_branch;
 use gammaray::gammaray;
 use hulk::hulk;
 use location::location;
@@ -35,6 +36,8 @@ mod analyze;
 mod cargo;
 mod communication;
 mod completions;
+mod deploy_config;
+mod game_branch;
 mod gammaray;
 mod git;
 mod hulk;
@@ -83,6 +86,8 @@ enum Command {
     Communication(communication::Arguments),
     /// Generate shell completion files
     Completions(completions::Arguments),
+    /// Create a game branch from the deploy.toml in the repository root
+    Gamebranch(game_branch::Arguments),
     /// Flash a HULKs-OS image to NAOs
     Gammaray(gammaray::Arguments),
     /// Control the HULK service
@@ -178,6 +183,9 @@ async fn main() -> Result<()> {
         Command::Completions(arguments) => completions(arguments, Arguments::command())
             .await
             .wrap_err("failed to execute completion command")?,
+        Command::Gamebranch(arguments) => game_branch(arguments, &repository?)
+            .await
+            .wrap_err("failed to execute gamebranch command")?,
         Command::Gammaray(arguments) => gammaray(arguments, &repository?)
             .await
             .wrap_err("failed to execute gammaray command")?,

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -84,7 +84,6 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
         .wrap_err("failed to populate upload directory")?;
 
     let arguments = &arguments.pre_game;
-    let config = &config;
     let upload_directory = &upload_directory;
 
     ProgressIndicator::map_tasks(
@@ -95,7 +94,7 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
                 nao_address,
                 upload_directory,
                 arguments,
-                config,
+                config.wifi,
                 progress_bar,
                 repository,
             )
@@ -111,7 +110,7 @@ async fn setup_nao(
     nao_address: &NaoAddress,
     upload_directory: impl AsRef<Path>,
     arguments: &PreGameArguments,
-    config: &DeployConfig,
+    wifi: Network,
     progress: ProgressBar,
     repository: &Repository,
 ) -> Result<()> {
@@ -145,7 +144,7 @@ async fn setup_nao(
     .await
     .wrap_err_with(|| format!("failed to upload binary to {nao_address}"))?;
 
-    if config.wifi != Network::None {
+    if wifi != Network::None {
         progress.set_message("Scanning for WiFi...");
         nao.scan_networks()
             .await
@@ -153,7 +152,7 @@ async fn setup_nao(
     }
 
     progress.set_message("Setting WiFi...");
-    nao.set_wifi(config.wifi)
+    nao.set_wifi(wifi)
         .await
         .wrap_err_with(|| format!("failed to set network on {nao_address}"))?;
 

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -19,7 +19,6 @@ use tokio::{
     process::Command,
 };
 use toml::from_str;
-use tracing::warn;
 
 use crate::{
     cargo::{self, build, cargo, environment::EnvironmentArguments, CargoCommand},
@@ -94,7 +93,7 @@ impl Config {
             .await
             .wrap_err("failed to check whether branch exists")?
         {
-            warn!("Branch already exists, switching to it instead");
+            eprintln!("Game branch already exists, switching to it instead");
 
             switch_to_branch(&branch_name)
                 .await

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -76,6 +76,7 @@ pub struct PreGameArguments {
 #[derive(Deserialize)]
 pub struct Config {
     opponent: Option<String>,
+    phase: Option<String>,
     location: String,
     #[serde(deserialize_with = "deserialize_network")]
     wifi: Network,
@@ -153,11 +154,18 @@ impl Config {
     fn branch_name(&self) -> String {
         let date = Utc::now().date_naive();
 
-        if let Some(opponent) = &self.opponent {
+        let mut branch_name = if let Some(opponent) = &self.opponent {
             format!("{date}-HULKs-vs-{opponent}")
         } else {
             format!("{date}-testgame")
+        };
+
+        if let Some(phase) = &self.phase {
+            branch_name.push('-');
+            branch_name.push_str(phase);
         }
+
+        branch_name
     }
 }
 


### PR DESCRIPTION
## Why? What?

This PR implements adds a `pepsi gamebranch` subcommand for creating a game branch from a `deploy.toml` file. The game branch is intended to be used with `pepsi pregame`, replacing the use of positional arguments (i.e. no more `pepsi pregame smd SPL_A 33:1 [...]` to set the location, network, etc.).

A corresponding example file is provided as `deploy.toml.example`.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

- [x] Add a script for outputting the remote/branch for deployment.
- [ ] Add an additional argument for performing the pregame to a subset of configured NAOs.

## How to Test

Copy the deploy.toml.example file, adjust it accordingly and execute a pregrame:

```sh
cp deploy.toml.example deploy.toml
helix deploy.toml
./pepsi gamebranch
./pepsi pregame
```
