### PR TITLE
Served hot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "geometry",
  "hardware",
  "hula_types",
+ "indicatif",
  "ittapi",
  "linear_algebra",
  "log",

--- a/crates/bevyhavior_simulator/Cargo.toml
+++ b/crates/bevyhavior_simulator/Cargo.toml
@@ -23,6 +23,7 @@ framework = { workspace = true }
 geometry = { workspace = true }
 hardware = { workspace = true }
 hula_types = { workspace = true }
+indicatif = { workspace = true }
 ittapi = { workspace = true }
 linear_algebra = { workspace = true }
 log = { workspace = true }

--- a/crates/bevyhavior_simulator/src/recorder.rs
+++ b/crates/bevyhavior_simulator/src/recorder.rs
@@ -6,6 +6,11 @@ use bevy::{
     time::Time,
 };
 use color_eyre::Result;
+use tokio::{
+    runtime::Runtime,
+    sync::mpsc::{self, UnboundedSender},
+    task::JoinHandle,
+};
 use tokio_util::sync::CancellationToken;
 
 use types::{ball_position::SimulatorBallState, players::Players};
@@ -18,35 +23,63 @@ pub struct Frame {
     pub robots: Players<Option<Database>>,
 }
 
-#[derive(Resource, Default)]
+#[derive(Resource)]
 pub struct Recording {
-    pub frames: Vec<Frame>,
+    frame_sender: UnboundedSender<Frame>,
+    join_handle: Option<JoinHandle<Result<()>>>,
+    runtime: Runtime,
+}
+
+impl Default for Recording {
+    fn default() -> Self {
+        let (frame_sender, frame_receiver) = mpsc::unbounded_channel();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let join_handle = runtime.spawn(server::run(
+            frame_receiver,
+            // std::mem::take(&mut self.frames),
+            "[::]:1337",
+            CancellationToken::new(),
+        ));
+        Self {
+            frame_sender,
+            join_handle: Some(join_handle),
+            runtime,
+        }
+    }
 }
 
 pub fn frame_recorder(
     robots: Query<&Robot>,
     ball: Res<BallResource>,
-    mut recording: ResMut<Recording>,
+    recording: ResMut<Recording>,
     time: Res<Time>,
 ) {
     let mut players = Players::<Option<Database>>::default();
     for robot in &robots {
         players[robot.parameters.player_number] = Some(robot.database.clone())
     }
-    recording.frames.push(Frame {
-        timestamp: UNIX_EPOCH + time.elapsed(),
-        robots: players,
-        ball: ball.state,
-    });
+    recording
+        .frame_sender
+        .send(Frame {
+            timestamp: UNIX_EPOCH + time.elapsed(),
+            robots: players,
+            ball: ball.state,
+        })
+        .expect("failed to send frame to server");
 }
 
 impl Recording {
-    pub fn serve(&mut self) -> Result<()> {
-        server::run(
-            std::mem::take(&mut self.frames),
-            "[::]:1337",
-            CancellationToken::new(),
-        )
+    pub fn join(self) -> Result<()> {
+        let Self {
+            frame_sender,
+            mut join_handle,
+            runtime,
+        } = self;
+        drop(frame_sender);
+        runtime.block_on(join_handle.take().unwrap())?
     }
 }
 

--- a/crates/bevyhavior_simulator/src/recorder.rs
+++ b/crates/bevyhavior_simulator/src/recorder.rs
@@ -39,7 +39,6 @@ impl Default for Recording {
             .unwrap();
         let join_handle = runtime.spawn(server::run(
             frame_receiver,
-            // std::mem::take(&mut self.frames),
             "[::]:1337",
             CancellationToken::new(),
         ));

--- a/crates/bevyhavior_simulator/src/recorder.rs
+++ b/crates/bevyhavior_simulator/src/recorder.rs
@@ -26,7 +26,7 @@ pub struct Frame {
 #[derive(Resource)]
 pub struct Recording {
     frame_sender: UnboundedSender<Frame>,
-    join_handle: Option<JoinHandle<Result<()>>>,
+    join_handle: JoinHandle<Result<()>>,
     runtime: Runtime,
 }
 
@@ -44,7 +44,7 @@ impl Default for Recording {
         ));
         Self {
             frame_sender,
-            join_handle: Some(join_handle),
+            join_handle,
             runtime,
         }
     }
@@ -74,11 +74,11 @@ impl Recording {
     pub fn join(self) -> Result<()> {
         let Self {
             frame_sender,
-            mut join_handle,
+            join_handle,
             runtime,
         } = self;
         drop(frame_sender);
-        runtime.block_on(join_handle.take().unwrap())?
+        runtime.block_on(join_handle)?
     }
 }
 

--- a/crates/bevyhavior_simulator/src/server.rs
+++ b/crates/bevyhavior_simulator/src/server.rs
@@ -46,10 +46,6 @@ async fn timeline_server(
     mut frame_receiver: UnboundedReceiver<Frame>,
 ) {
     let mut frames = Vec::<Frame>::new();
-    // Hack to provide frame count to clients initially.
-    // Can be removed if communication sends data for
-    // subscribed outputs immediately after subscribing
-    let mut interval = interval(Duration::from_secs(1));
 
     loop {
         select! {
@@ -61,7 +57,6 @@ async fn timeline_server(
                 }
             }
             _ = parameters_reader.wait_for_change() => { }
-            _ = interval.tick() => { }
             _ = keep_running.cancelled() => {
                 break
             }

--- a/crates/bevyhavior_simulator/src/server.rs
+++ b/crates/bevyhavior_simulator/src/server.rs
@@ -1,6 +1,6 @@
 use std::{
     io::Write,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use color_eyre::{
@@ -8,7 +8,7 @@ use color_eyre::{
     Result,
 };
 use serde::{Deserialize, Serialize};
-use tokio::{net::ToSocketAddrs, select, sync::mpsc::UnboundedReceiver, time::interval};
+use tokio::{net::ToSocketAddrs, select, sync::mpsc::UnboundedReceiver};
 use tokio_util::sync::CancellationToken;
 
 use hula_types::hardware::Ids;

--- a/crates/bevyhavior_simulator/src/simulator.rs
+++ b/crates/bevyhavior_simulator/src/simulator.rs
@@ -88,9 +88,8 @@ impl AppExt for App {
                 break exit;
             }
         };
-        if let Some(mut recording) = self.world_mut().get_resource_mut::<Recording>() {
-            println!("serving {} frames", recording.frames.len());
-            recording.serve()?
+        if let Some(recording) = self.world_mut().remove_resource::<Recording>() {
+            recording.join()?
         }
 
         match exit {


### PR DESCRIPTION
## Why? What?

Previously the behavior simulator would simulate the whole scenario before serving the frames via a communication server.
This was fine before, but with the new step planning, we had scenario runs which would take multiple minutes with some experimental parameters.
With this change, we are able to see the first frames results of our changes immediately.

(Also removes the hack which caused the server to re-send all data once every second.)

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Add a sleep in the update function of any scenario and run it with twix already running, you should see the first frames show up immediately.