### PR TITLE
Disable sacrificial lamb

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1262,11 +1262,11 @@
   "sacrificial_lamb": {
     "wait_for_opponent_penalties_period": {
       "nanos": 0,
-      "secs": 5
+      "secs": 0
     },
     "wait_for_own_penalties_period": {
       "nanos": 0,
-      "secs": 15
+      "secs": 0
     },
     "sacrificial_nao_playernumber": "Three"
   },


### PR DESCRIPTION
## Why? What?

The rule changes for 2025 make the sacrificial lamb strategy pretty much useless. Since the penalty for "Motion in standby" is now applied to the whole team, the concept of the sacrificial lamb does not work anymore. 
Therefore we disable it, by simply setting our wait timers for the sacrificial lamb strategy to 0s. 

Fixes #1613 

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

- Remove the complexity of the sacrificial lamb code and fully remove it, instead of just disabling it.

## How to Test

- Do a ready signal visual referee test
- All NAOs should instantly transition to ready after the detection of the ready signal pose
