### PR TITLE
Query booster's user id instead of hardcoding it

### DIFF
--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -11,7 +11,7 @@ chown -R booster:booster /home/booster/hulk/logs
 
 /usr/local/bin/podman exec \
   --env RUST_BACKTRACE=1 \
-  --user 1000 \
+  --user $(id -u booster) \
   hulk \
   /home/booster/hulk/bin/hulk_booster \
     --log-path "${INTERNAL_LOG_PATH}" \


### PR DESCRIPTION
## Why? What?

What it says.
The `booster` user has a different user ID on PeterFox than on the robots.

- Fixes #

## ToDo / Known Issues


## Ideas for Next Iterations (Not This PR)


## How to Test

gammaray then upload to peter fox.