### PR TITLE
Impl PathSerde for serde_json::Value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6539,6 +6539,7 @@ dependencies = [
  "num-traits",
  "path_serde_derive",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 

--- a/crates/path_serde/Cargo.toml
+++ b/crates/path_serde/Cargo.toml
@@ -11,4 +11,5 @@ ndarray = { workspace = true }
 num-traits = { workspace = true }
 path_serde_derive = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/path_serde/src/not_supported.rs
+++ b/crates/path_serde/src/not_supported.rs
@@ -9,6 +9,7 @@ use crate::{deserialize, serialize, PathDeserialize, PathIntrospect, PathSeriali
 use nalgebra::{DMatrix, Rotation3, SMatrix};
 use ndarray::Array2;
 use serde::{Deserializer, Serializer};
+use serde_json::Value;
 
 macro_rules! implement_as_not_supported {
     ($type:ty) => {
@@ -98,8 +99,10 @@ implement_as_not_supported!(DMatrix<f32>);
 implement_as_not_supported!(Rotation3<f32>);
 implement_as_not_supported!(SMatrix<f32, 3, 3>);
 implement_as_not_supported!(SMatrix<f32, 3, 4>);
-//ndarray
+// ndarray
 implement_as_not_supported!(Array2<f32>);
+// serde_json
+implement_as_not_supported!(Value);
 // stdlib
 implement_as_not_supported!(HashMap<K, V>, K, V);
 implement_as_not_supported!(HashSet<T>, T);

--- a/services/aliveness/Cargo.lock
+++ b/services/aliveness/Cargo.lock
@@ -911,6 +911,7 @@ dependencies = [
  "num-traits",
  "path_serde_derive",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/services/hula/Cargo.lock
+++ b/services/hula/Cargo.lock
@@ -737,6 +737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +979,7 @@ dependencies = [
  "num-traits",
  "path_serde_derive",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -1173,6 +1180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1212,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]


### PR DESCRIPTION
## Why? What?

This is really useful when debugging.
With this you can just add an additional output of type `serde_json::Value`, fill it with arbitrary data somewhere deep in the code and subscribe the whole thing in twix.
Realized you need some more information? Just put more data into the value and it immediately appears in twix without having to create yet another additional output, durchreichen it through the code and subscribing it in twix. That'd get out of hand quickly if you're looking at the interplay of more than a couple variables.

```rs
    my_debug_value.fill_if_subscribed(|| {
        json!(
            {
                "side": side,
                "supporting_position": supporting_position,
                "clamped_position": clamped_position,
                "filtered_game_state": filtered_game_state,
                "sub_state": sub_state,
                "ball": ball,
                "minimum_x": minimum_x,
                "maximum_x": maximum_x,
                "maximum_x_in_ready_and_when_ball_is_not_free": maximum_x_in_ready_and_when_ball_is_not_free,
            }
        )
    });
```

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Allow get_fields to look into the actual struct.

## How to Test

