### PR TITLE
Soft-error on degenerate image

### DIFF
--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -1,7 +1,10 @@
 use std::{env::temp_dir, fs::create_dir_all, path::PathBuf, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use color_eyre::{eyre::eyre, Result};
+use color_eyre::{
+    eyre::{bail, eyre},
+    Result,
+};
 use coordinate_systems::Pixel;
 use eframe::egui::{ColorImage, Response, SizeHint, TextureOptions, Ui, UiBuilder, Widget};
 use geometry::rectangle::Rectangle;
@@ -184,6 +187,13 @@ impl ImagePanel {
                 let ros_image = buffer
                     .get_last_value()?
                     .ok_or_else(|| eyre!("no image available"))?;
+                if ros_image.height == 0 || ros_image.width == 0 {
+                    bail!(
+                        "Image has no pixels. Dimensions: {}x{}",
+                        ros_image.width,
+                        ros_image.height
+                    );
+                }
                 let image = ColorImage::from_rgb(
                     [ros_image.width as usize, ros_image.height as usize],
                     &ros_image.data,


### PR DESCRIPTION
## Why? What?

On main, twix panics with some internal wgpu error if the communication server sends a raw image with no pixel area, i.e. one dimension has length 0.

This PR instead returns an error value from the image loader function if the raw image has size 0.
The JPEG decoder already generates an error when image is 0-sized.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

Either hope that the timing is shit enough so you get a default image right after framework startup or replace `control_and_vision` with `control_only` in `crates/hulk_mujoco/src/hardware_inferface.rs` line 143.