### PR TITLE
Extend leg if balancing over support foot

### DIFF
--- a/crates/walking_engine/src/parameters.rs
+++ b/crates/walking_engine/src/parameters.rs
@@ -2,7 +2,7 @@ use std::{ops::Range, time::Duration};
 
 use coordinate_systems::Walk;
 use geometry::rectangle::Rectangle;
-use linear_algebra::Vector3;
+use linear_algebra::{Vector2, Vector3};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
 use types::{
@@ -128,8 +128,8 @@ pub struct CatchingStepsParameters {
     pub enabled: bool,
     pub target_x_scale_backward: f32,
     pub target_x_scale_forward: f32,
-    pub max_target_distance: f32,
-    pub over_estimation_factor: f32,
+    pub max_target_distance: nalgebra::Vector2<f32>,
+    pub over_estimation_factor: Vector2<Walk>,
 }
 
 #[derive(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -366,8 +366,8 @@
       "enabled": true,
       "target_x_scale_backward": 1.1,
       "target_x_scale_forward": 1.0,
-      "max_target_distance": 0.1,
-      "over_estimation_factor": 0.4
+      "max_target_distance": [0.1, 0.15],
+      "over_estimation_factor": [0.4, 1.0]
     },
     "gyro_balancing": {
       "noise_scale": [0.5, 0.5],


### PR DESCRIPTION
## Why? What?

If the robot tilts over its support foot, we cannot catch in the existing way. Instead, this PR introduces a variant to extend the swing leg to the opposite side to regain balance and move the robot back to its swing foot.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

- improve parameters
- extend the arm as well

## How to Test

Let the robot tilt over the resting support foot, the swing foot should extend to the opposite side