### PR TITLE
Fix map amnesia

### DIFF
--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -114,7 +114,11 @@ impl Panel for MapPanel {
 
         let field_dimensions = nao.subscribe_value("parameters.field_dimensions");
         let ground_to_field = nao.subscribe_value("Control.main_outputs.ground_to_field");
-        let zoom_and_pan = ZoomAndPanTransform::default();
+
+        let zoom_and_pan = value
+            .and_then(|value| value.get("zoom_and_pan"))
+            .and_then(|value| serde_json::from_value::<ZoomAndPanTransform>(value.clone()).ok())
+            .unwrap_or_default();
 
         Self {
             current_plot_type: PlotType::Field,
@@ -146,6 +150,8 @@ impl Panel for MapPanel {
     fn save(&self) -> Value {
         json!({
             "current_plot_type": self.current_plot_type,
+            "zoom_and_pan": serde_json::to_value(&self.zoom_and_pan).expect("failed to serialize zoom_and_pan"),
+
             "field": self.field.save(),
             "image_segments": self.image_segments.save(),
             "line_correspondences": self.line_correspondences.save(),

--- a/tools/twix/src/panels/map/mod.rs
+++ b/tools/twix/src/panels/map/mod.rs
@@ -115,13 +115,17 @@ impl Panel for MapPanel {
         let field_dimensions = nao.subscribe_value("parameters.field_dimensions");
         let ground_to_field = nao.subscribe_value("Control.main_outputs.ground_to_field");
 
+        let current_plot_type = value
+            .and_then(|value| value.get("current_plot_type"))
+            .and_then(|value| serde_json::from_value::<PlotType>(value.clone()).ok())
+            .unwrap_or(PlotType::Ground);
         let zoom_and_pan = value
             .and_then(|value| value.get("zoom_and_pan"))
             .and_then(|value| serde_json::from_value::<ZoomAndPanTransform>(value.clone()).ok())
             .unwrap_or_default();
 
         Self {
-            current_plot_type: PlotType::Field,
+            current_plot_type,
             field_dimensions,
             ground_to_field,
             zoom_and_pan,

--- a/tools/twix/src/zoom_and_pan.rs
+++ b/tools/twix/src/zoom_and_pan.rs
@@ -2,10 +2,11 @@ use coordinate_systems::Screen;
 use eframe::egui::{pos2, Response, Ui};
 use linear_algebra::{point, IntoTransform, Transform};
 use nalgebra::{vector, Similarity2, Translation2};
+use serde::{Deserialize, Serialize};
 
 use crate::twix_painter::TwixPainter;
 
-#[derive(Default)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct ZoomAndPanTransform {
     transformation: Transform<Screen, Screen, Similarity2<f32>>,
 }


### PR DESCRIPTION
## Why? What?

Remembers map transformation (zoom and pan) and the current plot type (field or ground).

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Open twix map, meticulously craft a plot type and transformation, then restart twix and bask in the glory of your previous masterpiece.