### PR TITLE
Fix pepsi path autocompletions for fish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6692,7 +6692,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pepsi"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "6.4.0"
+version = "6.4.1"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -54,8 +54,7 @@ pub async fn completions(arguments: Arguments, mut command: Command) -> Result<(
 
 fn dynamic_completions(shell: Shell, static_completions: String) {
     let nao_completion_command = format!("pepsi completions --complete-naos {shell}");
-    let assignement_completion_command =
-        format!("pepsi completions --complete-assignments {shell}");
+    let assignment_completion_command = format!("pepsi completions --complete-assignments {shell}");
 
     match shell {
         Shell::Bash => {
@@ -65,7 +64,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
 
             let re = Regex::new("<ASSIGNMENTS>...").unwrap();
             let completions =
-                re.replace_all(&completions, format!("$({assignement_completion_command})"));
+                re.replace_all(&completions, format!("$({assignment_completion_command})"));
 
             print!("{completions}")
         }
@@ -109,7 +108,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
 
             println!(
                 "complete -c pepsi -n \"__fish_seen_subcommand_from playernumber\" \
-                     -f -a \"({assignement_completion_command})\""
+                     -f -a \"({assignment_completion_command})\""
             );
             println!(
                 "complete -c pepsi -n \"__fish_seen_subcommand_from postgame; \
@@ -145,7 +144,7 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
                 }}\n\
                 (( $+functions[_pepsi__complete_assignments] )) ||\n\
                 _pepsi__complete_assignments() {{\n    \
-                    local commands; commands=(\"${{(@f)$({assignement_completion_command})}}\")\n    \
+                    local commands; commands=(\"${{(@f)$({assignment_completion_command})}}\")\n    \
                     _describe -t commands 'pepsi complete assignments' commands \"$@\"\n\
                 }}"
             );

--- a/tools/pepsi/src/completions.rs
+++ b/tools/pepsi/src/completions.rs
@@ -121,7 +121,8 @@ fn dynamic_completions(shell: Shell, static_completions: String) {
             let manifest_paths: Vec<_> = MANIFEST_PATHS.keys().copied().collect();
             for subcommand in MANIFEST_COMPLETION_SUBCOMMANDS {
                 println!(
-                    "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}\" \
+                    "complete -c pepsi -n \"__fish_pepsi_using_subcommand {subcommand}; \
+                        and not __fish_seen_subcommand_from {manifest_paths}\" \
                          -f -a \"{manifest_paths}\"",
                     manifest_paths = manifest_paths.join(" ")
                 );


### PR DESCRIPTION
## Why? What?

This PR fixes the pepsi path completions when using `pepsi run`, `pepsi build`, etc.

Fixes #1836.

## ToDo / Known Issues

None.

## Ideas for Next Iterations (Not This PR)

None.

## How to Test

Generate new completions and restart your shell.

```sh
./pepsi completions fish > ~/.config/fish/completions/pepsi.fish
```
