### PR TITLE
Reduce openvino InferenceNumThreads to 1

### DIFF
--- a/crates/object_detection/src/pose_detection.rs
+++ b/crates/object_detection/src/pose_detection.rs
@@ -7,7 +7,8 @@ use color_eyre::{
 use itertools::Itertools;
 use ndarray::{s, ArrayView};
 use openvino::{
-    CompiledModel, Core, DeviceType, ElementType, InferenceError::GeneralError, Tensor,
+    CompiledModel, Core, DeviceType, ElementType, InferenceError::GeneralError, RwPropertyKey,
+    Tensor,
 };
 use serde::{Deserialize, Serialize};
 
@@ -81,6 +82,12 @@ impl PoseDetection {
             .with_extension("bin");
 
         let mut core = Core::new()?;
+        core.set_properties(
+            &DeviceType::CPU,
+            [(RwPropertyKey::InferenceNumThreads, "1")],
+        )
+        .wrap_err("failed to set InferenceNumThreads")?;
+
         let network = core
             .read_model_from_file(
                 model_path


### PR DESCRIPTION
## Why? What?

Most of the VisionTop cycles taking too long were apparently due to ObjectDetectionTop simply maxing out the CPU and leading to contention. This PR adds a property to the openvino core, which suggests the engine to only use 1 thread during inference. This does not completely eliminate the DONKs but dramatically reduces them. This however also increases the inference time of the pose detection model to over 450ms. Reducing the number of inference threads only to 2 did not significantly increase the inference time (~230ms -> ~255ms), but also did reduce the DONKing nearly as much.


Fixes #1822 

## ToDo / Known Issues

- [ ] More testing is probably needed to dig down on the root cause of #1822
- [ ] It has to be evaluated if the increase in inference time is still acceptable. 

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Use the new timings of #1823 in twix to inspect the cycle and node execution times of VisionTop.
