### PR TITLE
Only set leds at primary state transition

### DIFF
--- a/crates/world_state/src/led_handler.rs
+++ b/crates/world_state/src/led_handler.rs
@@ -40,6 +40,10 @@ impl LEDHandler {
             return Ok(MainOutputs {});
         }
 
+        if self.last_primary_state == Some(*context.primary_state) {
+            return Ok(MainOutputs {});
+        }
+
         let light_control_parameter = match context.primary_state {
             PrimaryState::Safe => SetLedLightColorParameter::BLUE,
             PrimaryState::Stop => SetLedLightColorParameter::LIGHT_BLUE,
@@ -54,6 +58,8 @@ impl LEDHandler {
         context
             .hardware_interface
             .set_led_color(light_control_parameter)?;
+
+        self.last_primary_state = Some(*context.primary_state);
 
         Ok(MainOutputs {})
     }


### PR DESCRIPTION
 ## Why? What?

Motion currently sometimes stutters. This is apparently due to flooding motion with set led calls. This PR now only does the LED setting at a primary state transition.

## How to Test

- Try the LED mode switching.
- Let the robot walk in and have behavior make decide to stand still. The robot should just stand still without twitching. 
