### PR TITLE
Don't trust network teamballs

### DIFF
--- a/crates/bevyhavior_simulator/src/bin/striker_from_unseen_ball.rs
+++ b/crates/bevyhavior_simulator/src/bin/striker_from_unseen_ball.rs
@@ -50,6 +50,13 @@ fn update(
             robot.parameters.player_number == PlayerNumber::Two
                 && robot.database.main_outputs.role == Role::Striker
         })
+        && robots
+            .iter()
+            .find(|robot| robot.parameters.player_number == PlayerNumber::Two)
+            .unwrap()
+            .parameters
+            .role_assignment
+            .claim_striker_from_team_ball
     {
         println!("Error: Two didn't become striker when sent a nearby ball position");
         exit.send(AppExit::from_code(2));

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1203,7 +1203,7 @@
     "forced_role": null,
     "keeper_replacementkeeper_switch_time": { "nanos": 0, "secs": 12 },
     "maximum_trusted_team_ball_age": { "nanos": 0, "secs": 1 },
-    "claim_striker_from_team_ball": true
+    "claim_striker_from_team_ball": false
   },
   "walk_speed": {
     "defend": "Normal",


### PR DESCRIPTION
## Why? What?

Parameter change to not claime Striker depending on network balls. In the last games on the RC25 lost of faulty striker claims could be observed.

## ToDo / Known Issues

Enable again when localisation is perfect.

## Ideas for Next Iterations (Not This PR)

Dynamicly trust network balls (see #????) or dynamic reclaim (see #1679).

## How to Test

None
