### PR TITLE
Multi task yolo/fix training weight reuse

### DIFF
--- a/tools/machine-learning/multi-task-yolo/src/model/train.py
+++ b/tools/machine-learning/multi-task-yolo/src/model/train.py
@@ -24,7 +24,7 @@ DEVICE_EMPTY_ERROR = "must contain at least one device index, e.g. 0"
 class TrainingConfig:
     name: str | Path
     data: str | Path
-    project: str | Path = "runs"
+    project: str | Path
     freeze: int
     epochs: int
     device: int | str | list

--- a/tools/machine-learning/multi-task-yolo/src/model/train.py
+++ b/tools/machine-learning/multi-task-yolo/src/model/train.py
@@ -25,16 +25,17 @@ class TrainingConfig:
     name: str | Path
     data: str | Path
     project: str | Path = "runs"
-    epochs: int = 100
+    freeze: int
+    epochs: int
+    device: int | str | list
+    patience: int = 100
     imgsz: int = 640
     batch: int = 32
     optimizer: str = "auto"
-    freeze: int = 11
     plots: bool = True
     exist_ok: bool = True
     val: bool = True
     save: bool = True
-    device: int | str | list = -1
 
     def to_dict(self, **overrides: Any) -> dict[str, Any]:
         """
@@ -156,6 +157,13 @@ def do_hyperparameter_tuning(config: TrainingConfig, model_path: Path) -> Path:
     help="Device to be used by ultralytics. Example: -1, cuda, cpu, or [1,2].",
 )
 @click.option(
+    "--epochs",
+    default="100",
+    type=int,
+    show_default=True,
+    help="Number of epochs to train.",
+)
+@click.option(
     "--do-tuning",
     is_flag=True,
     default=False,
@@ -178,6 +186,7 @@ def main(
     runs_dir: Path,
     val_dir: Path,
     device: str,
+    epochs: int,
     do_tuning: bool,
     use_tuned_hyperparameters: bool,
 ) -> None:
@@ -263,6 +272,7 @@ def main(
             name=Path("train") / run_name,
             freeze=hydra_model.number_of_frozen_modules,
             device=device,
+            epochs=epochs,
         )
         config_dict = config.to_dict()
 

--- a/tools/machine-learning/multi-task-yolo/src/validation/validator.py
+++ b/tools/machine-learning/multi-task-yolo/src/validation/validator.py
@@ -110,6 +110,10 @@ def validate_hydra_model(
     )
     set_backbone(head_model, backbone, hydra_model.number_of_frozen_modules)
 
+    head_model_yolo_wrapper.save(
+        validation_run_folder / (str(hydra_model) + ".pt")
+    )
+
     head_model_yolo_wrapper.eval()
 
     metrics = head_model_yolo_wrapper.val(
@@ -118,10 +122,6 @@ def validate_hydra_model(
     metrics = cast(DetMetrics, metrics)
 
     save_validation_results(validation_run_folder, metrics.results_dict, config)
-
-    head_model_yolo_wrapper.save(
-        validation_run_folder / (str(hydra_model) + ".pt")
-    )
 
 
 @click.command()

--- a/tools/machine-learning/multi-task-yolo/src/validation/validator.py
+++ b/tools/machine-learning/multi-task-yolo/src/validation/validator.py
@@ -110,6 +110,9 @@ def validate_hydra_model(
     )
     set_backbone(head_model, backbone, hydra_model.number_of_frozen_modules)
 
+    if not validation_run_folder.exists():
+        validation_run_folder.mkdir(parents=True)
+
     head_model_yolo_wrapper.save(
         validation_run_folder / (str(hydra_model) + ".pt")
     )


### PR DESCRIPTION
## Why? What?

Fixed the loading and reuse of models generated by the `src/validator/validation.py`. Currently, the saving is done after the validation call. This changes the pytorch architecture for inference optimization, causing the saved model to be different architecturally, than the original model, resulting in the model weights not correctly being transferred during training. 
Now the model is saved before the validation call.
