### PR TITLE
Fix realpath failing when $DATA_HOME is missing

### DIFF
--- a/scripts/remote_workspace
+++ b/scripts/remote_workspace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on error
 set -e

--- a/scripts/resolve_data_home
+++ b/scripts/resolve_data_home
@@ -5,6 +5,9 @@ HOME="${HOME:-$(echo ~)}"
 DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 HULK_DATA_HOME="${HULK_DATA_HOME:-$DATA_HOME/hulk}"
 
+# create data home if not present to ensure realpath does not fail
+mkdir -p "$HULK_DATA_HOME"
+
 if [ "$(uname)" == "Darwin" ]; then
     echo -n $(grealpath "$HULK_DATA_HOME")
 else


### PR DESCRIPTION
## Why? What?

Fixes #1611.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
XDG_DATA_HOME=/tmp/data ./pepsi build nao
```
