### PR TITLE
Initial side step fix

### DIFF
--- a/crates/control/src/motion/step_planner.rs
+++ b/crates/control/src/motion/step_planner.rs
@@ -170,7 +170,6 @@ impl StepPlanner {
         } else {
             Step::default()
         };
-        step += initial_side_bonus;
 
         let max_step_size = match speed {
             WalkSpeed::Slow => *context.max_step_size + *context.step_size_delta_slow,

--- a/crates/control/src/motion/step_planner.rs
+++ b/crates/control/src/motion/step_planner.rs
@@ -161,7 +161,11 @@ impl StepPlanner {
             step = *injected_step;
         }
 
-        let initial_side_bonus = if self.last_planned_step.left.abs() <= f32::EPSILON {
+        let initial_side_bonus = if self.last_planned_step.forward.abs()
+            + self.last_planned_step.left.abs()
+            + self.last_planned_step.turn.abs()
+            <= f32::EPSILON
+        {
             Step {
                 forward: 0.0,
                 left: *context.initial_side_bonus,


### PR DESCRIPTION
## Why? What?

- Currently, the initial side bonus is directly applied to steps, not only the `max_step_size`
- This makes no sense
- Further improvement: the initial side bonus is only applied, if the step before was a zero step, i.e. the robot stood still

## How to Test

- Let it walk and have a look at the additional output `max_step_size` and check if that makes sense