### PR TITLE
Prevent freewheeling when channel is closed

### DIFF
--- a/crates/bevyhavior_simulator/src/server.rs
+++ b/crates/bevyhavior_simulator/src/server.rs
@@ -46,7 +46,7 @@ async fn timeline_server(
     progress.set_style(ProgressStyle::with_template("[{elapsed}] {pos} {msg}").unwrap());
     loop {
         select! {
-            frame = frame_receiver.recv() => {
+            frame = frame_receiver.recv(), if !frame_receiver.is_closed() => {
                 match frame {
                     Some(frame) => {
                         frames.push(frame);


### PR DESCRIPTION
## Why? What?

Fixes #1860 
Once the frame sender channel was closed, the `recv` future would immediately return None, causing the loop to freewheel.
If a twix was connected, that would pin 3-4 cores on my machine.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

Start any scenario and look at your system monitor of choice.
Compared to main load should be massively reduced.