### PR TITLE
Require less ready signal percepts

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -8,8 +8,8 @@
     "minimum_visual_referee_keypoint_confidence": 0.8,
     "minimum_shoulder_angle": 0.2,
     "foot_z_offset": 0.025,
-    "referee_pose_queue_length": 8,
-    "minimum_number_poses_before_message": 3,
+    "referee_pose_queue_length": 10,
+    "minimum_number_poses_before_message": 2,
     "override_pose_detection": false
   },
   "feet_detection": {


### PR DESCRIPTION
## Why? What?

Since we didn't have a single false positive, but one false  negative ready signal percept during the game 2025-03-15-HULKs-vs-R-ZWEI_KICKERS, we can reduce the required amount of percepts needed for a successful ready signal detection.  

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Do visual referee with challenging ready signal pose
