### PR TITLE
Add Walk to Kickoff Behavior

### DIFF
--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -82,6 +82,7 @@ pub struct BehaviorParameters {
     pub path_planning: PathPlanningParameters,
     pub remote_control: RemoteControlParameters,
     pub role_positions: RolePositionsParameters,
+    pub kickoff_positions: KickOffPositionsParameters,
     pub search: SearchParameters,
     pub look_action: LookActionParameters,
     pub walk_and_stand: WalkAndStandParameters,
@@ -157,6 +158,25 @@ pub struct RolePositionsParameters {
     PathDeserialize,
     PathIntrospect,
     ros_z::Message,
+)]
+pub struct KickOffPositionsParameters {
+    pub one: Point2<Field>,
+    pub two: Point2<Field>,
+    pub three: Point2<Field>,
+    pub four: Point2<Field>,
+    pub five: Point2<Field>,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
 )]
 pub struct SearchParameters {
     pub position_reached_distance: f32,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -177,6 +177,7 @@ pub struct KickOffPositionsParameters {
     PathSerialize,
     PathDeserialize,
     PathIntrospect,
+    ros_z::Message,
 )]
 pub struct SearchParameters {
     pub position_reached_distance: f32,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -9,7 +9,7 @@ use coordinate_systems::{Camera, Field, Ground, NormalizedPixel, Pixel, Robot};
 use linear_algebra::{Point2, Vector2, Vector3};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
-use crate::{motion_command::MotionCommand, step::Step};
+use crate::{motion_command::MotionCommand, players::Players, step::Step};
 
 #[derive(
     Clone,
@@ -82,7 +82,7 @@ pub struct BehaviorParameters {
     pub path_planning: PathPlanningParameters,
     pub remote_control: RemoteControlParameters,
     pub role_positions: RolePositionsParameters,
-    pub kickoff_positions: KickOffPositionsParameters,
+    pub kickoff_positions: Players<KickOffPose>,
     pub search: SearchParameters,
     pub look_action: LookActionParameters,
     pub walk_and_stand: WalkAndStandParameters,
@@ -159,12 +159,9 @@ pub struct RolePositionsParameters {
     PathIntrospect,
     ros_z::Message,
 )]
-pub struct KickOffPositionsParameters {
-    pub one: Point2<Field>,
-    pub two: Point2<Field>,
-    pub three: Point2<Field>,
-    pub four: Point2<Field>,
-    pub five: Point2<Field>,
+pub struct KickOffPose {
+    pub position: Point2<Field>,
+    pub rotation: f32,
 }
 
 #[derive(

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -82,7 +82,7 @@ pub struct BehaviorParameters {
     pub path_planning: PathPlanningParameters,
     pub remote_control: RemoteControlParameters,
     pub role_positions: RolePositionsParameters,
-    pub kickoff_positions: Players<KickOffPose>,
+    pub standard_kickoff_positions: Players<KickOffPose>,
     pub search: SearchParameters,
     pub look_action: LookActionParameters,
     pub walk_and_stand: WalkAndStandParameters,

--- a/crates/world_state/src/behavior/condition.rs
+++ b/crates/world_state/src/behavior/condition.rs
@@ -1,6 +1,9 @@
 use filtering::hysteresis::less_than_with_hysteresis;
+use hsl_network_messages::Team;
 use linear_algebra::{point, vector};
-use types::primary_state::PrimaryState;
+use types::{
+    filtered_game_controller_state::FilteredGameControllerState, primary_state::PrimaryState,
+};
 
 use crate::behavior::node::Blackboard;
 
@@ -125,4 +128,14 @@ pub fn has_hypothetical_ball_position(blackboard: &mut Blackboard) -> bool {
         .world_state
         .hypothetical_ball_positions
         .is_empty()
+}
+
+pub fn hulks_is_kicking_team(blackboard: &mut Blackboard) -> bool {
+    matches!(
+        blackboard.world_state.filtered_game_controller_state,
+        Some(FilteredGameControllerState {
+            kicking_team: Some(Team::Hulks),
+            ..
+        })
+    )
 }

--- a/crates/world_state/src/behavior/substates.rs
+++ b/crates/world_state/src/behavior/substates.rs
@@ -1,4 +1,4 @@
-use hsl_network_messages::{SubState, Team};
+use hsl_network_messages::SubState;
 use linear_algebra::{Rotation2, point};
 use types::{
     behavior_tree::Status, field_dimensions::Side,
@@ -9,7 +9,7 @@ use crate::{
     action,
     behavior::{
         behavior_tree::Node,
-        condition::is_close_to_ball_aligned,
+        condition::{hulks_is_kicking_team, is_close_to_ball_aligned},
         kick::kick_subtree,
         node::Blackboard,
         walk::{walk_to_ball_subtree, walk_to_block_position},
@@ -72,16 +72,6 @@ pub fn is_sub_state(blackboard: &mut Blackboard, sub_state: SubState) -> bool {
             sub_state: Some(current_sub_state),
             ..
         }) if current_sub_state == sub_state
-    )
-}
-
-pub fn hulks_is_kicking_team(blackboard: &mut Blackboard) -> bool {
-    matches!(
-        blackboard.world_state.filtered_game_controller_state,
-        Some(FilteredGameControllerState {
-            kicking_team: Some(Team::Hulks),
-            ..
-        })
     )
 }
 

--- a/crates/world_state/src/behavior/tree.rs
+++ b/crates/world_state/src/behavior/tree.rs
@@ -16,7 +16,9 @@ use crate::{
         substates::{is_in_sub_state, sub_state_subtree},
         switch_motion_type::switch_motion_type,
         voronoi::calculate_voronoi_grid,
-        walk::{walk_alternatives_subtree, walk_to_ball_subtree, walk_to_centroid},
+        walk::{
+            walk_alternatives_subtree, walk_to_ball_subtree, walk_to_centroid, walk_to_kickoff_pose,
+        },
     },
     condition, negation, selection, sequence, subtree,
 };
@@ -66,7 +68,7 @@ pub fn create_tree() -> Node<Blackboard> {
 }
 
 fn ready_subtree() -> Node<Blackboard> {
-    sequence!(subtree!(look_at_ball_subtree), action!(stand))
+    sequence!(action!(walk_to_kickoff_pose))
 }
 
 fn playing_subtree() -> Node<Blackboard> {

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -212,15 +212,21 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
     ) {
         let field_to_ground = ground_to_field.inverse();
 
-        let mut target_position = blackboard.parameters.kickoff_positions[player_number].position;
+        let mut target_position =
+            blackboard.parameters.standard_kickoff_positions[player_number].position;
 
         if hulks_is_kicking_team(blackboard) && player_number == PlayerNumber::Three {
-            target_position = point!(-0.5, 0.0);
+            target_position = blackboard
+                .parameters
+                .role_positions
+                .striker_kickoff_position;
         }
 
         let kickoff_pose_in_field = Pose2::from_parts(
             target_position,
-            Orientation2::new(blackboard.parameters.kickoff_positions[player_number].rotation),
+            Orientation2::new(
+                blackboard.parameters.standard_kickoff_positions[player_number].rotation,
+            ),
         );
 
         let kickoff_pose_in_ground = field_to_ground * kickoff_pose_in_field;

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -215,17 +215,19 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
         let mut target_position = blackboard.parameters.kickoff_positions[player_number].position;
 
         if hulks_is_kicking_team(blackboard) && player_number == PlayerNumber::Three {
-            target_position = point!(0.0, -0.5);
+            target_position = point!(-0.5, 0.0);
         }
 
-        let tragtet_in_ground = field_to_ground * target_position;
+        let kickoff_pose_in_field = Pose2::from_parts(
+            target_position,
+            Orientation2::new(blackboard.parameters.kickoff_positions[player_number].rotation),
+        );
+
+        let kickoff_pose_in_ground = field_to_ground * kickoff_pose_in_field;
 
         walk_to(
             blackboard,
-            Pose2::from_parts(
-                tragtet_in_ground,
-                Orientation2::new(blackboard.parameters.kickoff_positions[player_number].rotation),
-            ),
+            kickoff_pose_in_ground,
             blackboard.parameters.walk_speed.kicking,
             OrientationMode::AlignWithPath,
             blackboard

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -212,20 +212,20 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
     ) {
         let field_to_ground = ground_to_field.inverse();
 
-        let target_position = match (player_number, hulks_is_kicking_team(blackboard)) {
-            (PlayerNumber::One, _) => blackboard.parameters.kickoff_positions.one,
-            (PlayerNumber::Two, _) => blackboard.parameters.kickoff_positions.two,
-            (PlayerNumber::Three, false) => blackboard.parameters.kickoff_positions.three,
-            (PlayerNumber::Three, true) => point!(0.0, -0.5),
-            (PlayerNumber::Four, _) => blackboard.parameters.kickoff_positions.four,
-            (PlayerNumber::Five, _) => blackboard.parameters.kickoff_positions.five,
-        };
+        let mut target_position = blackboard.parameters.kickoff_positions[player_number].position;
+
+        if hulks_is_kicking_team(blackboard) && player_number == PlayerNumber::Three {
+            target_position = point!(0.0, -0.5);
+        }
 
         let tragtet_in_ground = field_to_ground * target_position;
 
         walk_to(
             blackboard,
-            Pose2::from_parts(tragtet_in_ground, field_to_ground.orientation()),
+            Pose2::from_parts(
+                tragtet_in_ground,
+                Orientation2::new(blackboard.parameters.kickoff_positions[player_number].rotation),
+            ),
             blackboard.parameters.walk_speed.kicking,
             OrientationMode::AlignWithPath,
             blackboard

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -1,5 +1,6 @@
 use coordinate_systems::{Field, Ground};
 use filtering::hysteresis::less_than_with_relative_hysteresis;
+use hsl_network_messages::PlayerNumber;
 use linear_algebra::{Isometry2, Orientation2, Point, Point2, Pose2, point};
 use types::{
     behavior_tree::Status,
@@ -201,6 +202,36 @@ pub fn walk_to_block_position(blackboard: &mut Blackboard) -> Status {
     } else {
         Status::Failure
     }
+}
+
+pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
+    let ground_to_field = match blackboard.world_state.robot.ground_to_field {
+        Some(transform) => transform,
+        None => return Status::Failure,
+    };
+    let field_to_ground = ground_to_field.inverse();
+
+    let target_position = match blackboard.world_state.robot.player_number {
+        PlayerNumber::One => blackboard.parameters.kickoff_positions.one,
+        PlayerNumber::Two => blackboard.parameters.kickoff_positions.two,
+        PlayerNumber::Three => blackboard.parameters.kickoff_positions.three,
+        PlayerNumber::Four => blackboard.parameters.kickoff_positions.four,
+        PlayerNumber::Five => blackboard.parameters.kickoff_positions.five,
+    };
+    let tragtet_in_ground = field_to_ground * target_position;
+
+    walk_to(
+        blackboard,
+        Pose2::from_parts(tragtet_in_ground, field_to_ground.orientation()),
+        blackboard.parameters.walk_speed.kicking,
+        OrientationMode::AlignWithPath,
+        blackboard
+            .parameters
+            .walk_and_stand
+            .normal_distance_to_be_aligned,
+        blackboard.parameters.walk_and_stand.hysteresis,
+    );
+    Status::Success
 }
 
 pub fn walk_to_centroid(blackboard: &mut Blackboard) -> Status {

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -206,38 +206,38 @@ pub fn walk_to_block_position(blackboard: &mut Blackboard) -> Status {
 }
 
 pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
-    let ground_to_field = match blackboard.world_state.robot.ground_to_field {
-        Some(transform) => transform,
-        None => return Status::Failure,
-    };
-    let field_to_ground = ground_to_field.inverse();
-
-    let target_position = match (
+    if let (Some(ground_to_field), player_number) = (
+        blackboard.world_state.robot.ground_to_field,
         blackboard.world_state.robot.player_number,
-        hulks_is_kicking_team(blackboard),
     ) {
-        (PlayerNumber::One, _) => blackboard.parameters.kickoff_positions.one,
-        (PlayerNumber::Two, _) => blackboard.parameters.kickoff_positions.two,
-        (PlayerNumber::Three, false) => blackboard.parameters.kickoff_positions.three,
-        (PlayerNumber::Three, true) => point!(0.0, -0.5),
-        (PlayerNumber::Four, _) => blackboard.parameters.kickoff_positions.four,
-        (PlayerNumber::Five, _) => blackboard.parameters.kickoff_positions.five,
-    };
+        let field_to_ground = ground_to_field.inverse();
 
-    let tragtet_in_ground = field_to_ground * target_position;
+        let target_position = match (player_number, hulks_is_kicking_team(blackboard)) {
+            (PlayerNumber::One, _) => blackboard.parameters.kickoff_positions.one,
+            (PlayerNumber::Two, _) => blackboard.parameters.kickoff_positions.two,
+            (PlayerNumber::Three, false) => blackboard.parameters.kickoff_positions.three,
+            (PlayerNumber::Three, true) => point!(0.0, -0.5),
+            (PlayerNumber::Four, _) => blackboard.parameters.kickoff_positions.four,
+            (PlayerNumber::Five, _) => blackboard.parameters.kickoff_positions.five,
+        };
 
-    walk_to(
-        blackboard,
-        Pose2::from_parts(tragtet_in_ground, field_to_ground.orientation()),
-        blackboard.parameters.walk_speed.kicking,
-        OrientationMode::AlignWithPath,
-        blackboard
-            .parameters
-            .walk_and_stand
-            .normal_distance_to_be_aligned,
-        blackboard.parameters.walk_and_stand.hysteresis,
-    );
-    Status::Success
+        let tragtet_in_ground = field_to_ground * target_position;
+
+        walk_to(
+            blackboard,
+            Pose2::from_parts(tragtet_in_ground, field_to_ground.orientation()),
+            blackboard.parameters.walk_speed.kicking,
+            OrientationMode::AlignWithPath,
+            blackboard
+                .parameters
+                .walk_and_stand
+                .normal_distance_to_be_aligned,
+            blackboard.parameters.walk_and_stand.hysteresis,
+        );
+        Status::Success
+    } else {
+        Status::Failure
+    }
 }
 
 pub fn walk_to_centroid(blackboard: &mut Blackboard) -> Status {

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -14,6 +14,7 @@ use crate::{
     behavior::{
         action::stand,
         behavior_tree::Node,
+        condition::hulks_is_kicking_team,
         kick::{kick, select_kick_target, use_last_kick_power},
         node::Blackboard,
         switch_motion_type::{is_last_motion_type, switch_motion_type},
@@ -211,13 +212,18 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
     };
     let field_to_ground = ground_to_field.inverse();
 
-    let target_position = match blackboard.world_state.robot.player_number {
-        PlayerNumber::One => blackboard.parameters.kickoff_positions.one,
-        PlayerNumber::Two => blackboard.parameters.kickoff_positions.two,
-        PlayerNumber::Three => blackboard.parameters.kickoff_positions.three,
-        PlayerNumber::Four => blackboard.parameters.kickoff_positions.four,
-        PlayerNumber::Five => blackboard.parameters.kickoff_positions.five,
+    let target_position = match (
+        blackboard.world_state.robot.player_number,
+        hulks_is_kicking_team(blackboard),
+    ) {
+        (PlayerNumber::One, _) => blackboard.parameters.kickoff_positions.one,
+        (PlayerNumber::Two, _) => blackboard.parameters.kickoff_positions.two,
+        (PlayerNumber::Three, false) => blackboard.parameters.kickoff_positions.three,
+        (PlayerNumber::Three, true) => point!(0.0, -0.5),
+        (PlayerNumber::Four, _) => blackboard.parameters.kickoff_positions.four,
+        (PlayerNumber::Five, _) => blackboard.parameters.kickoff_positions.five,
     };
+
     let tragtet_in_ground = field_to_ground * target_position;
 
     walk_to(

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -465,6 +465,13 @@
       "striker_distance_to_non_free_center_circle": 0.4,
       "striker_kickoff_position": [-0.21, 0.03]
     },
+    "kickoff_positions": {
+      "one": [-3.5, 1],
+      "two": [-3, 0.5],
+      "three": [-2, 0],
+      "four": [-2.5, -1.5],
+      "five": [-2.5, 1.5]
+    },
     "lost_ball": {
       "offset_to_last_ball_location": [1.0, 0.0]
     },

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -466,11 +466,11 @@
       "striker_kickoff_position": [-0.21, 0.03]
     },
     "kickoff_positions": {
-      "one": [-3.5, 1],
-      "two": [-3, 0.5],
-      "three": [-2, 0],
-      "four": [-2.5, -1.5],
-      "five": [-2.5, 1.5]
+      "one": { "position": [-3.5, 1], "rotation": 0 },
+      "two": { "position": [-3, 0.5], "rotation": 0 },
+      "three": { "position": [-2, 0], "rotation": 0 },
+      "four": { "position": [-2.5, -1.5], "rotation": 0 },
+      "five": { "position": [-2.5, 1.5], "rotation": 0 }
     },
     "lost_ball": {
       "offset_to_last_ball_location": [1.0, 0.0]

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -463,14 +463,14 @@
       "keeper_x_offset": 0.1,
       "keeper_passive_distance": 4.5,
       "striker_distance_to_non_free_center_circle": 0.4,
-      "striker_kickoff_position": [-0.21, 0.03]
+      "striker_kickoff_position": [-0.5, 0.0]
     },
-    "kickoff_positions": {
-      "one": { "position": [-3.5, 1], "rotation": 0 },
-      "two": { "position": [-3, 0.5], "rotation": 0 },
+    "standard_kickoff_positions": {
+      "one": { "position": [-3.5, 0.5], "rotation": 0 },
+      "two": { "position": [-3, -0.5], "rotation": 0 },
       "three": { "position": [-2, 0], "rotation": 0 },
-      "four": { "position": [-2.5, -1.5], "rotation": 0 },
-      "five": { "position": [-2.5, 1.5], "rotation": 0 }
+      "four": { "position": [-2.5, -1.5], "rotation": 0.4 },
+      "five": { "position": [-2.5, 1.5], "rotation": -0.4 }
     },
     "lost_ball": {
       "offset_to_last_ball_location": [1.0, 0.0]

--- a/etc/parameters/ros_z/base/behavior_node.json5
+++ b/etc/parameters/ros_z/base/behavior_node.json5
@@ -76,7 +76,14 @@
     keeper_x_offset: 0.1,
     keeper_passive_distance: 4.5,
     striker_distance_to_non_free_center_circle: 0.4,
-    striker_kickoff_position: [-0.21, 0.03],
+    striker_kickoff_position: [-0.5, 0.0],
+  },
+  standard_kickoff_positions: {
+    one: { position: [-3.5, 0.5], rotation: 0 },
+    two: { position: [-3, -0.5], rotation: 0 },
+    three: { position: [-2, 0], rotation: 0 },
+    four: { position: [-2.5, -1.5], rotation: 0.4 },
+    five: { position: [-2.5, 1.5], rotation: -0.4 },
   },
   lost_ball: {
     offset_to_last_ball_location: [1.0, 0.0],
@@ -102,14 +109,14 @@
     distance_to_look_directly_at_the_ball: 4.0,
     kick_target_offset_angle: 0.1,
     target_distance_kick_power_threshold: 4.0,
-    kick_position_ball_distance: 0.3
+    kick_position_ball_distance: 0.3,
   },
   substates: {
     distance_for_kick: 0.4,
     distance_for_kick_hysteresis: 0.2,
     alignment_angle_threshold: 0.4,
     blocking_distance_offset: 0.2,
-    corner_kick_blocking_angle: 0.78
+    corner_kick_blocking_angle: 0.78,
   },
   maximum_lookaround_duration: { nanos: 0, secs: 50 },
   look_action: {


### PR DESCRIPTION
## Why? What?

The behaviour-tree is extended to handle the game-state ready. The players walk to their Kick-off poses, to be rule conform and have a better start of the game. Player 3 is placed depending on the kicking team, as he is sometimes allowed to be in the centre circle.

- Fixes #2447

## ToDo / Known Issues



## Ideas for Next Iterations (Not This PR)

- choose the pose dynamicly

## How to Test

Use a robot and a gamecontroller at a field.
