### PR TITLE
Build parameter tester faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6571,13 +6571,30 @@ checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 name = "parameter_tester"
 version = "0.1.0"
 dependencies = [
+ "ball_filter",
+ "calibration",
+ "code_generation",
  "color-eyre",
+ "coordinate_systems",
+ "energy_optimization",
  "framework",
+ "geometry",
  "hula_types",
- "hulk",
+ "hulk_manifest",
+ "linear_algebra",
+ "motionfile",
+ "nalgebra",
+ "ndarray",
  "parameters",
+ "path_serde",
+ "projection",
  "repository",
+ "serde",
  "serde_json",
+ "source_analyzer",
+ "spl_network_messages",
+ "types",
+ "walking_engine",
 ]
 
 [[package]]

--- a/tools/parameter_tester/Cargo.toml
+++ b/tools/parameter_tester/Cargo.toml
@@ -6,10 +6,30 @@ license.workspace = true
 homepage.workspace = true
 
 [dependencies]
+ball_filter = { workspace = true }
+calibration = { workspace = true }
 color-eyre = { workspace = true }
+coordinate_systems = { workspace = true }
+energy_optimization = { workspace = true }
 framework = { workspace = true }
+geometry = { workspace = true }
 hula_types = { workspace = true }
-hulk = { workspace = true }
+linear_algebra = { workspace = true }
+motionfile = { workspace = true }
+nalgebra = { workspace = true }
+ndarray = { workspace = true }
 parameters = { workspace = true }
+path_serde = { workspace = true }
+projection = { workspace = true }
 repository = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
+spl_network_messages = { workspace = true }
+types = { workspace = true }
+walking_engine = { workspace = true }
+
+[build-dependencies]
+code_generation = { workspace = true }
+color-eyre = { workspace = true }
+hulk_manifest = { workspace = true }
+source_analyzer = { workspace = true }

--- a/tools/parameter_tester/build.rs
+++ b/tools/parameter_tester/build.rs
@@ -1,0 +1,20 @@
+use color_eyre::eyre::{Result, WrapErr};
+
+use code_generation::{structs::generate_structs, write_to_file::WriteToFile};
+use hulk_manifest::collect_hulk_cyclers;
+use source_analyzer::{pretty::to_string_pretty, structs::Structs};
+
+fn main() -> Result<()> {
+    let cyclers = collect_hulk_cyclers("../../crates/")?;
+    for path in cyclers.watch_paths() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    println!();
+    println!("{}", to_string_pretty(&cyclers)?);
+
+    let structs = Structs::try_from_cyclers(&cyclers)?;
+    generate_structs(&structs)
+        .write_to_file("generated_code.rs")
+        .wrap_err("failed to write generated code to file")
+}

--- a/tools/parameter_tester/src/main.rs
+++ b/tools/parameter_tester/src/main.rs
@@ -33,8 +33,12 @@ fn main() -> Result<()> {
         body_id: String::new(),
         head_id: String::new(),
     };
-    let _robotics_parameters: hulk::structs::Parameters =
+    let _robotics_parameters: structs::Parameters =
         deserialize(framework_parameters.parameters_directory, &ids, false)?;
 
     Ok(())
+}
+
+mod structs {
+    include!(concat!(env!("OUT_DIR"), "/generated_code.rs"));
 }


### PR DESCRIPTION
## Why? What?

On main, the parameter tester depends on robotics code (vision, control crate, etc.), which is not strictly necessary.
This PR makes the parameter tester depend only on the dependencies of robotics code, which reduces the amount of crates to compile from 428 to 320 and the compile time on my machine from just over a minute to 40 seconds.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

```sh
time pepsi build parameter_tester
```