### PR TITLE
Fix intercept ball scenario

### DIFF
--- a/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
@@ -58,12 +58,12 @@ fn update(
         if ball.velocity.x() > 0.0 {
             robot.database.main_outputs.ground_to_field =
                 Some(Isometry2::from_parts(vector![-4.0, 0.0], 0.0));
-            ball.position = point![-2.0, 0.0];
+            ball.position = point![2.0, 0.0];
             let target = point![
                 -field_dimensions.length / 2.0,
-                field_dimensions.goal_inner_width * ((*state.count as f32 / 20.0) - 0.5)
+                field_dimensions.goal_inner_width * ((*state.count as f32 / 20.0) - 0.5) * 0.99
             ];
-            ball.velocity = (target - ball.position).normalize() * 2.0;
+            ball.velocity = (target - ball.position).normalize() * 1.0;
             *state.count += 1;
         }
 

--- a/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
@@ -87,8 +87,12 @@ fn update(
         println!("Failed to prevent goals from being scored :(");
         exit.send(AppExit::from_code(1));
     }
-    if time.ticks() >= 10_000 || *state.count > 20 {
+    if *state.count > 20 {
         println!("Done");
         exit.send(AppExit::Success);
+    }
+    if time.ticks() >= 20_000 {
+        println!("Scenario timed out, please fix");
+        exit.send(AppExit::from_code(2));
     }
 }

--- a/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
@@ -9,6 +9,7 @@ use bevyhavior_simulator::{
     ball::BallResource,
     game_controller::{GameController, GameControllerCommand},
     robot::Robot,
+    soft_error::SoftErrorSender,
     time::{Ticks, TicksTime},
 };
 
@@ -50,6 +51,7 @@ fn update(
     mut exit: EventWriter<AppExit>,
     mut robots: Query<&mut Robot>,
     mut state: State,
+    mut soft_error: SoftErrorSender,
 ) {
     if let Some(ball) = ball.state.as_mut() {
         let mut robot = robots.single_mut();
@@ -83,8 +85,8 @@ fn update(
         }
     }
 
-    if game_controller.state.opponent_team.score > 0 {
-        println!("Failed to prevent goals from being scored :(");
+    if time.ticks() >= 1_000 && game_controller.state.opponent_team.score > 0 {
+        soft_error.send("Failed to prevent goals from being scored :(");
         exit.send(AppExit::from_code(1));
     }
     if *state.count > 20 {

--- a/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
@@ -87,14 +87,12 @@ fn update(
 
     if time.ticks() >= 1_000 && game_controller.state.opponent_team.score > 0 {
         soft_error.send("Failed to prevent goals from being scored :(");
-        exit.send(AppExit::from_code(1));
     }
     if *state.count > 20 {
-        println!("Done");
         exit.send(AppExit::Success);
     }
     if time.ticks() >= 20_000 {
-        println!("Scenario timed out, please fix");
+        println!("Scenario timed out with insufficient balls held, please fix");
         exit.send(AppExit::from_code(2));
     }
 }

--- a/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/intercept_ball.rs
@@ -31,7 +31,7 @@ fn startup(
 ) {
     let mut robot = Robot::new(PlayerNumber::One);
     *robot.ground_to_field_mut() = Isometry2::from_parts(vector![-2.0, 0.0], 0.0);
-    robot.parameters.step_planner.max_step_size.forward = 0.45;
+    robot.parameters.step_planner.max_step_size.forward = 1.45;
     commands.spawn(robot);
     game_controller.state.game_state = GameState::Playing;
     game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Playing));


### PR DESCRIPTION
## Why? What?

Scenario was bronek, the ball flew past the keeper and the scenario was effectively testing nothing.
Now it properly fails in cases where the keeper does not intercept the ball.
Not intercepting the expected number of timeouts before the timeout is also considered a failure, previously reaching the timestep limit was considered success. 

The scenario now also uses the soft errors introduced in #1865 

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Read the code to fix the issue
