### PR TITLE
add fake localization

### DIFF
--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -56,6 +56,7 @@ pub fn collect_hulk_cyclers(root: impl AsRef<Path>) -> Result<Cyclers, Error> {
                     "world_state::ball_projector",
                     "world_state::behavior::node",
                     "world_state::camera_matrix_calculator",
+                    "world_state::fake_localization",
                     "world_state::game_controller_filter",
                     "world_state::game_controller_state_filter",
                     "world_state::ground_provider",

--- a/crates/world_state/src/fake_localization.rs
+++ b/crates/world_state/src/fake_localization.rs
@@ -1,0 +1,36 @@
+use color_eyre::Result;
+use linear_algebra::{Isometry, Isometry2};
+use serde::{Deserialize, Serialize};
+
+use context_attribute::context;
+use coordinate_systems::{Field, Ground};
+use framework::MainOutput;
+
+#[derive(Deserialize, Serialize)]
+pub struct Localization {}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub ground_to_field: MainOutput<Option<Isometry2<Ground, Field>>>,
+}
+
+impl Localization {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    pub fn cycle(&mut self, mut _context: CycleContext) -> Result<MainOutputs> {
+        let ground_to_field = Some(Isometry::identity());
+
+        Ok(MainOutputs {
+            ground_to_field: ground_to_field.into(),
+        })
+    }
+}

--- a/crates/world_state/src/lib.rs
+++ b/crates/world_state/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ball_filter;
 pub mod ball_projector;
 pub mod behavior;
 pub mod camera_matrix_calculator;
+pub mod fake_localization;
 pub mod game_controller_filter;
 pub mod game_controller_state_filter;
 pub mod ground_provider;


### PR DESCRIPTION
## Why? What?

Adds a dummy node which produces a `ground_to_field`. This is needed for upcoming PRs to compile, and should be removed as soon as proper localization is implemented. 
