### PR TITLE
Recommend `./pepsi install` instead of `cargo install`

### DIFF
--- a/crates/repository/src/inspect_version.rs
+++ b/crates/repository/src/inspect_version.rs
@@ -27,7 +27,11 @@ pub fn inspect_version(toml_path: impl AsRef<Path>) -> Result<Version> {
 }
 
 /// Checks whether the package has a newer version than the provided version.
-pub fn check_for_update(own_version: &str, cargo_toml: impl AsRef<Path>) -> Result<()> {
+pub fn check_for_update(
+    own_version: &str,
+    cargo_toml: impl AsRef<Path>,
+    binary_name: &str,
+) -> Result<()> {
     let own_version = Version::parse(own_version)
         .wrap_err_with(|| format!("failed to parse own version '{own_version}' as SemVer"))?;
     let cargo_toml_version = inspect_version(&cargo_toml).wrap_err_with(|| {
@@ -37,14 +41,12 @@ pub fn check_for_update(own_version: &str, cargo_toml: impl AsRef<Path>) -> Resu
         )
     })?;
     if own_version < cargo_toml_version {
-        let crate_path = cargo_toml.as_ref().parent().unwrap();
         warn!(
             "New version available!
         Own version: {own_version}
         New version: {cargo_toml_version}
         To install new version use:
-            cargo install --path {}",
-            crate_path.display()
+            ./pepsi install {binary_name}",
         );
     }
     Ok(())

--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -121,7 +121,7 @@ This downloads and builds all dependencies for the workspace and displays the he
     You can also install Pepsi into your local system to conveniently use it without rebuilding:
 
     ```
-    cargo install --path tools/pepsi
+    ./pepsi install pepsi
     ```
 
     Pepsi is subsequently installed at `~/.cargo/bin/pepsi`.

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -80,7 +80,7 @@ The shells completions for fish, zsh and bash include dynamic suggestions for al
 Those suggestions are retrieved using the aliveness service and require a version of pepsi to be installed in the `PATH`, e.g. by using
 
 ```
-cargo install --path tools/pepsi
+./pepsi install pepsi
 ```
 
 and adding `~/.cargo/bin` to the `PATH`.

--- a/docs/tooling/twix.md
+++ b/docs/tooling/twix.md
@@ -4,7 +4,7 @@ Twix doesn't have to be installed to be used, it can be directly run from the re
 But you can also install it into your local system to conveniently use it without rebuilding:
 
 ```
-cargo install --path tools/twix
+./pepsi install twix
 ```
 
 Twix is subsequently installed at `~/.cargo/bin/twix`. <br>

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -150,6 +150,7 @@ async fn main() -> Result<()> {
         if let Err(error) = check_for_update(
             env!("CARGO_PKG_VERSION"),
             repository.root.join("tools/pepsi/Cargo.toml"),
+            "pepsi",
         ) {
             warn!("{error:#?}");
         }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -104,6 +104,7 @@ fn main() -> Result<(), eframe::Error> {
             if let Err(error) = check_for_update(
                 env!("CARGO_PKG_VERSION"),
                 repository.root.join("tools/twix/Cargo.toml"),
+                "twix",
             ) {
                 error!("{error:#?}");
             }


### PR DESCRIPTION
## Why? What?

Since pepsi max, e.g. `./pepsi install pepsi` replaces e.g. `cargo install --path tools/pepsi`. This PR updates the documentation and update recommendations accordingly.

Please discuss whether we should recommend `pepsi install pepsi` or `./pepsi install pepsi` here.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

If you have installed an old version of pepsi, have a look at the old version warning of any pepsi command.
