### PR TITLE
Change jpeg compression rate

### DIFF
--- a/crates/types/src/jpeg.rs
+++ b/crates/types/src/jpeg.rs
@@ -18,7 +18,7 @@ impl TryFrom<&GrayscaleImage> for JpegImage {
             ImageBuffer::<Luma<u8>, &[u8]>::from_raw(image.width(), image.height(), image.buffer())
                 .unwrap();
         let mut jpeg_buffer = vec![];
-        let quality = 40;
+        let quality = 15;
         let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buffer, quality);
         encoder.encode_image(&gray_image)?;
 
@@ -32,7 +32,7 @@ impl TryFrom<&YCbCr422Image> for JpegImage {
     fn try_from(image: &YCbCr422Image) -> Result<Self, Self::Error> {
         let rgb_image = RgbImage::from(image);
         let mut jpeg_buffer = vec![];
-        let quality = 40;
+        let quality = 15;
         let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buffer, quality);
         encoder.encode_image(&rgb_image)?;
         Ok(Self { data: jpeg_buffer })


### PR DESCRIPTION
## Why? What?

- Jpeg compression delays communication
- Previously quality 40, now 15

Quality 1:
![image](https://github.com/user-attachments/assets/ee9509ec-9ef4-429c-97f3-8adec7d2d554)

Quality 5:
![image](https://github.com/user-attachments/assets/062b5e50-2d74-45f3-a0f6-d54ee0ae5162)

Quality 10:
![image](https://github.com/user-attachments/assets/c328e4dc-6ace-4977-84d7-69ba8cbc5d10)

Quality 15:
![image](https://github.com/user-attachments/assets/8a31e1ae-ef3e-4cdd-9c37-586de3afdfdb)

Quality 20:
![image](https://github.com/user-attachments/assets/ffa6febf-92d2-4771-9d1e-beaee2402ce8)

Quality 40:
![image](https://github.com/user-attachments/assets/b74d3548-2706-43cc-83f3-2fa4d44697de)

Original:
![image](https://github.com/user-attachments/assets/c0422d09-10ae-4409-ba5d-8456832dca17)


## Ideas for Next Iterations (Not This PR)

- Try other codec

## How to Test

- Look at images in twix panel
- Compare responsiveness of other plot, e.g. map panel with jpeg on/off, image on/off
