### PR TITLE
Do not produce segments with zero length

### DIFF
--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -649,6 +649,7 @@ fn detect_edge(
         };
         state.maximum_difference = 0;
         state.start_position = state.maximum_difference_position;
+        state.maximum_difference_position = position;
         state.start_edge_type = end_edge_type;
 
         Some(segment)


### PR DESCRIPTION
## Why? What?

If segments are 1 pixel wide, the main imagesegmenter produces a segment of zero length. This PR changes it to the minimum width we sample due to our stride.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

look at very thin lines in twix, there should be non-zero segments now, if there were zero-sized segments before
