### PR TITLE
Tune catching steps

### DIFF
--- a/crates/walking_engine/src/parameters.rs
+++ b/crates/walking_engine/src/parameters.rs
@@ -125,6 +125,8 @@ pub struct FootLevelingParameters {
 )]
 pub struct CatchingStepsParameters {
     pub enabled: bool,
+    pub zero_moment_point_x_scale_backward: f32,
+    pub zero_moment_point_x_scale_forward: f32,
     pub max_target_distance: f32,
     pub over_estimation_factor: f32,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -356,14 +356,14 @@
         "turn": 0.02
       },
       "step_midpoint": 0.5,
-      "torso_offset": -0.005,
-      "torso_tilt_base": 0.01,
+      "torso_offset": 0.0,
+      "torso_tilt_base": 0.025,
       "torso_tilt": {
-        "forward": 0.0,
+        "forward": 0.005,
         "left": 0.0,
         "turn": 0.05
       },
-      "walk_height": 0.225
+      "walk_height": 0.23
     },
     "catching_steps": {
       "enabled": true,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -367,6 +367,8 @@
     },
     "catching_steps": {
       "enabled": true,
+      "zero_moment_point_x_scale_backward": 0.7,
+      "zero_moment_point_x_scale_forward": 1.0,
       "max_target_distance": 0.15,
       "over_estimation_factor": 0.6
     },


### PR DESCRIPTION
## Why? What?

- Catching steps were often triggered too early when leaning back
- This scales the zero moment point in x direction when leaning backwards

## How to Test

- Let it walk and see how it does less unnecessary catching steps