### PR TITLE
Require ros-z attachment metadata

### DIFF
--- a/crates/ros-z-streams/src/announce.rs
+++ b/crates/ros-z-streams/src/announce.rs
@@ -229,6 +229,6 @@ mod tests {
                 .await
                 .expect("timeout waiting for payload")
                 .expect("receive payload");
-        assert_eq!(received_payload.publication_id(), Some(publication_id));
+        assert_eq!(received_payload.publication_id(), publication_id);
     }
 }

--- a/crates/ros-z-streams/src/future_queue.rs
+++ b/crates/ros-z-streams/src/future_queue.rs
@@ -16,7 +16,7 @@ type PublicationKey = (EndpointGlobalId, i64);
 const MAX_UNMATCHED_PUBLICATIONS: usize = 128;
 
 struct PendingData<T> {
-    source_time: Option<Time>,
+    source_time: Time,
     value: T,
 }
 
@@ -53,8 +53,6 @@ pub enum LagPolicy {
 /// Diagnostic warning emitted while deriving queue state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LagWarning {
-    /// Metadata did not contain source timestamp.
-    SourceTimeMissing,
     /// Measured lag exceeded configured watermark cap and was clamped.
     LagExceeded {
         /// Measured lag from source timestamp and announcement timestamp.
@@ -136,22 +134,15 @@ where
 
     fn update_reference_time(
         &mut self,
-        source_time: Option<Time>,
+        source_time: Time,
         announcement_time: Option<Time>,
     ) -> Option<LagWarning> {
         match self.lag_policy {
             LagPolicy::Immediate => {
-                if let Some(source_time) = source_time {
-                    self.reference_time = source_time;
-                }
+                self.reference_time = source_time;
                 None
             }
             LagPolicy::Watermark { max_lag } => {
-                let source_time = match source_time {
-                    Some(source_time) => source_time,
-                    None => return Some(LagWarning::SourceTimeMissing),
-                };
-
                 self.reference_time = source_time;
                 if let Some(announcement_time) = announcement_time {
                     let measured = source_time.duration_since(announcement_time);
@@ -172,7 +163,7 @@ where
     fn register_announcement(
         &mut self,
         announcement: Announcement,
-        source_time: Option<Time>,
+        source_time: Time,
     ) -> Option<LagWarning> {
         let publication_key = (announcement.source_global_id, announcement.sequence_number);
         if announcement.canceled {
@@ -253,10 +244,11 @@ where
                     let mut warning = self.ingest_pending_announcements().await?;
                     warning = warning.or(self.update_reference_time(received.source_time, None));
 
-                    let publication_id = received
-                        .publication_id()
-                        .ok_or_else(|| zenoh::Error::from("received data without attachment publication id"))?;
-                    let publication_key = (publication_id.endpoint_global_id(), publication_id.sequence_number());
+                    let publication_id = received.publication_id();
+                    let publication_key = (
+                        publication_id.endpoint_global_id(),
+                        publication_id.sequence_number(),
+                    );
 
                     if let Some(data_time) = self.inflight.remove(&publication_key) {
                         return Ok(QueueEvent::Data {
@@ -471,7 +463,7 @@ mod tests {
             pending_data.insert(
                 ([index as u8; 16], index),
                 PendingData {
-                    source_time: None,
+                    source_time: Time::from_nanos(index),
                     value: format!("payload {index}"),
                 },
             );

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -316,7 +316,6 @@ impl Node {
             session: self.session.clone(),
             graph: self.graph.clone(),
             clock: self.clock.clone(),
-            attachment: true,
             shm_config: self.shm_config.clone(),
             dyn_schema: None,
             _phantom_data: Default::default(),

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -116,9 +116,9 @@ mod tests {
         let received = Received {
             message: vec![1_u8, 2, 3],
             transport_time: None,
-            source_time: None,
-            sequence_number: None,
-            source_global_id: None,
+            source_time: crate::time::Time::from_nanos(0),
+            sequence_number: 1,
+            source_global_id: [0; 16],
         };
 
         assert_eq!(received.len(), 3);

--- a/crates/ros-z/src/pubsub/metadata.rs
+++ b/crates/ros-z/src/pubsub/metadata.rs
@@ -49,31 +49,31 @@ pub(super) fn publication_id_from_sample(sample: &Sample) -> Option<PublicationI
         })
 }
 
-pub(super) fn required_attachment_from_sample(sample: &Sample) -> zenoh::Result<Attachment> {
-    let raw = sample
-        .attachment()
-        .ok_or_else(|| zenoh::Error::from("received ros-z sample without attachment metadata"))?;
-
-    Attachment::try_from(raw).map_err(|error| {
-        zenoh::Error::from(format!(
-            "failed to decode ros-z attachment metadata: {error}"
-        ))
-    })
-}
-
 impl<T> Received<T> {
-    pub(super) fn from_sample(sample: &Sample, message: T, attachment: Attachment) -> Self {
+    pub(super) fn try_from_sample(sample: &Sample, message: T) -> zenoh::Result<Self> {
         let transport_time = sample
             .timestamp()
             .map(|ts| Time::from_wallclock(ts.get_time().to_system_time()));
 
-        Self {
+        let attachment = {
+            let raw = sample.attachment().ok_or_else(|| {
+                zenoh::Error::from("received ros-z sample without attachment metadata")
+            })?;
+
+            Attachment::try_from(raw).map_err(|error| {
+                zenoh::Error::from(format!(
+                    "failed to decode ros-z attachment metadata: {error}"
+                ))
+            })
+        }?;
+
+        Ok(Self {
             message,
             transport_time,
             source_time: attachment.source_time(),
             sequence_number: attachment.sequence_number,
             source_global_id: attachment.source_global_id,
-        }
+        })
     }
 
     pub fn message(&self) -> &T {

--- a/crates/ros-z/src/pubsub/metadata.rs
+++ b/crates/ros-z/src/pubsub/metadata.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 
-use tracing::warn;
 use zenoh::sample::Sample;
 
 use crate::attachment::{Attachment, EndpointGlobalId};
@@ -12,9 +11,9 @@ use crate::time::Time;
 pub struct Received<T> {
     pub message: T,
     pub transport_time: Option<Time>,
-    pub source_time: Option<Time>,
-    pub sequence_number: Option<i64>,
-    pub source_global_id: Option<EndpointGlobalId>,
+    pub source_time: Time,
+    pub sequence_number: i64,
+    pub source_global_id: EndpointGlobalId,
 }
 
 /// Unique identifier for one publication emitted by a specific publisher.
@@ -50,29 +49,30 @@ pub(super) fn publication_id_from_sample(sample: &Sample) -> Option<PublicationI
         })
 }
 
+pub(super) fn required_attachment_from_sample(sample: &Sample) -> zenoh::Result<Attachment> {
+    let raw = sample
+        .attachment()
+        .ok_or_else(|| zenoh::Error::from("received ros-z sample without attachment metadata"))?;
+
+    Attachment::try_from(raw).map_err(|error| {
+        zenoh::Error::from(format!(
+            "failed to decode ros-z attachment metadata: {error}"
+        ))
+    })
+}
+
 impl<T> Received<T> {
-    pub(super) fn from_sample(sample: &Sample, message: T) -> Self {
+    pub(super) fn from_sample(sample: &Sample, message: T, attachment: Attachment) -> Self {
         let transport_time = sample
             .timestamp()
             .map(|ts| Time::from_wallclock(ts.get_time().to_system_time()));
 
-        let attachment = match sample.attachment() {
-            Some(raw) => match Attachment::try_from(raw) {
-                Ok(attachment) => Some(attachment),
-                Err(err) => {
-                    warn!("[SUB] Failed to decode attachment metadata: {}", err);
-                    None
-                }
-            },
-            None => None,
-        };
-
         Self {
             message,
             transport_time,
-            source_time: attachment.as_ref().map(Attachment::source_time),
-            sequence_number: attachment.as_ref().map(|att| att.sequence_number),
-            source_global_id: attachment.as_ref().map(|att| att.source_global_id),
+            source_time: attachment.source_time(),
+            sequence_number: attachment.sequence_number,
+            source_global_id: attachment.source_global_id,
         }
     }
 
@@ -85,13 +85,8 @@ impl<T> Received<T> {
     }
 
     /// Return the publication id carried in transport attachment metadata.
-    pub fn publication_id(&self) -> Option<PublicationId> {
-        match (self.source_global_id, self.sequence_number) {
-            (Some(source_global_id), Some(sequence_number)) => {
-                Some(PublicationId::new(source_global_id, sequence_number))
-            }
-            _ => None,
-        }
+    pub fn publication_id(&self) -> PublicationId {
+        PublicationId::new(self.source_global_id, self.sequence_number)
     }
 }
 

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -50,7 +50,6 @@ pub struct Publisher<T, C: WireEncoder = <T as crate::Message>::Codec> {
     endpoint_global_id: EndpointGlobalId,
     inner: zenoh::pubsub::Publisher<'static>,
     _lv_token: LivelinessToken,
-    attachment: bool,
     clock: Clock,
     events_mgr: Arc<Mutex<EventsManager>>,
     shm_config: Option<Arc<ShmConfig>>,
@@ -122,9 +121,7 @@ async fn spawn_transient_local_replay_queryable(
                 if let Some(encoding) = sample.encoding {
                     reply = reply.encoding(encoding);
                 }
-                if let Some(attachment) = sample.attachment {
-                    reply = reply.attachment(attachment);
-                }
+                reply = reply.attachment(sample.attachment);
                 if let Err(err) = reply.await {
                     warn!("[PUB] Failed to replay transient local sample: {}", err);
                 }
@@ -163,7 +160,6 @@ pub struct PublisherBuilder<T, C = <T as crate::Message>::Codec> {
     pub(crate) session: Session,
     pub(crate) graph: Arc<Graph>,
     pub(crate) clock: Clock,
-    pub(crate) attachment: bool,
     pub(crate) shm_config: Option<Arc<ShmConfig>>,
     /// Schema for dynamic message publishing.
     /// When set, the schema will be registered with the schema service.
@@ -174,11 +170,6 @@ pub struct PublisherBuilder<T, C = <T as crate::Message>::Codec> {
 impl<T, C> PublisherBuilder<T, C> {
     pub fn qos(mut self, qos: QosProfile) -> Self {
         self.entity.qos = qos.to_protocol_qos();
-        self
-    }
-
-    pub fn attachment(mut self, with_attachment: bool) -> Self {
-        self.attachment = with_attachment;
         self
     }
 
@@ -356,7 +347,6 @@ where
             endpoint_global_id,
             clock: self.clock,
             events_mgr: Arc::new(Mutex::new(EventsManager::new(endpoint_global_id))),
-            attachment: self.attachment,
             shm_config: self.shm_config,
             dyn_schema: self.dyn_schema,
             encoding,
@@ -497,9 +487,7 @@ where
 
         put_builder = put_builder.encoding((*self.encoding).clone());
 
-        if let Some(att) = attachment.clone() {
-            put_builder = put_builder.attachment(att);
-        }
+        put_builder = put_builder.attachment(attachment.clone());
 
         put_builder.await?;
         self.retain_transient_local_sample(zbytes, attachment);
@@ -510,7 +498,7 @@ where
         &self,
         message: &T,
         publication_id: PublicationId,
-    ) -> Result<(zenoh::bytes::ZBytes, Option<Attachment>)> {
+    ) -> Result<(zenoh::bytes::ZBytes, Attachment)> {
         tracing::Span::current().record(
             "endpoint_global_id",
             format_args!("{:02x?}", publication_id.endpoint_global_id()),
@@ -555,18 +543,12 @@ where
         tracing::Span::current().record("payload_len", actual_size);
 
         let zbytes = zenoh::bytes::ZBytes::from(zbuf);
-        let attachment = self
-            .attachment
-            .then(|| self.new_attachment_for_publication(publication_id));
+        let attachment = self.new_attachment_for_publication(publication_id);
 
         Ok((zbytes, attachment))
     }
 
-    fn retain_transient_local_sample(
-        &self,
-        payload: zenoh::bytes::ZBytes,
-        attachment: Option<Attachment>,
-    ) {
+    fn retain_transient_local_sample(&self, payload: zenoh::bytes::ZBytes, attachment: Attachment) {
         if let Some(cache) = &self.transient_local_cache {
             cache.retain(RetainedSample {
                 payload,

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -17,7 +17,7 @@ use ros_z_protocol::qos::{QosDurability, QosHistory};
 pub(super) struct RetainedSample {
     pub(super) payload: zenoh::bytes::ZBytes,
     pub(super) encoding: Option<zenoh::bytes::Encoding>,
-    pub(super) attachment: Option<Attachment>,
+    pub(super) attachment: Attachment,
 }
 
 pub(super) struct TransientLocalCache {

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -12,7 +12,7 @@ use crate::entity::{EndpointEntity, EntityKind, endpoint_global_id};
 use crate::event::EventsManager;
 use crate::graph::Graph;
 use crate::message::WireDecoder;
-use crate::pubsub::metadata::Received;
+use crate::pubsub::metadata::{Received, required_attachment_from_sample};
 use crate::pubsub::raw::{self, RawSubscriberBuilder};
 use crate::pubsub::replay::{self, TransientLocalReplayCoordinator};
 use crate::qos::QosProfile;
@@ -388,9 +388,10 @@ where
     /// Receive and deserialize the next message together with metadata.
     pub async fn recv_with_metadata(&self) -> Result<Received<C::Output>> {
         let sample = self.queue.recv_async().await;
+        let attachment = required_attachment_from_sample(&sample)?;
         let payload = sample.payload().to_bytes();
         let message = C::deserialize(&payload).map_err(|e| zenoh::Error::from(e.to_string()))?;
-        Ok(Received::from_sample(&sample, message))
+        Ok(Received::from_sample(&sample, message, attachment))
     }
 }
 
@@ -422,11 +423,12 @@ impl Subscriber<DynamicPayload, DynamicCdrCodec> {
             .ok_or_else(|| zenoh::Error::from("dyn_schema required for DynamicPayload"))?;
 
         let sample = self.queue.recv_async().await;
+        let attachment = required_attachment_from_sample(&sample)?;
         let payload = sample.payload().to_bytes();
 
         let message = DynamicCdrCodec::deserialize((&payload, schema))
             .map_err(|e| zenoh::Error::from(e.to_string()))?;
-        Ok(Received::from_sample(&sample, message))
+        Ok(Received::from_sample(&sample, message, attachment))
     }
 
     /// Get the dynamic schema.

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -12,7 +12,7 @@ use crate::entity::{EndpointEntity, EntityKind, endpoint_global_id};
 use crate::event::EventsManager;
 use crate::graph::Graph;
 use crate::message::WireDecoder;
-use crate::pubsub::metadata::{Received, required_attachment_from_sample};
+use crate::pubsub::metadata::Received;
 use crate::pubsub::raw::{self, RawSubscriberBuilder};
 use crate::pubsub::replay::{self, TransientLocalReplayCoordinator};
 use crate::qos::QosProfile;
@@ -388,10 +388,9 @@ where
     /// Receive and deserialize the next message together with metadata.
     pub async fn recv_with_metadata(&self) -> Result<Received<C::Output>> {
         let sample = self.queue.recv_async().await;
-        let attachment = required_attachment_from_sample(&sample)?;
         let payload = sample.payload().to_bytes();
         let message = C::deserialize(&payload).map_err(|e| zenoh::Error::from(e.to_string()))?;
-        Ok(Received::from_sample(&sample, message, attachment))
+        Received::try_from_sample(&sample, message)
     }
 }
 
@@ -423,12 +422,11 @@ impl Subscriber<DynamicPayload, DynamicCdrCodec> {
             .ok_or_else(|| zenoh::Error::from("dyn_schema required for DynamicPayload"))?;
 
         let sample = self.queue.recv_async().await;
-        let attachment = required_attachment_from_sample(&sample)?;
         let payload = sample.payload().to_bytes();
 
         let message = DynamicCdrCodec::deserialize((&payload, schema))
             .map_err(|e| zenoh::Error::from(e.to_string()))?;
-        Ok(Received::from_sample(&sample, message, attachment))
+        Received::try_from_sample(&sample, message)
     }
 
     /// Get the dynamic schema.

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -232,6 +232,7 @@ where
         for<'a> <T::Response as Message>::Codec:
             WireDecoder<Output = T::Response, Input<'a> = &'a [u8]>,
     {
+        required_attachment_from_response(&sample)?;
         let payload_bytes = sample.payload().to_bytes();
         <<T::Response as Message>::Codec as WireDecoder>::deserialize(&payload_bytes[..])
             .map_err(|e| zenoh::Error::from(e.to_string()))
@@ -359,7 +360,13 @@ impl ServiceQueryHandler {
                     tracing::debug!("Queue full, dropped oldest service request");
                 }
             }
-            ServiceQueryHandler::Callback(callback) => callback(query),
+            ServiceQueryHandler::Callback(callback) => {
+                if let Err(error) = required_attachment_from_query(&query) {
+                    warn!("[SRV] Rejecting service callback query: {}", error);
+                    return;
+                }
+                callback(query)
+            }
         }
     }
 }
@@ -499,8 +506,32 @@ impl From<Attachment> for RequestId {
     }
 }
 
+fn required_attachment_from_query(query: &Query) -> Result<Attachment> {
+    let raw = query.attachment().ok_or_else(|| {
+        zenoh::Error::from("received ros-z service request without attachment metadata")
+    })?;
+
+    Attachment::try_from(raw).map_err(|error| {
+        zenoh::Error::from(format!(
+            "failed to decode ros-z service request attachment metadata: {error}"
+        ))
+    })
+}
+
+fn required_attachment_from_response(sample: &Sample) -> Result<Attachment> {
+    let raw = sample.attachment().ok_or_else(|| {
+        zenoh::Error::from("received ros-z service response without attachment metadata")
+    })?;
+
+    Attachment::try_from(raw).map_err(|error| {
+        zenoh::Error::from(format!(
+            "failed to decode ros-z service response attachment metadata: {error}"
+        ))
+    })
+}
+
 pub struct ServiceReply<T: Service> {
-    request_id: Option<RequestId>,
+    request_id: RequestId,
     key_expr: KeyExpr<'static>,
     query: Query,
     clock: Clock,
@@ -508,8 +539,8 @@ pub struct ServiceReply<T: Service> {
 }
 
 impl<T: Service> ServiceReply<T> {
-    pub fn id(&self) -> Option<&RequestId> {
-        self.request_id.as_ref()
+    pub fn id(&self) -> &RequestId {
+        &self.request_id
     }
 
     pub fn reply(self, message: &T::Response) -> Result<()>
@@ -520,14 +551,12 @@ impl<T: Service> ServiceReply<T> {
             &self.key_expr,
             <<T::Response as Message>::Codec as WireEncoder>::serialize(message),
         );
-        if let Some(request_id) = self.request_id {
-            let attachment = Attachment::with_clock(
-                request_id.sequence_number,
-                request_id.writer_global_id,
-                &self.clock,
-            );
-            reply = reply.attachment(attachment);
-        }
+        let attachment = Attachment::with_clock(
+            self.request_id.sequence_number,
+            self.request_id.writer_global_id,
+            &self.clock,
+        );
+        reply = reply.attachment(attachment);
         reply.wait()
     }
 
@@ -539,14 +568,12 @@ impl<T: Service> ServiceReply<T> {
             &self.key_expr,
             <<T::Response as Message>::Codec as WireEncoder>::serialize(message),
         );
-        if let Some(request_id) = self.request_id {
-            let attachment = Attachment::with_clock(
-                request_id.sequence_number,
-                request_id.writer_global_id,
-                &self.clock,
-            );
-            reply = reply.attachment(attachment);
-        }
+        let attachment = Attachment::with_clock(
+            self.request_id.sequence_number,
+            self.request_id.writer_global_id,
+            &self.clock,
+        );
+        reply = reply.attachment(attachment);
         reply.await
     }
 }
@@ -557,7 +584,7 @@ pub struct ServiceRequest<T: Service> {
 }
 
 impl<T: Service> ServiceRequest<T> {
-    pub fn id(&self) -> Option<&RequestId> {
+    pub fn id(&self) -> &RequestId {
         self.reply.id()
     }
 
@@ -597,11 +624,7 @@ where
         for<'a> <T::Request as Message>::Codec:
             WireDecoder<Output = T::Request, Input<'a> = &'a [u8]>,
     {
-        let request_id = query
-            .attachment()
-            .map(Attachment::try_from)
-            .transpose()?
-            .map(RequestId::from);
+        let request_id = RequestId::from(required_attachment_from_query(&query)?);
 
         let payload_bytes = query
             .payload()
@@ -682,12 +705,13 @@ mod tests {
     use crate::{
         Message, SerdeCdrCodec, ServiceTypeInfo,
         context::ContextBuilder,
-        entity::TypeInfo,
-        message::{Service, WireDecoder, WireEncoder},
+        entity::{EndpointEntity, EndpointKind, TypeInfo},
+        message::{Service, WireEncoder},
     };
     use ros_z_schema::{SchemaError, ServiceDef};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
+    use zenoh::Wait;
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, crate::Message)]
     #[message(name = "test_msgs::AddTwoIntsRequest")]
@@ -723,8 +747,32 @@ mod tests {
         }
     }
 
+    fn service_key_expr_for<T: ServiceTypeInfo>(
+        node: &crate::node::Node,
+        service: &str,
+    ) -> zenoh::key_expr::KeyExpr<'static> {
+        let qualified_service = crate::topic_name::qualify_service_name(
+            service,
+            &node.node_entity().namespace,
+            &node.node_entity().name,
+        )
+        .expect("service should qualify");
+        let entity = EndpointEntity {
+            id: 0,
+            node: Some(node.node_entity().clone()),
+            kind: EndpointKind::Service,
+            topic: qualified_service,
+            type_info: Some(T::service_type_info().expect("service type info should build")),
+            qos: Default::default(),
+        };
+
+        (*ros_z_protocol::format::topic_key_expr(&entity)
+            .expect("service key expression should build"))
+        .clone()
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn service_request_without_attachment_is_accepted_and_reply_has_no_attachment() {
+    async fn service_request_without_attachment_returns_clear_error() {
         let context = ContextBuilder::default()
             .disable_multicast_scouting()
             .with_json("connect/endpoints", json!([]))
@@ -751,21 +799,17 @@ mod tests {
             .expect("Failed to create service server");
         let key_expr = server.key_expr.clone();
 
-        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-        let reply_tx = std::sync::Arc::new(std::sync::Mutex::new(Some(reply_tx)));
         let request_task = tokio::spawn(async move {
-            let request = server
-                .take_request_async()
-                .await
-                .expect("Failed to take request");
-            assert!(request.id().is_none());
-            assert_eq!(request.message().a, 10);
-            assert_eq!(request.message().b, 32);
-
-            request
-                .reply_async(&AddTwoIntsResponse { sum: 42 })
-                .await
-                .expect("Failed to send response");
+            let error = match server.take_request_async().await {
+                Ok(_) => panic!("request without attachment should fail"),
+                Err(error) => error,
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("received ros-z service request without attachment metadata"),
+                "unexpected error: {error}"
+            );
         });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -776,28 +820,126 @@ mod tests {
             .payload(SerdeCdrCodec::<AddTwoIntsRequest>::serialize(
                 &AddTwoIntsRequest { a: 10, b: 32 },
             ))
-            .callback(move |reply| {
-                let sample = reply.into_result().expect("Expected service reply sample");
-                let sender = reply_tx
-                    .lock()
-                    .expect("Reply sender mutex poisoned")
-                    .take()
-                    .expect("Expected to deliver a single reply sample");
-                sender
-                    .send(sample)
-                    .expect("Expected to deliver a single reply sample");
-            })
+            .callback(|_| panic!("raw request should not receive a reply"))
             .await
             .expect("Failed to send raw service query");
 
-        let reply_sample = reply_rx.await.expect("Failed to receive reply sample");
-        assert!(reply_sample.attachment().is_none());
-
-        let payload = reply_sample.payload().to_bytes();
-        let response = SerdeCdrCodec::<AddTwoIntsResponse>::deserialize(&payload)
-            .expect("Failed to deserialize raw reply payload");
-        assert_eq!(response.sum, 42);
-
         request_task.await.expect("Service task panicked");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn service_callback_without_attachment_is_rejected() {
+        let context = ContextBuilder::default()
+            .disable_multicast_scouting()
+            .with_json("connect/endpoints", json!([]))
+            .build()
+            .await
+            .expect("Failed to create context");
+
+        let server_node = context
+            .create_node("raw_callback_server")
+            .build()
+            .await
+            .expect("Failed to create server node");
+        let client_node = context
+            .create_node("raw_callback_client")
+            .build()
+            .await
+            .expect("Failed to create client node");
+
+        let (called_tx, mut called_rx) = tokio::sync::mpsc::unbounded_channel();
+        let server = server_node
+            .create_service_server::<AddTwoInts>("raw_callback_add_two_ints")
+            .expect("service server factory should succeed")
+            .build_with_callback(move |_| {
+                called_tx
+                    .send(())
+                    .expect("callback invocation should be recorded");
+            })
+            .await
+            .expect("Failed to create callback service server");
+        let key_expr = server.key_expr.clone();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        client_node
+            .session()
+            .get(key_expr)
+            .payload(SerdeCdrCodec::<AddTwoIntsRequest>::serialize(
+                &AddTwoIntsRequest { a: 10, b: 32 },
+            ))
+            .callback(|_| panic!("raw callback request should not receive a reply"))
+            .await
+            .expect("Failed to send raw service query");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), called_rx.recv())
+                .await
+                .is_err(),
+            "callback should not receive requests without attachments"
+        );
+
+        drop(server);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn service_response_without_attachment_returns_clear_error() {
+        let context = ContextBuilder::default()
+            .disable_multicast_scouting()
+            .with_json("connect/endpoints", json!([]))
+            .build()
+            .await
+            .expect("Failed to create context");
+        let server_node = context
+            .create_node("raw_reply_server")
+            .build()
+            .await
+            .expect("Failed to create server node");
+        let client_node = context
+            .create_node("raw_reply_client")
+            .build()
+            .await
+            .expect("Failed to create client node");
+
+        let service = "raw_reply_add_two_ints";
+        let key_expr = service_key_expr_for::<AddTwoInts>(&server_node, service);
+        let reply_key_expr = key_expr.clone();
+        let queryable = server_node
+            .session()
+            .declare_queryable(key_expr)
+            .complete(true)
+            .callback(move |query| {
+                query
+                    .reply(
+                        &reply_key_expr,
+                        SerdeCdrCodec::<AddTwoIntsResponse>::serialize(&AddTwoIntsResponse {
+                            sum: 42,
+                        }),
+                    )
+                    .wait()
+                    .expect("raw reply should send");
+            })
+            .await
+            .expect("Failed to declare raw queryable");
+
+        let client = client_node
+            .create_service_client::<AddTwoInts>(service)
+            .expect("service client factory should succeed")
+            .build()
+            .await
+            .expect("Failed to create service client");
+
+        let error = client
+            .call_async(&AddTwoIntsRequest { a: 10, b: 32 })
+            .await
+            .expect_err("response without attachment should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("received ros-z service response without attachment metadata"),
+            "unexpected error: {error}"
+        );
+
+        drop(queryable);
     }
 }

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -232,7 +232,6 @@ where
         for<'a> <T::Response as Message>::Codec:
             WireDecoder<Output = T::Response, Input<'a> = &'a [u8]>,
     {
-        required_attachment_from_response(&sample)?;
         let payload_bytes = sample.payload().to_bytes();
         <<T::Response as Message>::Codec as WireDecoder>::deserialize(&payload_bytes[..])
             .map_err(|e| zenoh::Error::from(e.to_string()))
@@ -360,13 +359,7 @@ impl ServiceQueryHandler {
                     tracing::debug!("Queue full, dropped oldest service request");
                 }
             }
-            ServiceQueryHandler::Callback(callback) => {
-                if let Err(error) = required_attachment_from_query(&query) {
-                    warn!("[SRV] Rejecting service callback query: {}", error);
-                    return;
-                }
-                callback(query)
-            }
+            ServiceQueryHandler::Callback(callback) => callback(query),
         }
     }
 }
@@ -506,30 +499,6 @@ impl From<Attachment> for RequestId {
     }
 }
 
-fn required_attachment_from_query(query: &Query) -> Result<Attachment> {
-    let raw = query.attachment().ok_or_else(|| {
-        zenoh::Error::from("received ros-z service request without attachment metadata")
-    })?;
-
-    Attachment::try_from(raw).map_err(|error| {
-        zenoh::Error::from(format!(
-            "failed to decode ros-z service request attachment metadata: {error}"
-        ))
-    })
-}
-
-fn required_attachment_from_response(sample: &Sample) -> Result<Attachment> {
-    let raw = sample.attachment().ok_or_else(|| {
-        zenoh::Error::from("received ros-z service response without attachment metadata")
-    })?;
-
-    Attachment::try_from(raw).map_err(|error| {
-        zenoh::Error::from(format!(
-            "failed to decode ros-z service response attachment metadata: {error}"
-        ))
-    })
-}
-
 pub struct ServiceReply<T: Service> {
     request_id: RequestId,
     key_expr: KeyExpr<'static>,
@@ -624,7 +593,18 @@ where
         for<'a> <T::Request as Message>::Codec:
             WireDecoder<Output = T::Request, Input<'a> = &'a [u8]>,
     {
-        let request_id = RequestId::from(required_attachment_from_query(&query)?);
+        let attachment = {
+            let raw = query.attachment().ok_or_else(|| {
+                zenoh::Error::from("received ros-z service request without attachment metadata")
+            })?;
+
+            Attachment::try_from(raw).map_err(|error| {
+                zenoh::Error::from(format!(
+                    "failed to decode ros-z service request attachment metadata: {error}"
+                ))
+            })
+        }?;
+        let request_id = RequestId::from(attachment);
 
         let payload_bytes = query
             .payload()
@@ -705,13 +685,12 @@ mod tests {
     use crate::{
         Message, SerdeCdrCodec, ServiceTypeInfo,
         context::ContextBuilder,
-        entity::{EndpointEntity, EndpointKind, TypeInfo},
+        entity::TypeInfo,
         message::{Service, WireEncoder},
     };
     use ros_z_schema::{SchemaError, ServiceDef};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zenoh::Wait;
 
     #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, crate::Message)]
     #[message(name = "test_msgs::AddTwoIntsRequest")]
@@ -745,30 +724,6 @@ mod tests {
                 ros_z_schema::compute_hash(&descriptor),
             ))
         }
-    }
-
-    fn service_key_expr_for<T: ServiceTypeInfo>(
-        node: &crate::node::Node,
-        service: &str,
-    ) -> zenoh::key_expr::KeyExpr<'static> {
-        let qualified_service = crate::topic_name::qualify_service_name(
-            service,
-            &node.node_entity().namespace,
-            &node.node_entity().name,
-        )
-        .expect("service should qualify");
-        let entity = EndpointEntity {
-            id: 0,
-            node: Some(node.node_entity().clone()),
-            kind: EndpointKind::Service,
-            topic: qualified_service,
-            type_info: Some(T::service_type_info().expect("service type info should build")),
-            qos: Default::default(),
-        };
-
-        (*ros_z_protocol::format::topic_key_expr(&entity)
-            .expect("service key expression should build"))
-        .clone()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -825,121 +780,5 @@ mod tests {
             .expect("Failed to send raw service query");
 
         request_task.await.expect("Service task panicked");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn service_callback_without_attachment_is_rejected() {
-        let context = ContextBuilder::default()
-            .disable_multicast_scouting()
-            .with_json("connect/endpoints", json!([]))
-            .build()
-            .await
-            .expect("Failed to create context");
-
-        let server_node = context
-            .create_node("raw_callback_server")
-            .build()
-            .await
-            .expect("Failed to create server node");
-        let client_node = context
-            .create_node("raw_callback_client")
-            .build()
-            .await
-            .expect("Failed to create client node");
-
-        let (called_tx, mut called_rx) = tokio::sync::mpsc::unbounded_channel();
-        let server = server_node
-            .create_service_server::<AddTwoInts>("raw_callback_add_two_ints")
-            .expect("service server factory should succeed")
-            .build_with_callback(move |_| {
-                called_tx
-                    .send(())
-                    .expect("callback invocation should be recorded");
-            })
-            .await
-            .expect("Failed to create callback service server");
-        let key_expr = server.key_expr.clone();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        client_node
-            .session()
-            .get(key_expr)
-            .payload(SerdeCdrCodec::<AddTwoIntsRequest>::serialize(
-                &AddTwoIntsRequest { a: 10, b: 32 },
-            ))
-            .callback(|_| panic!("raw callback request should not receive a reply"))
-            .await
-            .expect("Failed to send raw service query");
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(100), called_rx.recv())
-                .await
-                .is_err(),
-            "callback should not receive requests without attachments"
-        );
-
-        drop(server);
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn service_response_without_attachment_returns_clear_error() {
-        let context = ContextBuilder::default()
-            .disable_multicast_scouting()
-            .with_json("connect/endpoints", json!([]))
-            .build()
-            .await
-            .expect("Failed to create context");
-        let server_node = context
-            .create_node("raw_reply_server")
-            .build()
-            .await
-            .expect("Failed to create server node");
-        let client_node = context
-            .create_node("raw_reply_client")
-            .build()
-            .await
-            .expect("Failed to create client node");
-
-        let service = "raw_reply_add_two_ints";
-        let key_expr = service_key_expr_for::<AddTwoInts>(&server_node, service);
-        let reply_key_expr = key_expr.clone();
-        let queryable = server_node
-            .session()
-            .declare_queryable(key_expr)
-            .complete(true)
-            .callback(move |query| {
-                query
-                    .reply(
-                        &reply_key_expr,
-                        SerdeCdrCodec::<AddTwoIntsResponse>::serialize(&AddTwoIntsResponse {
-                            sum: 42,
-                        }),
-                    )
-                    .wait()
-                    .expect("raw reply should send");
-            })
-            .await
-            .expect("Failed to declare raw queryable");
-
-        let client = client_node
-            .create_service_client::<AddTwoInts>(service)
-            .expect("service client factory should succeed")
-            .build()
-            .await
-            .expect("Failed to create service client");
-
-        let error = client
-            .call_async(&AddTwoIntsRequest { a: 10, b: 32 })
-            .await
-            .expect_err("response without attachment should fail");
-        assert!(
-            error
-                .to_string()
-                .contains("received ros-z service response without attachment metadata"),
-            "unexpected error: {error}"
-        );
-
-        drop(queryable);
     }
 }

--- a/crates/ros-z/tests/communication_pubsub_alignment.rs
+++ b/crates/ros-z/tests/communication_pubsub_alignment.rs
@@ -56,7 +56,7 @@ async fn publisher_message_id_is_reserved_and_observable() {
         .expect("Failed to receive message");
 
     assert_eq!(received.message(), &message);
-    assert_eq!(received.publication_id(), Some(publication_id));
+    assert_eq!(received.publication_id(), publication_id);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -105,7 +105,7 @@ async fn publisher_direct_publish_attaches_publication_id() {
 
     assert_eq!(received.message(), &message);
     assert!(
-        received.publication_id().is_some(),
+        received.publication_id().endpoint_global_id() != [0; 16],
         "direct publish should still carry a publication id"
     );
 }

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -4,8 +4,8 @@ use ros_z::{
     Message, SchemaHash,
     attachment::Attachment,
     context::ContextBuilder,
-    entity::{Entity, EntityKind, TypeInfo},
-    message::SerdeCdrCodec,
+    entity::{EndpointEntity, EndpointKind, Entity, EntityKind, TypeInfo},
+    message::{SerdeCdrCodec, WireEncoder},
     qos::{QosDurability, QosHistory, QosProfile, QosReliability},
     schema::{MessageSchema, SchemaBuilder},
     time::{Clock, Time},
@@ -46,6 +46,31 @@ impl MessageSchema for TestMessage {
             Ok(())
         })
     }
+}
+
+fn topic_key_expr_for<T: Message>(node: &ros_z::node::Node, topic: &str) -> String {
+    let qualified_topic = ros_z::topic_name::qualify_topic_name(
+        topic,
+        &node.node_entity().namespace,
+        &node.node_entity().name,
+    )
+    .expect("topic should qualify");
+
+    let entity = EndpointEntity {
+        id: 0,
+        node: Some(node.node_entity().clone()),
+        kind: EndpointKind::Publisher,
+        topic: qualified_topic,
+        type_info: Some(TypeInfo::with_hash(
+            &T::type_name(),
+            ros_z_schema::compute_hash(&T::schema().expect("schema should build")),
+        )),
+        qos: Default::default(),
+    };
+
+    ros_z_protocol::format::topic_key_expr(&entity)
+        .expect("topic key expression should build")
+        .to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -804,7 +829,7 @@ async fn dynamic_publisher_fills_missing_schema_hash_from_schema() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_recv_with_metadata_preserves_receive_context() {
+async fn recv_with_metadata_includes_transport_and_source_timestamps() {
     let context = ContextBuilder::default()
         .build()
         .await
@@ -843,9 +868,58 @@ async fn test_recv_with_metadata_preserves_receive_context() {
         .expect("receive should succeed");
     assert_eq!(received.message, message);
     assert!(received.transport_time.is_some());
-    assert!(received.source_time.is_some());
-    assert!(received.sequence_number.is_some());
-    assert!(received.source_global_id.is_some());
+    assert_eq!(received.sequence_number, 0);
+    assert_ne!(received.source_global_id, [0; 16]);
+    assert_eq!(
+        received.publication_id().sequence_number(),
+        received.sequence_number
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_subscriber_errors_when_sample_has_no_attachment() {
+    let context = ContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_json("connect/endpoints", json!([]))
+        .build()
+        .await
+        .expect("Failed to create context");
+    let node = context
+        .create_node("missing_attachment_subscriber")
+        .build()
+        .await
+        .expect("Failed to create node");
+
+    let topic = "/missing_attachment_pubsub";
+    let subscriber = node
+        .subscriber::<TestMessage>(topic)
+        .expect("subscriber factory should succeed")
+        .build()
+        .await
+        .expect("Failed to create subscriber");
+    let key_expr = topic_key_expr_for::<TestMessage>(&node, topic);
+    let message = TestMessage {
+        data: vec![1, 2, 3],
+        counter: 99,
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    node.session()
+        .put(key_expr, SerdeCdrCodec::<TestMessage>::serialize(&message))
+        .await
+        .expect("raw put should succeed");
+
+    let error = tokio::time::timeout(Duration::from_secs(1), subscriber.recv_with_metadata())
+        .await
+        .expect("receive should not time out")
+        .expect_err("typed receive should reject samples without attachments");
+
+    assert!(
+        error
+            .to_string()
+            .contains("received ros-z sample without attachment metadata"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/ros-z/tests/pubsub_qos.rs
+++ b/crates/ros-z/tests/pubsub_qos.rs
@@ -303,11 +303,18 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn transient_local_replay_preserves_cache_order_without_attachments() -> Result<()> {
+    async fn transient_local_replay_preserves_cache_order_with_required_attachments() -> Result<()>
+    {
         let context = ContextBuilder::default().build().await?;
-        let pub_node = context.create_node("no_attachment_pub").build().await?;
-        let sub_node = context.create_node("no_attachment_sub").build().await?;
-        let topic = "/transient_local_no_attachment";
+        let pub_node = context
+            .create_node("required_attachment_pub")
+            .build()
+            .await?;
+        let sub_node = context
+            .create_node("required_attachment_sub")
+            .build()
+            .await?;
+        let topic = "/transient_local_required_attachment";
         let qos = QosProfile {
             durability: QosDurability::TransientLocal,
             reliability: QosReliability::Reliable,
@@ -318,7 +325,6 @@ mod tests {
         let publisher = pub_node
             .publisher::<String>(topic)?
             .qos(qos)
-            .attachment(false)
             .build()
             .await?;
         for data in ["one", "two", "three"] {
@@ -332,12 +338,17 @@ mod tests {
             .await?;
 
         let mut received = Vec::new();
+        let mut sequence_numbers = Vec::new();
         for _ in 0..3 {
-            let message = tokio::time::timeout(Duration::from_secs(2), subscriber.recv()).await??;
-            received.push(message);
+            let message =
+                tokio::time::timeout(Duration::from_secs(2), subscriber.recv_with_metadata())
+                    .await??;
+            sequence_numbers.push(message.sequence_number);
+            received.push(message.into_message());
         }
 
         assert_eq!(received, ["one", "two", "three"]);
+        assert_eq!(sequence_numbers, [0, 1, 2]);
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation
ros-z messages need source timestamps for stream alignment, replay ordering, and latency handling. Letting publishers disable attachments creates a protocol state where typed ros-z consumers have to guess or degrade when metadata is missing.

## Changes
This removes the publisher attachment opt-out and makes typed pub/sub and service paths require valid attachment metadata. Typed receivers now fail with clear errors when raw Zenoh traffic reaches ros-z without the expected metadata.

## Review
Focus on API semantics, raw Zenoh boundaries, service callbacks, and transient-local replay.
- Does it make sense that typed ros-z rejects attachmentless samples, requests, and responses?