### PR TITLE
Kinematics based support foot estimator

### DIFF
--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -80,6 +80,7 @@ pub fn collect_hulk_cyclers(root: impl AsRef<Path>) -> Result<Cyclers, Error> {
                     "world_state::obstacle_receiver",
                     "world_state::primary_state_filter",
                     "world_state::robot_mode_handler",
+                    "world_state::fall_down_state_filter",
                     "world_state::rule_obstacle_composer",
                     "world_state::safe_pose_checker",
                     "world_state::search_suggestor",

--- a/crates/hulk_manifest/src/lib.rs
+++ b/crates/hulk_manifest/src/lib.rs
@@ -80,6 +80,7 @@ pub fn collect_hulk_cyclers(root: impl AsRef<Path>) -> Result<Cyclers, Error> {
                     "world_state::obstacle_receiver",
                     "world_state::primary_state_filter",
                     "world_state::robot_mode_handler",
+                    "world_state::support_foot_estimator",
                     "world_state::fall_down_state_filter",
                     "world_state::rule_obstacle_composer",
                     "world_state::safe_pose_checker",

--- a/crates/world_state/src/fall_down_state_filter.rs
+++ b/crates/world_state/src/fall_down_state_filter.rs
@@ -1,0 +1,56 @@
+use color_eyre::Result;
+use serde::{Deserialize, Serialize};
+
+use booster::FallDownState;
+use context_attribute::context;
+use framework::{MainOutput, PerceptionInput};
+
+#[derive(Deserialize, Serialize)]
+pub struct FallDownStateFilter {
+    last_fall_down_state: Option<FallDownState>,
+}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    fall_down_state: PerceptionInput<Option<FallDownState>, "FallDownState", "fall_down_state?">,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub fall_down_state: MainOutput<Option<FallDownState>>,
+}
+
+impl FallDownStateFilter {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            last_fall_down_state: None,
+        })
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        let fall_down_state = context
+            .fall_down_state
+            .persistent
+            .into_iter()
+            .chain(context.fall_down_state.temporary)
+            .flat_map(|(_time, fall_down_states)| fall_down_states)
+            .last()
+            .flatten()
+            .copied()
+            .map_or(self.last_fall_down_state, |fall_down_state| {
+                Some(fall_down_state)
+            });
+
+        if fall_down_state.is_some() {
+            self.last_fall_down_state = fall_down_state;
+        }
+
+        Ok(MainOutputs {
+            fall_down_state: fall_down_state.into(),
+        })
+    }
+}

--- a/crates/world_state/src/ground_provider.rs
+++ b/crates/world_state/src/ground_provider.rs
@@ -20,7 +20,7 @@ pub struct CreationContext {}
 #[context]
 pub struct CycleContext {
     robot_kinematics: Input<RobotKinematics, "robot_kinematics">,
-    // support_side: RequiredInput<Option<Side>, "support_foot.support_side?">,
+    support_side: RequiredInput<Option<Side>, "support_foot?">,
     imu_state: PerceptionInput<ImuState, "Motion", "imu_state">,
 }
 
@@ -105,10 +105,7 @@ impl GroundProvider {
             ] / 2.0,
         );
 
-        // todo: Rewrite control::ground_contact_detector
-        let support_side = Side::Left;
-
-        let ground_to_robot = match support_side {
+        let ground_to_robot = match context.support_side {
             Side::Left => left_sole_horizontal_to_robot * ground_to_left_sole,
             Side::Right => right_sole_horizontal_to_robot * ground_to_right_sole,
         };

--- a/crates/world_state/src/lib.rs
+++ b/crates/world_state/src/lib.rs
@@ -6,6 +6,7 @@ pub mod behavior;
 pub mod button_event_handler;
 pub mod camera_matrix_calculator;
 pub mod fake_odometry;
+pub mod fall_down_state_filter;
 pub mod game_controller_filter;
 pub mod game_controller_state_filter;
 pub mod ground_provider;

--- a/crates/world_state/src/lib.rs
+++ b/crates/world_state/src/lib.rs
@@ -22,6 +22,7 @@ pub mod robot_mode_handler;
 pub mod rule_obstacle_composer;
 pub mod safe_pose_checker;
 pub mod search_suggestor;
+pub mod support_foot_estimator;
 pub mod team_ball_filter;
 pub mod time_to_reach_kick_position;
 pub mod trigger;

--- a/crates/world_state/src/support_foot_estimator.rs
+++ b/crates/world_state/src/support_foot_estimator.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use context_attribute::context;
 use coordinate_systems::Robot;
+use filtering::hysteresis::less_than_with_hysteresis;
 use framework::{MainOutput, PerceptionInput};
 use linear_algebra::{Isometry3, Orientation3};
 use types::support_foot::Side;
@@ -24,7 +25,6 @@ pub struct CycleContext {
     fall_down_state: Input<Option<FallDownState>, "fall_down_state?">,
     robot_kinematics: Input<RobotKinematics, "robot_kinematics">,
 
-    height_epsilon: Parameter<f32, "support_foot_provider.height_epsilon">,
     switch_hysteresis: Parameter<f32, "support_foot_provider.switch_hysteresis">,
 }
 
@@ -84,7 +84,6 @@ impl SupportFootEstimator {
         let support_foot = Some(Self::select_support_side(
             height_difference,
             self.last_support_side,
-            *context.height_epsilon,
             *context.switch_hysteresis,
         ));
 
@@ -100,19 +99,21 @@ impl SupportFootEstimator {
     fn select_support_side(
         height_difference: f32,
         last_support_side: Side,
-        height_epsilon: f32,
         switch_hysteresis: f32,
     ) -> Side {
-        let candidate_side = if height_difference > height_epsilon {
-            Side::Right
-        } else {
-            Side::Left
-        };
+        let left_was_lower_last_time = last_support_side == Side::Left;
 
-        match (last_support_side, candidate_side) {
-            (Side::Left, Side::Right) if height_difference <= switch_hysteresis => Side::Left,
-            (Side::Right, Side::Left) if -height_difference <= switch_hysteresis => Side::Right,
-            _ => candidate_side,
+        let left_sole_is_lower_than_right_sole = less_than_with_hysteresis(
+            left_was_lower_last_time,
+            height_difference,
+            0.0,
+            switch_hysteresis,
+        );
+
+        if left_sole_is_lower_than_right_sole {
+            Side::Left
+        } else {
+            Side::Right
         }
     }
 

--- a/crates/world_state/src/support_foot_estimator.rs
+++ b/crates/world_state/src/support_foot_estimator.rs
@@ -23,6 +23,7 @@ pub struct CycleContext {
 
     fall_down_state: Input<Option<FallDownState>, "fall_down_state?">,
     robot_kinematics: Input<RobotKinematics, "robot_kinematics">,
+
     height_epsilon: Parameter<f32, "support_foot_provider.height_epsilon">,
     switch_hysteresis: Parameter<f32, "support_foot_provider.switch_hysteresis">,
 }
@@ -56,10 +57,13 @@ impl SupportFootEstimator {
         struct Horizontal;
 
         let imu_state = Self::latest_imu_state(&context);
-        let roll = imu_state.roll_pitch_yaw.x();
-        let pitch = imu_state.roll_pitch_yaw.y();
 
-        let imu_orientation = Orientation3::from_euler_angles(roll, pitch, 0.0).mirror();
+        let imu_orientation = Orientation3::from_euler_angles(
+            imu_state.roll_pitch_yaw.x(),
+            imu_state.roll_pitch_yaw.y(),
+            imu_state.roll_pitch_yaw.z(),
+        )
+        .mirror();
         let horizontal_to_robot = Isometry3::<Horizontal, Robot>::from(imu_orientation);
         let robot_to_horizontal = horizontal_to_robot.inverse();
 

--- a/crates/world_state/src/support_foot_estimator.rs
+++ b/crates/world_state/src/support_foot_estimator.rs
@@ -1,0 +1,125 @@
+use booster::{FallDownState, FallDownStateType, ImuState};
+use color_eyre::Result;
+use kinematics::robot_kinematics::RobotKinematics;
+use serde::{Deserialize, Serialize};
+
+use context_attribute::context;
+use coordinate_systems::Robot;
+use framework::{MainOutput, PerceptionInput};
+use linear_algebra::{Isometry3, Orientation3};
+use types::support_foot::Side;
+
+#[derive(Deserialize, Serialize)]
+pub struct SupportFootEstimator {
+    last_support_side: Side,
+}
+
+#[context]
+pub struct CreationContext {}
+
+#[context]
+pub struct CycleContext {
+    imu_state: PerceptionInput<ImuState, "Motion", "imu_state">,
+
+    fall_down_state: Input<Option<FallDownState>, "fall_down_state?">,
+    robot_kinematics: Input<RobotKinematics, "robot_kinematics">,
+    height_epsilon: Parameter<f32, "support_foot_provider.height_epsilon">,
+    switch_hysteresis: Parameter<f32, "support_foot_provider.switch_hysteresis">,
+}
+
+#[context]
+#[derive(Default)]
+pub struct MainOutputs {
+    pub support_foot: MainOutput<Option<Side>>,
+}
+
+impl SupportFootEstimator {
+    pub fn new(_context: CreationContext) -> Result<Self> {
+        Ok(Self {
+            last_support_side: Side::Left,
+        })
+    }
+
+    pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
+        if !matches!(
+            context.fall_down_state,
+            Some(FallDownState {
+                fall_down_state: FallDownStateType::IsReady,
+                ..
+            })
+        ) {
+            return Ok(MainOutputs {
+                support_foot: None.into(),
+            });
+        }
+
+        struct Horizontal;
+
+        let imu_state = Self::latest_imu_state(&context);
+        let roll = imu_state.roll_pitch_yaw.x();
+        let pitch = imu_state.roll_pitch_yaw.y();
+
+        let imu_orientation = Orientation3::from_euler_angles(roll, pitch, 0.0).mirror();
+        let horizontal_to_robot = Isometry3::<Horizontal, Robot>::from(imu_orientation);
+        let robot_to_horizontal = horizontal_to_robot.inverse();
+
+        let left_sole_in_horizontal = robot_to_horizontal
+            * context
+                .robot_kinematics
+                .left_leg
+                .sole_to_robot
+                .translation();
+        let right_sole_in_horizontal = robot_to_horizontal
+            * context
+                .robot_kinematics
+                .right_leg
+                .sole_to_robot
+                .translation();
+        let height_difference = left_sole_in_horizontal.z() - right_sole_in_horizontal.z();
+
+        let support_foot = Some(Self::select_support_side(
+            height_difference,
+            self.last_support_side,
+            *context.height_epsilon,
+            *context.switch_hysteresis,
+        ));
+
+        if let Some(side) = support_foot {
+            self.last_support_side = side;
+        }
+
+        Ok(MainOutputs {
+            support_foot: support_foot.into(),
+        })
+    }
+
+    fn select_support_side(
+        height_difference: f32,
+        last_support_side: Side,
+        height_epsilon: f32,
+        switch_hysteresis: f32,
+    ) -> Side {
+        let candidate_side = if height_difference > height_epsilon {
+            Side::Right
+        } else {
+            Side::Left
+        };
+
+        match (last_support_side, candidate_side) {
+            (Side::Left, Side::Right) if height_difference <= switch_hysteresis => Side::Left,
+            (Side::Right, Side::Left) if -height_difference <= switch_hysteresis => Side::Right,
+            _ => candidate_side,
+        }
+    }
+
+    fn latest_imu_state(context: &CycleContext) -> ImuState {
+        context
+            .imu_state
+            .persistent
+            .iter()
+            .chain(context.imu_state.temporary.iter())
+            .flat_map(|(_timestamp, imu_states)| imu_states.iter().copied().copied())
+            .next_back()
+            .unwrap_or_default()
+    }
+}

--- a/crates/world_state/src/world_state_composer.rs
+++ b/crates/world_state/src/world_state_composer.rs
@@ -6,7 +6,7 @@ use linear_algebra::{Isometry2, Point2};
 use serde::{Deserialize, Serialize};
 
 use context_attribute::context;
-use framework::{MainOutput, PerceptionInput};
+use framework::MainOutput;
 use types::{
     ball_position::HypotheticalBallPosition,
     cycle_time::CycleTime,
@@ -19,19 +19,16 @@ use types::{
 };
 
 #[derive(Deserialize, Serialize)]
-pub struct WorldStateComposer {
-    last_fall_down_state: Option<FallDownState>,
-}
+pub struct WorldStateComposer {}
 
 #[context]
 pub struct CreationContext {}
 
 #[context]
 pub struct CycleContext {
-    fall_down_state: PerceptionInput<Option<FallDownState>, "FallDownState", "fall_down_state?">,
-
     ball: Input<Option<BallState>, "ball_state?">,
     cycle_time: Input<CycleTime, "cycle_time">,
+    fall_down_state: Input<Option<FallDownState>, "fall_down_state?">,
     filtered_game_controller_state:
         Input<Option<FilteredGameControllerState>, "filtered_game_controller_state?">,
     ground_to_field: Input<Option<Isometry2<Ground, Field>>, "ground_to_field?">,
@@ -56,29 +53,10 @@ pub struct MainOutputs {
 
 impl WorldStateComposer {
     pub fn new(_context: CreationContext) -> Result<Self> {
-        Ok(Self {
-            last_fall_down_state: None,
-        })
+        Ok(Self {})
     }
 
     pub fn cycle(&mut self, context: CycleContext) -> Result<MainOutputs> {
-        let fall_down_state = context
-            .fall_down_state
-            .persistent
-            .into_iter()
-            .chain(context.fall_down_state.temporary)
-            .flat_map(|(_time, fall_down_states)| fall_down_states)
-            .last()
-            .flatten()
-            .copied()
-            .map_or(self.last_fall_down_state, |fall_down_state| {
-                Some(fall_down_state)
-            });
-
-        if fall_down_state.is_some() {
-            self.last_fall_down_state = fall_down_state;
-        }
-
         let robot: RobotState = RobotState {
             ground_to_field: context.ground_to_field.copied(),
             player_number: *context.player_number,
@@ -87,7 +65,7 @@ impl WorldStateComposer {
 
         let world_state = WorldState {
             ball: context.ball.copied(),
-            fall_down_state,
+            fall_down_state: context.fall_down_state.cloned(),
             filtered_game_controller_state: context.filtered_game_controller_state.cloned(),
             hypothetical_ball_positions: context.hypothetical_ball_position.clone(),
             now: context.cycle_time.start_time,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -327,6 +327,10 @@
     },
     "use_line_measurements": true
   },
+  "support_foot_provider": {
+    "height_epsilon": 0.003,
+    "switch_hysteresis": 0.008
+  },
   "game_controller_filter": {
     "time_since_last_message_to_consider_ip_active": {
       "nanos": 0,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -328,7 +328,6 @@
     "use_line_measurements": true
   },
   "support_foot_provider": {
-    "height_epsilon": 0.003,
     "switch_hysteresis": 0.008
   },
   "game_controller_filter": {


### PR DESCRIPTION
## Why? What?

We currently always calculate the ground_to_robot through the kinematics of the left foot, even when the right foot is the only support foot. This PR adds a kinematics based support foot estimator, to allow the ground provider to calculate the ground_to_robot based on the correct support foot.  

- Fixes #2156 

## How to Test

- Upload to the robot. 
- In twix look at `WorldState.main_outputs.support_foot`
- Let the robot walk
