### PR TITLE
Durchschleifen odometry data through zenoh bridge

### DIFF
--- a/crates/booster/src/lib.rs
+++ b/crates/booster/src/lib.rs
@@ -537,6 +537,16 @@ pub struct Kick {
     pub kick_power: f64,
 }
 
+#[repr(C)]
+#[derive(
+    Clone, Debug, Default, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
+)]
+pub struct Odometer {
+    pub x: f32,
+    pub y: f32,
+    pub theta: f32,
+}
+
 #[cfg(feature = "pyo3")]
 #[pymodule(name = "booster_types")]
 pub mod python_module {

--- a/crates/hardware/src/lib.rs
+++ b/crates/hardware/src/lib.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use booster::{
-    ButtonEventMsg, FallDownState, Kick, LowCommand, LowState, RemoteControllerState,
+    ButtonEventMsg, FallDownState, Kick, LowCommand, LowState, Odometer, RemoteControllerState,
     TransformMessage,
 };
 use booster_sdk::types::RobotMode;
@@ -118,4 +118,8 @@ pub trait HighLevelInterface {
 
 pub trait MotionRuntimeInteface {
     fn get_motion_runtime_type(&self) -> Result<MotionRuntime>;
+}
+
+pub trait OdometerInterface {
+    fn get_odometer(&self) -> Result<Odometer>;
 }

--- a/crates/hulk_booster/src/hardware_interface.rs
+++ b/crates/hulk_booster/src/hardware_interface.rs
@@ -32,7 +32,7 @@ use booster::{ButtonEventMsg, FallDownState, LowCommand, LowState, RemoteControl
 use hardware::{
     ButtonEventMsgInterface, CameraInterface, FallDownStateInterface, HighLevelInterface,
     IdInterface, LowCommandInterface, LowStateInterface, MicrophoneInterface,
-    MotionRuntimeInteface, NetworkInterface, PathsInterface, RecordingInterface,
+    MotionRuntimeInteface, NetworkInterface, OdometerInterface, PathsInterface, RecordingInterface,
     RemoteControllerStateInterface, SimulatorInterface, SpeakerInterface, TimeInterface,
     VisualKickInterface,
 };
@@ -61,6 +61,7 @@ struct TopicInfos {
     stereonet_depth_camera_info: TopicInfo,
     image_left_raw: TopicInfo,
     image_left_raw_camera_info: TopicInfo,
+    odometer: TopicInfo,
 }
 
 impl Default for TopicInfos {
@@ -79,6 +80,7 @@ impl Default for TopicInfos {
             ),
             image_left_raw: TopicInfo::new("image_left_raw"),
             image_left_raw_camera_info: TopicInfo::new("image_left_raw/camera_info"),
+            odometer: TopicInfo::new("booster/odometer_state"),
         }
     }
 }
@@ -116,6 +118,7 @@ pub struct BoosterHardwareInterface {
     stereonet_depth_camera_info_subscriber: Subscriber<RingChannelHandler<Sample>>,
     image_left_raw_subscriber: Subscriber<RingChannelHandler<Sample>>,
     image_left_raw_camera_info_subscriber: Subscriber<RingChannelHandler<Sample>>,
+    odometer_subscriber: Subscriber<RingChannelHandler<Sample>>,
 
     high_level_interface_client: Arc<BoosterClient>,
     robot_mode: Arc<Mutex<RobotMode>>,
@@ -195,6 +198,7 @@ impl BoosterHardwareInterface {
                 &topic_infos.image_left_raw_camera_info,
             )
             .await?,
+            odometer_subscriber: declare_subscriber(&session, &topic_infos.odometer).await?,
 
             robot_mode,
             high_level_interface_client,
@@ -499,6 +503,14 @@ impl HighLevelInterface for BoosterHardwareInterface {
 impl MotionRuntimeInteface for BoosterHardwareInterface {
     fn get_motion_runtime_type(&self) -> Result<MotionRuntime> {
         Ok(MotionRuntime::Booster)
+    }
+}
+
+impl OdometerInterface for BoosterHardwareInterface {
+    fn get_odometer(&self) -> Result<booster::Odometer> {
+        self.run_until_cancelled(self.odometer_subscriber.recv_async())?
+            .map_err(|error| eyre!(error))
+            .and_then(deserialize_sample)
     }
 }
 

--- a/crates/hulk_booster/src/main.rs
+++ b/crates/hulk_booster/src/main.rs
@@ -16,7 +16,7 @@ use framework::Parameters as FrameworkParameters;
 use hardware::{
     ButtonEventMsgInterface, CameraInterface, FallDownStateInterface, HighLevelInterface,
     IdInterface, LowCommandInterface, LowStateInterface, MicrophoneInterface,
-    MotionRuntimeInteface, NetworkInterface, PathsInterface, RecordingInterface,
+    MotionRuntimeInteface, NetworkInterface, OdometerInterface, PathsInterface, RecordingInterface,
     SimulatorInterface, SpeakerInterface, TimeInterface, VisualKickInterface,
 };
 use serde_json::from_reader;
@@ -67,6 +67,7 @@ pub trait HardwareInterface:
     + SimulatorInterface
     + HighLevelInterface
     + MotionRuntimeInteface
+    + OdometerInterface
 {
 }
 

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -109,6 +109,14 @@ pub fn collect_hulk_cyclers(root: impl AsRef<Path>) -> Result<Cyclers, Error> {
                 nodes: vec![],
                 execution_time_warning_threshold: None,
             },
+            CyclerManifest {
+                name: "Odometry",
+                kind: CyclerKind::Perception,
+                instances: vec![""],
+                setup_nodes: vec!["sensor_receiver::odometer_receiver"],
+                nodes: vec![],
+                execution_time_warning_threshold: None,
+            },
         ],
     };
 

--- a/crates/hulk_mujoco/src/hardware_interface.rs
+++ b/crates/hulk_mujoco/src/hardware_interface.rs
@@ -15,7 +15,7 @@ use color_eyre::{
 use futures_util::{SinkExt, StreamExt};
 use hardware::{
     ButtonEventMsgInterface, CameraInterface, HighLevelInterface, IdInterface, MicrophoneInterface,
-    MotionRuntimeInteface, NetworkInterface, PathsInterface, RecordingInterface,
+    MotionRuntimeInteface, NetworkInterface, OdometerInterface, PathsInterface, RecordingInterface,
     SimulatorInterface, SpeakerInterface, TimeInterface, TransformMessageInterface,
     VisualKickInterface,
 };
@@ -478,6 +478,12 @@ impl HighLevelInterface for MujocoHardwareInterface {
 impl MotionRuntimeInteface for MujocoHardwareInterface {
     fn get_motion_runtime_type(&self) -> Result<MotionRuntime> {
         Ok(MotionRuntime::Hulk)
+    }
+}
+
+impl OdometerInterface for MujocoHardwareInterface {
+    fn get_odometer(&self) -> Result<booster::Odometer> {
+        todo!()
     }
 }
 

--- a/crates/hulk_mujoco/src/main.rs
+++ b/crates/hulk_mujoco/src/main.rs
@@ -10,7 +10,7 @@ use framework::Parameters as FrameworkParameters;
 use hardware::{
     ButtonEventMsgInterface, CameraInterface, FallDownStateInterface, HighLevelInterface,
     IdInterface, LowCommandInterface, LowStateInterface, MicrophoneInterface,
-    MotionRuntimeInteface, NetworkInterface, PathsInterface, RecordingInterface,
+    MotionRuntimeInteface, NetworkInterface, OdometerInterface, PathsInterface, RecordingInterface,
     SimulatorInterface, SpeakerInterface, TimeInterface, TransformMessageInterface,
     VisualKickInterface,
 };
@@ -60,6 +60,7 @@ pub trait HardwareInterface:
     + SimulatorInterface
     + HighLevelInterface
     + MotionRuntimeInteface
+    + OdometerInterface
 {
 }
 

--- a/crates/sensor_receiver/src/lib.rs
+++ b/crates/sensor_receiver/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod button_event_receiver;
 pub mod fall_down_state_receiver;
 pub mod image_receiver;
+pub mod odometer_receiver;

--- a/crates/sensor_receiver/src/odometer_receiver.rs
+++ b/crates/sensor_receiver/src/odometer_receiver.rs
@@ -1,0 +1,58 @@
+use std::time::SystemTime;
+
+use booster::Odometer;
+use color_eyre::Result;
+use context_attribute::context;
+use framework::MainOutput;
+use hardware::{OdometerInterface, TimeInterface};
+use serde::{Deserialize, Serialize};
+use types::cycle_time::CycleTime;
+
+#[derive(Deserialize, Serialize)]
+pub struct FallDownStateReceiver {
+    last_cycle_start: SystemTime,
+}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    hardware_interface: HardwareInterface,
+}
+
+#[context]
+pub struct MainOutputs {
+    pub odometer: MainOutput<Option<Odometer>>,
+    pub cycle_time: MainOutput<CycleTime>,
+}
+
+impl FallDownStateReceiver {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            last_cycle_start: SystemTime::UNIX_EPOCH,
+        })
+    }
+
+    pub fn cycle(
+        &mut self,
+        context: CycleContext<impl OdometerInterface + TimeInterface>,
+    ) -> Result<MainOutputs> {
+        let odometer = Some(context.hardware_interface.get_odometer()?);
+        println!("got odometer");
+
+        let now = context.hardware_interface.get_now();
+        let cycle_time = CycleTime {
+            start_time: now,
+            last_cycle_duration: now
+                .duration_since(self.last_cycle_start)
+                .expect("time ran backwards"),
+        };
+        self.last_cycle_start = now;
+
+        Ok(MainOutputs {
+            odometer: odometer.into(),
+            cycle_time: cycle_time.into(),
+        })
+    }
+}

--- a/crates/zenoh_bridge/src/main.rs
+++ b/crates/zenoh_bridge/src/main.rs
@@ -4,7 +4,7 @@ mod ros;
 
 use std::fmt::Debug;
 
-use booster::{ButtonEventMsg, FallDownState, Kick, LowState};
+use booster::{ButtonEventMsg, FallDownState, Kick, LowState, Odometer};
 use color_eyre::eyre::{Result, WrapErr};
 use futures_util::{FutureExt, future::Fuse, select};
 use ros2_client::{
@@ -65,6 +65,14 @@ async fn main() -> Result<()> {
         MessageTypeName::new("booster_interface", "LowState"),
         "low_state",
     )?;
+    let mut odometer_forwarder = spawn_ros_to_zenoh_forwarder::<Odometer>(
+        &mut ros_node,
+        zenoh_session.clone(),
+        "/",
+        "odometer_state",
+        MessageTypeName::new("booster_interface", "Odometer"),
+        "odometer_state",
+    )?;
 
     let mut kick_ball_forwarder = spawn_zenoh_to_ros_forwarder::<Kick>(
         &mut ros_node,
@@ -80,6 +88,7 @@ async fn main() -> Result<()> {
         result = button_event_forwarder => result,
         result = fall_down_state_forwarder => result,
         result = low_state_forwarder => result,
+        result = odometer_forwarder => result,
         result = kick_ball_forwarder => result,
     }
     .wrap_err("failed to run forwarder to completion")?;


### PR DESCRIPTION
## Why? What?

Booster provides an odometry. This PR schleifs it durch to the robotics code.

## Ideas for Next Iterations (Not This PR)

Use it for jokerlization

## How to Test

1. Upload to robotör
1. `pepsi run fanta -- -a 10.1.24.43 Odometry.main_outputs.odometer`
