### PR TITLE
Use Heatmap in Searcher Subtree

### DIFF
--- a/crates/world_state/src/behavior/action.rs
+++ b/crates/world_state/src/behavior/action.rs
@@ -1,4 +1,3 @@
-use linear_algebra::vector;
 use types::{behavior_tree::Status, motion_command::BodyMotion};
 
 use crate::behavior::node::Blackboard;
@@ -10,14 +9,6 @@ pub fn injected_motion_command(blackboard: &mut Blackboard) -> Status {
     } else {
         Status::Failure
     }
-}
-
-pub fn leuchtturm(blackboard: &mut Blackboard) -> Status {
-    blackboard.body_motion = Some(BodyMotion::WalkWithVelocity {
-        velocity: vector!(0.0, 0.0),
-        angular_velocity: 1.0,
-    });
-    Status::Success
 }
 
 pub fn prepare(blackboard: &mut Blackboard) -> Status {

--- a/crates/world_state/src/behavior/condition.rs
+++ b/crates/world_state/src/behavior/condition.rs
@@ -78,3 +78,10 @@ pub fn has_ball_position(blackboard: &mut Blackboard) -> bool {
 pub fn has_new_ball_position(blackboard: &mut Blackboard) -> bool {
     blackboard.world_state.ball.is_some()
 }
+
+pub fn has_hypothetical_ball_position(blackboard: &mut Blackboard) -> bool {
+    !blackboard
+        .world_state
+        .hypothetical_ball_positions
+        .is_empty()
+}

--- a/crates/world_state/src/behavior/head.rs
+++ b/crates/world_state/src/behavior/head.rs
@@ -5,13 +5,27 @@ use types::{
 
 use crate::{
     action,
-    behavior::{behavior_tree::Node, condition::has_new_ball_position, node::Blackboard},
-    condition, selection, sequence,
+    behavior::{
+        behavior_tree::Node,
+        condition::{has_hypothetical_ball_position, has_new_ball_position},
+        node::Blackboard,
+    },
+    condition, selection, sequence, subtree,
 };
 
 pub fn look_at_ball_subtree() -> Node<Blackboard> {
     selection!(
         sequence!(condition!(has_new_ball_position), action!(look_at_ball)),
+        subtree!(search_for_lost_ball_subtree)
+    )
+}
+
+pub fn search_for_lost_ball_subtree() -> Node<Blackboard> {
+    selection!(
+        sequence!(
+            condition!(has_hypothetical_ball_position),
+            action!(look_at_hypothetical_ball_position)
+        ),
         action!(search_for_lost_ball)
     )
 }
@@ -38,4 +52,21 @@ pub fn look_straight_ahead(blackboard: &mut Blackboard) -> Status {
         image_region_target: ImageRegion::Center,
     });
     Status::Success
+}
+
+pub fn look_at_hypothetical_ball_position(blackboard: &mut Blackboard) -> Status {
+    let best_hypothetical_ball_position = blackboard
+        .world_state
+        .hypothetical_ball_positions
+        .iter()
+        .max_by(|a, b| a.validity.total_cmp(&b.validity));
+    if let Some(hypothesis) = best_hypothetical_ball_position {
+        blackboard.head_motion = Some(HeadMotion::LookAt {
+            target: hypothesis.position,
+            image_region_target: ImageRegion::Center,
+        });
+        Status::Success
+    } else {
+        Status::Failure
+    }
 }

--- a/crates/world_state/src/behavior/mod.rs
+++ b/crates/world_state/src/behavior/mod.rs
@@ -5,6 +5,7 @@ pub mod head;
 pub mod kick;
 pub mod motion_assembler;
 pub mod node;
+pub mod search;
 pub mod switch_motion_type;
 pub mod tree;
 pub mod walk;

--- a/crates/world_state/src/behavior/search.rs
+++ b/crates/world_state/src/behavior/search.rs
@@ -4,7 +4,7 @@ use types::{
     motion_command::{BodyMotion, OrientationMode},
 };
 
-use crate::behavior::{node::Blackboard, walk_actions::walk_to};
+use crate::behavior::{node::Blackboard, walk::walk_to};
 
 pub fn has_suggested_search_position(blackboard: &mut Blackboard) -> bool {
     blackboard.world_state.suggested_search_position.is_some()

--- a/crates/world_state/src/behavior/search.rs
+++ b/crates/world_state/src/behavior/search.rs
@@ -1,0 +1,42 @@
+use linear_algebra::{Pose2, vector};
+use types::{
+    behavior_tree::Status,
+    motion_command::{BodyMotion, OrientationMode},
+};
+
+use crate::behavior::{node::Blackboard, walk_actions::walk_to};
+
+pub fn has_suggested_search_position(blackboard: &mut Blackboard) -> bool {
+    blackboard.world_state.suggested_search_position.is_some()
+}
+
+pub fn leuchtturm(blackboard: &mut Blackboard) -> Status {
+    blackboard.body_motion = Some(BodyMotion::WalkWithVelocity {
+        velocity: vector!(0.0, 0.0),
+        angular_velocity: 1.0,
+    });
+    Status::Success
+}
+
+pub fn walk_to_search_position(blackboard: &mut Blackboard) -> Status {
+    if let (Some(search_position), Some(ground_to_field)) = (
+        blackboard.world_state.suggested_search_position,
+        blackboard.world_state.robot.ground_to_field,
+    ) {
+        let search_position_in_ground = ground_to_field.inverse() * search_position;
+
+        return walk_to(
+            blackboard,
+            Pose2::from(search_position_in_ground),
+            blackboard.parameters.walk_speed.search,
+            OrientationMode::AlignWithPath,
+            blackboard
+                .parameters
+                .walk_and_stand
+                .normal_distance_to_be_aligned,
+            blackboard.parameters.walk_and_stand.hysteresis,
+        );
+    }
+
+    Status::Failure
+}

--- a/crates/world_state/src/behavior/tree.rs
+++ b/crates/world_state/src/behavior/tree.rs
@@ -9,7 +9,7 @@ use crate::{
             has_ball_position, is_ball_interception_candidate, is_close_to_ball,
             is_closest_to_ball, is_fallen, is_goalkeeper, is_primary_state,
         },
-        head::{look_at_ball_subtree, look_straight_ahead, search_for_lost_ball},
+        head::{look_at_ball_subtree, look_straight_ahead, search_for_lost_ball_subtree},
         kick::{intercept, kick_subtree},
         node::Blackboard,
         search::{has_suggested_search_position, leuchtturm, walk_to_search_position},
@@ -80,7 +80,7 @@ fn goalkeeper_subtree() -> Node<Blackboard> {
 
 fn search_subtree() -> Node<Blackboard> {
     sequence!(
-        action!(search_for_lost_ball),
+        subtree!(search_for_lost_ball_subtree),
         switch_motion_type(
             MotionType::Walk,
             selection!(

--- a/crates/world_state/src/behavior/tree.rs
+++ b/crates/world_state/src/behavior/tree.rs
@@ -3,7 +3,7 @@ use types::{motion_type::MotionType, primary_state::PrimaryState};
 use crate::{
     action,
     behavior::{
-        action::{injected_motion_command, leuchtturm, prepare, stand, stand_up},
+        action::{injected_motion_command, prepare, stand, stand_up},
         behavior_tree::Node,
         condition::{
             has_ball_position, is_ball_interception_candidate, is_close_to_ball,
@@ -12,6 +12,7 @@ use crate::{
         head::{look_at_ball_subtree, look_straight_ahead, search_for_lost_ball},
         kick::{intercept, kick_subtree},
         node::Blackboard,
+        search::{has_suggested_search_position, leuchtturm, walk_to_search_position},
         switch_motion_type::switch_motion_type,
         walk::{walk_alternatives_subtree, walk_to_ball},
     },
@@ -82,7 +83,13 @@ fn search_subtree() -> Node<Blackboard> {
         action!(search_for_lost_ball),
         switch_motion_type(
             MotionType::Walk,
-            action!(leuchtturm),
+            selection!(
+                sequence!(
+                    condition!(has_suggested_search_position),
+                    action!(walk_to_search_position)
+                ),
+                action!(leuchtturm)
+            ),
             subtree!(walk_alternatives_subtree),
         )
     )

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -1029,7 +1029,7 @@
   "search_suggestor": {
     "cells_per_meter": 2.0,
     "heatmap_convolution_kernel_weight": 0.001007049,
-    "minimum_validity": 0.01,
+    "minimum_validity": 0.1,
     "own_ball_weight": 1.0,
     "team_ball_weight": 1.0,
     "rule_ball_weight": 1.0


### PR DESCRIPTION
depends on #2436 

## Why? What?
improves the searcher subtree: When we now loose a ball we first go look a the warmest position on the heatmap before doing leuchtturm. We also look a potential ball hypothesis when loosing the ball. 

## Ideas for Next Iterations (Not This PR)

- introduce different ballsearch for the other roles

## How to Test

In Playing let the robot see the ball, remove it. The robot should now walk to the former location of the ball and do the leuchtturm at some point. You can also look at the map panel in twix with the ball search heatmap overlay.