### PR TITLE
hack: spawn only one penalized pose

### DIFF
--- a/crates/world_state/src/localization.rs
+++ b/crates/world_state/src/localization.rs
@@ -1269,22 +1269,13 @@ fn generate_penalized_poses(
     field_dimensions: &FieldDimensions,
     penalized_distance: f32,
 ) -> Vec<Pose2<Field>> {
-    vec![
-        // Pose2::new(
-        //     point![
-        //         -field_dimensions.length * 0.5 + field_dimensions.penalty_marker_distance,
-        //         -field_dimensions.width * 0.5 - penalized_distance
-        //     ],
-        //     FRAC_PI_2,
-        // ),
-        Pose2::new(
-            point![
-                -field_dimensions.length * 0.5 + field_dimensions.penalty_marker_distance,
-                field_dimensions.width * 0.5 + penalized_distance
-            ],
-            -FRAC_PI_2,
-        ),
-    ]
+    vec![Pose2::new(
+        point![
+            -field_dimensions.length * 0.5 + field_dimensions.penalty_marker_distance,
+            field_dimensions.width * 0.5 + penalized_distance
+        ],
+        -FRAC_PI_2,
+    )]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
since we have trouble deciding which of the penalized poses is the correct one, and because we can control where to put down the robot, let's only spawn one hypothesis in penalized.

Robot handlers always need to put down the robot on the left side in the direction of play.