### PR TITLE
Fix replayer zoom

### DIFF
--- a/crates/hulk_replayer/src/coordinate_systems.rs
+++ b/crates/hulk_replayer/src/coordinate_systems.rs
@@ -278,6 +278,54 @@ impl ScreenRange {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct PanAndZoom {
+    scaling: f32,
+    shift: RelativeTime,
+}
+
+impl PanAndZoom {
+    pub fn new(scaling: f32, shift: RelativeTime) -> Self {
+        Self { scaling, shift }
+    }
+
+    pub fn from_shift(shift: RelativeTime) -> Self {
+        Self {
+            scaling: 1.0,
+            shift,
+        }
+    }
+}
+
+impl std::ops::Mul for PanAndZoom {
+    type Output = PanAndZoom;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self {
+            scaling: self.scaling * rhs.scaling,
+            shift: self.shift + rhs.shift * self.scaling,
+        }
+    }
+}
+
+impl std::ops::Mul<RelativeTime> for PanAndZoom {
+    type Output = RelativeTime;
+
+    fn mul(self, rhs: RelativeTime) -> Self::Output {
+        rhs * self.scaling + self.shift
+    }
+}
+
+impl std::ops::Mul<ViewportRange> for PanAndZoom {
+    type Output = ViewportRange;
+
+    fn mul(self, rhs: ViewportRange) -> Self::Output {
+        let start = self * rhs.start();
+        let end = self * rhs.end();
+        ViewportRange::new(start, end)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Why? What?

Fixes and refactors the zoom and pan implementation in the replayer.
This effectively fixes the replayer crashing on zoom, since the zoom implementation is now correct.
However it's still possible to zoom very far, which should result in the same issue again

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* Zoom and pan in the replayer, it should not crash
