### PR TITLE
Remote workspace fixes

### DIFF
--- a/scripts/remote_workspace
+++ b/scripts/remote_workspace
@@ -4,6 +4,7 @@
 set -e
 
 # cd to repository base directory for better referencing
+INVOCATION_DIR=`pwd -P`
 BASEDIR=`cd $(dirname $0); pwd -P`
 BASEDIR=${BASEDIR%/*}
 cd "$BASEDIR"
@@ -39,7 +40,7 @@ __helpText__
 
 remoteWorkspace="${REMOTE_WORKSPACE:-$(cat .REMOTE_WORKSPACE)}"
 files=()
-path="."
+path=`realpath --relative-to="${BASEDIR}" "${INVOCATION_DIR}"`
 while true; do
     case "$1" in
         -[h?] | --help)

--- a/scripts/remote_workspace
+++ b/scripts/remote_workspace
@@ -27,7 +27,7 @@ Options:
                         Can be repeated to return multiple files.
   --cd <path>      Change directory on remote before executing command
 
-If no --remote is given, the path loaded from `.REMOTE_WORKSPACE`
+If no --remote is given, the path loaded from \`.REMOTE_WORKSPACE\`
 The remote workspace path should follow this format:
 
     \`user@host:path/to/remote/repo\`

--- a/scripts/remote_workspace
+++ b/scripts/remote_workspace
@@ -95,5 +95,5 @@ if [ ${#files[@]} -gt 0 ]; then
     # fetch results
     echo Returning files
     printf '  %s\n' "${files[@]}"
-    printf '%s\n' "${files[@]}" | rsync -ahr --info=progress --files-from=- "$remoteWorkspace" .
+    printf '%s\n' "${files[@]}" | rsync -ahr --info=progress2 --files-from=- "$remoteWorkspace" .
 fi

--- a/scripts/remote_workspace
+++ b/scripts/remote_workspace
@@ -95,5 +95,5 @@ if [ ${#files[@]} -gt 0 ]; then
     # fetch results
     echo Returning files
     printf '  %s\n' "${files[@]}"
-    printf '%s\n' "${files[@]}" | rsync -ah --info=progress --files-from=- "$remoteWorkspace" .
+    printf '%s\n' "${files[@]}" | rsync -ahr --info=progress --files-from=- "$remoteWorkspace" .
 fi


### PR DESCRIPTION
## Why? What?

1. Preserve relative working directory for remote workspace
  Previously, the command would always be executed in the root of the repository. Now if you run the remote workspace script from within e.g. `tools/machine-learning/whatever`, the command will also run in this directory on the remote.. Note that this behavior can still be overriden by use of the `--cd` option.
2. Allow directories for `--return-file` option.
  Apparently rsync's `--archive` only implies `--recursive` when not using `--files-from`, so recursion needs to be enabled manually here.

          --archive, -a
              This is equivalent to -rlptgoD.  It is a quick way of saying you want recursion and want to preserve almost everything.
              [...]
              The only exception to the above equivalence is when --files-from is specified, in which case -r is not implied.
3. Use `info=progress2` for rsync when returning files.

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

1.
```sh
cd tools/machine-learning
../../scripts/remote_workspace pwd
# should print    ~/hulk/tools/machine-learning/multi-task-yolo
# was previously  ~/hulk/
```
2.
```sh
scripts/remote_workspace --return-file a mkdir -p a/b/c
tree a
# a
# └── b
#    └── c

# Previously only an empty directory `a` would be created
```
3. Look at rsync output when testing 2.