### PR TITLE
Prevent yielding striker to differently-localized robots

### DIFF
--- a/crates/control/src/obstacle_receiver.rs
+++ b/crates/control/src/obstacle_receiver.rs
@@ -40,7 +40,7 @@ impl ObstacleReceiver {
             .network_message
             .persistent
             .values()
-            .flat_map(|messages| messages.iter().filter_map(|message| (*message)))
+            .flat_map(|messages| messages.iter().filter_map(|message| *message))
             .filter_map(|message| match message {
                 IncomingMessage::Spl(message) => Some(*message),
                 _ => None,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1207,9 +1207,11 @@
   "role_assignment": {
     "forced_role": null,
     "keeper_replacementkeeper_switch_time": { "nanos": 0, "secs": 12 },
-    "maximum_trusted_team_ball_age": { "nanos": 0, "secs": 1 },
+    "claim_striker_from_team_ball": false,
     "loser_timeout": { "nanos": 0, "secs": 5 },
-    "claim_striker_from_team_ball": false
+    "claim_striker_from_team_ball": false,
+    "maximum_trusted_team_ball_age": { "nanos": 0, "secs": 1 },
+    "maximum_trusted_team_ball_distance": 0.5
   },
   "walk_speed": {
     "defend": "Normal",


### PR DESCRIPTION
## Why? What?

If another robot claims striker but sends a very different ball position, that most likely means one of the robots is not localized correctly. With this change, both robots will stay striker as only claims on the "same" ball are recognized.
The parameter value is just a guess, suggestions welcome.

Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)

## How to Test

This is currently not testable in simulator.
Deploy two robots, one localized correctly, the other one not. They should both be striker if they have different ideas on where the ball is on the field, but one should yield if they believe the ball to be in a similar location.