### PR TITLE
Record in Stop and Penalized states

### DIFF
--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -584,7 +584,7 @@
     "minimum_yaw": -0.785,
     "injected_head_joints": null
   },
-  "recorded_primary_states": ["Initial", "Ready", "Set", "Playing"],
+  "recorded_primary_states": ["Initial", "Ready", "Set", "Playing", "Stop", "Penalized"],
   "safe_mode_handler": {
     "joint_position_threshold": 0.1,
     "joint_velocity_threshold": 0.1,


### PR DESCRIPTION
## Why? What?

When looking through replays we noticed that we want to have data from `Stop` and `Penalized` states.
The only primary states we don't record now are `Safe` and `Finished`.

## How to Test

Record a replay and look for the new primary states.