### PR TITLE
Use correct mujoco camera fovy for camera info

### DIFF
--- a/tools/mujoco-simulator/mujoco-simulator/main.py
+++ b/tools/mujoco-simulator/mujoco-simulator/main.py
@@ -4,9 +4,16 @@ import time
 from datetime import timedelta
 
 import click
-import mujoco
 import numpy as np
-from mujoco import MjData, MjModel, mj_forward, mj_resetData, mj_step
+from mujoco import (
+    MjData,
+    MjModel,
+    mj_forward,
+    mj_name2id,
+    mj_resetData,
+    mj_step,
+    mjtObj,
+)
 from mujoco_rust_server import SimulationServer, TaskName
 from mujoco_rust_server.ros2_types import CameraInfo, Image
 from rich.logging import RichHandler
@@ -42,7 +49,7 @@ def request_image(renderer: CameraRenderer, data: MjData) -> Image:
 def request_camera_info(
     renderer: CameraRenderer, data: MjData, model: MjModel
 ) -> CameraInfo:
-    camera_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, "camera")
+    camera_id = mj_name2id(model, mjtObj.mjOBJ_CAMERA, "camera")
     fov = model.cam_fovy[camera_id]
 
     focal_scaling = (


### PR DESCRIPTION
## Why? What?

What the title says. Previously, we used some different fovy, which, after changing to the newer fov, cause the camera projection to be completely off.

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Setup simulator. Use `parameters.common_motor_command.default_positions.head` to make the robot look around. The ball measurement in the map panel should remain at the same place. 
