### PR TITLE
Default to jpg in twix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8794,7 +8794,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.9.5"
+version = "0.9.6"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -57,7 +57,7 @@ impl Panel for ImagePanel {
         let is_jpeg = value
             .and_then(|value| value.get("is_jpeg"))
             .and_then(|value| value.as_bool())
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         let image_buffer = if is_jpeg {
             let path = format!("{cycler_path}.main_outputs.image.jpeg");


### PR DESCRIPTION
## Why? What?

- Default to jpg in new twix image panels
- Save bandwidth per default 

## How to Test

- Open new image panel in twix
