### PR TITLE
Always restart bridge services

### DIFF
--- a/tools/k1-setup/zenoh-bridge-ros2dds.service
+++ b/tools/k1-setup/zenoh-bridge-ros2dds.service
@@ -9,6 +9,7 @@ WorkingDirectory=/home/booster
 Environment=RUST_LOG=DEBUG
 StandardOutput=journal
 StandardError=journal
+Restart=always
 
 [Install]
 WantedBy=default.target

--- a/tools/k1-setup/zenoh-bridge.service
+++ b/tools/k1-setup/zenoh-bridge.service
@@ -9,6 +9,7 @@ WorkingDirectory=/home/booster
 Environment=RUST_LOG=DEBUG
 StandardOutput=journal
 StandardError=journal
+Restart=always
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Why? What?

Our bridge services, mainly zenoh-bridge, sometimes still fail by crashing. To  mitigate the effect of this, this PR enbales `Restart=always` in the systemd unit file for the bridge services.

