### PR TITLE
Bevyhaviorsimulator parameters

### DIFF
--- a/crates/bevyhavior_simulator/default.json
+++ b/crates/bevyhavior_simulator/default.json
@@ -1,21 +1,4 @@
 {
   "selected_frame": 0,
-  "selected_robot": 7,
-  "field_dimensions": {
-    "ball_radius": 0.05,
-    "length": 9.0,
-    "width": 6.0,
-    "line_width": 0.05,
-    "penalty_marker_size": 0.1,
-    "goal_box_area_length": 0.6,
-    "goal_box_area_width": 2.2,
-    "penalty_area_length": 1.65,
-    "penalty_area_width": 4.0,
-    "penalty_marker_distance": 1.3,
-    "center_circle_diameter": 1.5,
-    "border_strip_width": 0.7,
-    "goal_inner_width": 1.5,
-    "goal_post_diameter": 0.1,
-    "goal_depth": 0.5
-  }
+  "selected_robot": 7
 }

--- a/crates/bevyhavior_simulator/src/recorder.rs
+++ b/crates/bevyhavior_simulator/src/recorder.rs
@@ -16,12 +16,19 @@ use tokio_util::sync::CancellationToken;
 
 use types::{ball_position::SimulatorBallState, players::Players};
 
-use crate::{ball::BallResource, cyclers::control::Database, robot::Robot, server};
+use crate::{
+    ball::BallResource, cyclers::control::Database, robot::Robot, server, structs::Parameters,
+};
 
 pub struct Frame {
     pub timestamp: SystemTime,
     pub ball: Option<SimulatorBallState>,
-    pub robots: Players<Option<Database>>,
+    pub robots: Players<Option<RobotFrame>>,
+}
+
+pub struct RobotFrame {
+    pub database: Database,
+    pub parameters: Parameters,
 }
 
 #[derive(Resource)]
@@ -37,9 +44,12 @@ pub fn frame_recorder(
     recording: ResMut<Recording>,
     time: Res<Time>,
 ) {
-    let mut players = Players::<Option<Database>>::default();
+    let mut players = Players::<Option<RobotFrame>>::default();
     for robot in &robots {
-        players[robot.parameters.player_number] = Some(robot.database.clone())
+        players[robot.parameters.player_number] = Some(RobotFrame {
+            database: robot.database.clone(),
+            parameters: robot.parameters.clone(),
+        })
     }
     recording
         .frame_sender

--- a/crates/bevyhavior_simulator/src/server.rs
+++ b/crates/bevyhavior_simulator/src/server.rs
@@ -138,7 +138,7 @@ pub async fn run(
 
     let mut communication_server = communication::server::Server::default();
 
-    let (subscribed_control_writer, _) = buffered_watch::channel(Default::default());
+    let (control_subscriptions, _) = buffered_watch::channel(Default::default());
     let (parameters_subscriptions, _) = buffered_watch::channel(Default::default());
     let (simulator_state_subscriptions, _) = buffered_watch::channel(Default::default());
 
@@ -147,7 +147,7 @@ pub async fn run(
         outputs_receiver,
         subscribed_outputs_sender,
     )?;
-    communication_server.expose_source("Control", control_reader, subscribed_control_writer)?;
+    communication_server.expose_source("Control", control_reader, control_subscriptions)?;
     communication_server.expose_source("parameters", parameter_reader, parameters_subscriptions)?;
     communication_server.expose_source(
         "simulator",

--- a/crates/bevyhavior_simulator/src/simulator.rs
+++ b/crates/bevyhavior_simulator/src/simulator.rs
@@ -24,8 +24,8 @@ use crate::{
     game_controller::{game_controller_plugin, GameController},
     recorder::Recording,
     robot::{cycle_robots, move_robots, Messages},
-    server::Parameters,
     soft_error::{soft_error_plugin, SoftErrorResource},
+    structs::Parameters,
     test_rules::check_robots_dont_walk_into_rule_obstacles,
     time::{update_time, Ticks},
     visual_referee::VisualRefereeResource,
@@ -127,7 +127,7 @@ fn load_parameters() -> Result<Parameters> {
     let current_directory = current_dir().wrap_err("failed to get current directory")?;
     let repository =
         Repository::find_root(current_directory).wrap_err("failed to get repository root")?;
-    let parameters_path = repository.root.join("crates/bevyhavior_simulator");
+    let parameters_path = repository.root.join("etc/parameters");
 
     parameters::directory::deserialize(parameters_path, &ids, true)
         .wrap_err("failed to parse initial parameters")

--- a/crates/types/src/players.rs
+++ b/crates/types/src/players.rs
@@ -28,6 +28,20 @@ pub struct Players<T> {
     pub seven: T,
 }
 
+impl<T> Players<T> {
+    pub fn as_ref(&self) -> Players<&T> {
+        Players {
+            one: &self.one,
+            two: &self.two,
+            three: &self.three,
+            four: &self.four,
+            five: &self.five,
+            six: &self.six,
+            seven: &self.seven,
+        }
+    }
+}
+
 impl<From> Players<From> {
     pub fn map<To>(self, mut f: impl FnMut(From) -> To) -> Players<To> {
         Players {

--- a/tools/twix/src/panels/behavior_simulator.rs
+++ b/tools/twix/src/panels/behavior_simulator.rs
@@ -23,7 +23,7 @@ impl Panel for BehaviorSimulatorPanel {
     const NAME: &'static str = "Behavior Simulator";
 
     fn new(nao: Arc<Nao>, value: Option<&Value>) -> Self {
-        let selected_frame_updater = nao.subscribe_value("parameters.selected_frame");
+        let selected_frame_updater = nao.subscribe_value("simulator.selected_frame");
 
         let frame_count = nao.subscribe_value("BehaviorSimulator.main_outputs.frame_count");
         let selected_frame = value
@@ -117,7 +117,7 @@ impl Widget for &mut BehaviorSimulatorPanel {
                         .ui(ui);
                         if response.changed() {
                             self.nao.write(
-                                "parameters.selected_robot",
+                                "simulator.selected_robot",
                                 TextOrBinary::Text(robots[self.selected_robot].into()),
                             );
                         };
@@ -138,7 +138,7 @@ impl Widget for &mut BehaviorSimulatorPanel {
         if let Some(new_frame) = new_frame {
             self.selected_frame = (new_frame + frame_count as f64) % frame_count as f64;
             self.nao.write(
-                "parameters.selected_frame",
+                "simulator.selected_frame",
                 TextOrBinary::Text((self.selected_frame as usize).into()),
             );
         }


### PR DESCRIPTION
## Why? What?

Previously, if you connect twix to the behavior simulator and subscribe to `parameters`, you would only get `selected_frame`, `selected_robot`, and `field_dimensions`.

Now, `parameters` contains all normal parameters you would get from a real robot,
and the selected frame/robot are exposed under `simulator`. 

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

- prevent selection of non-existent robots (currently, the map panel goes blank in this case due to missing field dimensions)

## How to Test

Use twix