### PR TITLE
Tighten individual cycler execution time bounds

### DIFF
--- a/crates/bevyhavior_simulator/build.rs
+++ b/crates/bevyhavior_simulator/build.rs
@@ -36,6 +36,7 @@ fn main() -> Result<()> {
                     "control::time_to_reach_kick_position",
                     "control::world_state_composer",
                 ],
+                execution_time_warning_threshold: None,
             },
             CyclerManifest {
                 name: "SplNetwork",
@@ -43,6 +44,7 @@ fn main() -> Result<()> {
                 instances: vec![""],
                 setup_nodes: vec!["spl_network::message_receiver"],
                 nodes: vec!["spl_network::message_filter"],
+                execution_time_warning_threshold: None,
             },
         ],
     };

--- a/crates/code_generation/src/accessor.rs
+++ b/crates/code_generation/src/accessor.rs
@@ -349,6 +349,7 @@ mod tests {
             instances: vec!["InstanceA".to_string(), "InstanceB".to_string()],
             setup_nodes: vec![],
             cycle_nodes: vec![],
+            execution_time_warning_threshold: None,
         };
 
         for (path, reference_type, expected_token_stream) in cases {

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -529,19 +529,25 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
                 }
             });
 
+            let duration_warning = cycler.execution_time_warning_threshold.map(|threshold| {
+                let threshold_seconds = threshold.as_secs_f32();
+                quote! {
+                    if recording_duration > std::time::Duration::from_secs_f32(#threshold_seconds) {
+                        log::warn!("Cycle took {}s!", recording_duration.as_secs_f32());
+                        self
+                            .hardware_interface
+                            .write_to_speakers(types::audio::SpeakerRequest::PlaySound {
+                                sound: types::audio::Sound::Donk,
+                            });
+                    }
+                }
+            });
+
             quote! {
                 #after_remaining_nodes
                 let recording_duration = recording_timestamp.elapsed().expect("time ran backwards");
 
-                const EXECUTION_TIME_UPPER_BOUND: f32 = 0.4;
-                if recording_duration.as_secs_f32() > EXECUTION_TIME_UPPER_BOUND {
-                    log::warn!("Cycle took {}s!", recording_duration.as_secs_f32());
-                    self
-                        .hardware_interface
-                        .write_to_speakers(types::audio::SpeakerRequest::PlaySound {
-                            sound: types::audio::Sound::Donk,
-                        });
-                }
+                #duration_warning
 
                 if enable_recording {
                     self.recording_sender.try_send(match instance {

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use source_analyzer::{
     cyclers::{CyclerKind, Cyclers},
     error::Error,
@@ -24,6 +26,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "vision::perspective_grid_candidates_provider",
                     "vision::segment_filter",
                 ],
+                execution_time_warning_threshold: Some(Duration::from_secs_f32(1.0 / 30.0)),
             },
             CyclerManifest {
                 name: "ObjectDetection",
@@ -35,6 +38,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "object_detection::pose_filter",
                     "object_detection::pose_interpretation",
                 ],
+                execution_time_warning_threshold: Some(Duration::from_secs_f32(1.0)),
             },
             CyclerManifest {
                 name: "Control",
@@ -110,6 +114,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                     "control::world_state_composer",
                     "control::zero_moment_point_provider",
                 ],
+                execution_time_warning_threshold: Some(Duration::from_secs_f32(1.0 / 83.0)),
             },
             CyclerManifest {
                 name: "SplNetwork",
@@ -117,6 +122,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                 instances: vec![""],
                 setup_nodes: vec!["spl_network::message_receiver"],
                 nodes: vec!["spl_network::message_filter"],
+                execution_time_warning_threshold: None,
             },
             CyclerManifest {
                 name: "Audio",
@@ -124,6 +130,7 @@ pub fn collect_hulk_cyclers() -> Result<Cyclers, Error> {
                 instances: vec![""],
                 setup_nodes: vec!["audio::microphone_recorder"],
                 nodes: vec!["audio::whistle_detection"],
+                execution_time_warning_threshold: None,
             },
         ],
     };

--- a/crates/source_analyzer/src/cyclers.rs
+++ b/crates/source_analyzer/src/cyclers.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::Path,
+    time::Duration,
 };
 
 use serde::Deserialize;
@@ -90,6 +91,7 @@ pub struct Cycler {
     pub instances: Vec<InstanceName>,
     pub setup_nodes: Vec<Node>,
     pub cycle_nodes: Vec<Node>,
+    pub execution_time_warning_threshold: Option<Duration>,
 }
 
 impl Cycler {
@@ -116,6 +118,7 @@ impl Cycler {
             instances,
             setup_nodes,
             cycle_nodes,
+            execution_time_warning_threshold: cycler_manifest.execution_time_warning_threshold,
         };
         cycler.sort_nodes()?;
 

--- a/crates/source_analyzer/src/manifest.rs
+++ b/crates/source_analyzer/src/manifest.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use serde::Deserialize;
 
 use crate::cyclers::CyclerKind;
@@ -14,4 +16,5 @@ pub struct CyclerManifest {
     pub instances: Vec<&'static str>,
     pub setup_nodes: Vec<&'static str>,
     pub nodes: Vec<&'static str>,
+    pub execution_time_warning_threshold: Option<Duration>,
 }


### PR DESCRIPTION
## Why? What?

Donk every time a cycler exceeds its individual cycle time bound.

Limits are set as follows:
- Control: 1/83 s
- Vision: 1/30 s
- Object detection: 1 s
- Audio: none
- SplNetwork: none

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
