### PR TITLE
fix injected motion command

### DIFF
--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -2,7 +2,11 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
-use types::{joints::Joints, motion_command::{HeadMotion, MotionCommand}, motor_commands::MotorCommands};
+use types::{
+    joints::Joints,
+    motion_command::{HeadMotion, MotionCommand},
+    motor_commands::MotorCommands,
+};
 
 #[derive(Deserialize, Serialize)]
 pub struct MotorCommandsOptimizer {}
@@ -34,7 +38,11 @@ impl MotorCommandsOptimizer {
         motor_commands.stiffnesses.right_arm.hand = 0.0;
 
         if (*context.only_one_foot_has_ground_contact || !*context.has_ground_contact)
-            && (*context.motion_command ==  MotionCommand::Initial { head: HeadMotion::Center, should_look_for_referee: false }
+            && (*context.motion_command
+                == MotionCommand::Initial {
+                    head: HeadMotion::Center,
+                    should_look_for_referee: false,
+                }
                 || *context.motion_command == MotionCommand::Penalized)
         {
             motor_commands.stiffnesses = Joints::fill(0.3);

--- a/crates/control/src/motion/motor_commands_optimizer.rs
+++ b/crates/control/src/motion/motor_commands_optimizer.rs
@@ -2,7 +2,7 @@ use color_eyre::Result;
 use context_attribute::context;
 use framework::MainOutput;
 use serde::{Deserialize, Serialize};
-use types::{joints::Joints, motor_commands::MotorCommands, primary_state::PrimaryState};
+use types::{joints::Joints, motion_command::{HeadMotion, MotionCommand}, motor_commands::MotorCommands};
 
 #[derive(Deserialize, Serialize)]
 pub struct MotorCommandsOptimizer {}
@@ -15,7 +15,7 @@ pub struct CycleContext {
     motor_commands: Input<MotorCommands<Joints<f32>>, "motor_commands">,
     only_one_foot_has_ground_contact: Input<bool, "only_one_foot_has_ground_contact">,
     has_ground_contact: Input<bool, "has_ground_contact">,
-    primary_state: Input<PrimaryState, "world_state.robot.primary_state">,
+    motion_command: Input<MotionCommand, "motion_command">,
 }
 
 #[context]
@@ -34,8 +34,8 @@ impl MotorCommandsOptimizer {
         motor_commands.stiffnesses.right_arm.hand = 0.0;
 
         if (*context.only_one_foot_has_ground_contact || !*context.has_ground_contact)
-            && (*context.primary_state == PrimaryState::Initial
-                || *context.primary_state == PrimaryState::Penalized)
+            && (*context.motion_command ==  MotionCommand::Initial { head: HeadMotion::Center, should_look_for_referee: false }
+                || *context.motion_command == MotionCommand::Penalized)
         {
             motor_commands.stiffnesses = Joints::fill(0.3);
         }

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -21,6 +21,7 @@ use crate::{
     PathSerialize,
     PathDeserialize,
     PathIntrospect,
+    PartialEq,
 )]
 pub enum WalkSpeed {
     Slow,
@@ -30,7 +31,7 @@ pub enum WalkSpeed {
 }
 
 #[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect,
+    Clone, Copy, Debug, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect, PartialEq,
 )]
 pub enum OrientationMode {
     AlignWithPath,
@@ -38,7 +39,7 @@ pub enum OrientationMode {
 }
 
 #[derive(
-    Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
+    Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect, PartialEq,
 )]
 pub enum MotionCommand {
     ArmsUpSquat,

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -31,7 +31,15 @@ pub enum WalkSpeed {
 }
 
 #[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, PathSerialize, PathDeserialize, PathIntrospect, PartialEq,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+    PartialEq,
 )]
 pub enum OrientationMode {
     AlignWithPath,
@@ -39,7 +47,15 @@ pub enum OrientationMode {
 }
 
 #[derive(
-    Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect, PartialEq,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+    PartialEq,
 )]
 pub enum MotionCommand {
     ArmsUpSquat,


### PR DESCRIPTION
# Fixes #
my lower pickupstiffnesses broke the injected motioncommand by overwriting stiffnesses

## How to Test
set an injected motion_command in twix (preferably a some thing that changes the stiffnesses) and the let the nao loose ground contact. Hopefully all stiffnesses don't get set to 0.3. 