### PR TITLE
Reduce `minimum_number_of_segments_per_circle` to 2

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -214,11 +214,11 @@
   "perspective_grid_candidates_provider": {
     "vision_top": {
       "minimum_radius": 3.0,
-      "minimum_number_of_segments_per_circle": 3
+      "minimum_number_of_segments_per_circle": 2
     },
     "vision_bottom": {
       "minimum_radius": 3.0,
-      "minimum_number_of_segments_per_circle": 3
+      "minimum_number_of_segments_per_circle": 2
     }
   },
   "current_minimizer_parameters": {


### PR DESCRIPTION
## Why? What?

We are currently not spawning enough ball candidates. In the game against wistex, we sometimes only spawned a single candidate for a clearly distinguishable ball. This PR reduces the `minimum_number_of_segments_per_circle` to 2.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
