### PR TITLE
Removed StandUp default actions

### DIFF
--- a/crates/world_state/src/behavior/node.rs
+++ b/crates/world_state/src/behavior/node.rs
@@ -56,7 +56,6 @@ impl Behavior {
             Action::Finish,
             Action::Penalize,
             Action::Initial,
-            Action::StandUp,
         ];
 
         if context.parameters.remote_control.enable {


### PR DESCRIPTION
## Why? What?

Standup isn't handled correctly at the moment as we don't have a fall down state yet. Therefore it was removed from the default actions.

## How to Test

Startup the simulator and set the `parameters.behavior.remote_control.enable` parameter to `false`. If the robot remains standing it works.
