### PR TITLE
Fix button handling

### DIFF
--- a/crates/types/src/buttons.rs
+++ b/crates/types/src/buttons.rs
@@ -18,7 +18,10 @@ impl ButtonPressType {
         current_button_event_type: &ButtonEventType,
     ) -> Option<Self> {
         match (last_button_event_type, current_button_event_type) {
-            (Some(ButtonEventType::LongPressEnd), ButtonEventType::PressUp) => Some(Self::Long),
+            (
+                Some(ButtonEventType::LongPressEnd) | Some(ButtonEventType::LongPressHold),
+                ButtonEventType::PressUp,
+            ) => Some(Self::Long),
             (_, ButtonEventType::PressUp) => Some(Self::Short),
             (_, _) => None,
         }


### PR DESCRIPTION
## Why? What?

Currently, the button event handling does not work reliably. This PR expands the long press detection to allow for the LongPressEnd to be missed and instead emits the button when either the button event LongPressHold or LongPressEnd has been received along with the PressUp.  


## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Upload and do the long presses. The primary state transition should be visible in the LED colors.
