### PR TITLE
Wait for NAOs during pre- and postgame

### DIFF
--- a/crates/nao/src/lib.rs
+++ b/crates/nao/src/lib.rs
@@ -55,6 +55,14 @@ impl Nao {
         Self { address }
     }
 
+    pub async fn ping_until_available(host: Ipv4Addr) -> Self {
+        loop {
+            if let Ok(nao) = Self::try_new_with_ping(host).await {
+                return nao;
+            }
+        }
+    }
+
     pub async fn try_new_with_ping(host: Ipv4Addr) -> Result<Self> {
         Self::try_new_with_ping_and_arguments(host, PING_TIMEOUT).await
     }

--- a/tools/pepsi/src/post_game.rs
+++ b/tools/pepsi/src/post_game.rs
@@ -60,7 +60,9 @@ pub async fn post_game(arguments: Arguments, repository: &Repository) -> Result<
         &naos,
         "Executing postgame tasks...",
         |nao_address, progress_bar| async move {
-            let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+            progress_bar.set_message("Pinging NAO...");
+            let nao = Nao::ping_until_available(nao_address.ip).await;
+
             progress_bar.set_message("Stopping HULK service...");
             nao.execute_systemctl(SystemctlAction::Stop, "hulk")
                 .await

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -151,7 +151,7 @@ async fn setup_nao(
     repository: &Repository,
 ) -> Result<()> {
     progress.set_message("Pinging NAO...");
-    let nao = Nao::try_new_with_ping(nao_address.ip).await?;
+    let nao = Nao::ping_until_available(nao_address.ip).await;
 
     if !arguments.skip_os_check {
         progress.set_message("Checking OS version...");


### PR DESCRIPTION
## Why? What?

This PR implements waiting for NAOs to become available via the network.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

```sh
pepsi pregame
pepsi postgame first-half
```

Pre- and postgame will now wait until the NAOs specified in the `deploy.toml` become available instead of throwing an error.
