### PR TITLE
Don't run booster jobs on borked CI runners

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -116,6 +116,27 @@ jobs:
           - imagine
           - replayer
           - mujoco
+        profile:
+          - dev
+          - release
+    runs-on:
+      - self-hosted
+      - v3
+    container:
+      image: ghcr.io/hulks/hulk-ci:1.92.0
+      options: --user=1000:1000 --privileged --device /dev/fuse:rw
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Build
+        run: ./pepsi build --locked --profile ${{ matrix.profile }} ${{ matrix.target }}
+  buil-booster:
+    name: Build
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
           - booster
         profile:
           - dev
@@ -123,6 +144,7 @@ jobs:
     runs-on:
       - self-hosted
       - v3
+      - not-borked
     container:
       image: ghcr.io/hulks/hulk-ci:1.92.0
       options: --user=1000:1000 --privileged --device /dev/fuse:rw


### PR DESCRIPTION
## Why? What?

For some reason, building with the booster container fails on CI runner 1 and 3. No idea why.
Instead of disabling them outright, this PR just prevents these jobs from running on these specific runners but they can still do the other jobs.

Fixes #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

Find out why CI is bronek in the first place

## How to Test

See if CI runs correctly
