### PR TITLE
refactor: remove enclave from ros-z

### DIFF
--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -11,7 +11,7 @@ use zenoh::{key_expr::KeyExpr, session::ZenohId};
 
 use crate::qos::{QosDecodeError, QosProfile};
 
-/// Placeholder for empty namespace/enclave.
+/// Placeholder for empty namespace.
 pub const EMPTY_PLACEHOLDER: &str = "%";
 
 /// Liveliness key expression wrapper.
@@ -61,17 +61,15 @@ pub struct NodeEntity {
     pub id: usize,
     pub name: String,
     pub namespace: String,
-    pub enclave: String,
 }
 
 impl NodeEntity {
-    pub fn new(z_id: ZenohId, id: usize, name: String, namespace: String, enclave: String) -> Self {
+    pub fn new(z_id: ZenohId, id: usize, name: String, namespace: String) -> Self {
         Self {
             z_id,
             id,
             name,
             namespace,
-            enclave,
         }
     }
 }
@@ -224,7 +222,6 @@ pub enum EntityConversionError {
     MissingNodeId,
     MissingEntityId,
     MissingEntityKind,
-    MissingEnclave,
     MissingNamespace,
     MissingNodeName,
     MissingTopicName,

--- a/crates/ros-z-protocol/src/format.rs
+++ b/crates/ros-z-protocol/src/format.rs
@@ -168,7 +168,6 @@ pub fn parse_liveliness(ke: &KeyExpr) -> Result<Entity> {
         id: node_id,
         name: node_name,
         namespace,
-        enclave: String::new(),
     };
 
     let entity = match entity_kind {

--- a/crates/ros-z-protocol/src/lib.rs
+++ b/crates/ros-z-protocol/src/lib.rs
@@ -22,7 +22,7 @@
 //! use ros_z_protocol::{entity::*, format};
 //!
 //! let zid: zenoh::session::ZenohId = "1234567890abcdef1234567890abcdef".parse().unwrap();
-//! let node = NodeEntity::new(zid, 0, "my_node".to_string(), "/".to_string(), String::new());
+//! let node = NodeEntity::new(zid, 0, "my_node".to_string(), "/".to_string());
 //!
 //! let entity = EndpointEntity {
 //!     id: 1,

--- a/crates/ros-z-protocol/tests/key_expr.rs
+++ b/crates/ros-z-protocol/tests/key_expr.rs
@@ -19,7 +19,6 @@ fn default_node() -> NodeEntity {
         id: 1,
         name: "test_node".to_string(),
         namespace: "/".to_string(),
-        enclave: "/".to_string(),
     }
 }
 
@@ -54,7 +53,6 @@ fn native_endpoint_liveliness(kind: EndpointKind) -> ros_z_protocol::entity::Liv
         id: 1,
         name: "talker".to_string(),
         namespace: String::new(),
-        enclave: String::new(),
     };
     let entity = EndpointEntity {
         id: 2,
@@ -189,6 +187,16 @@ fn test_type_info_without_hash_roundtrip() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn node_liveliness_key_uses_native_node_identity_fields() {
+    let z_id: ZenohId = "1234567890abcdef1234567890abcdef".parse().unwrap();
+    let node = NodeEntity::new(z_id, 5, "my_node".to_string(), "/my_ns".to_string());
+
+    let key_expr = format::node_liveliness_key_expr(&node).unwrap().to_string();
+
+    assert_eq!(key_expr, format!("@ros_z/{z_id}/5/5/NN/%my_ns/my_node"));
+}
+
+#[test]
 fn test_node_liveliness_roundtrip() {
     let z_id = ZenohId::default();
     let node = NodeEntity {
@@ -196,7 +204,6 @@ fn test_node_liveliness_roundtrip() {
         id: 5,
         name: "my_node".to_string(),
         namespace: "/my_ns".to_string(),
-        enclave: "/".to_string(),
     };
 
     let ke = format::node_liveliness_key_expr(&node).unwrap();

--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -41,7 +41,6 @@ pub struct RuntimeParameterInputs {
 #[derive(Default)]
 pub struct ContextBuilder {
     namespace: String,
-    enclave: String,
     zenoh_config: Option<zenoh::Config>,
     config_file: Option<PathBuf>,
     config_overrides: Vec<(String, serde_json::Value)>,
@@ -56,12 +55,6 @@ impl ContextBuilder {
     /// Set the default namespace inherited by nodes created from this context.
     pub fn with_namespace(mut self, namespace: impl AsRef<str>) -> Self {
         self.namespace = normalize_node_namespace(namespace.as_ref());
-        self
-    }
-
-    /// Set the enclave name
-    pub fn with_enclave<S: Into<String>>(mut self, enclave: S) -> Self {
-        self.enclave = enclave.into();
         self
     }
 
@@ -425,9 +418,6 @@ impl ContextBuilder {
             self.config_file.is_some()
         );
 
-        // Capture enclave before moving self
-        let enclave = self.enclave.clone();
-
         // Apply environment variable overrides first
         let builder = self.apply_env_overrides()?;
         debug!(
@@ -490,7 +480,6 @@ impl ContextBuilder {
             session: Arc::new(session),
             counter: Arc::new(GlobalCounter::default()),
             namespace: builder.namespace,
-            enclave,
             graph,
             shm_config: builder.shm_config,
             clock: builder.clock.unwrap_or_default(),
@@ -518,7 +507,6 @@ pub struct Context {
     // Global counter for the participants
     counter: Arc<GlobalCounter>,
     namespace: String,
-    enclave: String,
     graph: Arc<Graph>,
     pub(crate) shm_config: Option<Arc<ShmConfig>>,
     pub(crate) clock: Clock,
@@ -529,7 +517,6 @@ impl std::fmt::Debug for Context {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Context")
             .field("namespace", &self.namespace)
-            .field("enclave", &self.enclave)
             .finish_non_exhaustive()
     }
 }
@@ -541,7 +528,6 @@ impl Context {
         NodeBuilder {
             name: name.as_ref().to_owned(),
             namespace: self.namespace.clone(),
-            enclave: self.enclave.clone(),
             session: self.session.clone(),
             counter: self.counter.clone(),
             graph: self.graph.clone(),

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -188,7 +188,6 @@ mod tests {
                 id: 2,
                 name: "talker".to_string(),
                 namespace: "/".to_string(),
-                enclave: String::new(),
             }),
             kind: EndpointKind::Publisher,
             topic: "/chatter".to_string(),

--- a/crates/ros-z/src/dynamic/schema_service.rs
+++ b/crates/ros-z/src/dynamic/schema_service.rs
@@ -278,7 +278,6 @@ fn schema_service_server_builder(
         node.id,
         node.name.to_string(),
         node.namespace.to_string(),
-        String::new(),
     );
 
     let entity = EndpointEntity {

--- a/crates/ros-z/src/entity.rs
+++ b/crates/ros-z/src/entity.rs
@@ -118,7 +118,6 @@ mod tests {
             id: 1,
             name: "node".to_string(),
             namespace: "/".to_string(),
-            enclave: String::new(),
         }
     }
 

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -221,11 +221,4 @@ impl Graph {
     pub fn get_node_names(&self) -> Vec<(String, String)> {
         self.data.lock().node_names()
     }
-
-    /// Get all node names, namespaces, and enclaves discovered in the graph
-    ///
-    /// Returns a vector of tuples (node_name, node_namespace, enclave)
-    pub fn get_node_names_with_enclaves(&self) -> Vec<(String, String, String)> {
-        self.data.lock().node_names_with_enclaves()
-    }
 }

--- a/crates/ros-z/src/graph/state.rs
+++ b/crates/ros-z/src/graph/state.rs
@@ -442,33 +442,4 @@ impl GraphData {
         }
         result
     }
-
-    pub(super) fn node_names_with_enclaves(&mut self) -> Vec<(String, String, String)> {
-        self.parse_pending();
-        let mut result = Vec::new();
-        for ((namespace, name), slab) in self.by_node.iter() {
-            let denormalized_ns = if namespace.is_empty() {
-                "/".to_string()
-            } else if !namespace.starts_with('/') {
-                format!("/{namespace}")
-            } else {
-                namespace.clone()
-            };
-            for (_, weak_entity) in slab.iter() {
-                if let Some(entity_arc) = weak_entity.upgrade()
-                    && let Entity::Node(node) = &*entity_arc
-                {
-                    let enclave = if node.enclave.is_empty() {
-                        "/".to_string()
-                    } else if !node.enclave.starts_with('/') {
-                        format!("/{}", node.enclave)
-                    } else {
-                        node.enclave.clone()
-                    };
-                    result.push((name.clone(), denormalized_ns.clone(), enclave));
-                }
-            }
-        }
-        result
-    }
 }

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -58,7 +58,6 @@ impl std::fmt::Debug for Node {
 pub struct NodeBuilder {
     pub(crate) name: String,
     pub(crate) namespace: String,
-    pub(crate) enclave: String,
     pub(crate) session: Arc<Session>,
     pub(crate) counter: Arc<GlobalCounter>,
     pub(crate) graph: Arc<Graph>,
@@ -162,7 +161,6 @@ impl NodeBuilder {
             id,
             self.name.clone(),
             self.namespace.clone(),
-            self.enclave,
         );
         let liveliness_token_key_expr = node_lv_token_key_expr(&node)?;
         debug!("[NOD] Liveliness token KE: {}", liveliness_token_key_expr);

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -199,13 +199,7 @@ mod tests {
     async fn node_exists_returns_false_after_only_node_removed() -> Result<()> {
         let session = zenoh::open(zenoh::Config::default()).await?;
         let graph = ros_z::graph::Graph::new(&session).await?;
-        let node = NodeEntity::new(
-            session.zid(),
-            1,
-            "removed_node".to_string(),
-            String::new(),
-            String::new(),
-        );
+        let node = NodeEntity::new(session.zid(), 1, "removed_node".to_string(), String::new());
         let node_key = ros_z::entity::node_key(&node);
         let entity = Entity::Node(node);
 
@@ -673,22 +667,6 @@ mod tests {
         assert!(
             nodes.iter().any(|(name, _)| name == "test_graph_node"),
             "Expected to find our test node"
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn graph_lists_node_names_with_enclaves() -> Result<()> {
-        let (_ctx, node) = setup_test_node("test_graph_node").await?;
-
-        let graph = node.graph().clone();
-        let nodes = graph.get_node_names_with_enclaves();
-
-        assert!(!nodes.is_empty(), "Expected to find at least one node");
-        assert!(
-            nodes.iter().any(|(name, _, _)| name == "test_graph_node"),
-            "Expected to find our test node with enclave"
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

Remove unused enclave state from ros-z protocol entities, context/node builders, and graph APIs.

## Motivation

ros-z does not serialize or use enclave in its native liveliness format, and enclave is not a requirement. Keeping it in public APIs suggests support for a concept the runtime does not implement.

## Reviewer Notes

This is a breaking API cleanup by design. The native `@ros_z/<zid>/<nid>/<eid>/<kind>/<ns>/<name>` liveliness format stays unchanged, covered by a new protocol test.
