### PR TITLE
Draw more field lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8794,7 +8794,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/types/src/field_dimensions.rs
+++ b/crates/types/src/field_dimensions.rs
@@ -148,6 +148,11 @@ impl FieldDimensions {
         point![unsigned_x * half.sign(), unsigned_y * side.sign()]
     }
 
+    pub fn t_crossing(&self, side: Side) -> Point2<Field> {
+        let unsigned_y = self.width / 2.0;
+        point![0.0, unsigned_y * side.sign()]
+    }
+
     pub fn center(&self) -> Point2<Field> {
         Point2::origin()
     }

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/panels/image/overlay.rs
+++ b/tools/twix/src/panels/image/overlay.rs
@@ -13,8 +13,8 @@ use crate::{nao::Nao, twix_painter::TwixPainter};
 use super::{
     cycler_selector::VisionCycler,
     overlays::{
-        BallDetection, FeetDetection, FieldBorder, Horizon, LimbProjector, LineDetection,
-        PenaltyBoxes, PerspectiveGrid, PoseDetection,
+        BallDetection, FeetDetection, FieldBorder, FieldLines, Horizon, LimbProjector,
+        LineDetection, PerspectiveGrid, PoseDetection,
     },
 };
 
@@ -90,7 +90,7 @@ pub struct Overlays {
     pub ball_detection: EnabledOverlay<BallDetection>,
     pub perspective_grid: EnabledOverlay<PerspectiveGrid>,
     pub horizon: EnabledOverlay<Horizon>,
-    pub penalty_boxes: EnabledOverlay<PenaltyBoxes>,
+    pub penalty_boxes: EnabledOverlay<FieldLines>,
     pub feet_detection: EnabledOverlay<FeetDetection>,
     pub field_border: EnabledOverlay<FieldBorder>,
     pub limb_projector: EnabledOverlay<LimbProjector>,

--- a/tools/twix/src/panels/image/overlays/field_lines.rs
+++ b/tools/twix/src/panels/image/overlays/field_lines.rs
@@ -11,13 +11,13 @@ use crate::{
     value_buffer::BufferHandle,
 };
 
-pub struct PenaltyBoxes {
+pub struct FieldLines {
     penalty_boxes: BufferHandle<Option<ProjectedFieldLines>>,
     cycler: VisionCycler,
 }
 
-impl Overlay for PenaltyBoxes {
-    const NAME: &'static str = "Penalty Boxes";
+impl Overlay for FieldLines {
+    const NAME: &'static str = "Field Lines";
 
     fn new(nao: Arc<crate::nao::Nao>, selected_cycler: VisionCycler) -> Self {
         Self {
@@ -36,7 +36,7 @@ impl Overlay for PenaltyBoxes {
             VisionCycler::Bottom => &penalty_boxes_lines_in_image.bottom,
         };
         for line in lines {
-            painter.line_segment(line.0, line.1, Stroke::new(3.0, Color32::BLACK));
+            painter.line_segment(line.0, line.1, Stroke::new(3.0, Color32::GRAY));
         }
         Ok(())
     }

--- a/tools/twix/src/panels/image/overlays/mod.rs
+++ b/tools/twix/src/panels/image/overlays/mod.rs
@@ -1,19 +1,19 @@
 mod ball_detection;
 mod feet_detection;
 mod field_border;
+mod field_lines;
 mod horizon;
 mod limb_projector;
 mod line_detection;
-mod penalty_boxes;
 mod perspective_grid;
 mod pose_detection;
 
 pub use ball_detection::BallDetection;
 pub use feet_detection::FeetDetection;
 pub use field_border::FieldBorder;
+pub use field_lines::FieldLines;
 pub use horizon::Horizon;
 pub use limb_projector::LimbProjector;
 pub use line_detection::LineDetection;
-pub use penalty_boxes::PenaltyBoxes;
 pub use perspective_grid::PerspectiveGrid;
 pub use pose_detection::PoseDetection;


### PR DESCRIPTION
## Why? What?

Instead of just the penalty box, field lines are now drawn as well in the image overlay in twix.
This should help with calibration.
Also renames the "Penalty Boxes" image overlay to "Field Lines" to more accurately represent what it does.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Unify how lines are generated from FieldDimensions, this is currently duplicated in localization, Twix map layer, and camera matrix calculation.

## How to Test

Look at the renamed field lines image overlay