### PR TITLE
Fail softly and carry a big error

### DIFF
--- a/crates/bevyhavior_simulator/src/lib.rs
+++ b/crates/bevyhavior_simulator/src/lib.rs
@@ -14,6 +14,8 @@ pub mod robot;
 pub mod scenario;
 pub mod server;
 pub mod simulator;
+pub mod soft_error;
+pub mod test_rules;
 pub mod time;
 pub mod whistle;
 

--- a/crates/bevyhavior_simulator/src/server.rs
+++ b/crates/bevyhavior_simulator/src/server.rs
@@ -57,6 +57,7 @@ async fn timeline_server(
                         if !progress.is_finished() {
                             progress.finish();
                         }
+                        continue;
                     }
                 }
             }

--- a/crates/bevyhavior_simulator/src/server.rs
+++ b/crates/bevyhavior_simulator/src/server.rs
@@ -46,7 +46,7 @@ async fn timeline_server(
     progress.set_style(ProgressStyle::with_template("[{elapsed}] {pos} {msg}").unwrap());
     loop {
         select! {
-            frame = frame_receiver.recv() => {
+            frame = frame_receiver.recv(), if !frame_receiver.is_closed() => {
                 match frame {
                     Some(frame) => {
                         frames.push(frame);

--- a/crates/bevyhavior_simulator/src/soft_error.rs
+++ b/crates/bevyhavior_simulator/src/soft_error.rs
@@ -1,7 +1,10 @@
 use bevy::{
     app::App,
-    ecs::system::{ResMut, Resource, SystemParam},
+    ecs::system::{Res, ResMut, Resource, SystemParam},
+    time::Time,
 };
+
+use crate::time::{Ticks, TicksTime};
 
 #[derive(Clone)]
 pub struct SoftError;
@@ -13,13 +16,15 @@ pub struct SoftErrorResource {
 
 #[derive(SystemParam)]
 pub struct SoftErrorSender<'w> {
+    time: Res<'w, Time<Ticks>>,
     resource: ResMut<'w, SoftErrorResource>,
 }
 
 impl SoftErrorSender<'_> {
     pub fn send(&mut self, message: impl Into<String>) {
         let message = message.into();
-        println!("{message}");
+        let tick = self.time.ticks();
+        println!("{tick} {message}");
         if self.resource.errors.is_empty() {
             self.resource.errors.push(SoftError);
         }

--- a/crates/bevyhavior_simulator/src/soft_error.rs
+++ b/crates/bevyhavior_simulator/src/soft_error.rs
@@ -1,0 +1,31 @@
+use bevy::{
+    app::App,
+    ecs::system::{ResMut, Resource, SystemParam},
+};
+
+#[derive(Clone)]
+pub struct SoftError;
+
+#[derive(Default, Resource)]
+pub struct SoftErrorResource {
+    pub errors: Vec<SoftError>,
+}
+
+#[derive(SystemParam)]
+pub struct SoftErrorSender<'w> {
+    resource: ResMut<'w, SoftErrorResource>,
+}
+
+impl SoftErrorSender<'_> {
+    pub fn send(&mut self, message: impl Into<String>) {
+        let message = message.into();
+        println!("{message}");
+        if self.resource.errors.is_empty() {
+            self.resource.errors.push(SoftError);
+        }
+    }
+}
+
+pub fn soft_error_plugin(app: &mut App) {
+    app.insert_resource(SoftErrorResource::default());
+}

--- a/crates/bevyhavior_simulator/src/test_rules.rs
+++ b/crates/bevyhavior_simulator/src/test_rules.rs
@@ -1,10 +1,11 @@
-use bevy::ecs::system::Query;
-use types::{motion_command::MotionCommand, planned_path::PathSegment};
+use bevy::ecs::system::{Query, ResMut};
+use types::{motion_command::MotionCommand, planned_path::PathSegment, roles::Role};
 
-use crate::{robot::Robot, soft_error::SoftErrorSender};
+use crate::{game_controller::GameController, robot::Robot, soft_error::SoftErrorSender};
 
 pub fn check_robots_dont_walk_into_rule_obstacles(
     robots: Query<&Robot>,
+    game_controller: ResMut<GameController>,
     mut soft_error: SoftErrorSender,
 ) {
     for robot in robots.iter() {
@@ -17,6 +18,12 @@ pub fn check_robots_dont_walk_into_rule_obstacles(
             continue;
         };
         let destination_in_field = robot.ground_to_field() * segment.1;
+
+        if game_controller.state.sub_state == Some(spl_network_messages::SubState::PenaltyKick)
+            && robot.database.main_outputs.role == Role::Striker
+        {
+            continue;
+        }
 
         for obstacle in rule_obstacles {
             if obstacle.contains(destination_in_field) {

--- a/crates/bevyhavior_simulator/src/test_rules.rs
+++ b/crates/bevyhavior_simulator/src/test_rules.rs
@@ -1,0 +1,30 @@
+use bevy::ecs::system::Query;
+use types::{motion_command::MotionCommand, planned_path::PathSegment};
+
+use crate::{robot::Robot, soft_error::SoftErrorSender};
+
+pub fn check_robots_dont_walk_into_rule_obstacles(
+    robots: Query<&Robot>,
+    mut soft_error: SoftErrorSender,
+) {
+    for robot in robots.iter() {
+        let rule_obstacles = &robot.database.main_outputs.rule_obstacles;
+        let motion_command = &robot.database.main_outputs.motion_command;
+        let MotionCommand::Walk { path, .. } = motion_command else {
+            continue;
+        };
+        let Some(PathSegment::LineSegment(segment)) = path.last() else {
+            continue;
+        };
+        let destination_in_field = robot.ground_to_field() * segment.1;
+
+        for obstacle in rule_obstacles {
+            if obstacle.contains(destination_in_field) {
+                soft_error.send(format!(
+                    "Robot {} ran into rule obstacle",
+                    robot.parameters.player_number
+                ));
+            }
+        }
+    }
+}

--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -95,6 +95,9 @@ fn support_pose(
         (Some(FilteredGameState::Ready), Some(Some(SubState::PenaltyKick))) => {
             supporting_position.x().max(field_dimensions.length / 4.0)
         }
+        (Some(FilteredGameState::Playing { .. }), Some(Some(SubState::GoalKick))) => {
+            supporting_position.x().min(field_dimensions.length / 4.0)
+        }
         (Some(FilteredGameState::Ready), _)
         | (
             Some(FilteredGameState::Playing {

--- a/crates/geometry/src/rectangle.rs
+++ b/crates/geometry/src/rectangle.rs
@@ -42,4 +42,9 @@ impl<Frame> Rectangle<Frame> {
         let dimensions = self.max - self.min;
         dimensions.x() * dimensions.y()
     }
+
+    pub fn contains(self, point: Point2<Frame>) -> bool {
+        (self.min.x()..=self.max.x()).contains(&point.x())
+            && (self.min.y()..=self.max.y()).contains(&point.y())
+    }
 }

--- a/crates/path_serde/Cargo.toml
+++ b/crates/path_serde/Cargo.toml
@@ -11,4 +11,5 @@ ndarray = { workspace = true }
 num-traits = { workspace = true }
 path_serde_derive = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/path_serde/src/not_supported.rs
+++ b/crates/path_serde/src/not_supported.rs
@@ -9,6 +9,7 @@ use crate::{deserialize, serialize, PathDeserialize, PathIntrospect, PathSeriali
 use nalgebra::{DMatrix, Rotation3, SMatrix};
 use ndarray::Array2;
 use serde::{Deserializer, Serializer};
+use serde_json::Value;
 
 macro_rules! implement_as_not_supported {
     ($type:ty) => {
@@ -98,8 +99,10 @@ implement_as_not_supported!(DMatrix<f32>);
 implement_as_not_supported!(Rotation3<f32>);
 implement_as_not_supported!(SMatrix<f32, 3, 3>);
 implement_as_not_supported!(SMatrix<f32, 3, 4>);
-//ndarray
+// ndarray
 implement_as_not_supported!(Array2<f32>);
+// serde_json
+implement_as_not_supported!(Value);
 // stdlib
 implement_as_not_supported!(HashMap<K, V>, K, V);
 implement_as_not_supported!(HashSet<T>, T);

--- a/crates/types/src/rule_obstacles.rs
+++ b/crates/types/src/rule_obstacles.rs
@@ -1,4 +1,5 @@
 use geometry::{circle::Circle, rectangle::Rectangle};
+use linear_algebra::Point2;
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -10,4 +11,13 @@ use coordinate_systems::Field;
 pub enum RuleObstacle {
     Circle(Circle<Field>),
     Rectangle(Rectangle<Field>),
+}
+
+impl RuleObstacle {
+    pub fn contains(&self, point: Point2<Field>) -> bool {
+        match self {
+            RuleObstacle::Circle(circle) => circle.contains(point),
+            RuleObstacle::Rectangle(rectangle) => rectangle.contains(point),
+        }
+    }
 }


### PR DESCRIPTION
## Why? What?

- Introduces soft errors to the bevyhavior simulator. This allows scenarios or other bevy systems to emit errors which do not immediately cause the scenario to abort but still mark it as failed.
- Adds a check to all scenarios emitting such an error if at any point a robot attempts to knowingly walk into a `RuleObstacle`.
- Fixes #1820 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

All tests should pass.
Fix for the broken behavior can be observed in `kicking_team_filtering` scenario frame 6700.