### PR TITLE
Increase image region bottom target height 

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1135,7 +1135,7 @@
     },
     "minimum_bottom_focus_pitch": 0.2,
     "image_regions": {
-      "bottom": [0.5, 1.0],
+      "bottom": [0.5, 0.85],
       "center": [0.5, 0.5]
     }
   },


### PR DESCRIPTION
## Why? What?

The current `ImageRegion::Bottom.y` is `1.0`, which results in the target being looked at at the very edge of the image. For the visual referee ready pose detection the target, the image region is used to determine where the referee position on the field should be in the image. At `1.0` the feet of the referee were cut off slightly. Decreasing `ImageRegion::Bottom.y` to `0.85` brings the referee position and the referees feet into the field of view of the camera during ready pose detection. 

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- Do visual referee and check if the camera is correctly positioned. 