### PR TITLE
Drop `no_std` mode from `ros-z-protocol`

### DIFF
--- a/crates/ros-z-cli/Cargo.toml
+++ b/crates/ros-z-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }
 ros-z = { workspace = true }
-ros-z-protocol = { workspace = true, features = ["std"] }
+ros-z-protocol = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = [

--- a/crates/ros-z-protocol/Cargo.toml
+++ b/crates/ros-z-protocol/Cargo.toml
@@ -5,10 +5,6 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 
-[features]
-default = ["std"]
-std = ["zenoh/default"]
-
 [dependencies]
 ros-z-schema = { workspace = true }
 zenoh = { workspace = true }

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -1,12 +1,8 @@
 //! ros-z entity types for key expression generation.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
-extern crate alloc;
-
-use alloc::string::String;
 use core::{fmt::Display, ops::Deref};
 pub use ros_z_schema::SchemaHash;
+use std::string::String;
 use zenoh::{key_expr::KeyExpr, session::ZenohId};
 
 use crate::qos::{QosDecodeError, QosProfile};
@@ -241,5 +237,4 @@ impl Display for EntityConversionError {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for EntityConversionError {}

--- a/crates/ros-z-protocol/src/lib.rs
+++ b/crates/ros-z-protocol/src/lib.rs
@@ -7,15 +7,6 @@
 //!
 //! ros-z uses a native key expression format for nodes, topics, services, and actions.
 //!
-//! # no_std Support
-//!
-//! This crate is `no_std` compatible with `alloc`:
-//!
-//! ```toml
-//! [dependencies]
-//! ros-z-protocol = { version = "0.1", default-features = false }
-//! ```
-//!
 //! # Example
 //!
 //! ```rust

--- a/crates/ros-z-protocol/src/qos.rs
+++ b/crates/ros-z-protocol/src/qos.rs
@@ -1,11 +1,7 @@
 //! QoS profile encoding/decoding for liveliness tokens.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
-extern crate alloc;
-
-use alloc::string::String;
 use core::fmt::Display;
+use std::{string::String, vec::Vec};
 
 /// QoS profile for native ros-z entities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -23,7 +19,6 @@ impl QosProfile {
     /// Encode QoS to string for liveliness token.
     /// Format: [reliability]:[durability]:[history],[depth]:[deadline]:[lifespan]:[liveliness]
     pub fn encode(&self) -> String {
-        use alloc::format;
         let default_qos = Self::default();
 
         // Reliability - empty if default (encoded values: 1=Reliable, 2=BestEffort)
@@ -76,7 +71,7 @@ impl QosProfile {
 
     /// Decode QoS from liveliness token string.
     pub fn decode(s: &str) -> Result<Self, QosDecodeError> {
-        let fields: alloc::vec::Vec<&str> = s.split(':').collect();
+        let fields: Vec<&str> = s.split(':').collect();
         if fields.len() != 3 && fields.len() != 6 {
             return Err(QosDecodeError::InvalidFormat);
         }
@@ -100,7 +95,7 @@ impl QosProfile {
         };
 
         // Parse history: <kind>,<depth>
-        let history_parts: alloc::vec::Vec<&str> = fields[2].split(',').collect();
+        let history_parts: Vec<&str> = fields[2].split(',').collect();
         if history_parts.len() != 2 {
             return Err(QosDecodeError::InvalidHistory);
         }
@@ -152,8 +147,6 @@ impl QosProfile {
 }
 
 fn encode_duration(duration: QosDuration, default: QosDuration) -> String {
-    use alloc::format;
-
     if duration == default {
         ",".to_string()
     } else {
@@ -167,8 +160,6 @@ fn encode_liveliness(
     default_liveliness: QosLiveliness,
     default_lease: QosDuration,
 ) -> String {
-    use alloc::format;
-
     if liveliness == default_liveliness && lease == default_lease {
         ",,".to_string()
     } else {
@@ -182,7 +173,7 @@ fn encode_liveliness(
 }
 
 fn decode_duration(s: &str) -> Result<QosDuration, QosDecodeError> {
-    let parts: alloc::vec::Vec<&str> = s.split(',').collect();
+    let parts: Vec<&str> = s.split(',').collect();
     if parts.len() != 2 {
         return Err(QosDecodeError::InvalidDuration);
     }
@@ -204,7 +195,7 @@ fn decode_duration(s: &str) -> Result<QosDuration, QosDecodeError> {
 }
 
 fn decode_liveliness(s: &str) -> Result<(QosLiveliness, QosDuration), QosDecodeError> {
-    let parts: alloc::vec::Vec<&str> = s.split(',').collect();
+    let parts: Vec<&str> = s.split(',').collect();
     if parts.len() != 3 {
         return Err(QosDecodeError::InvalidLiveliness);
     }

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = { workspace = true }
 paste = { workspace = true }
 ros-z-cdr = { workspace = true }
 ros-z-derive = { workspace = true }
-ros-z-protocol = { workspace = true, features = ["std"] }
+ros-z-protocol = { workspace = true }
 ros-z-schema = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
# Description

`ros-z-protocol` now requires `std`, matching its actual dependency requirements and removing an unsupported `no_std` configuration path. This simplifies the crate feature setup and lets workspace consumers depend on `ros-z-protocol` without explicitly enabling `std`.

Treat this as an intentional feature/API cleanup.

