### PR TITLE
Override zenoh-bridge-dds user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7401,7 +7401,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.18.0"
+version = "7.19.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/k1-setup/zenoh-bridge-dds.service.override.conf
+++ b/tools/k1-setup/zenoh-bridge-dds.service.override.conf
@@ -1,0 +1,2 @@
+[Service]
+User=zenohd

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.18.0"
+version = "7.19.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -170,6 +170,31 @@ async fn gammaray_robot(
         .await?;
 
     robot
+        .ssh_to_robot()?
+        .arg("sudo mkdir -p /etc/systemd/system/zenoh-bridge-dds.service.d/")
+        .ssh_with_log(
+            "creating zenoh-bridge-dds systemd override directory",
+            &progress_bar,
+        )
+        .await?;
+    robot
+        .rsync_with_robot()?
+        .arg("--rsync-path=sudo rsync")
+        .arg("--info=progress2")
+        .arg(setup.join("zenoh-bridge-dds.service.override.conf"))
+        .arg(format!(
+            "{}:/etc/systemd/system/zenoh-bridge-dds.service.d/override.conf",
+            robot.address
+        ))
+        .rsync_with_log("uploading zenoh-bridge-dds service override", &progress_bar)
+        .await?;
+    robot
+        .ssh_to_robot()?
+        .arg("sudo systemctl daemon-reload")
+        .ssh_with_log("reloading service daemon", &progress_bar)
+        .await?;
+
+    robot
         .rsync_with_robot()?
         .arg("--info=progress2")
         .arg(setup.join("hulk.service"))


### PR DESCRIPTION
The apt sources zenoh-bridge-dds package wants to run the bridge with a user that does not exist... zenohd user does...
