### PR TITLE
use original bevy_panorbit_camera dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,8 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_panorbit_camera"
-version = "0.22.2"
-source = "git+https://github.com/schmidma/bevy_panorbit_camera.git?rev=dd14ccf4416b6259fc53d80f696cdb358ed61d00#dd14ccf4416b6259fc53d80f696cdb358ed61d00"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e22224619230504b7a439ba05df41e4e364b848e1cf336c60bb9e44fd38c273"
 dependencies = [
  "bevy",
  "bevy_egui 0.33.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ bevy-inspector-egui = "0.29.1"
 bevy_asset_loader = "0.22.0"
 bevy_egui = "0.33.0"
 bevy_obj = "0.15"
-bevy_panorbit_camera = { git = "https://github.com/schmidma/bevy_panorbit_camera.git", rev = "dd14ccf4416b6259fc53d80f696cdb358ed61d00", features = [
+bevy_panorbit_camera = { version = "0.23.0", features = [
   "bevy_egui",
 ] }
 bincode = "1.3.3"


### PR DESCRIPTION
## Why? What?

What the title says.
Can use the original dependency since https://github.com/Plonq/bevy_panorbit_camera/pull/101 has been merged

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* run mio, or compile
