### PR TITLE
Dont serialize motion interpolators

### DIFF
--- a/crates/control/src/motion/arms_up_squat.rs
+++ b/crates/control/src/motion/arms_up_squat.rs
@@ -1,5 +1,6 @@
 use color_eyre::Result;
 use context_attribute::context;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
@@ -14,8 +15,9 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct ArmsUpSquat {
-    state: InterpolatorState<Joints<f32>>,
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<Joints<f32>>,
+    state: InterpolatorState<Joints<f32>>,
 }
 
 #[context]
@@ -53,7 +55,7 @@ impl ArmsUpSquat {
 
         if motion_selection.current_motion == MotionType::ArmsUpSquat {
             self.interpolator
-                .advance_by(&mut self.state, last_cycle_duration, condition_input);
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
         } else {
             self.state.reset();
         }

--- a/crates/control/src/motion/arms_up_stand.rs
+++ b/crates/control/src/motion/arms_up_stand.rs
@@ -15,6 +15,7 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct ArmsUpstand {
     interpolator: MotionInterpolator<Joints<f32>>,
+    state: InterpolatorState<Joints<f32>>,
 }
 
 #[context]
@@ -41,6 +42,7 @@ impl ArmsUpstand {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("arms_up_stand.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
         })
     }
 
@@ -51,14 +53,14 @@ impl ArmsUpstand {
 
         if motion_selection.current_motion == MotionType::ArmsUpStand {
             self.interpolator
-                .advance_by(last_cycle_duration, condition_input);
+                .advance_by(&mut self.state, last_cycle_duration, condition_input);
         } else {
-            self.interpolator.reset();
+            self.state.reset();
         }
 
         Ok(MainOutputs {
             arms_up_stand_joints_command: MotorCommands {
-                positions: self.interpolator.value(),
+                positions: self.interpolator.value(self.state),
                 stiffnesses: Joints::fill(0.9),
             }
             .into(),

--- a/crates/control/src/motion/arms_up_stand.rs
+++ b/crates/control/src/motion/arms_up_stand.rs
@@ -1,8 +1,9 @@
 use color_eyre::Result;
 use context_attribute::context;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
@@ -14,6 +15,7 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct ArmsUpstand {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<Joints<f32>>,
     state: InterpolatorState<Joints<f32>>,
 }
@@ -53,7 +55,7 @@ impl ArmsUpstand {
 
         if motion_selection.current_motion == MotionType::ArmsUpStand {
             self.interpolator
-                .advance_by(&mut self.state, last_cycle_duration, condition_input);
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
         } else {
             self.state.reset();
         }

--- a/crates/control/src/motion/center_jump.rs
+++ b/crates/control/src/motion/center_jump.rs
@@ -1,5 +1,6 @@
 use color_eyre::Result;
 use context_attribute::context;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
@@ -13,6 +14,7 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct CenterJump {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<Joints<f32>>,
     state: InterpolatorState<Joints<f32>>,
 }
@@ -53,7 +55,7 @@ impl CenterJump {
 
         if context.motion_selection.current_motion == MotionType::CenterJump {
             self.interpolator
-                .advance_by(&mut self.state, last_cycle_duration, condition_input);
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
         } else {
             self.state.reset();
         }

--- a/crates/control/src/motion/center_jump.rs
+++ b/crates/control/src/motion/center_jump.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::PathsInterface;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
@@ -14,6 +14,7 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct CenterJump {
     interpolator: MotionInterpolator<Joints<f32>>,
+    state: InterpolatorState<Joints<f32>>,
 }
 
 #[context]
@@ -42,6 +43,7 @@ impl CenterJump {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("center_jump.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
         })
     }
 
@@ -51,14 +53,14 @@ impl CenterJump {
 
         if context.motion_selection.current_motion == MotionType::CenterJump {
             self.interpolator
-                .advance_by(last_cycle_duration, condition_input);
+                .advance_by(&mut self.state, last_cycle_duration, condition_input);
         } else {
-            self.interpolator.reset();
+            self.state.reset();
         }
-        context.motion_safe_exits[MotionType::CenterJump] = self.interpolator.is_finished();
+        context.motion_safe_exits[MotionType::CenterJump] = self.state.is_finished();
 
         Ok(MainOutputs {
-            center_jump_positions: self.interpolator.value().into(),
+            center_jump_positions: self.interpolator.value(self.state).into(),
         })
     }
 }

--- a/crates/control/src/motion/jump_right.rs
+++ b/crates/control/src/motion/jump_right.rs
@@ -1,8 +1,9 @@
 use color_eyre::Result;
 use context_attribute::context;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
@@ -14,7 +15,9 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct JumpRight {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<MotorCommands<Joints<f32>>>,
+    state: InterpolatorState<MotorCommands<Joints<f32>>>,
 }
 
 #[context]
@@ -43,6 +46,7 @@ impl JumpRight {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("jump_left.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
         })
     }
 
@@ -52,14 +56,14 @@ impl JumpRight {
 
         if context.motion_selection.current_motion == MotionType::JumpRight {
             self.interpolator
-                .advance_by(last_cycle_duration, condition_input);
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
         } else {
-            self.interpolator.reset();
+            self.state.reset();
         }
-        context.motion_safe_exits[MotionType::JumpRight] = self.interpolator.is_finished();
+        context.motion_safe_exits[MotionType::JumpRight] = self.state.is_finished();
 
         Ok(MainOutputs {
-            jump_right_joints_command: self.interpolator.value().mirrored().into(),
+            jump_right_joints_command: self.interpolator.value(self.state).mirrored().into(),
         })
     }
 }

--- a/crates/control/src/motion/keeper_jump_left.rs
+++ b/crates/control/src/motion/keeper_jump_left.rs
@@ -1,8 +1,9 @@
 use color_eyre::Result;
 use context_attribute::context;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use serde::{Deserialize, Serialize};
 use types::{
     condition_input::ConditionInput,
@@ -14,7 +15,9 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct KeeperJumpLeft {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<MotorCommands<Joints<f32>>>,
+    state: InterpolatorState<MotorCommands<Joints<f32>>>,
 }
 
 #[context]
@@ -43,6 +46,7 @@ impl KeeperJumpLeft {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("keeper_jump_right.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
         })
     }
 
@@ -52,14 +56,14 @@ impl KeeperJumpLeft {
 
         if context.motion_selection.current_motion == MotionType::KeeperJumpLeft {
             self.interpolator
-                .advance_by(last_cycle_duration, condition_input);
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
         } else {
-            self.interpolator.reset();
+            self.state.reset();
         }
-        context.motion_safe_exits[MotionType::KeeperJumpLeft] = self.interpolator.is_finished();
+        context.motion_safe_exits[MotionType::KeeperJumpLeft] = self.state.is_finished();
 
         Ok(MainOutputs {
-            keeper_jump_left_motor_commands: self.interpolator.value().mirrored().into(),
+            keeper_jump_left_motor_commands: self.interpolator.value(self.state).mirrored().into(),
         })
     }
 }

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use context_attribute::context;
 use coordinate_systems::Robot;
 use filtering::low_pass_filter::LowPassFilter;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use linear_algebra::Vector3;
@@ -18,6 +19,7 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct StandUpBack {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<Joints<f32>>,
     state: InterpolatorState<Joints<f32>>,
     filtered_gyro: LowPassFilter<nalgebra::Vector3<f32>>,
@@ -65,20 +67,21 @@ impl StandUpBack {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let estimated_remaining_duration =
-            if context.motion_selection.current_motion == MotionType::StandUpBack {
-                let last_cycle_duration = context.cycle_time.last_cycle_duration;
-                let condition_input = context.condition_input;
-                self.interpolator
-                    .advance_by(&mut self.state, last_cycle_duration, condition_input);
+        let estimated_remaining_duration = if context.motion_selection.current_motion
+            == MotionType::StandUpBack
+        {
+            let last_cycle_duration = context.cycle_time.last_cycle_duration;
+            let condition_input = context.condition_input;
+            self.interpolator
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
 
-                RemainingStandUpDuration::Running(
-                    self.interpolator.estimated_remaining_duration(self.state),
-                )
-            } else {
-                self.state.reset();
-                RemainingStandUpDuration::NotRunning
-            };
+            RemainingStandUpDuration::Running(
+                self.interpolator.estimated_remaining_duration(self.state),
+            )
+        } else {
+            self.state.reset();
+            RemainingStandUpDuration::NotRunning
+        };
 
         context.motion_safe_exits[MotionType::StandUpBack] = self.state.is_finished();
 

--- a/crates/control/src/motion/stand_up_back.rs
+++ b/crates/control/src/motion/stand_up_back.rs
@@ -7,7 +7,7 @@ use filtering::low_pass_filter::LowPassFilter;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use linear_algebra::Vector3;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -19,6 +19,7 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct StandUpBack {
     interpolator: MotionInterpolator<Joints<f32>>,
+    state: InterpolatorState<Joints<f32>>,
     filtered_gyro: LowPassFilter<nalgebra::Vector3<f32>>,
 }
 
@@ -55,6 +56,7 @@ impl StandUpBack {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("stand_up_back.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
             filtered_gyro: LowPassFilter::with_smoothing_factor(
                 nalgebra::Vector3::zeros(),
                 *context.gyro_low_pass_factor,
@@ -68,20 +70,22 @@ impl StandUpBack {
                 let last_cycle_duration = context.cycle_time.last_cycle_duration;
                 let condition_input = context.condition_input;
                 self.interpolator
-                    .advance_by(last_cycle_duration, condition_input);
+                    .advance_by(&mut self.state, last_cycle_duration, condition_input);
 
-                RemainingStandUpDuration::Running(self.interpolator.estimated_remaining_duration())
+                RemainingStandUpDuration::Running(
+                    self.interpolator.estimated_remaining_duration(self.state),
+                )
             } else {
-                self.interpolator.reset();
+                self.state.reset();
                 RemainingStandUpDuration::NotRunning
             };
 
-        context.motion_safe_exits[MotionType::StandUpBack] = self.interpolator.is_finished();
+        context.motion_safe_exits[MotionType::StandUpBack] = self.state.is_finished();
 
         self.filtered_gyro.update(context.angular_velocity.inner);
         let gyro = self.filtered_gyro.state();
 
-        let mut positions = self.interpolator.value();
+        let mut positions = self.interpolator.value(self.state);
         positions.left_leg.ankle_pitch += context.leg_balancing_factor.y * gyro.y;
         positions.left_leg.ankle_roll += context.leg_balancing_factor.x * gyro.x;
         positions.left_leg.hip_yaw_pitch += context.leg_balancing_factor.x * gyro.x;

--- a/crates/control/src/motion/stand_up_sitting.rs
+++ b/crates/control/src/motion/stand_up_sitting.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use context_attribute::context;
 use coordinate_systems::Robot;
 use filtering::low_pass_filter::LowPassFilter;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use linear_algebra::Vector3;
@@ -18,6 +19,7 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct StandUpSitting {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<Joints<f32>>,
     state: InterpolatorState<Joints<f32>>,
     filtered_gyro: LowPassFilter<nalgebra::Vector3<f32>>,
@@ -66,27 +68,28 @@ impl StandUpSitting {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let estimated_remaining_duration =
-            if context.motion_selection.current_motion == MotionType::StandUpSitting {
-                let last_cycle_duration = context.cycle_time.last_cycle_duration;
-                let condition_input = context.condition_input;
+        let estimated_remaining_duration = if context.motion_selection.current_motion
+            == MotionType::StandUpSitting
+        {
+            let last_cycle_duration = context.cycle_time.last_cycle_duration;
+            let condition_input = context.condition_input;
 
-                self.interpolator
-                    .advance_by(&mut self.state, last_cycle_duration, condition_input);
+            self.interpolator
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
 
-                RemainingStandUpDuration::Running(
-                    self.interpolator.estimated_remaining_duration(self.state),
-                )
-            } else {
-                self.state.reset();
-                RemainingStandUpDuration::NotRunning
-            };
+            RemainingStandUpDuration::Running(
+                self.interpolator.estimated_remaining_duration(self.state),
+            )
+        } else {
+            self.state.reset();
+            RemainingStandUpDuration::NotRunning
+        };
         context.motion_safe_exits[MotionType::StandUpSitting] = self.state.is_finished();
 
         self.filtered_gyro.update(context.angular_velocity.inner);
         let gyro = self.filtered_gyro.state();
 
-        let mut positions = self.interpolator.value();
+        let mut positions = self.interpolator.value(self.state);
         positions.left_leg.ankle_pitch += context.leg_balancing_factor.y * gyro.y;
         positions.left_leg.ankle_roll += context.leg_balancing_factor.x * gyro.x;
         positions.right_leg.ankle_pitch += context.leg_balancing_factor.y * gyro.y;

--- a/crates/control/src/motion/stand_up_sitting.rs
+++ b/crates/control/src/motion/stand_up_sitting.rs
@@ -7,7 +7,7 @@ use filtering::low_pass_filter::LowPassFilter;
 use framework::MainOutput;
 use hardware::PathsInterface;
 use linear_algebra::Vector3;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use types::{
     condition_input::ConditionInput,
     cycle_time::CycleTime,
@@ -19,6 +19,7 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct StandUpSitting {
     interpolator: MotionInterpolator<Joints<f32>>,
+    state: InterpolatorState<Joints<f32>>,
     filtered_gyro: LowPassFilter<nalgebra::Vector3<f32>>,
 }
 
@@ -56,6 +57,7 @@ impl StandUpSitting {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("stand_up_sitting.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
             filtered_gyro: LowPassFilter::with_smoothing_factor(
                 nalgebra::Vector3::zeros(),
                 *context.gyro_low_pass_factor,
@@ -70,14 +72,16 @@ impl StandUpSitting {
                 let condition_input = context.condition_input;
 
                 self.interpolator
-                    .advance_by(last_cycle_duration, condition_input);
+                    .advance_by(&mut self.state, last_cycle_duration, condition_input);
 
-                RemainingStandUpDuration::Running(self.interpolator.estimated_remaining_duration())
+                RemainingStandUpDuration::Running(
+                    self.interpolator.estimated_remaining_duration(self.state),
+                )
             } else {
-                self.interpolator.reset();
+                self.state.reset();
                 RemainingStandUpDuration::NotRunning
             };
-        context.motion_safe_exits[MotionType::StandUpSitting] = self.interpolator.is_finished();
+        context.motion_safe_exits[MotionType::StandUpSitting] = self.state.is_finished();
 
         self.filtered_gyro.update(context.angular_velocity.inner);
         let gyro = self.filtered_gyro.state();

--- a/crates/control/src/motion/wide_stance.rs
+++ b/crates/control/src/motion/wide_stance.rs
@@ -1,8 +1,9 @@
 use color_eyre::Result;
 use context_attribute::context;
+use framework::deserialize_not_implemented;
 use framework::MainOutput;
 use hardware::PathsInterface;
-use motionfile::{MotionFile, MotionInterpolator};
+use motionfile::{InterpolatorState, MotionFile, MotionInterpolator};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use types::{
@@ -14,7 +15,9 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct WideStance {
+    #[serde(skip, default = "deserialize_not_implemented")]
     interpolator: MotionInterpolator<Joints<f32>>,
+    state: InterpolatorState<Joints<f32>>,
 }
 
 #[context]
@@ -44,27 +47,29 @@ impl WideStance {
         Ok(Self {
             interpolator: MotionFile::from_path(paths.motions.join("wide_stance.json"))?
                 .try_into()?,
+            state: InterpolatorState::INITIAL,
         })
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let wide_stance_estimated_remaining_duration =
-            if let MotionType::WideStance = context.motion_selection.current_motion {
-                let last_cycle_duration = context.cycle_time.last_cycle_duration;
-                let condition_input = context.condition_input;
+        let wide_stance_estimated_remaining_duration = if let MotionType::WideStance =
+            context.motion_selection.current_motion
+        {
+            let last_cycle_duration = context.cycle_time.last_cycle_duration;
+            let condition_input = context.condition_input;
 
-                self.interpolator
-                    .advance_by(last_cycle_duration, condition_input);
+            self.interpolator
+                .advance_state(&mut self.state, last_cycle_duration, condition_input);
 
-                Some(self.interpolator.estimated_remaining_duration())
-            } else {
-                self.interpolator.reset();
-                None
-            };
-        context.motion_safe_exits[MotionType::WideStance] = self.interpolator.is_finished();
+            Some(self.interpolator.estimated_remaining_duration(self.state))
+        } else {
+            self.state.reset();
+            None
+        };
+        context.motion_safe_exits[MotionType::WideStance] = self.state.is_finished();
 
         Ok(MainOutputs {
-            wide_stance_positions: self.interpolator.value().into(),
+            wide_stance_positions: self.interpolator.value(self.state).into(),
             wide_stance_estimated_remaining_duration: wide_stance_estimated_remaining_duration
                 .into(),
         })

--- a/crates/motionfile/src/lib.rs
+++ b/crates/motionfile/src/lib.rs
@@ -10,7 +10,7 @@ pub mod timed_spline;
 pub use condition::{Condition, ContinuousConditionType, DiscreteConditionType, Response, TimeOut};
 pub use fallen_abort_condition::FallenAbort;
 pub use motion_file::*;
-pub use motion_interpolator::MotionInterpolator;
+pub use motion_interpolator::{InterpolatorState, MotionInterpolator};
 pub use no_ground_contact_condition::NoGroundContactAbort;
 pub use spline_interpolator::SplineInterpolator;
 pub use stabilized_condition::StabilizedCondition;

--- a/crates/motionfile/src/motion_interpolator.rs
+++ b/crates/motionfile/src/motion_interpolator.rs
@@ -136,7 +136,7 @@ impl<T: Debug + Interpolate<f32>> MotionInterpolator<T> {
         ReturnState::Continue
     }
 
-    fn advance_state(
+    fn handle_state_transitions(
         &self,
         state: &mut InterpolatorState<T>,
         time_step: Duration,
@@ -213,7 +213,7 @@ impl<T: Debug + Interpolate<f32>> MotionInterpolator<T> {
         };
     }
 
-    pub fn advance_by(
+    pub fn advance_state(
         &self,
         state: &mut InterpolatorState<T>,
         time_step: Duration,
@@ -223,7 +223,7 @@ impl<T: Debug + Interpolate<f32>> MotionInterpolator<T> {
             return;
         }
 
-        self.advance_state(state, time_step, condition_input);
+        self.handle_state_transitions(state, time_step, condition_input);
     }
 
     pub fn value(&self, state: InterpolatorState<T>) -> T {


### PR DESCRIPTION
## Why? What?

We serialized the non-changing interpolators in every control cycle, which is unecessary.
This PR extracts the mutable state from the interpolators and removes the serialization of interpolators in replay. Since we have a source distribution now, no information is lost.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Check if motions work as before
