### PR TITLE
deny standup after 3 tries and ouch

### DIFF
--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -296,7 +296,9 @@ impl Behavior {
                     Action::FallSafely => {
                         fall_safely::execute(world_state, *context.has_ground_contact)
                     }
-                    Action::StandUp => stand_up::execute(world_state),
+                    Action::StandUp => {
+                        stand_up::execute(world_state, context.parameters.maximum_standup_attempts)
+                    }
                     Action::NoGroundContact => no_ground_contact::execute(world_state),
                     Action::LookAround => look_around::execute(world_state),
                     Action::KeeperMotion => defend.keeper_motion(context.keeper_motion.clone()),

--- a/crates/control/src/behavior/stand_up.rs
+++ b/crates/control/src/behavior/stand_up.rs
@@ -4,7 +4,10 @@ use types::{
     world_state::WorldState,
 };
 
-pub fn execute(world_state: &WorldState) -> Option<MotionCommand> {
+pub fn execute(world_state: &WorldState, maximum_standup_attempts: u32) -> Option<MotionCommand> {
+    if world_state.robot.stand_up_count >= maximum_standup_attempts {
+        return Some(MotionCommand::Unstiff);
+    }
     let kind = match world_state.robot.fall_state {
         FallState::Fallen { kind } => kind,
         FallState::StandingUp { kind, .. } => kind,

--- a/crates/control/src/behavior/stand_up.rs
+++ b/crates/control/src/behavior/stand_up.rs
@@ -5,7 +5,7 @@ use types::{
 };
 
 pub fn execute(world_state: &WorldState, maximum_standup_attempts: u32) -> Option<MotionCommand> {
-    if world_state.robot.stand_up_count >= maximum_standup_attempts {
+    if world_state.robot.stand_up_count > maximum_standup_attempts {
         return Some(MotionCommand::Unstiff);
     }
     let kind = match world_state.robot.fall_state {

--- a/crates/control/src/motion/motion_selector.rs
+++ b/crates/control/src/motion/motion_selector.rs
@@ -60,8 +60,8 @@ impl MotionSelector {
         let stand_up_count =
             stand_up_counting(self.last_motion, current_motion, self.stand_up_count);
 
-        if self.stand_up_count < *context.maximum_standup_attempts
-            && stand_up_count >= *context.maximum_standup_attempts
+        if self.stand_up_count <= *context.maximum_standup_attempts
+            && stand_up_count > *context.maximum_standup_attempts
         {
             context
                 .hardware_interface

--- a/crates/types/src/motion_selection.rs
+++ b/crates/types/src/motion_selection.rs
@@ -72,7 +72,7 @@ impl MotionType {
         self == MotionType::Stand
             || self == MotionType::Walk
             || self == MotionType::Initial
-            || self == MotionType::Unstiff
+            || self == MotionType::Penalized
     }
 }
 

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -37,6 +37,7 @@ pub struct BehaviorParameters {
     pub look_action: LookActionParameters,
     pub intercept_ball: InterceptBallParameters,
     pub maximum_lookaround_duration: Duration,
+    pub maximum_standup_attempts: u32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1348,9 +1348,8 @@
     "maximum_lookaround_duration": {
       "nanos": 0,
       "secs": 6
-    },    
+    },
     "maximum_standup_attempts": 3
-
   },
   "game_controller_filter": {
     "time_since_last_message_to_consider_ip_active": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1348,7 +1348,9 @@
     "maximum_lookaround_duration": {
       "nanos": 0,
       "secs": 6
-    }
+    },    
+    "maximum_standup_attempts": 3
+
   },
   "game_controller_filter": {
     "time_since_last_message_to_consider_ip_active": {


### PR DESCRIPTION
## Why? What?

Make ouch sound and change motion command when starting 3rd stand up attempted (parameter debatable). This should be to avoid standing up too often in the competition when the robot is broken and the referee does not see it. 

Fixes #1756

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Let robot (gently) stand up 3 or more times in a row and observe an unstiff robot and a single ouch sound. Making the robot stable again (Penalized, Walking, Stand, Initial) brings it back to normal function. 
