### PR TITLE
Fix pepsi remote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7401,7 +7401,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.21.0"
+version = "7.22.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/repository/src/cargo.rs
+++ b/crates/repository/src/cargo.rs
@@ -5,7 +5,10 @@ use std::{
     path::Path,
 };
 
-use color_eyre::{Result, eyre::Context};
+use color_eyre::{
+    Result,
+    eyre::{Context, bail},
+};
 use tokio::process::Command;
 
 use crate::{
@@ -34,11 +37,13 @@ impl Display for Environment {
     }
 }
 
+#[derive(Debug)]
 pub enum Host {
     Local,
     Remote,
 }
 
+#[derive(Debug)]
 pub struct Cargo {
     host: Host,
     environment: Environment,
@@ -73,22 +78,20 @@ impl Cargo {
                     }
                 }
                 Host::Remote => {
-                    // let mut command =
-                    //     Command::new(repository.root.join("scripts/remote_workspace"));
+                    let mut command =
+                        Command::new(repository.root.join("scripts/remote_workspace"));
 
-                    // let status = command
-                    //     .arg("pepsi")
-                    //     .arg("sdk")
-                    //     .arg("install")
-                    //     .arg("--version")
-                    //     .arg(version)
-                    //     .status()
-                    //     .await
-                    //     .wrap_err("failed to run pepsi")?;
+                    let status = command
+                        .arg(format!("podman image exists {}", sdk_image.name_tagged()))
+                        .arg("|| ./pepsi sdk install --image")
+                        .arg(sdk_image.name_tagged())
+                        .status()
+                        .await
+                        .wrap_err("failed to run pepsi")?;
 
-                    // if !status.success() {
-                    //     bail!("pepsi failed with {status}");
-                    // }
+                    if !status.success() {
+                        bail!("pepsi failed with {status}");
+                    }
                 }
             }
         }
@@ -135,7 +138,7 @@ impl Cargo {
                     pwd.display().to_string(),
                 ));
                 command.push(arguments);
-                command.push(OsStr::new("'"));
+                command.push(OsStr::new("\""));
                 command
             }
             Environment::Docker { sdk_image } => {
@@ -201,7 +204,7 @@ fn build_command_string(
                 --pull=never \
                 --tty \
                 {tagged_image_name} \
-                /bin/sh -c '\
+                /bin/sh -c \"\
                     cd {pwd} && \
                     cargo \
         "

--- a/crates/repository/src/cargo.rs
+++ b/crates/repository/src/cargo.rs
@@ -83,7 +83,7 @@ impl Cargo {
 
                     let status = command
                         .arg(format!("podman image exists {}", sdk_image.name_tagged()))
-                        .arg("|| ./pepsi sdk install --image")
+                        .arg("|| ./pepsi sdk build --image")
                         .arg(sdk_image.name_tagged())
                         .status()
                         .await

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.21.0"
+version = "7.22.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Why? What?

`--remote` should now work again for the pepsi subcommands like `build`, `upload`, `(nex)test`, `pregame`, etc.

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

1. Richte yourself a remote workspace target ein, see `scripts/remote_workspace --help`.
2. `./pepsi upload --remote 42`
