### PR TITLE
Move camera viewport updating from PostUpdate to Update to fix crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8911,7 +8911,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/egui_bevy/src/lib.rs
+++ b/crates/egui_bevy/src/lib.rs
@@ -184,7 +184,7 @@ impl Plugin for EguiRenderPlugin {
             .add_systems(Startup, setup_camera)
             .add_systems(Startup, setup_scene)
             .add_systems(Update, update_active_camera)
-            .add_systems(PostUpdate, update_camera_render_target);
+            .add_systems(Update, update_camera_render_target);
     }
 }
 

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Why? What?

What it says.
For some reason doing it in PostUpdate leads to a crash when making large, sudden changes to the window size.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Issue was reproducible by moving the window between monitors.