### PR TITLE
Replayer: communicate hardware IDs over communication

### DIFF
--- a/crates/code_generation/src/execution.rs
+++ b/crates/code_generation/src/execution.rs
@@ -156,6 +156,9 @@ pub fn generate_replayer_struct(cyclers: &Cyclers, with_communication: bool) -> 
                                     let (parameters_subscriptions, _) = buffered_watch::channel(Default::default());
                                     communication_server.expose_source("parameters", parameters_receiver, parameters_subscriptions)?;
                                     communication_server.expose_sink("parameters", parameters_sender)?;
+                                    let (_, ids_receiver) = buffered_watch::channel((std::time::SystemTime::now(), hardware_ids));
+                                    let (ids_subscriptions, _) = buffered_watch::channel(Default::default());
+                                    communication_server.expose_source("hardware_ids", ids_receiver, ids_subscriptions)?;
                                     communication_server.serve(addresses, keep_running).await?;
                                     Ok(())
                                 })


### PR DESCRIPTION
## Why? What?

What the title says.

Part of fixing #1675.

## ToDo / Known Issues

The hardware ID returned is always `"replayer"`.
Thus, the "save to head" button saves the parameters to a `head.replayer.json`.

## Ideas for Next Iterations (Not This PR)

Save the hardware IDs of the recording robot to the replay, use it in the replayer

## How to Test

Use the "save to head" button