### PR TITLE
Fix HSL messages not being sent on wifi interface

### DIFF
--- a/crates/hsl_network/src/endpoint.rs
+++ b/crates/hsl_network/src/endpoint.rs
@@ -33,9 +33,12 @@ impl Endpoint {
         ))
         .await
         .map_err(Error::CannotBind)?;
-        let hsl_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, parameters.hsl))
-            .await
-            .map_err(Error::CannotBind)?;
+        let hsl_socket = UdpSocket::bind(SocketAddrV4::new(
+            Ipv4Addr::new(10, 0, 0, 0),
+            parameters.hsl,
+        ))
+        .await
+        .map_err(Error::CannotBind)?;
         hsl_socket
             .set_broadcast(true)
             .map_err(Error::EnableBroadcast)?;


### PR DESCRIPTION
## Why? What?

- Fixes #2369

The issue in #2369 was caused by the UDP broadcast packet ending up on the ethernet interface on the back of the robot instead of the wifi interface.
This is due to the fact that the robot has a default route on the ethernet interface, needed for internet connectivity.
We used to broadcast on an unspecified address, which was only sent on the default route.

## ToDo / Known Issues

Completely untested as of yet

## Ideas for Next Iterations (Not This PR)

Don't hardcode the 10.0.0.0/16 subnet?

alternatives considered:
- add parameter for subnet (like 10.108.x.x used in GO26 HSL_B)
- broadcast on all interfaces (manually iterate over interfaces in Rust)
- add default route on wifi interface
- add route to 255.255.255.255 on wifi interface

## How to Test

Check if our message count decreases in the game controller
