### PR TITLE
Pepsi tensorrt prebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7401,7 +7401,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.23.2"
+version = "7.24.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/repository/src/upload.rs
+++ b/crates/repository/src/upload.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 
-use color_eyre::{Result, eyre::Context};
+use color_eyre::{
+    Result,
+    eyre::{Context, ContextCompat},
+};
 use tokio::fs::{create_dir_all, symlink};
 
 use crate::Repository;
@@ -9,7 +12,7 @@ impl Repository {
     pub async fn populate_upload_directory(
         &self,
         upload_directory: impl AsRef<Path>,
-        hulk_binary: impl AsRef<Path>,
+        binaries: &[impl AsRef<Path>],
     ) -> Result<()> {
         let upload_directory = upload_directory.as_ref();
 
@@ -20,12 +23,19 @@ impl Repository {
         create_dir_all(upload_directory.join("bin"))
             .await
             .wrap_err("failed to create directory for binaries")?;
-        symlink(
-            self.root.join(hulk_binary),
-            upload_directory.join("bin/hulk"),
-        )
-        .await
-        .wrap_err("failed to link executable")?;
+        for binary in binaries {
+            let binary = binary.as_ref();
+            symlink(
+                self.root.join(binary),
+                upload_directory
+                    .join("bin")
+                    .join(binary.file_name().wrap_err_with(|| {
+                        format!("could not determine filename of {}", binary.display())
+                    })?),
+            )
+            .await
+            .wrap_err_with(|| format!("failed to symlink executable {}", binary.display()))?;
+        }
 
         create_dir_all(upload_directory.join("logs"))
             .await

--- a/crates/robot/src/lib.rs
+++ b/crates/robot/src/lib.rs
@@ -498,7 +498,7 @@ async fn monitor_rsync_progress_with(
             result = process.wait() => {
                 if let Ok(status) = result {
                     if !status.success() {
-                        bail!("failed to upload image")
+                        bail!("rsync failed")
                     }
                 }
             }

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -11,7 +11,7 @@ INTERNAL_LOG_PATH="/home/booster/hulk/logs/${CURRENT_DATE}"
   bash -c "
     mkdir -p \"${INTERNAL_LOG_PATH}\"
     ln -sfn \"${INTERNAL_LOG_PATH}\" \"/home/booster/hulk/logs/latest\"
-    exec /home/booster/hulk/bin/hulk --log-path \"${INTERNAL_LOG_PATH}\"
+    exec /home/booster/hulk/bin/hulk_booster --log-path \"${INTERNAL_LOG_PATH}\"
   " \
   > >(tee "${INTERNAL_LOG_PATH}/hulk.out") \
   2> >(tee "${INTERNAL_LOG_PATH}/hulk.err")

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.23.2"
+version = "7.24.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/format.rs
+++ b/tools/pepsi/src/format.rs
@@ -83,19 +83,19 @@ pub async fn format(arguments: Arguments, repository: &Repository) -> Result<()>
 
     let (rustfmt_result, taplo_result, ruff_result) = tokio::join!(
         async {
-            let task = progress_indicator.task("rustfmt");
+            let task = progress_indicator.task("rustfmt", true);
             let result = rustfmt(&repository.root, arguments.check).await;
             task.finish_with(result.as_ref());
             result
         },
         async {
-            let task = progress_indicator.task("taplo");
+            let task = progress_indicator.task("taplo", true);
             let result = taplo_fmt(&repository.root, arguments.check).await;
             task.finish_with(result.as_ref());
             result
         },
         async {
-            let task = progress_indicator.task("ruff");
+            let task = progress_indicator.task("ruff", true);
             let result = ruff_fmt(&repository.root, arguments.check).await;
             task.finish_with(result.as_ref());
             result

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -389,7 +389,7 @@ async fn set_up_wifi(
     Ok(())
 }
 
-trait CommandExt {
+pub trait CommandExt {
     async fn ssh_with_log(&mut self, prefix: &str, progress_bar: &ProgressBar) -> Result<()>;
 
     async fn rsync_with_log(&mut self, name: &str, progress_bar: &ProgressBar) -> Result<()>;
@@ -429,7 +429,12 @@ impl CommandExt for Command {
             select! {
                 Ok(Some(buffer)) = stdout_lines.next_segment() => {
                     if let Ok(text) = str::from_utf8(&buffer) {
-                        progress_bar.set_message(format!("{name}: {text}"));
+                        let message = if name.is_empty() {
+                            text.to_string()
+                        } else {
+                            format!("{name}: {text}")
+                        };
+                        progress_bar.set_message(message);
                     }
                 }
                 Ok(Some(buffer)) = stderr_lines.next_segment() => {

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -27,6 +27,7 @@ use reboot::reboot;
 use recording::recording;
 use sdk::sdk;
 use shell::shell;
+use tensorrt_compile::tensorrt_compile;
 use tracing::warn;
 use upload::upload;
 use wifi::wifi;
@@ -54,6 +55,7 @@ mod reboot;
 mod recording;
 mod sdk;
 mod shell;
+mod tensorrt_compile;
 mod upload;
 mod wifi;
 
@@ -157,6 +159,8 @@ enum Command {
     #[command(verbatim_doc_comment, visible_alias = "muschel")]
     Shell(shell::Arguments),
     /// Execute all unit and integration tests
+    #[command()]
+    TensorRTCompile(tensorrt_compile::Arguments),
     #[command(visible_alias = "prüf")]
     Test(cargo::Arguments<test::Arguments>),
     /// Upload the code to Robots
@@ -279,6 +283,9 @@ async fn main() -> Result<()> {
         Command::Shell(arguments) => shell(arguments)
             .await
             .wrap_err("failed to execute shell command")?,
+        Command::TensorRTCompile(arguments) => tensorrt_compile(arguments, &repository?)
+            .await
+            .wrap_err("failed to execute TensorRT compile command")?,
         Command::Test(arguments) => cargo(arguments, &repository?, &[] as &[&str])
             .await
             .wrap_err("failed to execute test command")?,

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -122,7 +122,7 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
     }
 
     repository
-        .populate_upload_directory(&upload_directory, hulk_binary)
+        .populate_upload_directory(&upload_directory, &[hulk_binary])
         .await
         .wrap_err("failed to populate upload directory")?;
 

--- a/tools/pepsi/src/progress_indicator.rs
+++ b/tools/pepsi/src/progress_indicator.rs
@@ -29,12 +29,12 @@ where
     }
 }
 
-impl TaskMessage for str {
+impl TaskMessage for &str {
     fn message(&self) -> Option<String> {
         if self.is_empty() {
             return None;
         }
-        Some(String::from(self))
+        Some(String::from(*self))
     }
 }
 
@@ -63,13 +63,20 @@ impl ProgressIndicator {
         }
     }
 
-    pub fn task(&self, prefix: impl Display) -> Task {
+    pub fn task(&self, prefix: impl Display, tick: bool) -> Task {
         let spinner = ProgressBar::new_spinner()
             .with_style(self.default_style.clone())
             .with_prefix(format!("[{prefix}]"));
-        spinner.enable_steady_tick(Duration::from_millis(100));
+        let progress = self.multi_progress.add(spinner);
+        if tick {
+            progress.enable_steady_tick(Duration::from_millis(100));
+        } else {
+            progress.set_style(self.success_style.clone());
+            progress.set_message("");
+            progress.set_style(self.default_style.clone());
+        }
         Task {
-            progress: self.multi_progress.add(spinner),
+            progress,
             success_style: self.success_style.clone(),
             error_style: self.error_style.clone(),
         }
@@ -87,7 +94,7 @@ impl ProgressIndicator {
     {
         items
             .into_iter()
-            .map(|item| (self.task(item.to_string()), item))
+            .map(|item| (self.task(item.to_string(), true), item))
             .map(|(progress, item)| {
                 progress.enable_steady_tick();
                 progress.set_message(message.clone());

--- a/tools/pepsi/src/tensorrt_compile.rs
+++ b/tools/pepsi/src/tensorrt_compile.rs
@@ -106,7 +106,7 @@ pub async fn tensorrt_compile(arguments: Arguments, repository: &Repository) -> 
     robot
         .ssh_to_robot()?
         .arg(format!(
-            r#"launch-hulk --executable "./bin/tensorrt-compile {}" 2>&1"#,
+            r#"sudo podman exec hulk ./bin/tensorrt-compile {} 2>&1"#,
             onnx_path.display(),
         ))
         .run_with_log("", &progress_compile.progress, b'\n')

--- a/tools/pepsi/src/tensorrt_compile.rs
+++ b/tools/pepsi/src/tensorrt_compile.rs
@@ -1,0 +1,174 @@
+use std::{path::PathBuf, process::Stdio, time::Duration};
+
+use clap::Args;
+use color_eyre::{
+    Result,
+    eyre::{Context, ContextCompat, bail, eyre},
+};
+
+use argument_parsers::RobotAddress;
+use pathdiff::diff_paths;
+use repository::Repository;
+use robot::Robot;
+use tempfile::tempdir;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use crate::{
+    cargo::{
+        self, CargoCommand, build, construct_cargo_command, environment::EnvironmentArguments,
+    },
+    gammaray::CommandExt,
+    progress_indicator::{ProgressIndicator, Task},
+};
+
+#[derive(Args)]
+pub struct Arguments {
+    #[command(flatten)]
+    pub tensorrt_compile: TensorRtCompileArguments,
+
+    #[command(flatten)]
+    pub environment: EnvironmentArguments,
+    #[command(flatten, next_help_heading = "Cargo Options")]
+    pub build: build::Arguments,
+}
+
+#[derive(Args)]
+pub struct TensorRtCompileArguments {
+    /// Path to onnx model
+    pub onnx_path: PathBuf,
+
+    // The robot to use for compiling the model
+    pub host: RobotAddress,
+
+    /// Do not build before uploading
+    #[arg(long)]
+    pub no_build: bool,
+}
+
+pub async fn tensorrt_compile(arguments: Arguments, repository: &Repository) -> Result<()> {
+    let robot = Robot::try_new_with_ping(arguments.tensorrt_compile.host.ip).await?;
+    let multiprogres = ProgressIndicator::new();
+    let progress_build = multiprogres.task("Build compiler", false);
+    let progress_upload = multiprogres.task("Upload", false);
+    let progress_compile = multiprogres.task("Compile", false);
+    let progress_download = multiprogres.task("Download", false);
+
+    let binary_path = get_binary_path(arguments.build.profile());
+    if !arguments.tensorrt_compile.no_build {
+        progress_build.enable_steady_tick();
+        let cargo_arguments = cargo::Arguments {
+            manifest: Some(
+                repository
+                    .root
+                    .join("tools/tensorrt-compile/Cargo.toml")
+                    .into_os_string(),
+            ),
+            environment: arguments.environment,
+            cargo: arguments.build,
+        };
+        build_binary(cargo_arguments, repository, &progress_build)
+            .await
+            .wrap_err("failed to build")
+            .inspect_err(|_| progress_build.progress.finish())?;
+    } else {
+        progress_build.finish_with_success("Skipped");
+    }
+
+    let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
+    progress_upload.enable_steady_tick();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    repository
+        .populate_upload_directory(&upload_directory, &[&binary_path])
+        .await
+        .wrap_err("failed to populate upload directory")?;
+    robot
+        .upload(upload_directory, "hulk", true, |status| {
+            progress_upload.set_message(format!("Uploading: {status}"))
+        })
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to upload binary to {}",
+                arguments.tensorrt_compile.host.ip
+            )
+        })
+        .inspect_err(|_| progress_upload.progress.finish())?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    progress_upload.finish_with_success(());
+
+    progress_compile.enable_steady_tick();
+    let onnx_path = if arguments.tensorrt_compile.onnx_path.is_absolute() {
+        diff_paths(arguments.tensorrt_compile.onnx_path, &repository.root)
+            .wrap_err("could not determinte relative onnx path")?
+    } else {
+        arguments.tensorrt_compile.onnx_path
+    };
+    robot
+        .ssh_to_robot()?
+        .arg(format!(
+            r#"launch-hulk --executable "./bin/tensorrt-compile {}" 2>&1"#,
+            onnx_path.display(),
+        ))
+        .run_with_log("", &progress_compile.progress, b'\n')
+        .await
+        .inspect_err(|_| progress_compile.progress.finish())?;
+    progress_compile.finish_with_success(progress_compile.progress.message());
+
+    progress_download.enable_steady_tick();
+    robot
+        .rsync_with_robot()?
+        .arg(format!("{}:hulk/etc/neural_networks/", robot.address))
+        .arg(format!(
+            "{}/",
+            repository.root.join("etc/neural_networks").display()
+        ))
+        .rsync_with_log("", &progress_download.progress)
+        .await
+        .inspect_err(|_| progress_download.progress.finish())?;
+    progress_download.finish_with_success(());
+
+    Ok(())
+}
+
+pub fn get_binary_path(profile: &str) -> String {
+    // the target directory is "debug" with --profile dev...
+    let profile_directory = match profile {
+        "dev" => "debug",
+        other => other,
+    };
+
+    format!("target/aarch64-unknown-linux-gnu/{profile_directory}/tensorrt-compile")
+}
+
+async fn build_binary(
+    cargo_arguments: cargo::Arguments<build::Arguments>,
+    repository: &Repository,
+    progress_bar: &Task,
+) -> Result<()> {
+    let binary_path = get_binary_path(cargo_arguments.cargo.profile());
+    let mut command = construct_cargo_command(cargo_arguments, repository, &[binary_path])
+        .await
+        .expect("failed to construct cargo command");
+
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::piped());
+    command.stdin(Stdio::null());
+    command.kill_on_drop(true);
+
+    let mut process = command.spawn().unwrap();
+
+    process.stdin.take();
+    process.stdout.take();
+    let mut lines = BufReader::new(process.stderr.take().unwrap()).lines();
+    while let Ok(Some(text)) = lines.next_line().await {
+        progress_bar.progress.println(&text);
+    }
+    let status = process.wait().await.unwrap();
+    if !status.success() {
+        progress_bar.finish_with_error(&eyre!("failed with code {}", status.code().unwrap()));
+        bail!("process failed");
+    }
+    progress_bar.finish_with_success(());
+
+    Ok(())
+}

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -125,7 +125,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
     }
 
     repository
-        .populate_upload_directory(&upload_directory, hulk_binary)
+        .populate_upload_directory(&upload_directory, &[hulk_binary])
         .await
         .wrap_err("failed to populate upload directory")?;
 
@@ -138,7 +138,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
         .robots
         .iter()
         .map(|robot_address| {
-            let progress = multi_progress.task(robot_address);
+            let progress = multi_progress.task(robot_address, true);
             progress.enable_steady_tick();
             async move {
                 progress.finish_with(

--- a/tools/tensorrt-compile/src/main.rs
+++ b/tools/tensorrt-compile/src/main.rs
@@ -16,7 +16,7 @@ struct CliArguments {
     onnx_path: PathBuf,
 
     /// Path to cache folder
-    #[arg(long, default_value = "/home/booster/.cache/hulk/tensor-rt")]
+    #[arg(long, default_value = "/home/booster/hulk/etc/neural_networks/")]
     cache_path: PathBuf,
 }
 


### PR DESCRIPTION
## Why? What?

Adds a pepsi command to prebuild the tensorrt cache for a particular model.
Since it has to be built in a similar environment to the real robot, the cache building also has to run on a robot or on our minipc.

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

```sh
# Remove old cache
rm etc/neural_networks/TensorrtExecutionProvider*
# Regenerate it
./pepsi tensor-rt-compile etc/neural_networks/yolo26m-tuned-nv12.onnx 10.1.24.99 # this is the mini-pc
# Now the files should exist again
ls etc/neural_networks/TensorrtExecutionProvider*
```