### PR TITLE
stand up counter

### DIFF
--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -44,22 +44,24 @@ impl MotionSelector {
         let motion_safe_to_exit = context.motion_safe_exits[self.current_motion];
         let requested_motion = motion_type_from_command(context.motion_command);
 
-        if self.current_motion == MotionType::StandUpBack
+        self.stand_up_count = if self.current_motion == MotionType::StandUpBack
             || self.current_motion == MotionType::StandUpFront
             || self.current_motion == MotionType::StandUpSitting
         {
-            self.stand_up_count = self.stand_up_count;
+            self.stand_up_count
         } else if self.current_motion == MotionType::Dispatching
             && (requested_motion == MotionType::StandUpFront
                 || requested_motion == MotionType::StandUpBack
                 || requested_motion == MotionType::StandUpSitting)
         {
-            self.stand_up_count += 1;
+            self.stand_up_count + 1
         } else {
-            self.stand_up_count = 0;
-        }
+            0
+        };
 
-        context.stand_up_count.fill_if_subscribed(|| self.stand_up_count);
+        context
+            .stand_up_count
+            .fill_if_subscribed(|| self.stand_up_count);
 
         self.current_motion = transition_motion(
             self.current_motion,

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -10,9 +10,8 @@ use types::{
 
 #[derive(Deserialize, Serialize)]
 pub struct MotionSelector {
-    current_motion: MotionType,
     last_motion: MotionType,
-    stand_up_count: i32,
+    stand_up_count: u32,
 }
 
 #[context]
@@ -24,7 +23,7 @@ pub struct CycleContext {
     has_ground_contact: Input<bool, "has_ground_contact">,
 
     motion_safe_exits: CyclerState<MotionSafeExits, "motion_safe_exits">,
-    stand_up_count: AdditionalOutput<i32, "stand_up_count">,
+    stand_up_count: AdditionalOutput<u32, "stand_up_count">,
 }
 
 #[context]
@@ -36,37 +35,30 @@ pub struct MainOutputs {
 impl MotionSelector {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
-            current_motion: MotionType::Unstiff,
             last_motion: MotionType::Unstiff,
             stand_up_count: 0,
         })
     }
 
     pub fn cycle(&mut self, mut context: CycleContext) -> Result<MainOutputs> {
-        let motion_safe_to_exit = context.motion_safe_exits[self.current_motion];
+        let motion_safe_to_exit = context.motion_safe_exits[self.last_motion];
         let requested_motion = motion_type_from_command(context.motion_command);
 
-        self.current_motion = transition_motion(
-            self.current_motion,
+        let current_motion = transition_motion(
+            self.last_motion,
             requested_motion,
             motion_safe_to_exit,
             *context.has_ground_contact,
         );
 
-        self.stand_up_count = match (
-            self.last_motion.is_standup_motion(),
-            self.current_motion.is_standup_motion(),
-        ) {
-            (false, true) => self.stand_up_count + 1,
-            (true, _) => self.stand_up_count,
-            (_, _) => 0,
-        };
+        self.stand_up_count =
+            stand_up_counting(self.last_motion, current_motion, self.stand_up_count);
 
         context
             .stand_up_count
             .fill_if_subscribed(|| self.stand_up_count);
 
-        let dispatching_motion = if self.current_motion == MotionType::Dispatching {
+        let dispatching_motion = if current_motion == MotionType::Dispatching {
             if requested_motion == MotionType::Unstiff {
                 Some(MotionType::SitDown)
             } else {
@@ -76,10 +68,10 @@ impl MotionSelector {
             None
         };
 
-        self.last_motion = self.current_motion;
+        self.last_motion = current_motion;
         Ok(MainOutputs {
             motion_selection: MotionSelection {
-                current_motion: self.current_motion,
+                current_motion,
                 dispatching_motion,
             }
             .into(),
@@ -173,4 +165,20 @@ fn transition_motion(
         (from, true, to, _) if from != to => MotionType::Dispatching,
         _ => from,
     }
+}
+
+fn stand_up_counting(
+    last_motion: MotionType,
+    current_motion: MotionType,
+    stand_up_count: u32,
+) -> u32 {
+    if !last_motion.is_standup_motion() && current_motion.is_standup_motion() {
+        return stand_up_count + 1;
+    }
+
+    if current_motion.is_stable() {
+        return 0;
+    }
+
+    stand_up_count
 }

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -59,6 +59,17 @@ impl MotionType {
             || self == MotionType::StandUpFront
             || self == MotionType::StandUpSitting
     }
+
+    pub fn is_dispatching(self) -> bool {
+        self == MotionType::Dispatching
+    }
+
+    pub fn is_stable(self) -> bool {
+        self == MotionType::Stand
+            || self == MotionType::Walk
+            || self == MotionType::Initial
+            || self == MotionType::Unstiff
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -53,6 +53,14 @@ impl Default for MotionType {
     }
 }
 
+impl MotionType {
+    pub fn is_standup_motion(self) -> bool {
+        self == MotionType::StandUpBack
+            || self == MotionType::StandUpFront
+            || self == MotionType::StandUpSitting
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
 pub struct MotionSafeExits {
     animation: bool,


### PR DESCRIPTION
## Why? What?

To avoid unnecessary stand up attempts when the robot cannot stand up any longer, this is a first step to count the number of stand up attempts.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Please test on a NAO, this is only tested on the replays from GO25 yet. I added an additional output to see in twix, it should increase when the robot makes a new stand up attempt (Dispatching -> Standup) and is reset when this does not hold true and no stand up is in progress. 
