### PR TITLE
Add parameter to ignore team balls for striker claiming

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1195,7 +1195,8 @@
   "role_assignment": {
     "forced_role": null,
     "keeper_replacementkeeper_switch_time": { "nanos": 0, "secs": 12 },
-    "striker_trusts_team_ball": { "nanos": 0, "secs": 1 }
+    "maximum_trusted_team_ball_age": { "nanos": 0, "secs": 1 },
+    "claim_striker_from_team_ball": true
   },
   "walk_speed": {
     "defend": "Normal",


### PR DESCRIPTION
## Why? What?

What the title says

Fixes #2014

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Disable parameter and have another robot send a robot a team ball.
The recipient should no longer claim striker until it has seen the ball itself.