### PR TITLE
Disable debug assertions and overflow-checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,9 +91,7 @@ bevy-inspector-egui = "0.29.1"
 bevy_asset_loader = "0.22.0"
 bevy_egui = "0.33.0"
 bevy_obj = "0.15"
-bevy_panorbit_camera = { version = "0.23.0", features = [
-  "bevy_egui",
-] }
+bevy_panorbit_camera = { version = "0.23.0", features = ["bevy_egui"] }
 bincode = "1.3.3"
 bindgen = "0.71.1"
 blake3 = { version = "1.8.2", features = ["mmap", "serde"] }
@@ -246,7 +244,9 @@ serde_derive = { git = "https://github.com/HULKs/serde.git", rev = "2e5e545dc995
 [profile.dev]
 opt-level = 3
 debug = false
-codegen-units = 16 # TODO: Evaluate performance for different values
+debug-assertions = false
+overflow-checks = false
+codegen-units = 16       # TODO: Evaluate performance for different values
 
 [profile.with-debug]
 inherits = "dev"


### PR DESCRIPTION
## Why? What?

Disable overflow-checks and debug assertions in dev mode.
This is what we did before pepsi max, anything more fancy can be discussed and solved after RC25 (#1963)
