### PR TITLE
Add individual and total node duration measurements

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -916,7 +916,7 @@ fn generate_execute_node_and_write_main_outputs(
         {
             #[allow(clippy::needless_else)]
             if #are_required_inputs_some {
-                let cycle_start = std::time::SystemTime::now();
+                let node_cycle_start = std::time::SystemTime::now();
                 let main_outputs = {
                     let _task = ittapi::Task::begin(&itt_domain, #node_name);
                     self.#node_member.cycle(
@@ -926,8 +926,8 @@ fn generate_execute_node_and_write_main_outputs(
                     )
                     .wrap_err(#cycle_error_message)?
                 };
-                let cycle_duration = cycle_start.elapsed().expect("time ran backwards");
-                own_database.cycle_timings.#node_member = cycle_duration;
+                let node_cycle_duration = node_cycle_start.elapsed().expect("time ran backwards");
+                own_database.cycle_timings.#node_member = node_cycle_duration;
                 #write_main_outputs
             }
             else {

--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -53,7 +53,7 @@ pub fn generate_cyclers(cyclers: &Cyclers, mode: CyclerMode) -> TokenStream {
 fn generate_module(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -> TokenStream {
     let module_name = format_ident!("{}", cycler.name.to_case(Case::Snake));
     let cycler_instance = generate_cycler_instance(cycler);
-    let database_struct = generate_database_struct();
+    let database_struct = generate_database_struct(cycler);
     let cycler_struct = generate_struct(cycler, cyclers, mode);
     let cycler_implementation = generate_implementation(cycler, cyclers, mode);
 
@@ -84,7 +84,9 @@ fn generate_cycler_instance(cycler: &Cycler) -> TokenStream {
     }
 }
 
-fn generate_database_struct() -> TokenStream {
+fn generate_database_struct(cycler: &Cycler) -> TokenStream {
+    let cycler_name = format_ident!("{}", cycler.name.to_case(Case::Snake));
+
     quote! {
         #[derive(
             Default,
@@ -97,6 +99,7 @@ fn generate_database_struct() -> TokenStream {
         pub struct Database {
             pub main_outputs: MainOutputs,
             pub additional_outputs: AdditionalOutputs,
+            pub cycle_timings: crate::structs::#cycler_name::CycleTimings,
         }
     }
 }
@@ -546,6 +549,7 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
             quote! {
                 #after_remaining_nodes
                 let recording_duration = recording_timestamp.elapsed().expect("time ran backwards");
+                own_database.cycle_timings.total = recording_duration;
 
                 #duration_warning
 
@@ -590,6 +594,8 @@ fn generate_cycle_method(cycler: &Cycler, cyclers: &Cyclers, mode: CyclerMode) -
             }
 
             #after_remaining_nodes
+
+
             Ok(())
         }
     }
@@ -910,6 +916,7 @@ fn generate_execute_node_and_write_main_outputs(
         {
             #[allow(clippy::needless_else)]
             if #are_required_inputs_some {
+                let cycle_start = std::time::SystemTime::now();
                 let main_outputs = {
                     let _task = ittapi::Task::begin(&itt_domain, #node_name);
                     self.#node_member.cycle(
@@ -919,6 +926,8 @@ fn generate_execute_node_and_write_main_outputs(
                     )
                     .wrap_err(#cycle_error_message)?
                 };
+                let cycle_duration = cycle_start.elapsed().expect("time ran backwards");
+                own_database.cycle_timings.#node_member = cycle_duration;
                 #write_main_outputs
             }
             else {

--- a/crates/code_generation/src/structs.rs
+++ b/crates/code_generation/src/structs.rs
@@ -52,12 +52,18 @@ pub fn generate_structs(structs: &Structs) -> TokenStream {
                 format_ident!("CyclerState"),
                 &derives,
             );
+            let cycle_times = hierarchy_to_token_stream(
+                &cycler_structs.cycle_times,
+                format_ident!("CycleTimings"),
+                &derives,
+            );
 
             quote! {
                 pub mod #cycler_module_identifier {
                     #main_outputs
                     #additional_outputs
                     #cycler_state
+                    #cycle_times
                 }
             }
         });


### PR DESCRIPTION
## Why? What?

Debugging #1822 was kind of annoying without proper timing measurements for node and cycle durations. 
This PR expands on #710 and adds the `cycle_timings` field to each cycler database. This includes a total time measurement from the start of the first node of a cycler until the last node's cycle function terminates, which is the same as the cycler recording timestamp. This can be used under `$cycler.cycle_timings.total`. 
Same as #710 did, this also adds node cycle durations for each individual node of a cycler. These can be accessed under `$cycler.cycle_timings.$node`

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Subscribe `$cycler.cycle_timings` in a twix text panel. 
