### PR TITLE
Make pepsi shell smarter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,7 +7400,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.17.0"
+version = "7.18.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.17.0"
+version = "7.18.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -127,6 +127,12 @@ enum Command {
     #[command(subcommand)]
     Sdk(sdk::Arguments),
     /// Open a command line shell to a Robot
+    ///
+    /// Example:
+    ///   pepsi shell 20w
+    ///   pepsi shell 42 btop
+    ///   pepsi shell 38 39 whoami
+    #[command(verbatim_doc_comment)]
     Shell(shell::Arguments),
     /// Execute all unit and integration tests
     Test(cargo::Arguments<test::Arguments>),

--- a/tools/pepsi/src/shell.rs
+++ b/tools/pepsi/src/shell.rs
@@ -1,22 +1,68 @@
+use std::str::FromStr;
+
 use clap::Args;
-use color_eyre::{Result, eyre::WrapErr};
+use color_eyre::{
+    Result,
+    eyre::{WrapErr, bail},
+};
 
 use robot::Robot;
 
+use crate::progress_indicator::ProgressIndicator;
 use argument_parsers::RobotAddress;
 
-#[derive(Args)]
+#[derive(Args, Debug)]
 pub struct Arguments {
-    /// The Robot to connect to e.g. 20w or 10.1.24.22
-    #[arg(required = true)]
-    pub robot: RobotAddress,
+    #[arg(num_args = 1..)]
+    pub arguments: Vec<String>,
 }
 
 pub async fn shell(arguments: Arguments) -> Result<()> {
-    let robot = Robot::try_new_with_ping(arguments.robot.ip).await?;
+    let mut iter = arguments.arguments.into_iter();
+    let mut robots = Vec::new();
+    let mut user_command = Vec::new();
+    for item in iter.by_ref() {
+        let Ok(address) = RobotAddress::from_str(&item) else {
+            user_command.push(item);
+            break;
+        };
+        robots.push(address);
+    }
+    user_command.extend(iter);
 
-    robot
-        .execute_shell()
-        .await
-        .wrap_err_with(|| format!("failed to execute shell on {}", arguments.robot))
+    if robots.len() == 1 {
+        let mut command = Robot::try_new_with_ping(robots[0].ip)
+            .await?
+            .ssh_to_robot()?;
+        command.arg("-t");
+        let status = command
+            .args(user_command)
+            .status()
+            .await
+            .wrap_err("failed to execute shell ssh command")?;
+        if !status.success() {
+            bail!("shell ssh command exited with {status}");
+        }
+        return Ok(());
+    }
+
+    let progress = ProgressIndicator::new();
+
+    progress
+        .map_tasks(robots, "".to_string(), |robot, _progress_bar| {
+            let user_command = user_command.clone();
+            async move {
+                let mut command = Robot::try_new_with_ping(robot.ip).await?.ssh_to_robot()?;
+                command.args(&user_command);
+                let output = command.output().await?;
+
+                let stdout = String::from_utf8(output.stdout).wrap_err("stdout was not UTF-8")?;
+                let stderr = String::from_utf8(output.stderr).wrap_err("stderr was not UTF-8")?;
+
+                Ok(format!("{}\n{}{}", user_command.join(" "), stdout, stderr))
+            }
+        })
+        .await;
+
+    Ok(())
 }


### PR DESCRIPTION
## Why? What?

This PR changes the pepsi shell command to allow running commands on multiple robots at once XOR running an interactive command on a single robot.

## How to Test

```bash
pepsi shell 42             # should work like before
pepsi shell 42 btop        # runs btop interactively
pepsi shell 42 ls /tmp     # multiple command arguments are supported
pepsi shell 42 43 ls /tmp  # multiple robots and multiple command arguments are supported

pepsi shell 42 43 btop     # is not supported. btop will complain about not being in an interactive shell
```
