### PR TITLE
Heatmap decay in FoV

### DIFF
--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -7,12 +7,11 @@ use std::{
 use color_eyre::{eyre::Context, Result};
 use context_attribute::context;
 use coordinate_systems::{Field, Ground};
-use filtering::hysteresis::greater_than_with_hysteresis;
 use framework::{AdditionalOutput, MainOutput, PerceptionInput};
 use geometry::direction::{Direction, Rotate90Degrees};
 use itertools::Itertools;
 use linear_algebra::{point, vector, Isometry2, Point2, Vector2};
-use nalgebra::{clamp, max};
+use nalgebra::clamp;
 use ndarray::{array, Array2};
 use ndarray_conv::{ConvExt, ConvMode, PaddingMode};
 use serde::{Deserialize, Serialize};

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -135,8 +135,8 @@ impl SearchSuggestor {
         if context.ball_position.is_none() {
             if let Some(ground_to_field) = context.ground_to_field {
                 let robot_position = ground_to_field.as_pose().position().coords();
-                let head_orientation = ground_to_field.orientation().angle()
-                    + context.sensor_data.positions.head.yaw;
+                let head_orientation =
+                    ground_to_field.orientation().angle() + context.sensor_data.positions.head.yaw;
                 let fov_angle_offset = 25.0 * consts::PI / 180.0;
                 let left_angle = head_orientation - fov_angle_offset;
                 let right_angle = head_orientation + fov_angle_offset;
@@ -145,23 +145,26 @@ impl SearchSuggestor {
 
                 let tile_width = 1.0 / self.heatmap.cells_per_meter;
                 let tile_center_offset = tile_width / 2.0;
-                let top_left_corner_in_field: Vector2<Field> = vector!(
+                let bottom_left_corner_in_field: Vector2<Field> = vector!(
                     -self.heatmap.field_dimensions.length / 2.0,
-                    self.heatmap.field_dimensions.width / 2.0
+                    -self.heatmap.field_dimensions.width / 2.0
                 );
-                self.heatmap.map.indexed_iter_mut().for_each(|((x, y ), value)| {
-                    let tile_center_in_field: Vector2<Field> = vector!(
-                        (x as f32) * tile_width + tile_center_offset,
-                        (y as f32) * tile_width + tile_center_offset,
-                    ) + top_left_corner_in_field;
-                    let robot_to_tile = tile_center_in_field - robot_position;
-                    let is_inside_sight = get_direction(left_edge, robot_to_tile)
-                        == Direction::Clockwise
-                        && get_direction(right_edge, robot_to_tile) == Direction::Counterclockwise;
-                    if is_inside_sight{
-                        *value *= 0.01;
-                    }
-                });
+                self.heatmap
+                    .map
+                    .indexed_iter_mut()
+                    .for_each(|((x, y), value)| {
+                        let tile_center_in_field: Vector2<Field> = vector!(
+                            (x as f32) * tile_width + tile_center_offset,
+                            (y as f32) * tile_width + tile_center_offset,
+                        ) + bottom_left_corner_in_field;
+                        let robot_to_tile = tile_center_in_field - robot_position;
+                        let is_inside_sight = get_direction(left_edge, robot_to_tile)
+                            == Direction::Counterclockwise
+                            && get_direction(right_edge, robot_to_tile) == Direction::Clockwise;
+                        if is_inside_sight {
+                            *value *= 0.9;
+                        }
+                    });
             }
         }
 

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -45,6 +45,7 @@ pub struct CycleContext {
     hypothetical_ball_positions:
         Input<Vec<HypotheticalBallPosition<Ground>>, "hypothetical_ball_positions">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
+    sensor_data: Input<SensorData, "sensor_data">,
     primary_state: Input<PrimaryState, "primary_state">,
     filtered_game_controller_state:
         Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
@@ -126,6 +127,16 @@ impl SearchSuggestor {
                 message,
                 context.search_suggestor_configuration.team_ball_weight,
             );
+        }
+
+        if context.ball_position.is_none() {
+            if let Sone(ground_to_field) = context.ground_to_field {
+                if let Some(sensor_data) = context.sensor_data {
+                    position_in_field = ground_to_field;
+                    head_orientation =
+                        ground_to_field.rotation.angle() + sensor_data.positions.head_yaw;
+                }
+            }
         }
 
         let kernel = create_kernel(

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -95,9 +95,16 @@ impl SearchSuggestor {
             if let Some(some_suggested_search_index) = suggested_search_index {
                 self.heatmap.has_decided_for_heatmap_tile = true;
                 let max_heatmap_value = self.heatmap.map[some_suggested_search_index];
-                self.heatmap.heat_change_threshold = max_heatmap_value * 0.80; // TODO: make parameter
+                self.heatmap.heat_change_threshold = max_heatmap_value * 0.8; // TODO: make parameter
             }
             self.heatmap.last_maximum_heatmap_position = suggested_search_index;
+        } else {
+            if let Some(last_maximum_heatmap_index) = self.heatmap.last_maximum_heatmap_position {
+                if self.heatmap.map[last_maximum_heatmap_index] < self.heatmap.heat_change_threshold
+                {
+                    self.heatmap.has_decided_for_heatmap_tile = false;
+                }
+            }
         }
         let mut suggested_search_position: Option<Point2<Field>> = None;
         if let Some(max_heatmap_position) = self.heatmap.last_maximum_heatmap_position {

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -161,8 +161,14 @@ impl SearchSuggestor {
                         let is_inside_sight = get_direction(left_edge, robot_to_tile)
                             == Direction::Counterclockwise
                             && get_direction(right_edge, robot_to_tile) == Direction::Clockwise;
-                        if is_inside_sight {
-                            *value *= 0.9;
+                        let distancse_to_tile = robot_to_tile.norm();
+                        let relative_distance_to_tile = clamp(
+                            distancse_to_tile / self.heatmap.field_dimensions.length,
+                            0.0,
+                            1.0,
+                        );
+                        if is_inside_sight && distancse_to_tile > 0.25 {
+                            *value *= 1.0 - 0.05 * relative_distance_to_tile;
                         }
                     });
             }

--- a/crates/control/src/search_suggestor.rs
+++ b/crates/control/src/search_suggestor.rs
@@ -94,7 +94,10 @@ impl SearchSuggestor {
             if let Some(some_suggested_search_index) = suggested_search_index {
                 self.heatmap.has_decided_for_heatmap_tile = true;
                 let max_heatmap_value = self.heatmap.map[some_suggested_search_index];
-                self.heatmap.heat_change_threshold = max_heatmap_value * 0.8; // TODO: make parameter
+                self.heatmap.heat_change_threshold = max_heatmap_value
+                    * context
+                        .search_suggestor_configuration
+                        .tile_target_heat_threshold_factor; // TODO: make parameter
             }
             self.heatmap.last_maximum_heatmap_position = suggested_search_index;
         } else {
@@ -191,7 +194,9 @@ impl SearchSuggestor {
                             1.0,
                         );
                         if is_inside_sight && distancse_to_tile > 0.25 {
-                            *value *= 1.0 - 0.05 * relative_distance_to_tile;
+                            *value *= 1.0
+                                - context.search_suggestor_configuration.decay_distance_factor
+                                    * relative_distance_to_tile;
                         }
                     });
             }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -430,6 +430,7 @@ pub struct SearchSuggestorParameters {
     pub team_ball_weight: f32,
     pub rule_ball_weight: f32,
     pub decay_distance_factor: f32,
+    pub heatmap_decay_range: Range<f32>,
     pub tile_target_heat_threshold_factor: f32,
 }
 

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -429,6 +429,8 @@ pub struct SearchSuggestorParameters {
     pub own_ball_weight: f32,
     pub team_ball_weight: f32,
     pub rule_ball_weight: f32,
+    pub decay_distance_factor: f32,
+    pub tile_target_heat_threshold_factor: f32,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1562,7 +1562,8 @@
     "own_ball_weight": 1.0,
     "team_ball_weight": 1.0,
     "rule_ball_weight": 1.0,
-    "decay_distance_factor": 0.05,
+    "decay_distance_factor": 0.3,
+    "heatmap_decay_range": [0.25, 2.0],
     "tile_target_heat_threshold_factor": 0.5
   },
   "physical_constants": {

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1561,7 +1561,9 @@
     "minimum_validity": 0.01,
     "own_ball_weight": 1.0,
     "team_ball_weight": 1.0,
-    "rule_ball_weight": 1.0
+    "rule_ball_weight": 1.0,
+    "decay_distance_factor": 0.05,
+    "tile_target_heat_threshold_factor": 0.5
   },
   "physical_constants": {
     "gravity_acceleration": 9.81


### PR DESCRIPTION
## Why? What?

Implementing a decay of heatmap tiles if a robot is looking in its direction. This decay is scaled by the distance from the robot to the center of the tile (changeable with  `decay_distance_factor`). 
In addition a kind of hysteresis is added. A robot decides to investigate a tile with the maximal heat and will do so until the heat of this tile has decreased to `tile_target_heat_threshold_factor` percent.

Fixes #1288

## ToDo / Known Issues

Parameter tuning based on a real game.

## Ideas for Next Iterations (Not This PR)

This approach don't take in account, if the view of the robot is blocked by an obstacle. 
A better approach would be to project the tiles in the camera view and check for the color of the segment or to use something like a particle filter.

## How to Test

To test the decay of the heatmap you can run the ball_search-scenario. Use the map-overlay for the ball_search_heatmap and observe the robot looking in both corners.
