### PR TITLE
rescale midpoint to base_step_duration

### DIFF
--- a/crates/walking_engine/src/step_plan.rs
+++ b/crates/walking_engine/src/step_plan.rs
@@ -64,11 +64,13 @@ impl StepPlan {
                     .div_or_zero(context.max_step_size),
             ));
 
-        let midpoint = interpolate_midpoint(
+        let base_midpoint = interpolate_midpoint(
             swing_foot_travel,
             parameters.step_midpoint,
             parameters.base.step_midpoint,
         );
+        let midpoint_time = parameters.base.step_duration.mul_f32(base_midpoint);
+        let midpoint = midpoint_time.as_secs_f32() / step_duration.as_secs_f32();
 
         StepPlan {
             step_duration,


### PR DESCRIPTION
## Why? What?

rescale the midpoint to be always relative to the base (minimal) step duration. Increasing the step duration only extends the right (descending) part of the parabolic return.
