### PR TITLE
Implement walking engine mode balancing

### DIFF
--- a/crates/walking_engine/src/mode.rs
+++ b/crates/walking_engine/src/mode.rs
@@ -6,12 +6,13 @@ use types::{
     step::Step, support_foot::Side,
 };
 
-use crate::{step_state::StepState, Context, WalkTransition};
+use crate::{mode::balancing::Balancing, step_state::StepState, Context, WalkTransition};
 
 use self::{
     kicking::Kicking, standing::Standing, starting::Starting, stopping::Stopping, walking::Walking,
 };
 
+pub mod balancing;
 pub mod catching;
 pub mod kicking;
 pub mod standing;
@@ -28,6 +29,7 @@ pub enum Mode {
     Walking(Walking),
     Kicking(Kicking),
     Catching(Catching),
+    Balancing(Balancing),
     Stopping(Stopping),
 }
 
@@ -45,6 +47,7 @@ impl WalkTransition for Mode {
             Self::Walking(walking) => walking.stand(context),
             Self::Kicking(kicking) => kicking.stand(context),
             Self::Catching(catching) => catching.stand(context),
+            Self::Balancing(balancing) => balancing.stand(context),
             Self::Stopping(stopping) => stopping.stand(context),
         }
     }
@@ -56,6 +59,7 @@ impl WalkTransition for Mode {
             Self::Walking(walking) => walking.walk(context, step),
             Self::Kicking(kicking) => kicking.walk(context, step),
             Self::Catching(catching) => catching.walk(context, step),
+            Self::Balancing(balancing) => balancing.walk(context, step),
             Self::Stopping(stopping) => stopping.walk(context, step),
         }
     }
@@ -67,6 +71,7 @@ impl WalkTransition for Mode {
             Self::Walking(walking) => walking.kick(context, variant, side, strength),
             Self::Kicking(kicking) => kicking.kick(context, variant, side, strength),
             Self::Catching(catching) => catching.kick(context, variant, side, strength),
+            Self::Balancing(balancing) => balancing.kick(context, variant, side, strength),
             Self::Stopping(stopping) => stopping.kick(context, variant, side, strength),
         }
     }
@@ -80,6 +85,7 @@ impl Mode {
             Self::Walking(walking) => walking.compute_commands(context),
             Self::Kicking(kicking) => kicking.compute_commands(context),
             Self::Catching(catching) => catching.compute_commands(context),
+            Self::Balancing(balancing) => balancing.compute_commands(context),
             Self::Stopping(stopping) => stopping.compute_commands(context),
         }
     }
@@ -91,6 +97,7 @@ impl Mode {
             Mode::Walking(walking) => walking.tick(context),
             Mode::Kicking(kicking) => kicking.tick(context),
             Mode::Catching(catching) => catching.tick(context),
+            Mode::Balancing(balancing) => balancing.tick(context),
             Mode::Stopping(stopping) => stopping.tick(context),
         }
     }
@@ -102,7 +109,8 @@ impl Mode {
             | Mode::Walking(Walking { step, .. })
             | Mode::Kicking(Kicking { step, .. })
             | Mode::Stopping(Stopping { step, .. })
-            | Mode::Catching(Catching { step, .. }) => Some(*step),
+            | Mode::Catching(Catching { step, .. })
+            | Mode::Balancing(Balancing { step, .. }) => Some(*step),
         }
     }
 

--- a/crates/walking_engine/src/mode/walking.rs
+++ b/crates/walking_engine/src/mode/walking.rs
@@ -12,7 +12,11 @@ use types::{
 };
 
 use crate::{
-    kick_state::KickState, step_plan::StepPlan, step_state::StepState, stiffness::Stiffness as _,
+    kick_state::KickState,
+    mode::balancing::{self, Balancing},
+    step_plan::StepPlan,
+    step_state::StepState,
+    stiffness::Stiffness as _,
     Context,
 };
 
@@ -104,6 +108,18 @@ impl WalkTransition for Walking {
             ));
         }
 
+        if balancing::should_balance(
+            context,
+            self.step.plan.end_feet,
+            self.step.plan.support_side,
+        ) {
+            return Mode::Balancing(Balancing::new(
+                context,
+                self.step,
+                self.step.plan.support_side,
+            ));
+        }
+
         Mode::Walking(self)
     }
 
@@ -125,6 +141,18 @@ impl WalkTransition for Walking {
             self.step.plan.support_side,
         ) {
             return Mode::Catching(Catching::new(
+                context,
+                self.step,
+                self.step.plan.support_side,
+            ));
+        }
+
+        if balancing::should_balance(
+            context,
+            self.step.plan.end_feet,
+            self.step.plan.support_side,
+        ) {
+            return Mode::Balancing(Balancing::new(
                 context,
                 self.step,
                 self.step.plan.support_side,
@@ -177,6 +205,18 @@ impl WalkTransition for Walking {
             self.step.plan.support_side,
         ) {
             return Mode::Catching(Catching::new(
+                context,
+                self.step,
+                self.step.plan.support_side,
+            ));
+        }
+
+        if balancing::should_balance(
+            context,
+            self.step.plan.end_feet,
+            self.step.plan.support_side,
+        ) {
+            return Mode::Balancing(Balancing::new(
                 context,
                 self.step,
                 self.step.plan.support_side,

--- a/crates/walking_engine/src/parameters.rs
+++ b/crates/walking_engine/src/parameters.rs
@@ -16,7 +16,8 @@ use types::{
 pub struct Parameters {
     pub anatomic_constraints: AnatomicConstraintsParameters,
     pub base: Base,
-    pub catching_steps: CatchingStepsParameters,
+    pub balancing_steps: BalancingStepParameters,
+    pub catching_steps: CatchingStepParameters,
     pub gyro_balancing: GyroBalancingParameters,
     pub dynamic_interpolation_speed: DynamicInterpolationSpeedParameters,
     pub foot_leveling: FootLevelingParameters,
@@ -124,10 +125,28 @@ pub struct FootLevelingParameters {
     PathDeserialize,
     PathIntrospect,
 )]
-pub struct CatchingStepsParameters {
+pub struct CatchingStepParameters {
     pub enabled: bool,
     pub zero_moment_point_x_scale_backward: f32,
     pub zero_moment_point_x_scale_forward: f32,
+    pub max_target_distance: f32,
+    pub over_estimation_factor: f32,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+)]
+pub struct BalancingStepParameters {
+    pub enabled: bool,
+    pub zero_moment_point_y_scale: f32,
     pub max_target_distance: f32,
     pub over_estimation_factor: f32,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -359,6 +359,12 @@
       },
       "walk_height": 0.23
     },
+    "balancing_steps": {
+      "enabled": true,
+      "zero_moment_point_y_scale": 1.1,
+      "max_target_distance": 0.3,
+      "over_estimation_factor": 5.0
+    },
     "catching_steps": {
       "enabled": true,
       "zero_moment_point_x_scale_backward": 0.5,


### PR DESCRIPTION
## Why? What?

- Simple idea: if we fall over the side to the left, extend the right leg to shift the center of gravity to the right

## How to Test

- Let it walk and push it sideways over the edge of the foot