### PR TITLE
Fix rsync to remote when using multiple worktrees

### DIFF
--- a/scripts/remote_workspace
+++ b/scripts/remote_workspace
@@ -72,7 +72,7 @@ address="$(echo $remoteWorkspace | cut -d':' -f 1)"
 remotePath="$(echo $remoteWorkspace | cut -d':' -f 2-)"
 
 # send local state to remote
-rsync -ah --info progress2 --exclude='.git' --filter="dir-merge,- .gitignore" --delete . "$remoteWorkspace"
+rsync -rlpgoDhc --info progress2 --exclude='.git' --filter="dir-merge,- .gitignore" --delete . "$remoteWorkspace"
 
 # if stdout is a tty/pty, make ssh behave as one as well
 SSH_FLAGS=""


### PR DESCRIPTION
## Why? What?

When using multiple worktrees `pepsi ... --remote` fails due to rsync syncing time stamps and confusing cargo. 
This PR removes the `-t` flag to stop rsync from changing the time stamps when syncing (note: `-a` includes `-rlpgoD` besides `-t`). `Additionally, this adds the `-c` flag to use checksums when checking for file differences. This significantly increases the use of cached crates when compiling.


## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- run `./pepsi test --remote` from two different worktrees 
