### PR TITLE
fix index in behavior panel

### DIFF
--- a/tools/twix/src/panels/behavior_simulator.rs
+++ b/tools/twix/src/panels/behavior_simulator.rs
@@ -118,7 +118,7 @@ impl Widget for &mut BehaviorSimulatorPanel {
                         if response.changed() {
                             self.nao.write(
                                 "parameters.selected_robot",
-                                TextOrBinary::Text(self.selected_robot.into()),
+                                TextOrBinary::Text(robots[self.selected_robot].into()),
                             );
                         };
                     });


### PR DESCRIPTION
## Why? What?

behavior panel selected with players 0-6 instead of 1-7

## How to Test

open behavior panel look if the right robot is selected in map panel
