### PR TITLE
Bump K1 firmware to 1.5.3

### DIFF
--- a/hulk.toml
+++ b/hulk.toml
@@ -1,2 +1,2 @@
-os_version = "v1.5.2.1-release-0801-2026-02-28"
+os_version = "v1.5.3.0-release-1174-2026-03-20"
 sdk_version = "1.0.0"


### PR DESCRIPTION
## Why? What?

Update hulk.toml os_version to 1.5.3 that matches the currently installed firmware on both robots.
