### PR TITLE
Change time reference from Systemtime to Instant

### DIFF
--- a/crates/code_generation/src/cyclers.rs
+++ b/crates/code_generation/src/cyclers.rs
@@ -916,7 +916,7 @@ fn generate_execute_node_and_write_main_outputs(
         {
             #[allow(clippy::needless_else)]
             if #are_required_inputs_some {
-                let node_cycle_start = std::time::SystemTime::now();
+                let node_cycle_start = std::time::Instant::now();
                 let main_outputs = {
                     let _task = ittapi::Task::begin(&itt_domain, #node_name);
                     self.#node_member.cycle(
@@ -926,7 +926,7 @@ fn generate_execute_node_and_write_main_outputs(
                     )
                     .wrap_err(#cycle_error_message)?
                 };
-                let node_cycle_duration = node_cycle_start.elapsed().expect("time ran backwards");
+                let node_cycle_duration = node_cycle_start.elapsed();
                 own_database.cycle_timings.#node_member = node_cycle_duration;
                 #write_main_outputs
             }


### PR DESCRIPTION
## Why? What?

The time reference in cyclers.rs uses [`std::time::Systemtime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html) which is not necessarily monotonic. In rare cases this can crash because the "`time ran backwards`". For such use cases [`std::time::Instant`](https://doc.rust-lang.org/std/time/struct.Instant.html)  should be used for more precise time measurements

## How to Test

if it works it works :)
