### PR TITLE
Halving of step height for the first step (starting).

### DIFF
--- a/crates/walking_engine/src/mode/starting.rs
+++ b/crates/walking_engine/src/mode/starting.rs
@@ -20,7 +20,8 @@ pub struct Starting {
 
 impl Starting {
     pub fn new(context: &Context, support_side: Side) -> Self {
-        let plan = StepPlan::new_from_request(context, Step::ZERO, support_side);
+        let mut plan = StepPlan::new_from_request(context, Step::ZERO, support_side);
+        plan.foot_lift_apex= plan.foot_lift_apex / 2.0;
         let step = StepState::new(plan);
         Self { step }
     }


### PR DESCRIPTION
## Why? What?

Abruptly going from standing to full thrust walking (in "starting")  can lead to walking instability.
The goal of/the reasoning behind this PR is to improve walking balance and stability (of "starting").
In this PR the step height of the first step (in "starting") gets halved, thus improving walking balance and stability


## How to Test

Visual test for the reviewer: 
Does the code do what it is supposed to do (half the step height of the first step in "starting")?
Does the code improve walking balance and stability (of "starting")?

