### PR TITLE
Increase Defender-Searching-Delay

### DIFF
--- a/crates/control/src/behavior/search.rs
+++ b/crates/control/src/behavior/search.rs
@@ -108,7 +108,11 @@ pub fn execute(
     let distance_to_ball = (ground_to_field.inverse() * last_known_ball_position)
         .coords()
         .norm();
-    let estimated_ball_arrival_time = distance_to_ball / parameters.estimated_ball_speed;
+    let is_ball_near_opponent_goal = last_known_ball_position.x() > field_dimensions.length / 3.0;
+    let mut estimated_ball_arrival_time = distance_to_ball / parameters.estimated_ball_speed;
+    if is_ball_near_opponent_goal {
+        estimated_ball_arrival_time *= 1.5;
+    }
     let near_own_penalty_box = ground_to_field.as_pose().position().y().abs()
         < field_dimensions.penalty_area_width / 2.0
         && ground_to_field.as_pose().position().x() < 0.0;


### PR DESCRIPTION
## Why? What?

Increase the Time of the Stand Command at the beginn of the Searcher switch, if the ball is clearly in the opponent half. 

Fixes #2085 

## Ideas for Next Iterations (Not This PR)

Differentiate better between Searcher that was a defender and a searcher that was a midfealder,  striker supporter or loser.

## How to Test

*Describe how to test your changes. (For the reviewer)*
