### PR TITLE
Head motion lowpass filter

### DIFF
--- a/crates/control/src/motion/head_motion.rs
+++ b/crates/control/src/motion/head_motion.rs
@@ -48,7 +48,7 @@ impl HeadMotion {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             last_positions: Default::default(),
-            lowpass_filter: LowPassFilter::with_smoothing_factor(Default::default(), 0.075),
+            lowpass_filter: LowPassFilter::with_smoothing_factor(Default::default(), 0.0075),
         })
     }
 


### PR DESCRIPTION
## Why? What?

This applies the low pass filtering, that was already applied to the injected head motion, to every head motion. 
This fixes the abruptness when starting to look at the referee in standby.

Fixes #

## ToDo / Known Issues

- [ ] Adapt low pass filter smoothnening for normal head motions 

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Do different head motions and observe _smoothness_