### PR TITLE
Implement kick-in logic for ball search heat map

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1577,9 +1577,9 @@
     "cells_per_meter": 2.0,
     "heatmap_convolution_kernel_weight": 0.001007049,
     "minimum_validity": 0.01,
-    "own_ball_weight": 1.0,
-    "team_ball_weight": 1.0,
-    "rule_ball_weight": 1.0
+    "own_ball_weight": 0.1,
+    "team_ball_weight": 0.1,
+    "rule_ball_weight": 0.5
   },
   "physical_constants": {
     "gravity_acceleration": 9.81


### PR DESCRIPTION
## Why? What?

The ball search heat map is quite a mess.
Among other things, it was completely missing handling for kick in.
This PR adds such handling, by projecting the heat to the sidelines. The heat is projected to the left/right side-line proportionally depending on the cell's position.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

- Ball search neu schreiben

## How to Test

Look at the ball search heat map map overlay in twix during the `kick_in` bevyhavior scenario.