### PR TITLE
Remove last measurement button

### DIFF
--- a/tools/twix/src/panels/camera_calibration/panel.rs
+++ b/tools/twix/src/panels/camera_calibration/panel.rs
@@ -122,6 +122,17 @@ impl Widget for &mut SemiAutomaticCameraCalibrationPanel {
                 self.drawn_lines.clear();
             }
 
+            if ui.button("Remove last measurement").clicked() {
+                self.saved_measurements.pop();
+                let result = self
+                    .optimization
+                    .run_optimization(self.saved_measurements.clone());
+
+                if let Err(error) = result {
+                    println!("Error: {error}");
+                }
+            }
+
             if ui.button("Clear Drawings").clicked() {
                 self.drawn_lines.clear();
             }


### PR DESCRIPTION
## Why? What?

Add a button to semi-automatic camera calibration ui to remove the last saved measurement.
This allows to select other lines, if the optimization resulted in nan.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- add line, remove line
