### PR TITLE
Collect all penalties for challenge shield

### DIFF
--- a/crates/spl_network_messages/src/game_controller_state_message.rs
+++ b/crates/spl_network_messages/src/game_controller_state_message.rs
@@ -118,7 +118,7 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
                 message.playersPerTeam
             );
         }
-        let hulks_players = (0..message.playersPerTeam)
+        let hulks_players = (0..MAX_NUM_PLAYERS)
             .map(|player_index| {
                 message.teams[hulks_team_index].players[player_index as usize].try_into()
             })


### PR DESCRIPTION
We now collect all penalties for our team in the message we receive and parse. The subsequent `Players` struct picks only the relevant players (1-7) for our team.
