### PR TITLE
Next-gen postgame

### DIFF
--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "4.1.0"
+version = "5.0.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -72,7 +72,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const COMPLETION_SUBCOMMANDS: [(&str, &str); 15] = [
+            const COMPLETION_SUBCOMMANDS: [(&str, &str); 14] = [
                 ("aliveness", ""),
                 ("gammaray", ""),
                 ("hulk", ""),
@@ -80,7 +80,6 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 ("logs", "downloads"),
                 ("logs", "show"),
                 ("ping", ""),
-                ("postgame", ""),
                 ("poweroff", ""),
                 ("reboot", ""),
                 ("shell", ""),

--- a/tools/pepsi/src/deploy_config.rs
+++ b/tools/pepsi/src/deploy_config.rs
@@ -36,14 +36,18 @@ impl DeployConfig {
         from_str(&deploy_config).wrap_err("could not deserialize config from deploy.toml")
     }
 
-    pub fn branch_name(&self) -> String {
+    pub fn log_directory_name(&self) -> String {
         let date = Utc::now().date_naive();
 
-        let mut branch_name = if let Some(opponent) = &self.opponent {
+        if let Some(opponent) = &self.opponent {
             format!("{date}-HULKs-vs-{opponent}")
         } else {
             format!("{date}-testgame")
-        };
+        }
+    }
+
+    pub fn branch_name(&self) -> String {
+        let mut branch_name = self.log_directory_name();
 
         if let Some(phase) = &self.phase {
             branch_name.push('-');

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -206,7 +206,7 @@ async fn main() -> Result<()> {
         Command::Playernumber(arguments) => player_number(arguments, &repository?)
             .await
             .wrap_err("failed to execute player_number command")?,
-        Command::Postgame(arguments) => post_game(arguments)
+        Command::Postgame(arguments) => post_game(arguments, &repository?)
             .await
             .wrap_err("failed to execute post_game command")?,
         Command::Poweroff(arguments) => power_off(arguments, &repository?)


### PR DESCRIPTION
## Why? What?

Blocked on #1632.

This PR follows the improvements of #1632 to simplify the postgame to make use of the information provided in the `deploy.toml`.

The semantic of postgame now changes to the following:

```sh
pepsi postgame <phase>
```
where `<phase>` is one of `golden-goal`, `first-half` or `second-half`.

The postgame is applied to all robots listed in the `deploy.toml`, placing the logs in the form `logs` folder in the repository root, following the structure `logs/2025-03-03-HULKs-vs-HTWK/<phase>/<robot>`.

The logs folder is intended to by symlinked/mounted to our USB SSD or a network drive.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

- [ ] Allow to specify a subset of robots specified in the `deploy.toml` to apply the postgame to

## How to Test

Deploy a robot and execute the following:

```sh
./pepsi postgame first-half
```
