### PR TITLE
Create log directory before writing to it

### DIFF
--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -6,6 +6,8 @@ INTERNAL_LOG_PATH="/home/booster/hulk/logs/${CURRENT_DATE}"
 
 mkdir -p "${INTERNAL_LOG_PATH}"
 ln -sfn "${INTERNAL_LOG_PATH}" "/home/booster/hulk/logs/latest"
+touch "${INTERNAL_LOG_PATH}/hulk.out" "${INTERNAL_LOG_PATH}/hulk.err"
+chown -R booster:booster /home/booster/hulk/logs
 
 /usr/local/bin/podman exec \
   --env RUST_BACKTRACE=1 \

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -13,8 +13,7 @@ chown -R booster:booster /home/booster/hulk/logs
   --env RUST_BACKTRACE=1 \
   --user 1000 \
   hulk \
-  bash -c "
-    exec /home/booster/hulk/bin/hulk_booster --log-path \"${INTERNAL_LOG_PATH}\"
-  " \
+  /home/booster/hulk/bin/hulk_booster \
+    --log-path "${INTERNAL_LOG_PATH}" \
   > >(tee "${INTERNAL_LOG_PATH}/hulk.out") \
   2> >(tee "${INTERNAL_LOG_PATH}/hulk.err")

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -4,13 +4,14 @@ set -euo pipefail
 CURRENT_DATE="$(date +%Y-%m-%dT%H:%M:%S.%3N%:z)"
 INTERNAL_LOG_PATH="/home/booster/hulk/logs/${CURRENT_DATE}"
 
+mkdir -p "${INTERNAL_LOG_PATH}"
+ln -sfn "${INTERNAL_LOG_PATH}" "/home/booster/hulk/logs/latest"
+
 /usr/local/bin/podman exec \
   --env RUST_BACKTRACE=1 \
   --user 1000 \
   hulk \
   bash -c "
-    mkdir -p \"${INTERNAL_LOG_PATH}\"
-    ln -sfn \"${INTERNAL_LOG_PATH}\" \"/home/booster/hulk/logs/latest\"
     exec /home/booster/hulk/bin/hulk_booster --log-path \"${INTERNAL_LOG_PATH}\"
   " \
   > >(tee "${INTERNAL_LOG_PATH}/hulk.out") \


### PR DESCRIPTION
## Why? What?

Fixes an issue introduced in #2280. Since that was merged, the log directory with the timestamp was created after the `tee`s tried to write to it, causing them to emit an error message but no log files being created.

- Fixes  #

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

- Gammaray a robot with the new launch-hulk script
- Restart hulk service and see the logs being created correctly