### PR TITLE
Replace `Arc<Vec<YCbCr422>>` with `Arc<[YCbCr422]>`

### DIFF
--- a/crates/types/src/ycbcr422_image.rs
+++ b/crates/types/src/ycbcr422_image.rs
@@ -29,7 +29,7 @@ pub struct YCbCr422Image {
     width_422: u32,
     height: u32,
     #[path_serde(leaf)]
-    buffer: Arc<Vec<YCbCr422>>,
+    buffer: Arc<[YCbCr422]>,
 }
 
 impl From<RgbImage> for YCbCr422Image {
@@ -54,12 +54,12 @@ impl From<RgbImage> for YCbCr422Image {
                 .into();
                 [left_color, right_color].into()
             })
-            .collect();
+            .collect::<Vec<YCbCr422>>();
 
         Self {
             width_422,
             height,
-            buffer: Arc::new(data),
+            buffer: Arc::from(data),
         }
     }
 }
@@ -127,7 +127,7 @@ impl YCbCr422Image {
         Self {
             width_422,
             height,
-            buffer: Arc::new(buffer),
+            buffer: Arc::from(buffer),
         }
     }
 
@@ -150,7 +150,7 @@ impl YCbCr422Image {
         Self {
             width_422,
             height,
-            buffer: Arc::new(buffer),
+            buffer: Arc::from(buffer),
         }
     }
 


### PR DESCRIPTION
## Why? What?

`YCbCr422` image had an unnecessary double indirection. 

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

* CI takes care of that
