### PR TITLE
fixing defender_positioning scenarion in bevy

### DIFF
--- a/crates/bevyhavior_simulator/src/bin/defender_positioning.rs
+++ b/crates/bevyhavior_simulator/src/bin/defender_positioning.rs
@@ -10,6 +10,7 @@ use bevyhavior_simulator::{
     robot::Robot,
     time::{Ticks, TicksTime},
 };
+use types::ball_position::SimulatorBallState;
 
 #[scenario]
 fn defender_positioning(app: &mut App) {
@@ -37,19 +38,24 @@ fn startup(
 
 fn update(time: Res<Time<Ticks>>, mut ball: ResMut<BallResource>, mut exit: EventWriter<AppExit>) {
     if time.ticks() == 5000 {
-        let state = ball.state.as_mut().expect("ball state not found");
-        state.position = point![-3.6, 2.5];
+        ball.state = Some(SimulatorBallState {
+            position: point![-3.6, 2.5],
+            velocity: vector![0.0, 0.0],
+        });
     }
 
     if time.ticks() == 8000 {
-        let state = ball.state.as_mut().expect("ball state not found");
-        state.position = point![-3.6, -2.5];
+        ball.state = Some(SimulatorBallState {
+            position: point![-3.6, -2.5],
+            velocity: vector![0.0, 0.0],
+        });
     }
 
     if time.ticks() == 16000 {
-        let state = ball.state.as_mut().expect("ball state not found");
-        state.position = point![-1.5, 0.0];
-        state.velocity = vector![-3.0, -0.2];
+        ball.state = Some(SimulatorBallState {
+            position: point![-1.5, 0.0],
+            velocity: vector![-3.0, -0.2],
+        });
     }
 
     if time.ticks() == 30000 {


### PR DESCRIPTION
## Why? What?

change ball.state.as_mut() to SimulatorBallState because if we have no ball_state at these ticks the test fails like in PR #1938  but we only want to test the behavior of the defender positioning and not if there is no ball_state.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
