### PR TITLE
Fix GCC 15 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,6 +3613,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
 name = "fanta"
 version = "0.1.0"
 dependencies = [
@@ -6260,28 +6270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8172,10 +8160,10 @@ checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
+ "fancy-regex",
  "flate2",
  "fnv",
  "once_cell",
- "onig",
  "regex-syntax 0.8.5",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ ball_filter = { path = "crates/ball_filter" }
 base64 = "0.22.1"
 bat = { version = "0.25.0", default-features = false, features = [
   "paging",
-  "regex-onig",
+  "regex-fancy",
 ] }
 bevy = { version = "0.15.2", default-features = false }
 bevy-inspector-egui = "0.29.1"


### PR DESCRIPTION
## Why? What?

After upgrading to GCC 15,  `onig-sys` no longer builds (https://github.com/rust-onig/rust-onig/issues/196). In other news, the underlying `Oniguruma` library was just archived (https://github.com/rust-onig/rust-onig/issues/194).

This PR replaces the dependency with a pure rust regex implementation.

## ToDo / Known Issues

It's perfect

## Ideas for Next Iterations (Not This PR)

It's perfect

## How to Test

CI