### PR TITLE
Add manifest path completions for fish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6515,7 +6515,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "6.0.0"
+version = "6.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/cargo.rs
+++ b/tools/pepsi/src/cargo.rs
@@ -35,7 +35,7 @@ mod heading {
 }
 
 lazy_static! {
-    static ref MANIFEST_PATHS: HashMap<&'static str, &'static str> = {
+    pub static ref MANIFEST_PATHS: HashMap<&'static str, &'static str> = {
         HashMap::from([
             ("imagine", "crates/hulk_imagine"),
             ("nao", "crates/hulk_nao"),

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -3,7 +3,7 @@ use clap_complete::{generate, Shell};
 use color_eyre::Result;
 use regex::Regex;
 
-use crate::aliveness::completions as complete_naos;
+use crate::{aliveness::completions as complete_naos, cargo::MANIFEST_PATHS};
 
 #[derive(Args)]
 pub struct Arguments {
@@ -72,7 +72,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const COMPLETION_SUBCOMMANDS: [(&str, &str); 18] = [
+            const ALIVENESS_COMPLETION_SUBCOMMANDS: [(&str, &str); 18] = [
                 ("aliveness", ""),
                 ("gammaray", ""),
                 ("hulk", ""),
@@ -92,7 +92,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 ("wifi", "set"),
                 ("wifi", "status"),
             ];
-            for (subcommand, argument) in COMPLETION_SUBCOMMANDS {
+            for (subcommand, argument) in ALIVENESS_COMPLETION_SUBCOMMANDS {
                 if argument.is_empty() {
                     println!(
                         "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}\" \
@@ -116,6 +116,17 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                      and not __fish_seen_subcommand_from golden-goal first-half second-half\" \
                      -f -a \"golden-goal first-half second-half\""
             );
+
+            const MANIFEST_COMPLETION_SUBCOMMANDS: [&str; 6] =
+                ["build", "check", "clippy", "install", "run", "test"];
+            let manifest_paths: Vec<_> = MANIFEST_PATHS.keys().copied().collect();
+            for subcommand in MANIFEST_COMPLETION_SUBCOMMANDS {
+                println!(
+                    "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}\" \
+                         -f -a \"{manifest_paths}\"",
+                    manifest_paths = manifest_paths.join(" ")
+                );
+            }
         }
         Shell::Zsh => {
             let re = Regex::new("(:naos? -- .*):").unwrap();

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -72,7 +72,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
         Shell::Fish => {
             print!("{static_completions}");
 
-            const ALIVENESS_COMPLETION_SUBCOMMANDS: [(&str, &str); 18] = [
+            const NAO_COMPLETION_SUBCOMMANDS: [(&str, &str); 18] = [
                 ("aliveness", ""),
                 ("gammaray", ""),
                 ("hulk", ""),
@@ -92,7 +92,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 ("wifi", "set"),
                 ("wifi", "status"),
             ];
-            for (subcommand, argument) in ALIVENESS_COMPLETION_SUBCOMMANDS {
+            for (subcommand, argument) in NAO_COMPLETION_SUBCOMMANDS {
                 if argument.is_empty() {
                     println!(
                         "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}\" \


### PR DESCRIPTION
## Why? What?

This PR adds fish completions for the manifest path for pepsi build, run, etc.

## ToDo / Known Issues

Only fish completions are added for now.

## Ideas for Next Iterations (Not This PR)

Cross-Shell completions with clap are currently quite a pain. We should revisit the whole completion generation once the [Rust-Native Completion engine is stabilized](https://github.com/clap-rs/clap/issues/3166).

## How to Test

```
./pepsi completions fish > ~/.config/fish/completions/pepsi.fish
```

Open a new terminal and observe the completions of `pepsi run`.
