### PR TITLE
Removed ball-detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,28 +1671,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 1.0.109",
- "which 4.4.2",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
@@ -2223,15 +2201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "code_generation"
 version = "0.1.0"
 dependencies = [
@@ -2332,28 +2301,6 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "uuid",
-]
-
-[[package]]
-name = "compiled-nn"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1995a40abb8030d5e84cac9cc8917f1a79ea11bf32bf0cc90a64e7a578e1dc4d"
-dependencies = [
- "compiled-nn-bindings",
-]
-
-[[package]]
-name = "compiled-nn-bindings"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015b3be08e86208bcf26d3aa12d46348380e24d88f1bc8ac0eb98af5f8fd4860"
-dependencies = [
- "bindgen 0.63.0",
- "cmake",
- "glob",
- "pkg-config",
- "walkdir",
 ]
 
 [[package]]
@@ -4983,12 +4930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lbfgs"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5156,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
 dependencies = [
  "cc",
- "which 7.0.3",
+ "which",
 ]
 
 [[package]]
@@ -6541,12 +6482,6 @@ dependencies = [
  "rustc-hash 2.1.1",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem-rfc7468"
@@ -9267,7 +9202,6 @@ dependencies = [
  "approx 0.5.1",
  "calibration",
  "color-eyre",
- "compiled-nn",
  "context_attribute",
  "coordinate_systems",
  "fast_image_resize",
@@ -9715,18 +9649,6 @@ dependencies = [
  "log",
  "serde",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/crates/vision/Cargo.toml
+++ b/crates/vision/Cargo.toml
@@ -9,7 +9,6 @@ homepage.workspace = true
 approx = { workspace = true }
 calibration = { workspace = true }
 color-eyre = { workspace = true }
-compiled-nn = { workspace = true }
 context_attribute = { workspace = true }
 coordinate_systems = { workspace = true }
 fast_image_resize = { workspace = true }

--- a/crates/vision/src/lib.rs
+++ b/crates/vision/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod ball_detection;
 pub mod calibration_measurement_provider;
 pub mod feet_detection;
 pub mod field_border_detection;


### PR DESCRIPTION
## Why? What?

Ball-detection dependency was built only for x86 architecture and was not working in arm. So Have removed the lines from vision related to compiled-nn in `Cargo.toml` and ball-detection in `lib.rs` of vision.

## Ideas for Next Iterations (Not This PR)

Use different inference engine that works on arm for vision.

## How to Test

Compile on arm
