### PR TITLE
Add Stop Button in Twix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10532,7 +10532,7 @@ dependencies = [
 
 [[package]]
 name = "twix"
-version = "0.12.12"
+version = "0.12.13"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/world_state/src/primary_state_filter.rs
+++ b/crates/world_state/src/primary_state_filter.rs
@@ -16,6 +16,7 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct PrimaryStateFilter {
     last_primary_state: PrimaryState,
+    last_safe_pose: u32,
 }
 
 #[context]
@@ -29,6 +30,7 @@ pub struct CycleContext {
     is_safe_pose: Input<bool, "is_safe_pose">,
 
     injected_primary_state: Parameter<Option<PrimaryState>, "injected_primary_state?">,
+    injected_safe_pose: Parameter<u32, "injected_safe_pose">,
     player_number: Parameter<PlayerNumber, "player_number">,
     recorded_primary_states: Parameter<HashSet<PrimaryState>, "recorded_primary_states">,
 
@@ -45,6 +47,7 @@ impl PrimaryStateFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             last_primary_state: PrimaryState::Safe,
+            last_safe_pose: 0,
         })
     }
 
@@ -54,6 +57,25 @@ impl PrimaryStateFilter {
             impl RecordingInterface + HighLevelInterface + SimulatorInterface + SpeakerInterface,
         >,
     ) -> Result<MainOutputs> {
+        if matches!(
+            context.buttons,
+            Buttons {
+                f1: Some(ButtonPressType::Short),
+                ..
+            } | Buttons {
+                stand: Some(ButtonPressType::Short),
+                ..
+            }
+        ) {
+            self.last_safe_pose = *context.injected_safe_pose;
+        }
+
+        if self.last_safe_pose != *context.injected_safe_pose {
+            return Ok(MainOutputs {
+                primary_state: PrimaryState::Safe.into(),
+            });
+        }
+
         if let Some(injected_primary_state) = context.injected_primary_state {
             self.last_primary_state = *injected_primary_state;
             return Ok(MainOutputs {

--- a/crates/world_state/src/primary_state_filter.rs
+++ b/crates/world_state/src/primary_state_filter.rs
@@ -30,7 +30,6 @@ pub struct CycleContext {
     is_safe_pose: Input<bool, "is_safe_pose">,
 
     injected_primary_state: Parameter<Option<PrimaryState>, "injected_primary_state?">,
-    injected_safe_pose: Parameter<u32, "injected_safe_pose">,
     player_number: Parameter<PlayerNumber, "player_number">,
     recorded_primary_states: Parameter<HashSet<PrimaryState>, "recorded_primary_states">,
 
@@ -57,25 +56,6 @@ impl PrimaryStateFilter {
             impl RecordingInterface + HighLevelInterface + SimulatorInterface + SpeakerInterface,
         >,
     ) -> Result<MainOutputs> {
-        if matches!(
-            context.buttons,
-            Buttons {
-                f1: Some(ButtonPressType::Short),
-                ..
-            } | Buttons {
-                stand: Some(ButtonPressType::Short),
-                ..
-            }
-        ) {
-            self.last_safe_pose = *context.injected_safe_pose;
-        }
-
-        if self.last_safe_pose != *context.injected_safe_pose {
-            return Ok(MainOutputs {
-                primary_state: PrimaryState::Safe.into(),
-            });
-        }
-
         if let Some(injected_primary_state) = context.injected_primary_state {
             self.last_primary_state = *injected_primary_state;
             return Ok(MainOutputs {

--- a/crates/world_state/src/primary_state_filter.rs
+++ b/crates/world_state/src/primary_state_filter.rs
@@ -16,7 +16,6 @@ use types::{
 #[derive(Deserialize, Serialize)]
 pub struct PrimaryStateFilter {
     last_primary_state: PrimaryState,
-    last_safe_pose: u32,
 }
 
 #[context]
@@ -46,7 +45,6 @@ impl PrimaryStateFilter {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             last_primary_state: PrimaryState::Safe,
-            last_safe_pose: 0,
         })
     }
 

--- a/crates/world_state/src/robot_mode_handler.rs
+++ b/crates/world_state/src/robot_mode_handler.rs
@@ -18,7 +18,7 @@ use types::{
 pub struct BoosterModeHandler {
     last_primary_state_change_time: SystemTime,
     last_primary_state: PrimaryState,
-    button_pressed: bool,
+    local_stop_toggle: bool,
 }
 
 #[context]
@@ -31,7 +31,7 @@ pub struct CycleContext {
     buttons: Input<Buttons<Option<ButtonPressType>>, "buttons">,
 
     wait_before_prepare: Parameter<Duration, "wait_before_prepare">,
-    force_stop_robot: Parameter<bool, "force_stop_robot">,
+    remote_stop_toggle: Parameter<bool, "remote_stop_toggle">,
 
     hardware_interface: HardwareInterface,
 }
@@ -47,7 +47,7 @@ impl BoosterModeHandler {
         Ok(Self {
             last_primary_state_change_time: SystemTime::UNIX_EPOCH,
             last_primary_state: PrimaryState::default(),
-            button_pressed: false,
+            local_stop_toggle: false,
         })
     }
 
@@ -61,20 +61,17 @@ impl BoosterModeHandler {
             });
         }
 
-        if self.button_pressed != *context.force_stop_robot {
-            if matches!(
-                context.buttons,
-                Buttons {
-                    f1: Some(ButtonPressType::Short),
-                    ..
-                } | Buttons {
-                    stand: Some(ButtonPressType::Short),
-                    ..
-                }
-            ) {
-                self.button_pressed = !self.button_pressed;
-            }
+        let is_local_stop_toggle_short_press =
+            matches!(context.buttons.f1, Some(ButtonPressType::Short))
+                || matches!(context.buttons.stand, Some(ButtonPressType::Short));
 
+        let should_enter_damping_mode = self.local_stop_toggle != *context.remote_stop_toggle;
+
+        if should_enter_damping_mode && is_local_stop_toggle_short_press {
+            self.local_stop_toggle = !self.local_stop_toggle;
+        }
+
+        if should_enter_damping_mode {
             change_mode(&context, RobotMode::Damping);
             return Ok(MainOutputs {
                 robot_mode: Some(RobotMode::Damping).into(),

--- a/crates/world_state/src/robot_mode_handler.rs
+++ b/crates/world_state/src/robot_mode_handler.rs
@@ -61,7 +61,7 @@ impl BoosterModeHandler {
             });
         }
 
-        if self.button_pressed ^ *context.force_stop_robot {
+        if self.button_pressed != *context.force_stop_robot {
             if matches!(
                 context.buttons,
                 Buttons {

--- a/crates/world_state/src/robot_mode_handler.rs
+++ b/crates/world_state/src/robot_mode_handler.rs
@@ -7,12 +7,18 @@ use serde::{Deserialize, Serialize};
 use context_attribute::context;
 use framework::MainOutput;
 use hardware::{HighLevelInterface, MotionRuntimeInterface};
-use types::{cycle_time::CycleTime, motion_runtime::MotionRuntime, primary_state::PrimaryState};
+use types::{
+    buttons::{ButtonPressType, Buttons},
+    cycle_time::CycleTime,
+    motion_runtime::MotionRuntime,
+    primary_state::PrimaryState,
+};
 
 #[derive(Deserialize, Serialize)]
 pub struct BoosterModeHandler {
     last_primary_state_change_time: SystemTime,
     last_primary_state: PrimaryState,
+    button_pressed: bool,
 }
 
 #[context]
@@ -22,8 +28,10 @@ pub struct CreationContext {}
 pub struct CycleContext {
     primary_state: Input<PrimaryState, "primary_state">,
     cycle_time: Input<CycleTime, "cycle_time">,
+    buttons: Input<Buttons<Option<ButtonPressType>>, "buttons">,
 
     wait_before_prepare: Parameter<Duration, "wait_before_prepare">,
+    force_stop_robot: Parameter<bool, "force_stop_robot">,
 
     hardware_interface: HardwareInterface,
 }
@@ -39,6 +47,7 @@ impl BoosterModeHandler {
         Ok(Self {
             last_primary_state_change_time: SystemTime::UNIX_EPOCH,
             last_primary_state: PrimaryState::default(),
+            button_pressed: false,
         })
     }
 
@@ -49,6 +58,26 @@ impl BoosterModeHandler {
         if context.hardware_interface.get_motion_runtime_type()? != MotionRuntime::Booster {
             return Ok(MainOutputs {
                 robot_mode: None.into(),
+            });
+        }
+
+        if self.button_pressed ^ *context.force_stop_robot {
+            if matches!(
+                context.buttons,
+                Buttons {
+                    f1: Some(ButtonPressType::Short),
+                    ..
+                } | Buttons {
+                    stand: Some(ButtonPressType::Short),
+                    ..
+                }
+            ) {
+                self.button_pressed = !self.button_pressed;
+            }
+
+            change_mode(&context, RobotMode::Damping);
+            return Ok(MainOutputs {
+                robot_mode: Some(RobotMode::Damping).into(),
             });
         }
 

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -365,9 +365,9 @@
       "secs": 30
     }
   },
+  "force_stop_robot": false,
   "injected_primary_state": null,
-  "injected_safe_pose": 0,
-   "behavior": {
+  "behavior": {
     "injected_motion_command": null,
     "goal_keeper_number": "One",
     "optional_roles": ["Defender", "Midfielder", "StrikerSupporter"],

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -365,7 +365,7 @@
       "secs": 30
     }
   },
-  "force_stop_robot": false,
+  "remote_stop_toggle": false,
   "injected_primary_state": null,
   "behavior": {
     "injected_motion_command": null,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -366,6 +366,7 @@
     }
   },
   "injected_primary_state": null,
+  "injected_safe_pose": 0,
    "behavior": {
     "injected_motion_command": null,
     "goal_keeper_number": "One",

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twix"
-version = "0.12.12"
+version = "0.12.13"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -182,7 +182,7 @@ struct TwixApp {
     address: String,
     reachable_robots: ReachableRobots,
     connection_intent: bool,
-    injected_safe_pose: BufferHandle<u32>,
+    force_stop_robot: BufferHandle<bool>,
     panel_selection: String,
     last_focused_tab: (NodeIndex, TabIndex),
     dock_state: DockState<Tab>,
@@ -235,7 +235,7 @@ impl TwixApp {
             robot.connect();
         }
 
-        let injected_safe_pose = robot.subscribe_value("parameters.injected_safe_pose");
+        let force_stop_robot = robot.subscribe_value("parameters.force_stop_robot");
 
         let dock_state: Option<DockState<Value>> = if arguments.clear {
             None
@@ -293,7 +293,7 @@ impl TwixApp {
             robot,
             reachable_robots,
             connection_intent,
-            injected_safe_pose,
+            force_stop_robot,
             panel_selection,
             dock_state,
             last_focused_tab: (0.into(), 0.into()),
@@ -539,17 +539,17 @@ impl App for TwixApp {
                         )
                         .clicked()
                     {
-                        match self.injected_safe_pose.get_last_value() {
+                        match self.force_stop_robot.get_last_value() {
                             Ok(Some(value)) => {
-                                let new_injected_safe_pose = value + 1;
+                                let new_force_stop_robot = !value;
                                 self.robot.write(
-                                    "parameters.injected_safe_pose",
-                                    TextOrBinary::Text(new_injected_safe_pose.into()),
+                                    "parameters.force_stop_robot",
+                                    TextOrBinary::Text(new_force_stop_robot.into()),
                                 );
                             }
                             Ok(None) => {}
                             Err(error) => {
-                                error!("failed to read injected_safe_pose: {error:#?}")
+                                error!("failed to read force_stop_robot: {error:#?}")
                             }
                         }
                     }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -182,7 +182,7 @@ struct TwixApp {
     address: String,
     reachable_robots: ReachableRobots,
     connection_intent: bool,
-    force_stop_robot: BufferHandle<bool>,
+    remote_stop_toggle: BufferHandle<bool>,
     panel_selection: String,
     last_focused_tab: (NodeIndex, TabIndex),
     dock_state: DockState<Tab>,
@@ -235,7 +235,7 @@ impl TwixApp {
             robot.connect();
         }
 
-        let force_stop_robot = robot.subscribe_value("parameters.force_stop_robot");
+        let remote_stop_toggle = robot.subscribe_value("parameters.remote_stop_toggle");
 
         let dock_state: Option<DockState<Value>> = if arguments.clear {
             None
@@ -293,7 +293,7 @@ impl TwixApp {
             robot,
             reachable_robots,
             connection_intent,
-            force_stop_robot,
+            remote_stop_toggle,
             panel_selection,
             dock_state,
             last_focused_tab: (0.into(), 0.into()),
@@ -539,17 +539,17 @@ impl App for TwixApp {
                         )
                         .clicked()
                     {
-                        match self.force_stop_robot.get_last_value() {
+                        match self.remote_stop_toggle.get_last_value() {
                             Ok(Some(value)) => {
-                                let new_force_stop_robot = !value;
+                                let new_remote_stop_toggle = !value;
                                 self.robot.write(
-                                    "parameters.force_stop_robot",
-                                    TextOrBinary::Text(new_force_stop_robot.into()),
+                                    "parameters.remote_stop_toggle",
+                                    TextOrBinary::Text(new_remote_stop_toggle.into()),
                                 );
                             }
                             Ok(None) => {}
                             Err(error) => {
-                                error!("failed to read force_stop_robot: {error:#?}")
+                                error!("failed to read remote_stop_toggle: {error:#?}")
                             }
                         }
                     }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -12,8 +12,8 @@ use color_eyre::{
 use eframe::{
     App, CreationContext, Frame, NativeOptions, Renderer, Storage,
     egui::{
-        CentralPanel, Context, CornerRadius, Id, Label, Layout, Sense, StrokeKind, TopBottomPanel,
-        Ui, Widget, WidgetText,
+        Button, CentralPanel, Context, CornerRadius, Id, Label, Layout, RichText, Sense,
+        StrokeKind, TopBottomPanel, Ui, Widget, WidgetText,
     },
     egui_wgpu::{WgpuConfiguration, WgpuSetup},
     emath::Align,
@@ -28,6 +28,7 @@ use serde_json::{Value, from_str, to_string};
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 use communication::client::Status;
+use communication::messages::TextOrBinary;
 use configuration::{
     Configuration,
     keybind_plugin::{self, KeybindSystem},
@@ -60,6 +61,8 @@ mod twix_painter;
 mod value_buffer;
 mod visuals;
 mod zoom_and_pan;
+
+use crate::value_buffer::BufferHandle;
 
 #[derive(Debug, Parser)]
 struct Arguments {
@@ -179,6 +182,7 @@ struct TwixApp {
     address: String,
     reachable_robots: ReachableRobots,
     connection_intent: bool,
+    injected_safe_pose: BufferHandle<u32>,
     panel_selection: String,
     last_focused_tab: (NodeIndex, TabIndex),
     dock_state: DockState<Tab>,
@@ -230,6 +234,8 @@ impl TwixApp {
         if connection_intent {
             robot.connect();
         }
+
+        let injected_safe_pose = robot.subscribe_value("parameters.injected_safe_pose");
 
         let dock_state: Option<DockState<Value>> = if arguments.clear {
             None
@@ -287,6 +293,7 @@ impl TwixApp {
             robot,
             reachable_robots,
             connection_intent,
+            injected_safe_pose,
             panel_selection,
             dock_state,
             last_focused_tab: (0.into(), 0.into()),
@@ -523,7 +530,29 @@ impl App for TwixApp {
                                 }
                             })
                         });
-                    })
+                    });
+
+                    if ui
+                        .add(
+                            Button::new(RichText::new("STOP").color(Color32::WHITE))
+                                .fill(Color32::RED),
+                        )
+                        .clicked()
+                    {
+                        match self.injected_safe_pose.get_last_value() {
+                            Ok(Some(value)) => {
+                                let new_injected_safe_pose = value + 1;
+                                self.robot.write(
+                                    "parameters.injected_safe_pose",
+                                    TextOrBinary::Text(new_injected_safe_pose.into()),
+                                );
+                            }
+                            Ok(None) => {}
+                            Err(error) => {
+                                error!("failed to read injected_safe_pose: {error:#?}")
+                            }
+                        }
+                    }
                 });
             })
         });


### PR DESCRIPTION
## Why? What?
Adds a stop button in twix which sets the primary state to safe until the stand or f1 button is pressed. With this we can then stop the robot remotely during emergencies or scary behavior. 

## Ideas for Next Iterations (Not This PR)
- one maybe could go into dampening instead, since this would not harm the robot as much when it falls
- 
## How to Test

1. put the robot into any primary state but safe
2. put the robot in a safe position 
3. press stop