### PR TITLE
Remove penalty_shot_direction from ball state

### DIFF
--- a/crates/types/src/world_state.rs
+++ b/crates/types/src/world_state.rs
@@ -11,8 +11,7 @@ use crate::{
     ball_position::HypotheticalBallPosition, calibration::CalibrationCommand,
     fall_state::FallState, field_dimensions::Side,
     filtered_game_controller_state::FilteredGameControllerState, kick_decision::KickDecision,
-    obstacles::Obstacle, primary_state::PrimaryState,
-    roles::Role, rule_obstacles::RuleObstacle,
+    obstacles::Obstacle, primary_state::PrimaryState, roles::Role, rule_obstacles::RuleObstacle,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PathSerialize, PathIntrospect)]


### PR DESCRIPTION
We're going to need a ball state later, but we're not going to implement penalty shot behavior soon. Removing this field makes it easier to implement the ball state composer.