### PR TITLE
Add seeed orin to team.toml for pepsi

### DIFF
--- a/etc/parameters/team.toml
+++ b/etc/parameters/team.toml
@@ -24,3 +24,8 @@ id = "1421625075359"
 number = 46
 hostname = "Charlie"
 id = "1421625074270"
+
+[[robots]]
+number = 99
+hostname = "PeterFox"
+id = "1421625071398"


### PR DESCRIPTION
Adds an entry for the local Orin NX developer board to the team.toml, for pepsi integration.
