### PR TITLE
Add fish completions for postgame phase

### DIFF
--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -107,6 +107,10 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 "complete -c pepsi -n \"__fish_seen_subcommand_from playernumber\" \
                      -f -a \"({assignement_completion_command})\""
             );
+            println!(
+                "complete -c pepsi -n \"__fish_seen_subcommand_from postgame\" \
+                     -f -a \"golden-goal first-half second-half\""
+            );
         }
         Shell::Zsh => {
             let re = Regex::new("(:naos? -- .*):").unwrap();


### PR DESCRIPTION
## Why? What?

Clap doesn't seem to generate the correct completions for ValueEnums, this PR adds them manually.

Fixes #

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
./pepsi completions fish > ~/.config/fish/completions/pepsi.fish
```

Open a new shell, enter `pepsi postgame` and observe the completions.
