### PR TITLE
Run param-alarm in pregame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6506,7 +6506,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "5.2.0"
+version = "5.3.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "5.2.0"
+version = "5.3.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/cargo/environment.rs
+++ b/tools/pepsi/src/cargo/environment.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use color_eyre::eyre::{bail, Context, Error, Result};
 use repository::{cargo::Environment as RepositoryEnvironment, Repository};
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct EnvironmentArguments {
     /// The execution environment (default: native)
     #[arg(long)]

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -13,7 +13,7 @@ use repository::{upload::get_hulk_binary, Repository};
 use tempfile::tempdir;
 
 use crate::{
-    cargo::{self, build, cargo, environment::EnvironmentArguments, CargoCommand},
+    cargo::{self, build, cargo, environment::EnvironmentArguments, run, CargoCommand},
     deploy_config::DeployConfig,
     progress_indicator::ProgressIndicator,
     recording::parse_key_value,
@@ -63,6 +63,8 @@ pub struct PreGameArguments {
 }
 
 pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<()> {
+    run_parameter_tester(arguments.environment.clone(), repository).await?;
+
     let mut config = DeployConfig::read_from_file(repository)
         .await
         .wrap_err("failed to read deploy config from file")?;
@@ -140,6 +142,26 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
     .await;
 
     Ok(())
+}
+
+async fn run_parameter_tester(
+    environment: EnvironmentArguments,
+    repository: &Repository,
+) -> Result<()> {
+    let cargo_arguments = cargo::Arguments {
+        manifest: Some(
+            repository
+                .root
+                .join("tools/parameter_tester/Cargo.toml")
+                .into_os_string(),
+        ),
+        environment,
+        cargo: run::Arguments::default(),
+    };
+
+    cargo(cargo_arguments, repository, &[] as &[&str])
+        .await
+        .wrap_err("failed to run parameter tester")
 }
 
 async fn setup_nao(

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -32,6 +32,9 @@ pub struct Arguments {
 
 #[derive(Args)]
 pub struct PreGameArguments {
+    /// Skip running the parameter tester
+    #[arg(long)]
+    pub skip_parameter_check: bool,
     /// Do not build before uploading
     #[arg(long)]
     pub no_build: bool,
@@ -63,7 +66,9 @@ pub struct PreGameArguments {
 }
 
 pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<()> {
-    run_parameter_tester(arguments.environment.clone(), repository).await?;
+    if !arguments.pre_game.skip_parameter_check {
+        run_parameter_tester(arguments.environment.clone(), repository).await?;
+    }
 
     let mut config = DeployConfig::read_from_file(repository)
         .await


### PR DESCRIPTION
## Why? What?

Resolves #1728.

Additionally introduces a flag to skip the parameter check.

## ToDo / Known Issues

Currently the environment for both running the parameter tester and building the code for the NAO is the same, i.e. `./pepsi pregame --remote` runs the parameter tester and builds the code for the NAO both on the remote workspace.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Introduce an error in the `etc/parameters/default.json` file by e.g. removing a line and check the output of the following commands:

```
./pepsi pregame
./pepsi pregame --skip-parameter-check 
```
