### PR TITLE
Add hysteresis to kick mode

### DIFF
--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -543,5 +543,6 @@ impl Default for WalkSpeedParameters {
 pub struct KickingParameters {
     pub kick_power: f64,
     pub distance_for_kick: f32,
+    pub distance_for_kick_hysteresis: f32,
     pub distance_to_look_directly_at_the_ball: f32,
 }

--- a/crates/world_state/src/behavior/kicking.rs
+++ b/crates/world_state/src/behavior/kicking.rs
@@ -1,4 +1,5 @@
 use coordinate_systems::Field;
+use filtering::hysteresis::less_than_with_hysteresis;
 use framework::AdditionalOutput;
 use hsl_network_messages::GamePhase;
 use linear_algebra::{Orientation2, Vector2, vector};
@@ -13,6 +14,7 @@ use types::{
 
 use super::walk_to_pose::WalkPathPlanner;
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute(
     world_state: &WorldState,
     walk_path_planner: &WalkPathPlanner,
@@ -21,6 +23,7 @@ pub fn execute(
     distance_to_be_aligned: f32,
     field_dimensions: FieldDimensions,
     path_obstacles_output: &mut AdditionalOutput<Vec<PathObstacle>>,
+    last_close_enough_to_kick: &mut bool,
 ) -> Option<MotionCommand> {
     let ball_position = world_state.ball?.ball_in_ground;
     let ground_to_field = world_state.robot.ground_to_field?;
@@ -44,7 +47,14 @@ pub fn execute(
     let robot_theta_to_field: Orientation2<Field> = ground_to_field.orientation();
     let target_position = (field_to_ground * goal_position).as_point();
 
-    if distance_to_ball < parameters.distance_for_kick {
+    let close_enough_to_kick = less_than_with_hysteresis(
+        *last_close_enough_to_kick,
+        distance_to_ball,
+        parameters.distance_for_kick,
+        parameters.distance_for_kick_hysteresis,
+    );
+    *last_close_enough_to_kick = close_enough_to_kick;
+    if close_enough_to_kick {
         Some(MotionCommand::VisualKick {
             head,
             ball_position,

--- a/crates/world_state/src/behavior/node.rs
+++ b/crates/world_state/src/behavior/node.rs
@@ -44,6 +44,7 @@ pub struct Behavior {
     last_known_ball_position: Point2<Field>,
     previous_role: Role,
     last_time_role_changed: SystemTime,
+    last_close_enough_to_kick: bool,
 }
 
 #[context]
@@ -80,6 +81,7 @@ impl Behavior {
             last_known_ball_position: point![0.0, 0.0],
             previous_role: Role::Searcher,
             last_time_role_changed: UNIX_EPOCH,
+            last_close_enough_to_kick: false,
         })
     }
 
@@ -282,6 +284,7 @@ impl Behavior {
                             .normal_distance_to_be_aligned,
                         *context.field_dimensions,
                         &mut context.path_obstacles_output,
+                        &mut self.last_close_enough_to_kick,
                     ),
                     Action::Search => search::execute(
                         world_state,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -448,6 +448,7 @@
     "kicking": {
       "kick_power": 1.0,
       "distance_for_kick": 1.5,
+      "distance_for_kick_hysteresis": 0.5,
       "distance_to_look_directly_at_the_ball": 4.0
     },
     "maximum_lookaround_duration": {


### PR DESCRIPTION
## Why? What?

What it says. Prevents unnecessary jitter when approaching the ball since transitioning between walking and kicking is not smooth.

Fixes #

## How to Test

Robot should only twitch once instead of multiple times
