### PR TITLE
Update PrimaryState and add primary state filter scaffold

### DIFF
--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -60,6 +60,7 @@ pub fn collect_hulk_cyclers(root: impl AsRef<Path>) -> Result<Cyclers, Error> {
                     "world_state::game_controller_state_filter",
                     "world_state::ground_provider",
                     "world_state::kinematics_provider",
+                    "world_state::primary_state_filter",
                 ],
                 execution_time_warning_threshold: Some(Duration::from_secs_f32(1.0 / 100.0)),
             },

--- a/crates/types/src/primary_state.rs
+++ b/crates/types/src/primary_state.rs
@@ -17,16 +17,11 @@ use serde::{Deserialize, Serialize};
 )]
 pub enum PrimaryState {
     #[default]
-    Unstiff,
-    Animation {
-        stiff: bool,
-    },
+    Safe,
     Initial,
     Ready,
     Set,
     Playing,
     Penalized,
     Finished,
-    Calibration,
-    Standby,
 }

--- a/crates/world_state/src/lib.rs
+++ b/crates/world_state/src/lib.rs
@@ -6,4 +6,5 @@ pub mod game_controller_filter;
 pub mod game_controller_state_filter;
 pub mod ground_provider;
 pub mod kinematics_provider;
+pub mod primary_state_filter;
 pub mod trigger;

--- a/crates/world_state/src/primary_state_filter.rs
+++ b/crates/world_state/src/primary_state_filter.rs
@@ -1,0 +1,71 @@
+use std::collections::HashSet;
+
+use color_eyre::Result;
+use context_attribute::context;
+use framework::MainOutput;
+use hardware::{RecordingInterface, SpeakerInterface};
+use hsl_network_messages::PlayerNumber;
+use serde::{Deserialize, Serialize};
+use types::{
+    filtered_game_controller_state::FilteredGameControllerState, primary_state::PrimaryState,
+};
+
+#[derive(Deserialize, Serialize)]
+pub struct PrimaryStateFilter {
+    last_primary_state: PrimaryState,
+}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    filtered_game_controller_state:
+        Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
+
+    player_number: Parameter<PlayerNumber, "player_number">,
+    recorded_primary_states: Parameter<HashSet<PrimaryState>, "recorded_primary_states">,
+
+    hardware_interface: HardwareInterface,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub primary_state: MainOutput<PrimaryState>,
+}
+
+impl PrimaryStateFilter {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            last_primary_state: PrimaryState::Safe,
+        })
+    }
+
+    pub fn cycle(
+        &mut self,
+        context: CycleContext<impl RecordingInterface + SpeakerInterface>,
+    ) -> Result<MainOutputs> {
+        let _is_penalized = match context.filtered_game_controller_state {
+            Some(game_controller_state) => {
+                game_controller_state.penalties[*context.player_number].is_some()
+            }
+            None => false,
+        };
+
+        // TODO mode switching state machine
+        let next_primary_state = PrimaryState::Safe;
+
+        context.hardware_interface.set_whether_to_record(
+            context
+                .recorded_primary_states
+                .contains(&next_primary_state),
+        );
+
+        self.last_primary_state = next_primary_state;
+
+        Ok(MainOutputs {
+            primary_state: next_primary_state.into(),
+        })
+    }
+}

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -395,5 +395,6 @@
     "inner_minimum_pitch": -0.4,
     "outer_yaw": 0,
     "injected_head_joints": null
-  }
+  },
+  "recorded_primary_states": ["Ready", "Set", "Playing"]
 }


### PR DESCRIPTION
## Why? What?

We need a primary state for the ball state composer (later PR).
Some unused states were removed (Animation, Calibration, Standby), and `Unstiff` was renamed to `Safe` to align with booster terminology.