### PR TITLE
Allow specifying Frame in point! and vector! macros

### DIFF
--- a/crates/linear_algebra/src/point.rs
+++ b/crates/linear_algebra/src/point.rs
@@ -11,8 +11,11 @@ pub type Point3<Frame, T = f32> = Point<Frame, 3, T>;
 
 #[macro_export]
 macro_rules! point {
+    (<$frame:ty>, $($parameters:expr),* $(,)?) => {
+        $crate::Framed::<$frame, _>::wrap(nalgebra::point![$($parameters),*])
+    };
     ($($parameters:expr),* $(,)?) => {
-        linear_algebra::Framed::wrap(nalgebra::point![$($parameters),*])
+        $crate::Framed::wrap(nalgebra::point![$($parameters),*])
     };
 }
 

--- a/crates/linear_algebra/src/vector.rs
+++ b/crates/linear_algebra/src/vector.rs
@@ -10,6 +10,9 @@ pub type Vector3<Frame, Scalar = f32> = Vector<Frame, 3, Scalar>;
 
 #[macro_export]
 macro_rules! vector {
+    (<$frame:ty>, $($parameters:expr),* $(,)?) => {
+        $crate::Framed::<$frame, _>::wrap(nalgebra::vector![$($parameters),*])
+    };
     ($($parameters:expr),* $(,)?) => {
         $crate::Framed::wrap(nalgebra::vector![$($parameters),*])
     };


### PR DESCRIPTION
## Why? What?

This PR allows writing
```rs
point![<Ground>, 1.0, 2.0];
```
to generate values in places where the compiler cannot infer the Frame and specifying it otherwise would be unwieldy.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

See code snippet above.