### PR TITLE
upgrade CI image to 1.84.1

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -20,7 +20,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: hulk-ci
-        tags: latest 1.81.0 ${{ github.sha }}
+        tags: latest 1.84.1 ${{ github.sha }}
         containerfiles: |
           tools/ci/github-runners/Containerfile
 

--- a/tools/ci/github-runners/Containerfile
+++ b/tools/ci/github-runners/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.81.0
+FROM docker.io/rust:1.84.1
 
 RUN apt-get update && apt-get install --no-install-recommends --yes \
   buildah \


### PR DESCRIPTION
## Why? What?

get the newest stuff

Pipeline already ran upstream, and CI image is already published.