### PR TITLE
Weighted residuals for calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,8 +2169,10 @@ checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 name = "calibration"
 version = "0.1.0"
 dependencies = [
+ "approx",
  "coordinate_systems",
  "geometry",
+ "itertools 0.14.0",
  "levenberg-marquardt",
  "linear_algebra",
  "nalgebra",

--- a/crates/calibration/Cargo.toml
+++ b/crates/calibration/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 [dependencies]
 coordinate_systems = { workspace = true }
 geometry = { workspace = true }
+itertools = { workspace = true }
 levenberg-marquardt = { workspace = true }
 linear_algebra = { workspace = true }
 nalgebra = { workspace = true }
@@ -16,3 +17,6 @@ projection = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 types = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/calibration/src/center_circle/circle_points.rs
+++ b/crates/calibration/src/center_circle/circle_points.rs
@@ -1,3 +1,4 @@
+use geometry::{line::Line2, rectangle::Rectangle};
 use serde::{Deserialize, Serialize};
 
 use linear_algebra::Point2;
@@ -8,5 +9,29 @@ use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 )]
 pub struct CenterCirclePoints<Frame> {
     pub center: Point2<Frame>,
+    pub points: Vec<Point2<Frame>>,
+    pub bounding_box: Rectangle<Frame>,
+}
+
+#[derive(
+    Clone, Debug, Default, Serialize, Deserialize, PathSerialize, PathIntrospect, PathDeserialize,
+)]
+pub struct CenterCirclePointsSeperated<Frame> {
+    pub center: Point2<Frame>,
+    pub inner_points: Vec<Point2<Frame>>,
+    pub outer_points: Vec<Point2<Frame>>,
+}
+
+impl<Frame> CenterCirclePoints<Frame> {
+    pub fn total_points(&self) -> usize {
+        self.points.len()
+    }
+}
+
+#[derive(
+    Clone, Debug, Default, Serialize, Deserialize, PathSerialize, PathIntrospect, PathDeserialize,
+)]
+pub struct MidLineAndPoints<Frame> {
+    pub mid_line: Option<Line2<Frame>>,
     pub points: Vec<Point2<Frame>>,
 }

--- a/crates/calibration/src/center_circle/fine_tuner.rs
+++ b/crates/calibration/src/center_circle/fine_tuner.rs
@@ -1,0 +1,269 @@
+use std::f32::consts::PI;
+
+use geometry::ellipse::Ellipse;
+use linear_algebra::{point, Point2};
+use nalgebra::{linalg::SymmetricEigen, DMatrix, DVector, Matrix3, Matrix3xX};
+
+/// Implements the ElliFit algorithm for fitting an ellipse to a set of 2D points.
+///
+/// References:
+/// * "ElliFit: An unconstrained, non-iterative, least squares based geometric Ellipse Fitting method"
+/// * "Center circle detection on the NAO robotic platform for the RoboCup Standard Platform League"
+///
+/// # Arguments
+///
+/// * `points`: A vector of 2D points representing the data.
+///
+///
+/// # Notes
+/// * Equation numbers and matrix names are marked according to the ElliFit paper
+/// * This implementation assumes that the input data contains at least 5 points.
+
+pub fn ellifit<Frame>(points: &[Point2<Frame, f32>]) -> Result<Ellipse<Frame>, String> {
+    if points.len() < 5 {
+        return Err("ElliFit requires at least 5 points.".to_owned());
+    }
+
+    // Calculate the centroid of the points
+    let centroid = points.iter().fold(point![0.0, 0.0], |acc, &p| {
+        (acc.coords() + p.cast().coords()).as_point()
+    }) / points.len() as f64;
+
+    // Translate the points to the centroid
+    let translated_points: Vec<_> = points.iter().map(|&p| p.cast() - centroid).collect();
+
+    // works but biased
+    let a_mat = DMatrix::from_row_iterator(
+        translated_points.len(),
+        5,
+        translated_points
+            .iter()
+            .map(|p| {
+                // x^2, 2xy, -x, -y, -1
+                [-p.x().powi(2), -p.x() * p.y(), p.x(), p.y(), -1.0f64]
+            })
+            .flatten(),
+    );
+
+    let b_mat = DVector::from_iterator(
+        translated_points.len(),
+        translated_points.iter().map(|p| p.y().powi(2)),
+    );
+
+    // Instead of inv(A.T * A) * A.T * b, we can use the QR decomposition (See Nicholas ' PA)
+    let qr = a_mat.clone().qr();
+    let phi = qr
+        .r()
+        .solve_upper_triangular(&qr.q().tr_mul(&b_mat))
+        .expect("There should be a solution");
+
+    // let residuel = ((a_mat * &phi) - &b_mat).norm() / &b_mat.norm();
+
+    let p1 = phi[0];
+    let p2 = phi[1];
+    let p3 = phi[2];
+    let p4 = phi[3];
+    let p5 = phi[4];
+
+    let p1_4 = 4.0 * p1;
+    let one_minus_p1 = 1.0 - p1;
+    let one_plus_p1 = 1.0 + p1;
+    let p2_sq = p2.powi(2);
+    let p2sq_minus_p1_4 = p2_sq - p1_4;
+    let x = (p2 * p4 - 2.0 * p3) / p2sq_minus_p1_4;
+    let y = (p2 * p3 - 2.0 * p1 * p4) / p2sq_minus_p1_4;
+
+    let temp1 = (one_minus_p1.powi(2) + (4.0 * p2_sq)).sqrt();
+    let numerator = p2 * p3 * p4 - p4.powi(2) * p1 - p3.powi(2) - p5 * p2sq_minus_p1_4;
+    let major = 2.0 * (numerator / (p2sq_minus_p1_4 * (one_plus_p1 - temp1))).sqrt();
+    let minor = 2.0 * (numerator / (p2sq_minus_p1_4 * (one_plus_p1 + temp1))).sqrt();
+
+    let angle = -0.5 * (-p2).atan2(one_minus_p1);
+
+    let center = (point![x, y].coords() + centroid.cast().coords()).as_point();
+
+    // Return the ellipse parameters
+    Ok(Ellipse {
+        center: center.cast(),
+        major_radius: major as f32,
+        minor_radius: minor as f32,
+        angle: angle as f32,
+    })
+}
+
+pub fn least_square_ellipse<Frame>(points: &[Point2<Frame>]) -> Result<Ellipse<Frame>, String> {
+    // 1. Construct the design matrix D
+    // TODO change to Matrix3xX style
+    let d1 = Matrix3xX::from_iterator(
+        points.len(),
+        points
+            .iter()
+            .map(|p| [(p.x()).powi(2), p.x() * p.y(), (p.y()).powi(2)])
+            .flatten(),
+    )
+    .transpose();
+
+    let d2 = Matrix3xX::from_iterator(
+        points.len(),
+        points.iter().map(|p| [p.x(), p.y(), 1.0]).flatten(),
+    )
+    .transpose();
+
+    let s1: Matrix3<_> = d1.tr_mul(&d1);
+    let s2: Matrix3<_> = d1.tr_mul(&d2);
+    let s3: Matrix3<_> = d2.tr_mul(&d2);
+
+    // 2. Construct the constraint matrix C
+    let c1_inv = Matrix3::new(0.0, 0.0, 2.0, 0.0, -1.0, 0.0, 2.0, 0.0, 0.0)
+        .try_inverse()
+        .expect("The matrix should be invertible");
+
+    let m: Matrix3<f32> = c1_inv * (s1 - s2 * s3.try_inverse().unwrap() * s2.transpose());
+    // 3. Solve the generalized eigenvalue problem
+    // Unlike the original python version, we do M.T * M to get a symmetric matrix
+    let eig = SymmetricEigen::new(m.tr_mul(&m));
+
+    // 4. Find the eigenvector corresponding to the smallest eigenvalue
+    let eigenvectors = eig.eigenvectors;
+    // 4ac - b^2 > 0
+    let cond = 4.0 * eigenvectors.row(0).component_mul(&eigenvectors.row(2))
+        - eigenvectors.row(1).component_mul(&eigenvectors.row(1));
+    // cond = 4*np.multiply(eigvec[0, :], eigvec[2, :]) - np.power(eigvec[1, :], 2)
+    // a1 = eigvec[:, np.nonzero(cond > 0)[0]]
+    // println!("cond: {cond}");
+    let Some(min_eigenvalue_index) = cond.iter().position(|&x| x > 0.0) else {
+        return Err("No valid ellipse found!".to_owned());
+    };
+    let a1 = eigenvectors.column(min_eigenvalue_index);
+    // find another way to do this.
+    let a2 = (-s3).try_inverse().unwrap() * s2.transpose() * a1;
+    // 5. Extract ellipse parameters
+    let a = a1[0];
+    let b = a1[1] / 2.0;
+    let c = a1[2];
+    let d = a2[0] / 2.0;
+    let f = a2[1] / 2.0;
+    let g = a2[2];
+
+    // 6. Calculate ellipse parameters
+    // let center = point![-0.5 * a / c, -0.5 * b / c];
+    // let major = 1.0 / (2.0 * c * (1.0 - (a * a + b * b) / (4.0 * c)).sqrt());
+    // let minor = 1.0 / (2.0 * c * (1.0 + (a * a + b * b) / (4.0 * c)).sqrt());
+    // let angle = 0.5 * (-b / a).atan2(1.0);
+
+    let x0 = (c * d - b * f) / (b.powi(2) - a * c);
+    let y0 = (a * f - b * d) / (b.powi(2) - a * c);
+    let center = point![x0, y0];
+
+    let numerator =
+        2.0 * (a * f.powi(2) + c * d.powi(2) + g * b.powi(2) - 2.0 * b * d * f - a * c * g);
+    let denominator1 = (b.powi(2) - a * c) * (((a - c).powi(2) + 4.0 * b.powi(2)).sqrt() - (c + a));
+    let denominator2 =
+        (b.powi(2) - a * c) * (-((a - c).powi(2) + 4.0 * b.powi(2)).sqrt() - (c + a));
+    let height = (numerator / denominator1).sqrt();
+    let width = (numerator / denominator2).sqrt();
+
+    let angle = if a == c {
+        0.0
+    } else {
+        0.5 * (PI + (2.0 * b).atan2(a - c))
+    };
+    // if a == c {
+    // if b == 0.0 && a > c:
+    //     phi = 0.0
+    // elif b == 0 and a < c:
+    //     phi = np.pi/2
+    // elif b != 0 and a > c:
+    //     phi = 0.5 * np.arctan(2*b/(a-c))
+    // elif b != 0 and a < c:
+    //     phi = 0.5 * (np.pi + np.arctan(2*b/(a-c)))
+    // elif a == c:
+    //     logger.warning("Ellipse is a perfect circle, the answer is degenerate")
+    //     phi = 0.0
+    // else:
+    //     raise RuntimeError("Unreachable")
+
+    Ok(Ellipse {
+        center: center.cast(),
+        major_radius: width as f32,
+        minor_radius: height as f32,
+        angle: angle as f32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+
+    use approx::assert_relative_eq;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct DummyFrame;
+
+    #[test]
+    fn ellifit_test() {
+        // let points = vec![
+        //     point![1.0, 1.0],
+        //     point![2.0, 2.0],
+        //     point![3.0, 3.0],
+        //     point![4.0, 4.0],
+        //     point![5.0, 5.0],
+        // ];
+
+        // Define a set of points on an ellipse (centered at origin, rotated by 45 degrees)
+        // let points: Vec<_> = vec![
+        //     point![1.0, 1.0],
+        //     point![-1.0, -1.0],
+        //     point![1.4142, 0.0],  // sqrt(2)
+        //     point![-1.4142, 0.0], // -sqrt(2)
+        //     point![0.0, 1.4142],  // sqrt(2)
+        //     point![0.0, -1.4142], // -sqrt(2)
+        // ];
+
+        // expected from python
+        // center: 2.776, -0.010
+        // width: 0.756
+        // height: 0.837
+        // phi: 0.658 <class 'numpy.float64'>
+
+        let points: Vec<_> = vec![
+            point![2.08537573, 0.48030994],
+            point![3.10540613, 0.70164787],
+            point![3.55411641, 0.13879143],
+            point![2.02915708, -0.18899235],
+            point![3.56519477, -0.06717689],
+            point![3.57986527, 0.05212252],
+            point![3.44286905, -0.46697632],
+            point![2.01739203, -0.10048445],
+            point![3.44157189, -0.47737772],
+            point![2.14705919, 0.55092497],
+        ];
+
+        // sampled center: 2.780, 0.024
+        // sampled width: 0.827
+        // sampled height: 0.750
+        // sampled phi: -0.678 <class 'numpy.float64'>
+        let expected_center = point![2.780, 0.024];
+        let expected_major_axis = 0.827;
+        let expected_minor_axis = 0.750;
+        let expected_rotation = -0.678;
+
+        let fitted_result = least_square_ellipse::<DummyFrame>(&points).unwrap();
+        // let fitted_result =
+        // ellifit::<DummyFrame>(&points).expect("Cannot fail as there is an ellipse!");
+        let center = fitted_result.center;
+        let major_axis = fitted_result.major_radius;
+        let minor_axis = fitted_result.minor_radius;
+        let rotation = fitted_result.angle;
+
+        // println!("Other ellipse: {b:?}");
+
+        println!("center: {center:?},\nmajor_axis: {major_axis:?},\nminor_axis: {minor_axis:?},\nrotation: {rotation:?}");
+        // let (center, a, b, phi) = ellifit::<DummyFrame>(&points);
+        assert_relative_eq!(center, expected_center);
+        assert_relative_eq!(major_axis, expected_major_axis);
+        assert_relative_eq!(minor_axis, expected_minor_axis);
+        assert_relative_eq!(rotation, expected_rotation);
+    }
+}

--- a/crates/calibration/src/center_circle/mod.rs
+++ b/crates/calibration/src/center_circle/mod.rs
@@ -1,3 +1,4 @@
 pub mod circle_points;
 pub mod measurement;
 pub mod residuals;
+pub mod fine_tuner;

--- a/crates/calibration/src/center_circle/residuals.rs
+++ b/crates/calibration/src/center_circle/residuals.rs
@@ -1,7 +1,10 @@
-use coordinate_systems::Ground;
-use linear_algebra::Point2;
-use projection::Error as ProjectionError;
-use projection::Projection;
+use coordinate_systems::{Ground, Pixel};
+use linear_algebra::{distance_squared, point, vector, Point2, Vector2};
+use projection::{
+    camera_matrix::CameraMatrix, camera_projection::InverseCameraProjection,
+    Error as ProjectionError, Projection,
+};
+
 use types::field_dimensions::FieldDimensions;
 
 use crate::{
@@ -9,6 +12,8 @@ use crate::{
     corrections::{get_corrected_camera_matrix, Corrections},
     residuals::CalculateResiduals,
 };
+
+use super::fine_tuner::ellifit;
 
 pub struct CenterCircleResiduals {
     radial_residuals: Vec<f32>,
@@ -26,33 +31,99 @@ impl CalculateResiduals for CenterCircleResiduals {
         let corrected =
             get_corrected_camera_matrix(&measurement.matrix, measurement.position, parameters);
 
-        let radius_squared = field_dimensions.center_circle_diameter / 2.0;
-
         let projected_center = corrected.pixel_to_ground(measurement.circle_and_points.center)?;
-        let projected_points: Vec<Point2<Ground>> = measurement
-            .circle_and_points
-            .points
-            .iter()
-            .filter_map(|&point| corrected.pixel_to_ground(point).ok())
-            .collect();
+        let radius = field_dimensions.center_circle_diameter / 2.0;
 
-        // TODO figure out a better way
-        let has_projection_error =
-            projected_points.len() != measurement.circle_and_points.points.len();
-        if has_projection_error {
+        let min_y_point = measurement.circle_and_points.bounding_box.min;
+        let max_y_point = measurement.circle_and_points.bounding_box.max;
+        if !corrected
+            .horizon
+            .is_none_or(|horizon| horizon.is_above_with_margin(min_y_point, 5.0))
+        {
             return Err(ProjectionError::NotOnProjectionPlane);
-        }
-        let residual_values = projected_points
-            .into_iter()
-            .map(|projected_point| {
-                (projected_point - projected_center).norm_squared() - radius_squared
-            })
-            .collect();
+        };
 
-        Ok(CenterCircleResiduals {
-            radial_residuals: residual_values,
-        })
+        let pixel_y_range = max_y_point.y() - min_y_point.y();
+        let pixel_to_ground = &corrected.pixel_to_ground;
+
+        // we are skipping variance along x axis[pixel] for now.
+        // min weight = 1.0
+        let max_weight =
+            max_weight_calculation_unchecked(&min_y_point, &max_y_point, pixel_to_ground).y();
+        let min_y = min_y_point.y();
+
+        let residuals = CenterCircleResiduals {
+            radial_residuals: measurement
+                .circle_and_points
+                .points
+                .iter()
+                .map(|&point| {
+                    let projected = pixel_to_ground.back_project_unchecked(point).xy();
+                    let residual = average_circle_residual(projected, projected_center, radius);
+                    let weight = interpolate(point.y(), min_y, pixel_y_range, max_weight);
+                    residual * weight
+                })
+                .collect(),
+        };
+
+        Ok(residuals)
     }
+}
+
+#[inline(always)]
+fn average_circle_residual<'a>(
+    projected_point: Point2<Ground>,
+    center: Point2<Ground>,
+    radius: f32,
+) -> f32 {
+    let center_to_point_distance = (projected_point - center).norm();
+    center_to_point_distance - radius
+}
+
+/// Interpolate weight based on the y coordinate of pixel.
+#[inline(always)]
+fn interpolate(pixel_y: f32, pixel_y_min: f32, pixel_y_range: f32, weight_max: f32) -> f32 {
+    1.0 + (weight_max / pixel_y_range) * (pixel_y - pixel_y_min)
+}
+
+/// Calculates minimum and maximum variations (kinda like covariance) at top and bottom of circle.
+/// This kind of calculation is needed as the pixel noise (+-0.5) has different variances in the ground plane after projection.
+/// Therefore it has to be compensated in the residual calculation to avoid biasing towards further away points
+fn max_weight_calculation_unchecked(
+    min_y_point: &Point2<Pixel>,
+    max_y_point: &Point2<Pixel>,
+    pixel_to_ground: &InverseCameraProjection<Ground>,
+) -> Vector2<Ground> {
+    // Note: This is an approximation, a more precise value could/ should be calculated.
+    // highest y (closest to nao) has lowest variance as the camera looks down.
+
+    let get_variance = |point: &Point2<Pixel>| {
+        let inner = &point.coords().inner;
+        pixel_to_ground
+            .back_project_unchecked(inner.add_scalar(0.5).into())
+            .xy()
+            - pixel_to_ground
+                .back_project_unchecked(inner.add_scalar(-0.5).into())
+                .xy()
+    };
+
+    // max_y = closest to robot
+    let variance_min = get_variance(max_y_point);
+    let variance_max = get_variance(min_y_point);
+
+    // rescale
+    // variance_max /= variance_min;
+    // variance_min /= variance_min; // one!
+
+    // as weight
+    // 1.0/variance
+
+    // combined scaling and weight (reciprocal)
+    // variance_min / variance_max
+    vector![
+        variance_min.x() / variance_max.x(),
+        variance_min.y() / variance_max.y()
+    ]
 }
 
 impl From<CenterCircleResiduals> for Vec<f32> {
@@ -60,3 +131,16 @@ impl From<CenterCircleResiduals> for Vec<f32> {
         residuals.radial_residuals
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     #[test]
+//     fn test() {
+
+//         let radial_direction_in_ground = corrected.pixel_to_ground(*point).ok()?.coords();
+//         radial_direction_in_ground.normalize();
+
+//         let circle_point =
+//             (inner_radius * radial_direction_in_ground.inner + projected_center.coords().inner);
+//     }
+// }

--- a/crates/calibration/src/corrections.rs
+++ b/crates/calibration/src/corrections.rs
@@ -1,7 +1,8 @@
-use nalgebra::{vector, Rotation3, SVector, UnitQuaternion};
+use coordinate_systems::{Camera, Robot};
+use nalgebra::{vector, SVector, UnitQuaternion};
 use serde::{Deserialize, Serialize};
 
-use linear_algebra::IntoTransform;
+use linear_algebra::{IntoTransform, Rotation3};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use projection::camera_matrix::CameraMatrix;
 use types::camera_position::CameraPosition;
@@ -20,40 +21,45 @@ pub const AMOUNT_OF_PARAMETERS: usize = 9;
     PathIntrospect,
 )]
 pub struct Corrections {
-    pub correction_in_robot: Rotation3<f32>,
-    pub correction_in_camera_top: Rotation3<f32>,
-    pub correction_in_camera_bottom: Rotation3<f32>,
+    pub correction_in_robot: Rotation3<Robot, Robot, f32>,
+    pub correction_in_camera_top: Rotation3<Camera, Camera, f32>,
+    pub correction_in_camera_bottom: Rotation3<Camera, Camera, f32>,
 }
 
 impl From<&SVector<f32, AMOUNT_OF_PARAMETERS>> for Corrections {
     fn from(parameters: &SVector<f32, AMOUNT_OF_PARAMETERS>) -> Self {
         Self {
-            correction_in_robot: Rotation3::from_euler_angles(
-                parameters[0],
-                parameters[1],
-                parameters[2],
-            ),
-            correction_in_camera_top: Rotation3::from_euler_angles(
+            // correction_in_robot: UnitQuaternion::from_euler_angles(
+            //     parameters[0],
+            //     parameters[1],
+            //     parameters[2],
+            // )
+            // .framed_transform(),
+            correction_in_robot: UnitQuaternion::identity().framed_transform(),
+            correction_in_camera_top: UnitQuaternion::from_euler_angles(
                 parameters[3],
                 parameters[4],
                 parameters[5],
-            ),
-            correction_in_camera_bottom: Rotation3::from_euler_angles(
+            )
+            .framed_transform(),
+            correction_in_camera_bottom: UnitQuaternion::from_euler_angles(
                 parameters[6],
                 parameters[7],
                 parameters[8],
-            ),
+            )
+            .framed_transform(),
         }
     }
 }
 
 impl From<&Corrections> for SVector<f32, AMOUNT_OF_PARAMETERS> {
     fn from(parameters: &Corrections) -> Self {
-        let (robot_roll, robot_pitch, robot_yaw) = parameters.correction_in_robot.euler_angles();
+        let (robot_roll, robot_pitch, robot_yaw) =
+            parameters.correction_in_robot.inner.euler_angles();
         let (camera_top_roll, camera_top_pitch, camera_top_yaw) =
-            parameters.correction_in_camera_top.euler_angles();
+            parameters.correction_in_camera_top.inner.euler_angles();
         let (camera_bottom_roll, camera_bottom_pitch, camera_bottom_yaw) =
-            parameters.correction_in_camera_bottom.euler_angles();
+            parameters.correction_in_camera_bottom.inner.euler_angles();
         vector![
             robot_roll,
             robot_pitch,
@@ -74,16 +80,10 @@ pub(crate) fn get_corrected_camera_matrix(
     parameters: &Corrections,
 ) -> CameraMatrix {
     input_matrix.to_corrected(
-        UnitQuaternion::from_rotation_matrix(&parameters.correction_in_robot).framed_transform(),
+        parameters.correction_in_robot,
         match position {
-            CameraPosition::Top => {
-                UnitQuaternion::from_rotation_matrix(&parameters.correction_in_camera_top)
-                    .framed_transform()
-            }
-            CameraPosition::Bottom => {
-                UnitQuaternion::from_rotation_matrix(&parameters.correction_in_camera_bottom)
-                    .framed_transform()
-            }
+            CameraPosition::Top => parameters.correction_in_camera_top,
+            CameraPosition::Bottom => parameters.correction_in_camera_bottom,
         },
     )
 }

--- a/crates/calibration/src/goal_box/lines.rs
+++ b/crates/calibration/src/goal_box/lines.rs
@@ -38,7 +38,7 @@ pub enum LinesError {
     },
 }
 
-fn project_line_and_map_error(
+pub(crate) fn project_line_and_map_error(
     matrix: &CameraMatrix,
     line: LineSegment<Pixel>,
     which: &str,

--- a/crates/calibration/src/jacobian.rs
+++ b/crates/calibration/src/jacobian.rs
@@ -49,11 +49,8 @@ fn get_parameter_support_points_from_parameters_with_epsilon(
     epsilon: f32,
 ) -> (Corrections, Corrections) {
     let parameters: SVector<f32, AMOUNT_OF_PARAMETERS> = parameters.into();
-    let epsilon_vector = SVector::<f32, AMOUNT_OF_PARAMETERS>::from_vec(
-        (0..AMOUNT_OF_PARAMETERS)
-            .map(|index| if index == epsilon_index { epsilon } else { 0.0 })
-            .collect(),
-    );
+    let mut epsilon_vector = SVector::<f32, AMOUNT_OF_PARAMETERS>::zeros();
+    epsilon_vector[epsilon_index] = epsilon;
     (
         (&(parameters + epsilon_vector)).into(),
         (&(parameters - epsilon_vector)).into(),

--- a/crates/calibration/src/lib.rs
+++ b/crates/calibration/src/lib.rs
@@ -1,10 +1,11 @@
+use itertools::Itertools;
 use levenberg_marquardt::LevenbergMarquardt;
 
 use types::field_dimensions::FieldDimensions;
 
 use corrections::Corrections;
 use problem::CalibrationProblem;
-use residuals::CalculateResiduals;
+use residuals::{calculate_residuals_from_parameters, CalculateResiduals};
 
 pub mod center_circle;
 pub mod corrections;
@@ -21,15 +22,68 @@ pub fn solve<MeasurementResidualsType>(
 where
     MeasurementResidualsType: CalculateResiduals,
     Vec<f32>: From<MeasurementResidualsType>,
+    MeasurementResidualsType::Measurement: Clone,
 {
     let problem = CalibrationProblem::<MeasurementResidualsType>::new(
         initial_corrections,
-        measurements,
+        measurements.clone(),
         field_dimensions,
     );
+
     let (result, report) = LevenbergMarquardt::new().minimize(problem);
     println!("Report: {report:?}");
+
+    // let residuals = calculate_residuals_from_parameters(
+    //     &result.get_corrections(),
+    //     &measurements,
+    //     &field_dimensions,
+    // );
+    // if let Some(residuals) = residuals {
+    //     // println!("residuals: {residuals:?}");
+    //     _simple_hist(residuals.as_slice(), 20);
+    // }
+
     let corrections = result.get_corrections();
-    println!("Corrections: {corrections:?}");
+    // println!("Corrections: {corrections:?}");
+
+    let euler_top = corrections.correction_in_camera_top.inner.euler_angles();
+    let euler_bottom = corrections.correction_in_camera_bottom.inner.euler_angles();
+    let euler_robot = corrections.correction_in_robot.inner.euler_angles();
+    println!(
+        "Euler Angles, top: {:?}deg, bottom: {:?}deg, robot: {:?}deg",
+        (
+            euler_top.0.to_degrees(),
+            euler_top.1.to_degrees(),
+            euler_top.2.to_degrees()
+        ),
+        (
+            euler_bottom.0.to_degrees(),
+            euler_bottom.1.to_degrees(),
+            euler_bottom.2.to_degrees()
+        ),
+        (
+            euler_robot.0.to_degrees(),
+            euler_robot.1.to_degrees(),
+            euler_robot.2.to_degrees()
+        ),
+    );
     corrections
+}
+
+fn _simple_hist(input: &[f32], bins: usize) -> Vec<u32> {
+    let min_max = input.iter().copied().minmax().into_option().unwrap();
+
+    let bin_size = min_max.1 - min_max.0;
+
+    let mut histogram = vec![0; bins];
+    for distance in input {
+        let bin = (distance - min_max.0) / bin_size;
+        histogram[bin as usize] += 1;
+    }
+
+    println!(
+        "range: [{}, {}], histogram: {:?}",
+        min_max.0, min_max.1, histogram
+    );
+    histogram
 }

--- a/crates/calibration/src/problem.rs
+++ b/crates/calibration/src/problem.rs
@@ -53,17 +53,14 @@ where
     type ParameterStorage = Owned<f32, Const<AMOUNT_OF_PARAMETERS>>;
 
     fn set_params(&mut self, parameters: &SVector<f32, AMOUNT_OF_PARAMETERS>) {
-        println!("set_params({parameters:?})");
         self.parameters = parameters.into();
     }
 
     fn params(&self) -> SVector<f32, AMOUNT_OF_PARAMETERS> {
-        println!("params()");
         (&self.parameters).into()
     }
 
     fn residuals(&self) -> Option<ResidualVector> {
-        println!("residuals()");
         calculate_residuals_from_parameters::<MeasurementResidualsType>(
             &self.parameters,
             &self.measurements,
@@ -72,7 +69,6 @@ where
     }
 
     fn jacobian(&self) -> Option<Jacobian> {
-        println!("jacobian()");
         calculate_jacobian_from_parameters::<MeasurementResidualsType>(
             &self.parameters,
             &self.measurements,

--- a/crates/geometry/src/ellipse.rs
+++ b/crates/geometry/src/ellipse.rs
@@ -1,0 +1,69 @@
+use core::f32;
+
+use approx::AbsDiffEq;
+use linear_algebra::Point2;
+use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::circle::Circle;
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Deserialize,
+    PartialEq,
+    PathDeserialize,
+    PathIntrospect,
+    PathSerialize,
+    Serialize,
+)]
+pub struct Ellipse<Frame> {
+    pub center: Point2<Frame>,
+    pub major_radius: f32,
+    pub minor_radius: f32,
+    pub angle: f32,
+}
+
+impl<Frame> Ellipse<Frame> {
+    pub fn new(center: Point2<Frame>, major_radius: f32, minor_radius: f32, angle: f32) -> Self {
+        Self {
+            center,
+            major_radius,
+            minor_radius,
+            angle,
+        }
+    }
+
+    pub fn is_circle(&self) -> bool {
+        self.major_radius
+            .abs_diff_eq(&self.minor_radius, f32::EPSILON)
+    }
+}
+
+impl<Frame> From<Circle<Frame>> for Ellipse<Frame> {
+    fn from(circle: Circle<Frame>) -> Self {
+        Self {
+            center: circle.center,
+            major_radius: circle.radius,
+            minor_radius: circle.radius,
+            angle: 0.0,
+        }
+    }
+}
+
+impl<Frame> TryInto<Circle<Frame>> for Ellipse<Frame> {
+    type Error = ();
+
+    fn try_into(self) -> Result<Circle<Frame>, Self::Error> {
+        if self.is_circle() {
+            Ok(Circle {
+                center: self.center,
+                radius: self.major_radius,
+            })
+        } else {
+            Err(())
+        }
+    }
+}

--- a/crates/geometry/src/lib.rs
+++ b/crates/geometry/src/lib.rs
@@ -3,6 +3,7 @@ pub mod circle;
 pub mod circle_tangents;
 pub mod convex_hull;
 pub mod direction;
+pub mod ellipse;
 pub mod is_inside_polygon;
 pub mod line;
 pub mod line_segment;

--- a/crates/geometry/src/rectangle.rs
+++ b/crates/geometry/src/rectangle.rs
@@ -7,6 +7,7 @@ use linear_algebra::{Point2, Vector2};
     Clone,
     Copy,
     Debug,
+    Default,
     Deserialize,
     PartialEq,
     PathDeserialize,


### PR DESCRIPTION
## Why? What?

The residual calculation is done in Ground plane and affected by the pixel-noise (+-0.5px position). While this variance is constant in Pixel plane, it varies on Ground plane once projected depending on Pixel position.

This PR introduces weights based on the variance and successfully reduced/ eliminated bias caused on least square optimisation

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
