### PR TITLE
Move `expected_referee_position` from `Field` to `Ground`

### DIFF
--- a/crates/bevyhavior_simulator/src/robot.rs
+++ b/crates/bevyhavior_simulator/src/robot.rs
@@ -341,17 +341,12 @@ pub fn move_robots(mut robots: Query<&mut Robot>, mut ball: ResMut<BallResource>
             }
             HeadMotion::LookAt { target, .. } => Orientation2::from_vector(target.coords()).angle(),
             HeadMotion::LookAtReferee { .. } => {
-                if let Some(ground_to_field) = robot.database.main_outputs.ground_to_field {
-                    let expected_referee_position = ground_to_field.inverse()
-                        * robot
-                            .database
-                            .main_outputs
-                            .expected_referee_position
-                            .unwrap_or_default();
-                    Orientation2::from_vector(expected_referee_position.coords()).angle()
-                } else {
-                    0.0
-                }
+                let expected_referee_position = robot
+                        .database
+                        .main_outputs
+                        .expected_referee_position
+                        .unwrap_or_default();
+                Orientation2::from_vector(expected_referee_position.coords()).angle()
             }
             HeadMotion::LookLeftAndRightOf { target } => {
                 let glance_factor = 0.0; //self.time_elapsed.as_secs_f32().sin();

--- a/crates/control/src/behavior/look_at_referee.rs
+++ b/crates/control/src/behavior/look_at_referee.rs
@@ -1,11 +1,10 @@
-use coordinate_systems::{Field, Ground};
+use coordinate_systems::Ground;
 use framework::AdditionalOutput;
 use linear_algebra::{Point2, Pose2, Rotation2};
 use types::{
     camera_position::CameraPosition,
     motion_command::{HeadMotion, ImageRegion, MotionCommand, WalkSpeed},
     path_obstacles::PathObstacle,
-    world_state::WorldState,
 };
 
 use super::walk_to_pose::WalkAndStand;
@@ -13,17 +12,14 @@ use super::walk_to_pose::WalkAndStand;
 pub fn execute(
     enable_pose_detection: bool,
     walk_and_stand: &WalkAndStand,
-    expected_referee_position: Option<&Point2<Field>>,
-    world_state: &WorldState,
+    expected_referee_position: Option<&Point2<Ground>>,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
     walk_speed: WalkSpeed,
     distance_to_be_aligned: f32,
 ) -> Option<MotionCommand> {
-    let pose_looking_at_referee = if let (Some(expected_referee_position), Some(ground_to_field)) =
-        (expected_referee_position, world_state.robot.ground_to_field)
+    let pose_looking_at_referee = if let Some(expected_referee_position) = expected_referee_position
     {
-        Rotation2::from_vector((ground_to_field.inverse() * expected_referee_position).coords())
-            * Pose2::<Ground>::default()
+        Rotation2::from_vector((expected_referee_position).coords()) * Pose2::<Ground>::default()
     } else {
         Pose2::<Ground>::default()
     };

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use serde::{Deserialize, Serialize};
 
 use context_attribute::context;
-use coordinate_systems::Field;
+use coordinate_systems::{Field, Ground};
 use framework::{AdditionalOutput, MainOutput};
 use linear_algebra::{point, Point2};
 use spl_network_messages::{GamePhase, PlayerNumber, SubState, Team};
@@ -57,7 +57,7 @@ pub struct CycleContext {
     dribble_path_plan: Input<Option<DribblePathPlan>, "dribble_path_plan?">,
     cycle_time: Input<CycleTime, "cycle_time">,
     is_localization_converged: Input<bool, "is_localization_converged">,
-    expected_referee_position: Input<Option<Point2<Field>>, "expected_referee_position?">,
+    expected_referee_position: Input<Option<Point2<Ground>>, "expected_referee_position?">,
 
     parameters: Parameter<BehaviorParameters, "behavior">,
     kick_decision_parameters: Parameter<DecisionParameters, "kick_selector">,
@@ -285,7 +285,6 @@ impl Behavior {
                         *context.enable_pose_detection,
                         &walk_and_stand,
                         context.expected_referee_position,
-                        context.world_state,
                         &mut context.path_obstacles_output,
                         *context.support_walk_speed,
                         context

--- a/crates/control/src/motion/look_at.rs
+++ b/crates/control/src/motion/look_at.rs
@@ -6,7 +6,7 @@ use projection::{camera_matrices::CameraMatrices, camera_matrix::CameraMatrix};
 use serde::{Deserialize, Serialize};
 
 use context_attribute::context;
-use coordinate_systems::{Camera, Field, Ground, Head, Robot};
+use coordinate_systems::{Camera, Ground, Head, Robot};
 use framework::MainOutput;
 use linear_algebra::{distance, point, vector, Isometry3, Point2};
 use types::{
@@ -16,7 +16,6 @@ use types::{
     motion_command::{GlanceDirection, HeadMotion, ImageRegion, MotionCommand},
     parameters::ImageRegionParameters,
     sensor_data::SensorData,
-    world_state::WorldState,
 };
 
 #[derive(Deserialize, Serialize)]
@@ -35,8 +34,7 @@ pub struct CycleContext {
     ground_to_robot: Input<Option<Isometry3<Ground, Robot>>, "ground_to_robot?">,
     motion_command: Input<MotionCommand, "motion_command">,
     sensor_data: Input<SensorData, "sensor_data">,
-    expected_referee_position: Input<Option<Point2<Field>>, "expected_referee_position?">,
-    world_state: Input<WorldState, "world_state">,
+    expected_referee_position: Input<Option<Point2<Ground>>, "expected_referee_position?">,
 
     glance_angle: Parameter<f32, "look_at.glance_angle">,
     image_region_parameters: Parameter<ImageRegionParameters, "look_at.image_regions">,
@@ -76,11 +74,6 @@ impl LookAt {
             None => return default_output,
         };
 
-        let ground_to_field = match context.world_state.robot.ground_to_field {
-            Some(ground_to_robot) => ground_to_robot,
-            None => return default_output,
-        };
-
         let head_motion = match context.motion_command {
             MotionCommand::Initial { head, .. } => head,
             MotionCommand::SitDown { head } => head,
@@ -100,11 +93,6 @@ impl LookAt {
             self.last_glance_direction_toggle = Some(cycle_start_time);
         }
 
-        let expected_referee_position = ground_to_field.inverse()
-            * context
-                .expected_referee_position
-                .unwrap_or(&point!(0.0, 0.0));
-
         let (target, image_region_target, camera) = match *head_motion {
             HeadMotion::LookAt {
                 target,
@@ -114,7 +102,7 @@ impl LookAt {
             HeadMotion::LookAtReferee {
                 image_region_target,
                 camera,
-            } => (expected_referee_position, image_region_target, camera),
+            } => (*context.expected_referee_position.unwrap_or(&point!(0.0, 0.0)), image_region_target, camera),
             HeadMotion::LookLeftAndRightOf { target } => {
                 let left_right_shift = vector![
                     0.0,

--- a/crates/control/src/referee_position_provider.rs
+++ b/crates/control/src/referee_position_provider.rs
@@ -1,9 +1,10 @@
 use color_eyre::Result;
 use context_attribute::context;
-use coordinate_systems::Field;
+use coordinate_systems::Ground;
 use framework::MainOutput;
 use linear_algebra::{point, Point2};
 use serde::{Deserialize, Serialize};
+use spl_network_messages::PlayerNumber;
 use types::{
     field_dimensions::{FieldDimensions, GlobalFieldSide},
     filtered_game_controller_state::FilteredGameControllerState,
@@ -19,14 +20,14 @@ pub struct CreationContext {}
 pub struct CycleContext {
     filtered_game_controller_state:
         RequiredInput<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
-
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
+    player_number: Parameter<PlayerNumber, "player_number">,
 }
 
 #[context]
 #[derive(Default)]
 pub struct MainOutputs {
-    pub expected_referee_position: MainOutput<Option<Point2<Field>>>,
+    pub expected_referee_position: MainOutput<Option<Point2<Ground>>>,
 }
 
 impl RefereePositionProvider {
@@ -35,15 +36,27 @@ impl RefereePositionProvider {
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let expected_referee_position =
-            if context.filtered_game_controller_state.global_field_side == GlobalFieldSide::Home {
-                point![0.0, context.field_dimensions.width / 2.0,]
-            } else {
-                point![0.0, -context.field_dimensions.width / 2.0,]
-            };
+        let expected_referee_position: Option<Point2<Ground>> = match (
+            context.player_number,
+            context.filtered_game_controller_state.global_field_side,
+        ) {
+            (PlayerNumber::Four, GlobalFieldSide::Home) => {
+                Some(point![2.0, context.field_dimensions.width,])
+            }
+            (PlayerNumber::Seven, GlobalFieldSide::Home) => {
+                Some(point![1.0, context.field_dimensions.width,])
+            }
+            (PlayerNumber::Two, GlobalFieldSide::Away) => {
+                Some(point![-2.0, context.field_dimensions.width,])
+            }
+            (PlayerNumber::Six, GlobalFieldSide::Away) => {
+                Some(point![-1.0, context.field_dimensions.width,])
+            }
+            _ => None,
+        };
 
         Ok(MainOutputs {
-            expected_referee_position: Some(expected_referee_position).into(),
+            expected_referee_position: expected_referee_position.into(),
         })
     }
 }

--- a/crates/object_detection/src/pose_interpretation.rs
+++ b/crates/object_detection/src/pose_interpretation.rs
@@ -35,7 +35,7 @@ pub struct CycleContext {
     accepted_human_poses: Input<Vec<HumanPose>, "accepted_human_poses">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "Control", "ground_to_field?">,
     expected_referee_position:
-        Input<Option<Point2<Field>>, "Control", "expected_referee_position?">,
+        Input<Option<Point2<Ground>>, "Control", "expected_referee_position?">,
 
     player_number: Parameter<PlayerNumber, "player_number">,
     maximum_distance_to_referee_position:
@@ -68,9 +68,7 @@ impl PoseInterpretation {
         &mut self,
         mut context: CycleContext<impl NetworkInterface>,
     ) -> Result<MainOutputs> {
-        let (Some(ground_to_field), Some(expected_referee_position)) =
-            (context.ground_to_field, context.expected_referee_position)
-        else {
+        let Some(expected_referee_position) = context.expected_referee_position else {
             context
                 .rejected_pose_kind_positions
                 .fill_if_subscribed(Vec::new);
@@ -89,7 +87,7 @@ impl PoseInterpretation {
             context.accepted_human_poses.clone(),
             context.camera_matrices.top.clone(),
             *context.maximum_distance_to_referee_position,
-            ground_to_field.inverse() * expected_referee_position,
+            *expected_referee_position,
             *context.foot_z_offset,
         );
 

--- a/tools/twix/src/panels/map/layers/referee_position.rs
+++ b/tools/twix/src/panels/map/layers/referee_position.rs
@@ -1,16 +1,17 @@
 use std::sync::Arc;
 
 use color_eyre::Result;
-use coordinate_systems::Field;
+use coordinate_systems::{Field, Ground};
 use eframe::egui::{Color32, Stroke};
-use linear_algebra::Point2;
+use linear_algebra::{Isometry2, Point2};
 
 use crate::{
     nao::Nao, panels::map::layer::Layer, twix_painter::TwixPainter, value_buffer::BufferHandle,
 };
 
 pub struct RefereePosition {
-    expected_referee_position: BufferHandle<Option<Point2<Field>>>,
+    expected_referee_position: BufferHandle<Option<Point2<Ground>>>,
+    ground_to_field: BufferHandle<Option<Isometry2<Ground, Field>>>,
     maximum_distance_to_referee_position: BufferHandle<f32>,
 }
 
@@ -20,10 +21,13 @@ impl Layer<Field> for RefereePosition {
     fn new(nao: Arc<Nao>) -> Self {
         let expected_referee_position =
             nao.subscribe_value("Control.main_outputs.expected_referee_position");
+        let ground_to_field =
+            nao.subscribe_value("Control.main_outputs.ground_to_field");
         let maximum_distance_to_referee_position =
             nao.subscribe_value("parameters.pose_detection.maximum_distance_to_referee_position");
         Self {
             expected_referee_position,
+            ground_to_field,
             maximum_distance_to_referee_position,
         }
     }
@@ -37,11 +41,11 @@ impl Layer<Field> for RefereePosition {
             width: 0.05,
             color: Color32::BLACK,
         };
-        if let Some(expected_referee_position_ground) =
-            self.expected_referee_position.get_last_value()?.flatten()
+        if let (Some(expected_referee_position), Some(ground_to_field)) =
+            (self.expected_referee_position.get_last_value()?.flatten(),self.ground_to_field.get_last_value()?.flatten())
         {
             painter.circle(
-                expected_referee_position_ground,
+                ground_to_field * expected_referee_position,
                 0.15,
                 Color32::BLUE,
                 position_stroke,
@@ -51,7 +55,7 @@ impl Layer<Field> for RefereePosition {
                 self.maximum_distance_to_referee_position.get_last_value()?
             {
                 painter.circle(
-                    expected_referee_position_ground,
+                    ground_to_field * expected_referee_position,
                     maximum_distance_to_referee_position,
                     Color32::TRANSPARENT,
                     position_stroke,


### PR DESCRIPTION
## Why? What?

This removes multiplication of the expected referee position iwht a `ground_to_field`. This removes inaccuracies of the `expected_referee_poisiton` during standby visual referee.

Fixes #1947 
Fixes #1888 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Do visual referee
