### PR TITLE
Fix enum plot crashes

### DIFF
--- a/tools/twix/src/change_buffer.rs
+++ b/tools/twix/src/change_buffer.rs
@@ -100,7 +100,9 @@ impl<T: PartialEq, E> ChangeBuffer<T, E> {
                             let maybe_datum = op(maybe_datum);
                             match maybe_datum {
                                 Ok(datum) => {
-                                    self.sender.send_modify(|value| handle_update(value, datum))
+                                    if datum.timestamp != SystemTime::UNIX_EPOCH {
+                                        self.sender.send_modify(|value| handle_update(value, datum))
+                                    }
                                 }
                                 Err(error) => {
                                     let _ = self.sender.send(Err(error));


### PR DESCRIPTION
## Why? What?

On main twix crashes reliably when an enum plot panel is open, twix is set to automatically connect to localhost and a replayer is started.
The root cause is that the subscription goes through before the replayer replays the first frame, causing the response to the subscription request to contain data from the Default element of the `buffered_watch` channel, which is a default database timestamped at `SystemTime::UNIX_EPOCH`.

Since the enum plot panel has to calculate the range for its X-axis, mixing unix epoch timestamps with about now timestamps breaks the f32 resolution used for the range calculation.
A proper fix would require rethinking what data should be transmitted by the communication server, which probably would result in some major changes in communication. This PR is just a hotfix to filter the bad updates on the client side.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

- Start a replayer
- Open twix with an enum plot panel and a valid subscription and connect to replayer
- Close replayer and open it again
- Twix should no longer crash