### PR TITLE
Everyone should look for referee in Standby

### DIFF
--- a/crates/control/src/behavior/initial.rs
+++ b/crates/control/src/behavior/initial.rs
@@ -33,9 +33,12 @@ pub fn execute(world_state: &WorldState, enable_pose_detection: bool) -> Option<
             filtered_game_controller_state.global_field_side,
         ),
         (
-            PlayerNumber::Four | PlayerNumber::Seven,
+            PlayerNumber::Seven | PlayerNumber::Five | PlayerNumber::Four | PlayerNumber::Three,
             GlobalFieldSide::Home
-        ) | (PlayerNumber::Two | PlayerNumber::Six, GlobalFieldSide::Away)
+        ) | (
+            PlayerNumber::Six | PlayerNumber::Two | PlayerNumber::One,
+            GlobalFieldSide::Away
+        )
     );
 
     Some(MotionCommand::Initial {


### PR DESCRIPTION
## Why? What?

We sometimes have not the best camera calibrations. This leads to false negatives in Standby visual referee. Since we don't get false positives, we can easily afford to simply have more robots doing the detection.
This changes behavior, such that all NAOs opposite of the referee do the detection. 

Fixes #1954 

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

- Played in the game against HTWK