### PR TITLE
Create logs folder if !exist()

### DIFF
--- a/crates/hulk_mujoco/src/main.rs
+++ b/crates/hulk_mujoco/src/main.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "256"]
-use std::{env::args, fs::File, io::stdout, sync::Arc};
+use std::{env::args, fs::File, io::stdout, path::Path, sync::Arc};
 
 use color_eyre::{
     eyre::{Result, WrapErr},
@@ -67,6 +67,10 @@ async fn main() -> Result<()> {
             keep_running.cancel();
         }
     })?;
+
+    if !Path::new("logs").exists() {
+        std::fs::create_dir("logs").wrap_err("failed to create logs directory")?;
+    }
 
     let file =
         File::open(framework_parameters_path).wrap_err("failed to open framework parameters")?;


### PR DESCRIPTION
## Why? What?

When running `hulk_mujoco` the the folder `logs` is expected at the root of the repository. This PR creates it if it does not exist yet.

Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Delete `logs` if it already exists.
- Run `pepsi run _mujoco`_
