### PR TITLE
Pickup stiffnesses

### DIFF
--- a/crates/control/src/ground_contact_detector.rs
+++ b/crates/control/src/ground_contact_detector.rs
@@ -12,6 +12,7 @@ pub struct GroundContactDetector {
     last_has_pressure: bool,
     last_time_switched: SystemTime,
     has_ground_contact: bool,
+    one_foot_has_ground_contact: bool,
 }
 
 #[context]
@@ -31,6 +32,7 @@ pub struct CycleContext {
 #[derive(Default)]
 pub struct MainOutputs {
     pub has_ground_contact: MainOutput<bool>,
+    pub one_foot_has_ground_contact: MainOutput<bool>,
 }
 
 impl GroundContactDetector {
@@ -39,6 +41,7 @@ impl GroundContactDetector {
             last_has_pressure: false,
             last_time_switched: UNIX_EPOCH,
             has_ground_contact: false,
+            one_foot_has_ground_contact: false,
         })
     }
 
@@ -49,6 +52,18 @@ impl GroundContactDetector {
             *context.pressure_threshold,
             *context.hysteresis,
         );
+        let one_foot_has_pressure = greater_than_with_hysteresis(
+            self.last_has_pressure,
+            context.sole_pressure.left,
+            *context.pressure_threshold,
+            *context.hysteresis,
+        ) ^ greater_than_with_hysteresis(
+            self.last_has_pressure,
+            context.sole_pressure.right,
+            *context.pressure_threshold,
+            *context.hysteresis,
+        );
+
         if self.last_has_pressure != has_pressure {
             self.last_time_switched = context.cycle_time.start_time;
         }
@@ -60,11 +75,13 @@ impl GroundContactDetector {
             > *context.timeout
         {
             self.has_ground_contact = has_pressure;
+            self.one_foot_has_ground_contact = one_foot_has_pressure
         }
         self.last_has_pressure = has_pressure;
 
         Ok(MainOutputs {
             has_ground_contact: self.has_ground_contact.into(),
+            one_foot_has_ground_contact: self.one_foot_has_ground_contact.into(),
         })
     }
 }

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -32,7 +32,7 @@ impl MotorCommandsOptimizer {
         motor_commands.stiffnesses.left_arm.hand = 0.0;
         motor_commands.stiffnesses.right_arm.hand = 0.0;
 
-        if *context.has_ground_contact && *context.primary_state == PrimaryState::Initial  {
+        if !*context.has_ground_contact && *context.primary_state == PrimaryState::Initial  {
             motor_commands.stiffnesses = Joints::fill(0.3);
         }
 

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
-use types::{joints::Joints, motor_commands::MotorCommands};
+use types::{joints::Joints, motor_commands::MotorCommands, primary_state::PrimaryState};
 
 #[derive(Deserialize, Serialize)]
 pub struct MotorCommandsOptimizer {}
@@ -13,6 +13,8 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     motor_commands: Input<MotorCommands<Joints<f32>>, "motor_commands">,
+    has_ground_contact: Input<bool, "has_ground_contact">,
+    primary_state: Input<PrimaryState, "world_state.robot.primary_state">,
 }
 
 #[context]
@@ -29,6 +31,10 @@ impl MotorCommandsOptimizer {
         let mut motor_commands = *context.motor_commands;
         motor_commands.stiffnesses.left_arm.hand = 0.0;
         motor_commands.stiffnesses.right_arm.hand = 0.0;
+
+        if *context.has_ground_contact && *context.primary_state == PrimaryState::Initial  {
+            motor_commands.stiffnesses = Joints::fill(0.3);
+        }
 
         Ok(MainOutputs {
             optimized_motor_commands: motor_commands.into(),

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -14,6 +14,7 @@ pub struct CreationContext {}
 pub struct CycleContext {
     motor_commands: Input<MotorCommands<Joints<f32>>, "motor_commands">,
     one_foot_has_ground_contact: Input<bool, "one_foot_has_ground_contact">,
+    has_ground_contact: Input<bool, "has_ground_contact">,
     primary_state: Input<PrimaryState, "world_state.robot.primary_state">,
 }
 
@@ -32,7 +33,7 @@ impl MotorCommandsOptimizer {
         motor_commands.stiffnesses.left_arm.hand = 0.0;
         motor_commands.stiffnesses.right_arm.hand = 0.0;
 
-        if *context.one_foot_has_ground_contact && *context.primary_state == PrimaryState::Initial  {
+        if (*context.one_foot_has_ground_contact || !*context.has_ground_contact) && *context.primary_state == PrimaryState::Initial  {
             motor_commands.stiffnesses = Joints::fill(0.3);
         }
 

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -13,7 +13,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     motor_commands: Input<MotorCommands<Joints<f32>>, "motor_commands">,
-    has_ground_contact: Input<bool, "has_ground_contact">,
+    one_foot_has_ground_contact: Input<bool, "one_foot_has_ground_contact">,
     primary_state: Input<PrimaryState, "world_state.robot.primary_state">,
 }
 
@@ -32,7 +32,7 @@ impl MotorCommandsOptimizer {
         motor_commands.stiffnesses.left_arm.hand = 0.0;
         motor_commands.stiffnesses.right_arm.hand = 0.0;
 
-        if !*context.has_ground_contact && *context.primary_state == PrimaryState::Initial  {
+        if *context.one_foot_has_ground_contact && *context.primary_state == PrimaryState::Initial  {
             motor_commands.stiffnesses = Joints::fill(0.3);
         }
 


### PR DESCRIPTION
## Why? What?

When we pick up the Nao the stiffnesses get set to 30%. This should reduce stress on the motors and gears. Also it ensures that if we manually test pitches, we don't move or damage gears.

## How to Test
Pick up a nao and look at the stiffnesses in twix. Then move the ankle pitch. The stiffnesses should only stay at 0.3 when one or no foot has "ground contact" 
