### PR TITLE
Add awk to fedora dependencies

### DIFF
--- a/docs/setup/development_environment.md
+++ b/docs/setup/development_environment.md
@@ -48,7 +48,7 @@ Use your distribution's package manager to install the following dependencies:
 === "Fedora"
 
     ```sh
-    sudo dnf install git git-lfs clang cmake python3 which zstd xz file rsync alsa-lib-devel opusfile-devel hdf5-devel systemd-devel luajit-devel
+    sudo dnf install git git-lfs clang cmake python3 awk which zstd xz file rsync alsa-lib-devel opusfile-devel hdf5-devel systemd-devel luajit-devel
     ```
 
 === "Ubuntu"


### PR DESCRIPTION
## Why? What?

Tried to install sdk in a fedora container which failed because awk was not found.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

```sh
podman run -it fedora
sudo dnf install ... # from the documentation
git clone https://github.com/hulks/hulk
cd hulk
./pepsi sdk install
```