### PR TITLE
Allow applying pre-/postgame only to specific NAOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6318,7 +6318,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "5.0.0"
+version = "5.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -72,7 +72,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const COMPLETION_SUBCOMMANDS: [(&str, &str); 14] = [
+            const COMPLETION_SUBCOMMANDS: [(&str, &str); 18] = [
                 ("aliveness", ""),
                 ("gammaray", ""),
                 ("hulk", ""),
@@ -80,7 +80,11 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 ("logs", "downloads"),
                 ("logs", "show"),
                 ("ping", ""),
+                ("postgame", "golden-goal"),
+                ("postgame", "first-half"),
+                ("postgame", "second-half"),
                 ("poweroff", ""),
+                ("pregame", ""),
                 ("reboot", ""),
                 ("shell", ""),
                 ("upload", ""),
@@ -88,16 +92,16 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 ("wifi", "set"),
                 ("wifi", "status"),
             ];
-            for (first, second) in COMPLETION_SUBCOMMANDS {
-                if second.is_empty() {
+            for (subcommand, argument) in COMPLETION_SUBCOMMANDS {
+                if argument.is_empty() {
                     println!(
-                        "complete -c pepsi -n \"__fish_seen_subcommand_from {first}\" \
+                        "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}\" \
                              -f -a \"({nao_completion_command})\""
                     );
                 } else {
                     println!(
-                        "complete -c pepsi -n \"__fish_seen_subcommand_from {first}; \
-                             and __fish_seen_subcommand_from {second}\" \
+                        "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}; \
+                             and __fish_seen_subcommand_from {argument}\" \
                              -f -a \"({nao_completion_command})\""
                     );
                 }
@@ -108,7 +112,8 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                      -f -a \"({assignement_completion_command})\""
             );
             println!(
-                "complete -c pepsi -n \"__fish_seen_subcommand_from postgame\" \
+                "complete -c pepsi -n \"__fish_seen_subcommand_from postgame; \
+                     and not __fish_seen_subcommand_from golden-goal first-half second-half\" \
                      -f -a \"golden-goal first-half second-half\""
             );
         }

--- a/tools/pepsi/src/post_game.rs
+++ b/tools/pepsi/src/post_game.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use argument_parsers::NaoAddress;
 use clap::{Args, ValueEnum};
 use color_eyre::{eyre::WrapErr, Result};
 
@@ -19,6 +20,8 @@ pub struct Arguments {
     /// Current game phase
     #[arg(value_enum)]
     pub phase: Phase,
+    /// The NAOs to apply the postgame to, queried from the deploy.toml if not specified
+    pub naos: Option<Vec<NaoAddress>>,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -32,7 +35,7 @@ pub async fn post_game(arguments: Arguments, repository: &Repository) -> Result<
     let config = DeployConfig::read_from_file(repository)
         .await
         .wrap_err("failed to read deploy config from file")?;
-    let naos = config.naos();
+    let naos = arguments.naos.unwrap_or_else(|| config.naos());
 
     let log_directory = &arguments.log_directory.unwrap_or_else(|| {
         let log_directory_name = config.log_directory_name();


### PR DESCRIPTION
## Why? What?

This PR adds the ability to apply the pre- and postgame only to specific NAOs instead of all deployed ones.

For pregame, all specified NAOs have to be present in the `deploy.toml`, this is not enforced for the postgame.


## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```
pepsi pregame 33
pepsi postgame first-half 33
```
