### PR TITLE
remove duplicate parameter in default.json

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -410,7 +410,6 @@
     "max_forward_acceleration": 0.01,
     "max_base_inside_turn": 0.1,
     "max_inside_turn_increase": 4,
-    "max_rotation_speed": 50000.0,
     "max_foot_speed": 0.6,
     "max_step_duration": { "nanos": 0, "secs": 2 },
     "max_support_foot_lift_speed": 0.025,


### PR DESCRIPTION
## Why? What?

`max_rotation_speed` was twice in the default json

