### PR TITLE
use release profile by default for upload and pre_game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6692,7 +6692,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "6.3.0"
+version = "6.4.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,9 +91,7 @@ bevy-inspector-egui = "0.29.1"
 bevy_asset_loader = "0.22.0"
 bevy_egui = "0.33.0"
 bevy_obj = "0.15"
-bevy_panorbit_camera = { version = "0.23.0", features = [
-  "bevy_egui",
-] }
+bevy_panorbit_camera = { version = "0.23.0", features = ["bevy_egui"] }
 bincode = "1.3.3"
 bindgen = "0.71.1"
 blake3 = { version = "1.8.2", features = ["mmap", "serde"] }
@@ -245,9 +243,10 @@ serde_derive = { git = "https://github.com/HULKs/serde.git", rev = "2e5e545dc995
 
 [profile.dev]
 opt-level = 3
-debug = false
-codegen-units = 16 # TODO: Evaluate performance for different values
 
-[profile.with-debug]
-inherits = "dev"
+[profile.release]
+incremental = true
+
+[profile.release-with-debug]
+inherits = "release"
 debug = true

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "6.3.0"
+version = "6.4.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/cargo/build.rs
+++ b/tools/pepsi/src/cargo/build.rs
@@ -12,19 +12,19 @@ use super::{common::CommonOptions, heading};
 #[command(display_order = 1)]
 pub struct Arguments {
     #[command(flatten)]
-    common: CommonOptions,
+    pub common: CommonOptions,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
-    release: bool,
+    pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
-    ignore_rust_version: bool,
+    pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
-    unit_graph: bool,
+    pub unit_graph: bool,
 
     /// Package to build (see `cargo help pkgid`)
     #[arg(
@@ -35,11 +35,11 @@ pub struct Arguments {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
-    packages: Vec<String>,
+    pub packages: Vec<String>,
 
     /// Build all packages in the workspace
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
-    workspace: bool,
+    pub workspace: bool,
 
     /// Exclude packages from the build
     #[arg(
@@ -48,15 +48,15 @@ pub struct Arguments {
         action = ArgAction::Append,
         help_heading = heading::PACKAGE_SELECTION,
     )]
-    exclude: Vec<String>,
+    pub exclude: Vec<String>,
 
     /// Alias for workspace (deprecated)
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
-    all: bool,
+    pub all: bool,
 
     /// Build only this package's library
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
-    lib: bool,
+    pub lib: bool,
 
     /// Build only the specified binary
     #[arg(
@@ -66,11 +66,11 @@ pub struct Arguments {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
-    bin: Vec<String>,
+    pub bin: Vec<String>,
 
     /// Build all binaries
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
-    bins: bool,
+    pub bins: bool,
 
     /// Build only the specified example
     #[arg(
@@ -80,11 +80,11 @@ pub struct Arguments {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
-    example: Vec<String>,
+    pub example: Vec<String>,
 
     /// Build all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
-    examples: bool,
+    pub examples: bool,
 
     /// Build only the specified test target
     #[arg(
@@ -93,11 +93,11 @@ pub struct Arguments {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
-    test: Vec<String>,
+    pub test: Vec<String>,
 
     /// Build all tests
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
-    tests: bool,
+    pub tests: bool,
 
     /// Build only the specified bench target
     #[arg(
@@ -106,27 +106,27 @@ pub struct Arguments {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
-    bench: Vec<String>,
+    pub bench: Vec<String>,
 
     /// Build all benches
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
-    benches: bool,
+    pub benches: bool,
 
     /// Build all targets
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
-    all_targets: bool,
+    pub all_targets: bool,
 
     /// Copy final artifacts to this directory (unstable)
     #[arg(long, alias = "out-dir", value_name = "PATH", help_heading = heading::COMPILATION_OPTIONS)]
-    artifact_dir: Option<PathBuf>,
+    pub artifact_dir: Option<PathBuf>,
 
     /// Output the build plan in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
-    build_plan: bool,
+    pub build_plan: bool,
 
     /// Outputs a future incompatibility report at the end of the build (unstable)
     #[arg(long)]
-    future_incompat_report: bool,
+    pub future_incompat_report: bool,
 }
 
 impl CargoCommand for Arguments {

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -98,9 +98,8 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
         .wrap_err("failed to configure repository")?;
 
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
-    let hulk_binary = get_hulk_binary(arguments.build.profile());
 
-    let cargo_arguments = cargo::Arguments {
+    let mut cargo_arguments = cargo::Arguments {
         manifest: Some(
             repository
                 .root
@@ -110,6 +109,11 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
         environment: arguments.environment,
         cargo: arguments.build,
     };
+    if cargo_arguments.cargo.common.profile.is_none() {
+        cargo_arguments.cargo.common.profile = Some("release".to_string());
+    }
+
+    let hulk_binary = get_hulk_binary(arguments.build.profile());
 
     if !arguments.pre_game.no_build {
         cargo(cargo_arguments, repository, &[&hulk_binary])

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -98,9 +98,8 @@ async fn upload_with_progress(
 
 pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()> {
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
-    let hulk_binary = get_hulk_binary(arguments.build.profile());
 
-    let cargo_arguments = cargo::Arguments {
+    let mut cargo_arguments = cargo::Arguments {
         manifest: Some(
             repository
                 .root
@@ -110,6 +109,11 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
         environment: arguments.environment,
         cargo: arguments.build,
     };
+    if cargo_arguments.cargo.common.profile.is_none() {
+        cargo_arguments.cargo.common.profile = Some("release".to_string());
+    }
+
+    let hulk_binary = get_hulk_binary(arguments.build.profile());
 
     if !arguments.upload.no_build {
         cargo(cargo_arguments, repository, &[&hulk_binary])


### PR DESCRIPTION
## Why? What?

Switches the default Cargo profile to `release` when none is specified,
ensuring optimized builds without debug assertions or checks. This
avoids runtime overhead during deployment to the nao, where performance
is more important.
