### PR TITLE
Parameter based Standby visual referee robot selection

### DIFF
--- a/crates/control/src/behavior/initial.rs
+++ b/crates/control/src/behavior/initial.rs
@@ -1,14 +1,20 @@
-use spl_network_messages::PlayerNumber;
 use types::{
     camera_position::CameraPosition,
     field_dimensions::GlobalFieldSide,
     filtered_game_state::FilteredGameState,
+    initial_pose::InitialPose,
     motion_command::{HeadMotion, ImageRegion, MotionCommand},
+    players::Players,
     primary_state::PrimaryState,
+    support_foot::Side,
     world_state::WorldState,
 };
 
-pub fn execute(world_state: &WorldState, enable_pose_detection: bool) -> Option<MotionCommand> {
+pub fn execute(
+    world_state: &WorldState,
+    enable_pose_detection: bool,
+    initial_poses: &Players<InitialPose>,
+) -> Option<MotionCommand> {
     if world_state.robot.primary_state != PrimaryState::Initial
         && world_state.robot.primary_state != PrimaryState::Standby
     {
@@ -27,24 +33,20 @@ pub fn execute(world_state: &WorldState, enable_pose_detection: bool) -> Option<
         && filtered_game_controller_state.game_state == FilteredGameState::Standby
         && enable_pose_detection;
 
-    let player_number_should_look_for_referee = matches!(
-        (
-            world_state.robot.player_number,
-            filtered_game_controller_state.global_field_side,
-        ),
-        (
-            PlayerNumber::Seven | PlayerNumber::Five | PlayerNumber::Four | PlayerNumber::Three,
-            GlobalFieldSide::Home
-        ) | (
-            PlayerNumber::Six | PlayerNumber::Two | PlayerNumber::One,
-            GlobalFieldSide::Away
-        )
-    );
+    let initial_pose_should_look_for_referee = match (
+        initial_poses[world_state.robot.player_number].side,
+        filtered_game_controller_state.global_field_side,
+    ) {
+        (Side::Left, GlobalFieldSide::Home) => false,
+        (Side::Left, GlobalFieldSide::Away) => true,
+        (Side::Right, GlobalFieldSide::Home) => true,
+        (Side::Right, GlobalFieldSide::Away) => false,
+    };
 
     Some(MotionCommand::Initial {
         head: match (
             should_pose_detection_be_active,
-            player_number_should_look_for_referee,
+            initial_pose_should_look_for_referee,
         ) {
             (true, true) => HeadMotion::LookAtReferee {
                 image_region_target: ImageRegion::Bottom,

--- a/crates/control/src/behavior/node.rs
+++ b/crates/control/src/behavior/node.rs
@@ -15,6 +15,7 @@ use types::{
     field_dimensions::{FieldDimensions, GlobalFieldSide, Side},
     filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState,
+    initial_pose::InitialPose,
     kick_decision::DecisionParameters,
     motion_command::{MotionCommand, WalkSpeed},
     parameters::{
@@ -22,6 +23,7 @@ use types::{
         LostBallParameters,
     },
     path_obstacles::PathObstacle,
+    players::Players,
     primary_state::PrimaryState,
     roles::Role,
     world_state::WorldState,
@@ -69,14 +71,15 @@ pub struct CycleContext {
     use_stand_head_unstiff_calibration:
         Parameter<bool, "calibration_controller.use_stand_head_unstiff_calibration">,
 
-    defend_walk_speed: Parameter<WalkSpeed, "walk_speed.defend">,
     dribble_walk_speed: Parameter<WalkSpeed, "walk_speed.dribble">,
+    initial_poses: Parameter<Players<InitialPose>, "localization.initial_poses">,
     intercept_ball_walk_speed: Parameter<WalkSpeed, "walk_speed.intercept_ball">,
     lost_ball_walk_speed: Parameter<WalkSpeed, "walk_speed.lost_ball">,
     search_walk_speed: Parameter<WalkSpeed, "walk_speed.search">,
     support_walk_speed: Parameter<WalkSpeed, "walk_speed.support">,
     walk_to_kickoff_walk_speed: Parameter<WalkSpeed, "walk_speed.walk_to_kickoff">,
     walk_to_penalty_kick_walk_speed: Parameter<WalkSpeed, "walk_speed.walk_to_penalty_kick">,
+    defend_walk_speed: Parameter<WalkSpeed, "walk_speed.defend">,
 
     path_obstacles_output: AdditionalOutput<Vec<PathObstacle>, "path_obstacles">,
     active_action_output: AdditionalOutput<Action, "active_action">,
@@ -276,9 +279,11 @@ impl Behavior {
                     Action::Unstiff => unstiff::execute(world_state),
                     Action::SitDown => sit_down::execute(world_state),
                     Action::Penalize => penalize::execute(world_state),
-                    Action::Initial => {
-                        initial::execute(world_state, *context.enable_pose_detection)
-                    }
+                    Action::Initial => initial::execute(
+                        world_state,
+                        *context.enable_pose_detection,
+                        context.initial_poses,
+                    ),
                     Action::LookAtReferee => look_at_referee::execute(
                         *context.enable_pose_detection,
                         &walk_and_stand,


### PR DESCRIPTION
## Why? What?

Currently, what robots do visual referee detection in Standby is hard coded in the `initial.rs` Action. 
To make this more dynamic, this PR changes this, so that this is determined by the `Side` provided in the `InitialPose` of the `localization::initial_poses` parameters. 

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

- Open a GameController, go to Standby. Set different parameters `player_number` through twix and see if the nao looks to the side. This depends on the Home/Away side chosen in the gamecontroller.