### PR TITLE
Eat larger patches

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -71,7 +71,7 @@
       "correction_proximity_merge_factor": 1.0,
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
-      "ball_radius_enlargement_factor": 1.5,
+      "ball_radius_enlargement_factor": 1.8,
       "detection_noise": [4.0, 4.0],
       "noise_increase_slope": 0.0,
       "noise_increase_distance_threshold": 0.0

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -71,7 +71,7 @@
       "correction_proximity_merge_factor": 1.0,
       "image_containment_merge_factor": 1.0,
       "cluster_merge_radius_factor": 1.5,
-      "ball_radius_enlargement_factor": 1.8,
+      "ball_radius_enlargement_factor": 1.7,
       "detection_noise": [4.0, 4.0],
       "noise_increase_slope": 0.0,
       "noise_increase_distance_threshold": 0.0


### PR DESCRIPTION
## Why? What?

- Increases the `enlargement_factor` for ball candidates
- Increases the probability, that the ball is completely in the patch for the classifier

Fixes #1695 

## ToDo / Known Issues

- Find out, why this is a problem now?!

## Ideas for Next Iterations (Not This PR)

- Search for a root cause and fix it

## How to Test

- Checked it using the replay of the game HULKs vs. DutchNao (2025-03-12-testgame)
- Have a look at the `Ball Candidates` Panel in twix
