### PR TITLE
avoid collision between striker and striker supporter

### DIFF
--- a/crates/bevyhavior_simulator/src/bin/kick_off_after_opponent_goal.rs
+++ b/crates/bevyhavior_simulator/src/bin/kick_off_after_opponent_goal.rs
@@ -29,7 +29,7 @@ fn startup(
     ] {
         commands.spawn(Robot::new(number));
     }
-    game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Ready));
+    game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Standby));
     game_controller_commands.send(GameControllerCommand::SetKickingTeam(Team::Opponent));
 }
 fn update(
@@ -38,17 +38,17 @@ fn update(
     mut exit: EventWriter<AppExit>,
     mut game_controller_commands: EventWriter<GameControllerCommand>,
 ) {
+    if time.ticks() == 100 {
+        game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Ready));
+    }
+
     if game_controller.state.hulks_team.score > 0 {
         game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Ready));
         game_controller_commands.send(GameControllerCommand::SetKickingTeam(Team::Opponent));
     }
 
-    if game_controller.state.hulks_team.score > 1 {
+    if time.ticks() == 10_000 {
         println!("Done");
         exit.send(AppExit::Success);
-    }
-    if time.ticks() >= 10_000 {
-        println!("No second goal was scored :(");
-        exit.send(AppExit::from_code(1));
     }
 }

--- a/crates/bevyhavior_simulator/src/bin/kick_off_after_opponent_goal.rs
+++ b/crates/bevyhavior_simulator/src/bin/kick_off_after_opponent_goal.rs
@@ -1,0 +1,54 @@
+use bevy::prelude::*;
+
+use scenario::scenario;
+use spl_network_messages::{GameState, PlayerNumber, Team};
+
+use bevyhavior_simulator::{
+    game_controller::{GameController, GameControllerCommand},
+    robot::Robot,
+    time::{Ticks, TicksTime},
+};
+
+#[scenario]
+fn hulks_vs_ghosts(app: &mut App) {
+    app.add_systems(Startup, startup);
+    app.add_systems(Update, update);
+}
+fn startup(
+    mut commands: Commands,
+    mut game_controller_commands: EventWriter<GameControllerCommand>,
+) {
+    for number in [
+        PlayerNumber::One,
+        PlayerNumber::Two,
+        PlayerNumber::Three,
+        PlayerNumber::Four,
+        PlayerNumber::Five,
+        PlayerNumber::Six,
+        PlayerNumber::Seven,
+    ] {
+        commands.spawn(Robot::new(number));
+    }
+    game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Ready));
+    game_controller_commands.send(GameControllerCommand::SetKickingTeam(Team::Opponent));
+}
+fn update(
+    game_controller: ResMut<GameController>,
+    time: Res<Time<Ticks>>,
+    mut exit: EventWriter<AppExit>,
+    mut game_controller_commands: EventWriter<GameControllerCommand>,
+) {
+    if game_controller.state.hulks_team.score > 0 {
+        game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Ready));
+        game_controller_commands.send(GameControllerCommand::SetKickingTeam(Team::Opponent));
+    }
+
+    if game_controller.state.hulks_team.score > 1 {
+        println!("Done");
+        exit.send(AppExit::Success);
+    }
+    if time.ticks() >= 10_000 {
+        println!("No second goal was scored :(");
+        exit.send(AppExit::from_code(1));
+    }
+}

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -429,6 +429,7 @@ impl Behavior {
                             .parameters
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
+                        None,
                     ),
                     Action::SupportRight => support::execute(
                         world_state,
@@ -451,6 +452,7 @@ impl Behavior {
                             .parameters
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
+                        None,
                     ),
                     Action::SupportStriker => support::execute(
                         world_state,
@@ -460,10 +462,7 @@ impl Behavior {
                             .parameters
                             .role_positions
                             .striker_supporter_distance_to_ball,
-                        context
-                            .parameters
-                            .role_positions
-                            .striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free,
+                        context.parameters.role_positions.striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free,
                         context
                             .parameters
                             .role_positions
@@ -476,6 +475,7 @@ impl Behavior {
                             .parameters
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
+                        Some(context.parameters.role_positions.striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_first_checkpoint)
                     ),
                     Action::WalkToKickOff => walk_to_kick_off::execute(
                         world_state,

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -430,6 +430,7 @@ impl Behavior {
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
                         None,
+                        context.parameters.intermediate_checkpoint_reached_threshold,
                     ),
                     Action::SupportRight => support::execute(
                         world_state,
@@ -453,6 +454,7 @@ impl Behavior {
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
                         None,
+                        context.parameters.intermediate_checkpoint_reached_threshold,
                     ),
                     Action::SupportStriker => support::execute(
                         world_state,
@@ -475,7 +477,8 @@ impl Behavior {
                             .parameters
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
-                        Some(context.parameters.role_positions.striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_intermediate_checkpoint)
+                        Some(context.parameters.role_positions.striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_intermediate_checkpoint),
+                        context.parameters.intermediate_checkpoint_reached_threshold,
                     ),
                     Action::WalkToKickOff => walk_to_kick_off::execute(
                         world_state,

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -475,7 +475,7 @@ impl Behavior {
                             .parameters
                             .walk_and_stand
                             .normal_distance_to_be_aligned,
-                        Some(context.parameters.role_positions.striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_first_checkpoint)
+                        Some(context.parameters.role_positions.striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_intermediate_checkpoint)
                     ),
                     Action::WalkToKickOff => walk_to_kick_off::execute(
                         world_state,

--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -4,7 +4,7 @@ use coordinate_systems::{Field, Ground};
 use framework::AdditionalOutput;
 use geometry::look_at::LookAt;
 use linear_algebra::{point, Pose2, Rotation2, Vector2};
-use spl_network_messages::SubState;
+use spl_network_messages::{SubState, Team};
 use types::{
     field_dimensions::{FieldDimensions, Side},
     filtered_game_controller_state::FilteredGameControllerState,
@@ -29,6 +29,7 @@ pub fn execute(
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     walk_speed: WalkSpeed,
     distance_to_be_aligned: f32,
+    striker_supporter_maximum_x_path_checkpoint: Option<f32>,
 ) -> Option<MotionCommand> {
     let pose = support_pose(
         world_state,
@@ -37,6 +38,7 @@ pub fn execute(
         distance_to_ball,
         maximum_x_in_ready_and_when_ball_is_not_free,
         minimum_x,
+        striker_supporter_maximum_x_path_checkpoint,
     )?;
     walk_and_stand.execute(
         pose,
@@ -53,8 +55,9 @@ fn support_pose(
     field_dimensions: &FieldDimensions,
     field_side: Option<Side>,
     distance_to_ball: f32,
-    maximum_x_in_ready_and_when_ball_is_not_free: f32,
+    mut maximum_x_in_ready_and_when_ball_is_not_free: f32,
     minimum_x: f32,
+    striker_supporter_maximum_x_path_checkpoint: Option<f32>,
 ) -> Option<Pose2<Ground>> {
     let ground_to_field = world_state.robot.ground_to_field?;
     let ball = world_state
@@ -91,6 +94,28 @@ fn support_pose(
         .filtered_game_controller_state
         .as_ref()
         .map(|filtered_game_controller_state| filtered_game_controller_state.sub_state);
+
+    if let Some(striker_supporter_maximum_x_path_checkpoint) =
+        striker_supporter_maximum_x_path_checkpoint
+    {
+        let is_opponent_kickoff = if let Some(filtered_game_controller_state) =
+            &world_state.filtered_game_controller_state
+        {
+            filtered_game_controller_state.kicking_team == Some(Team::Opponent)
+        } else {
+            false
+        };
+
+        if is_opponent_kickoff {
+            let robot_position = ground_to_field.as_pose().position();
+
+            if robot_position.y().abs() > supporting_position.y().abs() + 0.1 {
+                maximum_x_in_ready_and_when_ball_is_not_free =
+                    striker_supporter_maximum_x_path_checkpoint
+            }
+        }
+    };
+
     let mut clamped_x = match (filtered_game_state, sub_state) {
         (Some(FilteredGameState::Ready), Some(Some(SubState::PenaltyKick))) => {
             supporting_position.x().max(field_dimensions.length / 4.0)

--- a/crates/control/src/behavior/support.rs
+++ b/crates/control/src/behavior/support.rs
@@ -95,23 +95,25 @@ fn support_pose(
         .as_ref()
         .map(|filtered_game_controller_state| filtered_game_controller_state.sub_state);
 
-    if let Some(striker_supporter_maximum_x_path_checkpoint) =
+    if let Some(striker_supporter_maximum_x_intermediate_path_checkpoint) =
         striker_supporter_maximum_x_path_checkpoint
     {
-        let is_opponent_kickoff = if let Some(filtered_game_controller_state) =
+        let is_opponent_kick_off_after_initial = if let Some(filtered_game_controller_state) =
             &world_state.filtered_game_controller_state
         {
             filtered_game_controller_state.kicking_team == Some(Team::Opponent)
+                && filtered_game_controller_state.previous_own_game_state
+                    == Some(FilteredGameState::Initial)
         } else {
             false
         };
 
-        if is_opponent_kickoff {
+        if is_opponent_kick_off_after_initial {
             let robot_position = ground_to_field.as_pose().position();
 
             if robot_position.y().abs() > supporting_position.y().abs() + 0.1 {
                 maximum_x_in_ready_and_when_ball_is_not_free =
-                    striker_supporter_maximum_x_path_checkpoint
+                    striker_supporter_maximum_x_intermediate_path_checkpoint
             }
         }
     };

--- a/crates/types/src/filtered_game_controller_state.rs
+++ b/crates/types/src/filtered_game_controller_state.rs
@@ -12,6 +12,7 @@ use crate::{
 pub struct FilteredGameControllerState {
     pub game_state: FilteredGameState,
     pub opponent_game_state: FilteredGameState,
+    pub previous_own_game_state: Option<FilteredGameState>,
     pub remaining_time_in_half: Duration,
     pub game_phase: GamePhase,
     pub kicking_team: Option<Team>,
@@ -29,6 +30,7 @@ impl Default for FilteredGameControllerState {
         Self {
             game_state: Default::default(),
             opponent_game_state: Default::default(),
+            previous_own_game_state: None,
             remaining_time_in_half: Duration::ZERO,
             game_phase: Default::default(),
             kicking_team: Default::default(),

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -83,6 +83,7 @@ pub struct RolePositionsParameters {
     pub right_midfielder_minimum_x: f32,
     pub striker_supporter_distance_to_ball: f32,
     pub striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free: f32,
+    pub striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_first_checkpoint: f32,
     pub striker_supporter_minimum_x: f32,
     pub keeper_x_offset: f32,
     pub keeper_passive_distance: f32,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -38,6 +38,7 @@ pub struct BehaviorParameters {
     pub intercept_ball: InterceptBallParameters,
     pub maximum_lookaround_duration: Duration,
     pub maximum_standup_attempts: u32,
+    pub intermediate_checkpoint_reached_threshold: f32,
 }
 
 #[derive(

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -83,7 +83,7 @@ pub struct RolePositionsParameters {
     pub right_midfielder_minimum_x: f32,
     pub striker_supporter_distance_to_ball: f32,
     pub striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free: f32,
-    pub striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_first_checkpoint: f32,
+    pub striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_intermediate_checkpoint: f32,
     pub striker_supporter_minimum_x: f32,
     pub keeper_x_offset: f32,
     pub keeper_passive_distance: f32,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1231,6 +1231,7 @@
       "right_midfielder_minimum_x": 0.0,
       "striker_supporter_distance_to_ball": 1.2,
       "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free": -1.0,
+      "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_first_checkpoint": -1.7,
       "striker_supporter_minimum_x": -2.0,
       "keeper_x_offset": 0.1,
       "keeper_passive_distance": 4.5,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1231,7 +1231,7 @@
       "right_midfielder_minimum_x": 0.0,
       "striker_supporter_distance_to_ball": 1.2,
       "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free": -1.0,
-      "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_first_checkpoint": -1.7,
+      "striker_supporter_maximum_x_in_ready_and_when_ball_is_not_free_intermediate_checkpoint": -1.7,
       "striker_supporter_minimum_x": -2.0,
       "keeper_x_offset": 0.1,
       "keeper_passive_distance": 4.5,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1294,7 +1294,8 @@
       "nanos": 0,
       "secs": 6
     },
-    "maximum_standup_attempts": 3
+    "maximum_standup_attempts": 3,
+    "intermediate_checkpoint_reached_threshold": 0.1
   },
   "game_controller_filter": {
     "time_since_last_message_to_consider_ip_active": {


### PR DESCRIPTION
## Why? What?

To avoid collisions between striker and striker supporter when entering the field for opponent kickoff, the path of the striker supporter (4) is split into two segments depending on a path checkpoint. 

Fixes #1298

## ToDo / Known Issues

- [ ] Only needed for 7 vs 7. In 5 vs 5 both positions collide.

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

We tested it in the bevyhavior simulator so far because we need a field. Run the `golden_goal_opponent_kickoff` in the bevyhavior simulator and there should still not be a collision in `golden_goal`. 