### PR TITLE
Better kickoff pose

### DIFF
--- a/crates/world_state/src/behavior/walk_to_kick_off.rs
+++ b/crates/world_state/src/behavior/walk_to_kick_off.rs
@@ -29,7 +29,10 @@ pub fn execute(
         look_action.execute(),
         path_obstacles_output,
         walk_speed,
-        OrientationMode::AlignWithPath,
+        OrientationMode::LookAt {
+            target: Point2::origin(),
+            tolerance: 0.1,
+        },
         distance_to_be_aligned,
         walk_and_stand.parameters.hysteresis,
     )

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -433,7 +433,7 @@
       "keeper_x_offset": 0.1,
       "keeper_passive_distance": 4.5,
       "striker_distance_to_non_free_center_circle": 0.4,
-      "striker_kickoff_position": [-0.21, 0.03]
+      "striker_kickoff_position": [-0.4, 0.0]
     },
     "lost_ball": {
       "offset_to_last_ball_location": [1.0, 0.0]

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -407,7 +407,7 @@
       }
     },
     "walk_and_stand": {
-      "hysteresis": [0.3, 0.3],
+      "hysteresis": [0.15, 0.15],
       "target_reached_thresholds": [0.05, 0.1],
       "hybrid_align_distance": 0.95,
       "normal_distance_to_be_aligned": 0.05,
@@ -432,8 +432,8 @@
       "striker_supporter_minimum_x": -2.0,
       "keeper_x_offset": 0.1,
       "keeper_passive_distance": 4.5,
-      "striker_distance_to_non_free_center_circle": 0.4,
-      "striker_kickoff_position": [-0.4, 0.0]
+      "striker_distance_to_non_free_center_circle": 1.0,
+      "striker_kickoff_position": [-0.8, 0.0]
     },
     "lost_ball": {
       "offset_to_last_ball_location": [1.0, 0.0]


### PR DESCRIPTION
## Why? What?

Currently the old NAO kickoff pose is used which is adjusted for the indirect kick rule. The Robot will now position itself in front of the ball looking in the direction of the opponent goal for the kickoff.

## Ideas for Next Iterations (Not This PR)

For the indirect-kick-rule the angle of the kickoff would have to be adjusted.

## How to Test

Deploy on the K1 and let the robot walk in to kickoff. The robot should place itself in front of the ball facing the opponent goal.