### PR TITLE
Unterbinde doppelte Keeper Motion

### DIFF
--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -130,10 +130,19 @@ fn transition_motion(
         (MotionType::Walk, _, MotionType::WideStance, _) => MotionType::WideStance,
         (MotionType::Walk, _, MotionType::KeeperJumpRight, _) => MotionType::KeeperJumpRight,
         (MotionType::Walk, _, MotionType::KeeperJumpLeft, _) => MotionType::KeeperJumpLeft,
+
+        (MotionType::WideStance, true, MotionType::WideStance, _) => MotionType::WideStance,
+        (MotionType::KeeperJumpRight, true, MotionType::KeeperJumpRight, _) => {
+            MotionType::KeeperJumpRight
+        }
+        (MotionType::KeeperJumpLeft, true, MotionType::KeeperJumpLeft, _) => {
+            MotionType::KeeperJumpLeft
+        }
         (_, true, MotionType::WideStance, _) => MotionType::WideStance,
         (_, true, MotionType::KeeperJumpRight, _) => MotionType::KeeperJumpRight,
         (_, true, MotionType::KeeperJumpLeft, _) => MotionType::KeeperJumpLeft,
         (_, _, MotionType::CenterJump, _) => MotionType::CenterJump,
+
         (MotionType::ArmsUpStand, _, _, false) => MotionType::ArmsUpStand,
         (MotionType::Dispatching, true, _, _) => to,
         (MotionType::Stand, _, MotionType::Walk, _) => MotionType::Walk,


### PR DESCRIPTION
## Why? What?

Manchamal wird während der Motion WideStance getriggert. 

Das wird hierdurch unterbunden 

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
