### PR TITLE
revert simulator gcc fix

### DIFF
--- a/etc/parameters/hardware.json
+++ b/etc/parameters/hardware.json
@@ -9,6 +9,6 @@
   "hsl_network_ports": {
     "game_controller_return": 3939,
     "game_controller_state": 3838,
-    "hsl": 11024
+    "hsl": 10024
   }
 }


### PR DESCRIPTION
## Why? What?
I*m confused by our jsons. Are the hardware.json in the simulator and on the robots the same? Because i checked and definitely changed only one parameter in the simulator json, but i think it change for all of them..
