### PR TITLE
Require strict ros-z endpoint metadata

### DIFF
--- a/crates/nodes/booster_sdk_interface/src/lib.rs
+++ b/crates/nodes/booster_sdk_interface/src/lib.rs
@@ -107,7 +107,15 @@ pub struct GetRobotMode;
 
 impl ServiceTypeInfo for GetRobotMode {
     fn service_type_info() -> std::prelude::v1::Result<ros_z::prelude::TypeInfo, SchemaError> {
-        Ok(TypeInfo::new("hardware_interface::GetRobotMode", None))
+        let descriptor = ros_z::__private::ros_z_schema::ServiceDef::new(
+            "hardware_interface::GetRobotMode",
+            "hardware_interface::GetRobotModeRequest",
+            "hardware_interface::GetRobotModeResponse",
+        )?;
+        Ok(TypeInfo::new(
+            "hardware_interface::GetRobotMode",
+            ros_z::__private::ros_z_schema::compute_hash(&descriptor),
+        ))
     }
 }
 

--- a/crates/ros-z-cli/src/commands/echo.rs
+++ b/crates/ros-z-cli/src/commands/echo.rs
@@ -34,16 +34,10 @@ pub async fn run(
     let _schema = subscriber
         .schema()
         .ok_or_else(|| eyre!("dynamic subscriber missing schema for {topic}"))?;
-    let type_name = subscriber
-        .entity()
-        .type_info
-        .as_ref()
-        .map(|type_info| type_info.name.clone())
-        .unwrap_or_else(|| "unknown".to_string());
     let header = EchoHeader::new(
         topic.to_string(),
-        type_name.clone(),
-        display_schema_hash(&subscriber),
+        subscriber.entity().type_info.name.clone(),
+        subscriber.entity().type_info.hash.to_hash_string(),
     );
     let deadline = timeout
         .map(Duration::from_secs_f64)
@@ -66,7 +60,7 @@ pub async fn run(
             OutputMode::Json => {
                 let view = EchoMessageView::new(
                     header.topic.clone(),
-                    type_name.clone(),
+                    subscriber.entity().type_info.name.clone(),
                     header.schema_hash.clone(),
                     dynamic_payload_to_json(&message),
                 );
@@ -77,17 +71,6 @@ pub async fn run(
             }
         }
     }
-}
-
-fn display_schema_hash(subscriber: &DynamicSubscriber) -> String {
-    display_schema_hash_from_type_info(subscriber.entity().type_info.as_ref())
-}
-
-fn display_schema_hash_from_type_info(type_info: Option<&ros_z::TypeInfo>) -> String {
-    type_info
-        .and_then(|type_info| type_info.hash)
-        .map(|hash| hash.to_hash_string())
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
 async fn receive_message(
@@ -314,36 +297,5 @@ fn format_enum_payload_pretty(output: &mut String, payload: &EnumPayloadValue, i
 fn format_named_fields_pretty(output: &mut String, fields: &[DynamicNamedValue], indent: usize) {
     for field in fields {
         format_value_pretty(output, &field.name, &field.value, indent);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ros_z::{SchemaHash, TypeInfo};
-
-    use super::display_schema_hash_from_type_info;
-
-    #[test]
-    fn display_schema_hash_prefers_advertised_canonical_hash() {
-        let hash = SchemaHash::from_hash_string(
-            "RZHS02_1111111111111111111111111111111111111111111111111111111111111111",
-        )
-        .expect("hash");
-        let type_info = TypeInfo::with_hash("std_msgs::String", hash);
-
-        assert_eq!(
-            display_schema_hash_from_type_info(Some(&type_info)),
-            "RZHS02_1111111111111111111111111111111111111111111111111111111111111111"
-        );
-    }
-
-    #[test]
-    fn display_schema_hash_reports_unknown_without_advertised_hash() {
-        let type_info = TypeInfo::new("std_msgs::String", None);
-
-        assert_eq!(
-            display_schema_hash_from_type_info(Some(&type_info)),
-            "unknown"
-        );
     }
 }

--- a/crates/ros-z-cli/src/model/info.rs
+++ b/crates/ros-z-cli/src/model/info.rs
@@ -2,8 +2,8 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EndpointSummary {
-    pub node: Option<String>,
-    pub schema_hash: Option<String>,
+    pub node: String,
+    pub schema_hash: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/ros-z-cli/src/render/text.rs
+++ b/crates/ros-z-cli/src/render/text.rs
@@ -280,12 +280,9 @@ fn print_endpoint_section(label: &str, endpoints: &[EndpointSummary]) {
     }
 
     for endpoint in endpoints {
-        match (&endpoint.node, &endpoint.schema_hash) {
-            (Some(node), Some(schema_hash)) => println!("{node} [{schema_hash}]"),
-            (Some(node), None) => println!("{node}"),
-            (None, Some(schema_hash)) => println!("unknown [{schema_hash}]"),
-            (None, None) => println!("unknown"),
-        }
+        let node = &endpoint.node;
+        let schema_hash = &endpoint.schema_hash;
+        println!("{node} [{schema_hash}]");
     }
 }
 

--- a/crates/ros-z-cli/src/support/endpoints.rs
+++ b/crates/ros-z-cli/src/support/endpoints.rs
@@ -1,27 +1,19 @@
 use std::{collections::BTreeSet, sync::Arc};
 
-use ros_z::entity::{Entity, entity_get_endpoint};
+use ros_z::entity::Entity;
 
-use crate::{
-    model::info::{EndpointSummary, NamedType},
-    support::nodes::fully_qualified_node_name,
-};
+use crate::model::info::{EndpointSummary, NamedType};
 
 pub fn summarize_endpoints(entities: Vec<Arc<Entity>>) -> Vec<EndpointSummary> {
     let mut endpoints = BTreeSet::new();
 
     for entity in entities {
-        if let Some(endpoint) = entity_get_endpoint(&entity) {
-            let node = endpoint
-                .node
-                .as_ref()
-                .map(|node| fully_qualified_node_name(&node.namespace, &node.name));
-            let schema_hash = endpoint
-                .type_info
-                .as_ref()
-                .and_then(|type_info| type_info.hash.as_ref().map(|hash| hash.to_string()));
-            endpoints.insert((node, schema_hash));
-        }
+        let Entity::Endpoint(endpoint) = &*entity else {
+            continue;
+        };
+        let node = endpoint.node.fully_qualified_name();
+        let schema_hash = endpoint.type_info.hash.to_string();
+        endpoints.insert((node, schema_hash));
     }
 
     endpoints
@@ -47,38 +39,26 @@ mod tests {
     use super::summarize_endpoints;
 
     #[test]
-    fn summarize_endpoints_keeps_missing_schema_hash() {
-        let entities = vec![Arc::new(Entity::Endpoint(EndpointEntity {
-            id: 7,
-            node: None,
-            kind: EndpointKind::Publisher,
-            topic: "/demo".to_string(),
-            type_info: Some(TypeInfo::new("std_msgs::String", None)),
-            qos: Default::default(),
-        }))];
-
-        let summaries = summarize_endpoints(entities);
-
-        assert_eq!(summaries.len(), 1);
-        assert_eq!(summaries[0].schema_hash, None);
-    }
-
-    #[test]
     fn summarize_endpoints_formats_present_schema_hash() {
         let hash = SchemaHash([0xcd; 32]);
         let expected = hash.to_string();
         let entities = vec![Arc::new(Entity::Endpoint(EndpointEntity {
             id: 7,
-            node: None,
+            node: ros_z::entity::NodeEntity {
+                z_id: Default::default(),
+                id: 1,
+                name: "node".to_string(),
+                namespace: "/".to_string(),
+            },
             kind: EndpointKind::Publisher,
             topic: "/demo".to_string(),
-            type_info: Some(TypeInfo::with_hash("std_msgs::String", hash)),
+            type_info: TypeInfo::new("std_msgs::String", hash),
             qos: Default::default(),
         }))];
 
         let summaries = summarize_endpoints(entities);
 
         assert_eq!(summaries.len(), 1);
-        assert_eq!(summaries[0].schema_hash.as_deref(), Some(expected.as_str()));
+        assert_eq!(summaries[0].schema_hash, expected.as_str());
     }
 }

--- a/crates/ros-z-cli/tests/e2e.rs
+++ b/crates/ros-z-cli/tests/e2e.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ros_z::__private::ros_z_schema::SchemaError;
+use ros_z::__private::ros_z_schema::{self, SchemaError};
 use ros_z::{
     Message, ServiceTypeInfo,
     context::{Context, ContextBuilder},
@@ -74,7 +74,15 @@ struct AddTwoInts;
 
 impl ServiceTypeInfo for AddTwoInts {
     fn service_type_info() -> Result<TypeInfo, SchemaError> {
-        Ok(TypeInfo::new("test_cli::AddTwoInts", None))
+        let descriptor = ros_z_schema::ServiceDef::new(
+            "test_cli::AddTwoInts",
+            "test_cli::AddRequest",
+            "test_cli::AddResponse",
+        )?;
+        Ok(TypeInfo::new(
+            "test_cli::AddTwoInts",
+            ros_z_schema::compute_hash(&descriptor),
+        ))
     }
 }
 

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -68,6 +68,14 @@ impl NodeEntity {
             namespace,
         }
     }
+
+    pub fn fully_qualified_name(&self) -> String {
+        if self.namespace == "/" {
+            format!("/{}", self.name)
+        } else {
+            format!("{}/{}", self.namespace, self.name)
+        }
+    }
 }
 
 /// ros-z entity kind (node, publisher, subscription, service, client).
@@ -166,23 +174,19 @@ impl TryFrom<EntityKind> for EndpointKind {
     }
 }
 
-/// Type information (name + hash).
+/// Type information (name + schema hash).
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct TypeInfo {
     pub name: String,
-    pub hash: Option<SchemaHash>,
+    pub hash: SchemaHash,
 }
 
 impl TypeInfo {
-    pub fn new(name: &str, hash: Option<SchemaHash>) -> Self {
+    pub fn new(name: impl Into<String>, hash: SchemaHash) -> Self {
         TypeInfo {
-            name: name.to_string(),
+            name: name.into(),
             hash,
         }
-    }
-
-    pub fn with_hash(name: &str, hash: SchemaHash) -> Self {
-        Self::new(name, Some(hash))
     }
 }
 
@@ -190,10 +194,10 @@ impl TypeInfo {
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct EndpointEntity {
     pub id: usize,
-    pub node: Option<NodeEntity>,
+    pub node: NodeEntity,
     pub kind: EndpointKind,
     pub topic: String,
-    pub type_info: Option<TypeInfo>,
+    pub type_info: TypeInfo,
     pub qos: QosProfile,
 }
 
@@ -235,3 +239,32 @@ impl Display for EntityConversionError {
 }
 
 impl std::error::Error for EntityConversionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::NodeEntity;
+
+    fn node(namespace: &str) -> NodeEntity {
+        NodeEntity::new(
+            Default::default(),
+            1,
+            "node".to_string(),
+            namespace.to_string(),
+        )
+    }
+
+    #[test]
+    fn fully_qualified_name_formats_root_namespace() {
+        assert_eq!(node("/").fully_qualified_name(), "/node");
+    }
+
+    #[test]
+    fn fully_qualified_name_formats_empty_namespace_as_root() {
+        assert_eq!(node("").fully_qualified_name(), "/node");
+    }
+
+    #[test]
+    fn fully_qualified_name_inserts_separator_after_non_root_namespace() {
+        assert_eq!(node("/robot").fully_qualified_name(), "/robot/node");
+    }
+}

--- a/crates/ros-z-protocol/src/format.rs
+++ b/crates/ros-z-protocol/src/format.rs
@@ -16,15 +16,8 @@ use crate::{
 
 pub const ADMIN_SPACE: &str = "@ros_z";
 pub const EMPTY_PLACEHOLDER: &str = "%";
-pub const EMPTY_TYPE_NAME: &str = "EMPTY_TYPE_NAME";
-pub const EMPTY_SCHEMA_HASH: &str = "EMPTY_SCHEMA_HASH";
 
 const ESCAPE_CHAR: char = '%';
-
-fn format_type_hash(hash: Option<&SchemaHash>) -> String {
-    hash.map(SchemaHash::to_hash_string)
-        .unwrap_or_else(|| EMPTY_SCHEMA_HASH.to_string())
-}
 
 fn stripped_topic(topic: &str) -> &str {
     let topic = topic.strip_prefix('/').unwrap_or(topic);
@@ -33,51 +26,34 @@ fn stripped_topic(topic: &str) -> &str {
 
 pub fn topic_key_expr(entity: &EndpointEntity) -> Result<TopicKE> {
     let EndpointEntity {
-        node: Some(_),
-        topic,
-        type_info,
-        ..
-    } = entity
-    else {
-        return Err(zenoh::Error::from(
-            "native endpoint keys require node identity",
-        ));
-    };
+        topic, type_info, ..
+    } = entity;
 
     let topic = stripped_topic(topic);
-    let type_info =
-        type_info
-            .as_ref()
-            .map_or(format!("{EMPTY_TYPE_NAME}/{EMPTY_SCHEMA_HASH}"), |info| {
-                let type_name = demangle_name(&info.name);
-                let type_hash = demangle_name(&format_type_hash(info.hash.as_ref()));
-                format!("{type_name}/{type_hash}")
-            });
+    let type_name = demangle_name(&type_info.name);
+    let type_hash = demangle_name(&type_info.hash.to_hash_string());
 
-    Ok(TopicKE::new(format!("rt/{topic}/{type_info}").try_into()?))
+    Ok(TopicKE::new(
+        format!("rt/{topic}/{type_name}/{type_hash}").try_into()?,
+    ))
 }
 
 pub fn liveliness_key_expr(entity: &EndpointEntity, _zid: &ZenohId) -> Result<LivelinessKE> {
     let EndpointEntity {
         id,
         node:
-            Some(NodeEntity {
+            NodeEntity {
                 z_id,
                 id: node_id,
                 name: node_name,
                 namespace: node_namespace,
                 ..
-            }),
+            },
         kind,
         topic: topic_name,
         type_info,
         qos,
-    } = entity
-    else {
-        return Err(zenoh::Error::from(
-            "native liveliness requires node identity",
-        ));
-    };
+    } = entity;
 
     let node_namespace = if node_namespace.is_empty() {
         EMPTY_PLACEHOLDER.to_string()
@@ -86,20 +62,12 @@ pub fn liveliness_key_expr(entity: &EndpointEntity, _zid: &ZenohId) -> Result<Li
     };
     let node_name = mangle_name(node_name);
     let topic_name = mangle_name(topic_name.strip_suffix('/').unwrap_or(topic_name));
-    let type_info_str =
-        type_info
-            .as_ref()
-            .map_or(format!("{EMPTY_TYPE_NAME}/{EMPTY_SCHEMA_HASH}"), |info| {
-                format!(
-                    "{}/{}",
-                    mangle_name(&info.name),
-                    format_type_hash(info.hash.as_ref())
-                )
-            });
+    let type_name = mangle_name(&type_info.name);
+    let type_hash = type_info.hash.to_hash_string();
     let qos_str = qos.encode();
 
     let ke = format!(
-        "{ADMIN_SPACE}/{z_id}/{node_id}/{id}/{kind}/{node_namespace}/{node_name}/{topic_name}/{type_info_str}/{qos_str}"
+        "{ADMIN_SPACE}/{z_id}/{node_id}/{id}/{kind}/{node_namespace}/{node_name}/{topic_name}/{type_name}/{type_hash}/{qos_str}"
     );
 
     Ok(LivelinessKE::new(ke.try_into()?))
@@ -177,24 +145,17 @@ pub fn parse_liveliness(ke: &KeyExpr) -> Result<Entity> {
             let topic_type = iter.next().ok_or(MissingTopicType)?;
             let topic_hash = iter.next().ok_or(MissingTopicHash)?;
 
-            let type_info = match (topic_type, topic_hash) {
-                (EMPTY_TYPE_NAME, EMPTY_SCHEMA_HASH) => None,
-                (EMPTY_TYPE_NAME, _) => None,
-                (topic_type, EMPTY_SCHEMA_HASH) => {
-                    Some(TypeInfo::new(&demangle_name(topic_type), None))
-                }
-                (topic_type, topic_hash) => Some(TypeInfo::new(
-                    &demangle_name(topic_type),
-                    Some(SchemaHash::from_hash_string(topic_hash).map_err(|_| ParsingError)?),
-                )),
-            };
+            let type_info = TypeInfo::new(
+                demangle_name(topic_type),
+                SchemaHash::from_hash_string(topic_hash).map_err(|_| ParsingError)?,
+            );
 
             let qos =
                 QosProfile::decode(iter.next().ok_or(MissingTopicQoS)?).map_err(QosDecodeError)?;
 
             Entity::Endpoint(EndpointEntity {
                 id: entity_id,
-                node: Some(node),
+                node,
                 kind: EndpointKind::try_from(entity_kind).map_err(|_| ParsingError)?,
                 topic: topic_name,
                 type_info,

--- a/crates/ros-z-protocol/src/lib.rs
+++ b/crates/ros-z-protocol/src/lib.rs
@@ -17,10 +17,10 @@
 //!
 //! let entity = EndpointEntity {
 //!     id: 1,
-//!     node: Some(node),
+//!     node,
 //!     kind: EndpointKind::Publisher,
 //!     topic: "/chatter".to_string(),
-//!     type_info: None,
+//!     type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
 //!     qos: Default::default(),
 //! };
 //!

--- a/crates/ros-z-protocol/tests/key_expr.rs
+++ b/crates/ros-z-protocol/tests/key_expr.rs
@@ -25,13 +25,10 @@ fn default_node() -> NodeEntity {
 fn endpoint_entity(kind: EndpointKind, topic: &str) -> EndpointEntity {
     EndpointEntity {
         id: 42,
-        node: Some(default_node()),
+        node: default_node(),
         kind,
         topic: topic.to_string(),
-        type_info: Some(TypeInfo {
-            name: "std_msgs::String".to_string(),
-            hash: Some(SchemaHash::zero()),
-        }),
+        type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
         qos: QosProfile {
             reliability: QosReliability::Reliable,
             durability: QosDurability::Volatile,
@@ -56,10 +53,10 @@ fn native_endpoint_liveliness(kind: EndpointKind) -> ros_z_protocol::entity::Liv
     };
     let entity = EndpointEntity {
         id: 2,
-        node: Some(node),
+        node,
         kind,
         topic: "/chatter".to_string(),
-        type_info: Some(TypeInfo::new("std_msgs::String", None)),
+        type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
         qos: QosProfile::default(),
     };
 
@@ -90,32 +87,12 @@ fn parse_native_endpoint_liveliness_preserves_endpoint_kind_and_topic() {
 fn reject_ros2_liveliness_prefix() {
     let key_expr: zenoh::key_expr::KeyExpr<'static> = concat!(
         "@ros2",
-        "_lv/0/1234567890abcdef1234567890abcdef/1/1/MP/%/%/talker/chatter/std_msgs::String/EMPTY_SCHEMA_HASH/Q"
+        "_lv/0/1234567890abcdef1234567890abcdef/1/1/MP/%/%/talker/chatter/std_msgs::String/0000000000000000000000000000000000000000000000000000000000000000/Q"
     )
     .try_into()
     .unwrap();
 
     assert!(format::parse_liveliness(&key_expr).is_err());
-}
-
-#[test]
-fn missing_type_info_uses_endpoint_neutral_placeholders() {
-    let mut entity = endpoint_entity(EndpointKind::Publisher, "/chatter");
-    entity.type_info = None;
-
-    let topic_key = format::topic_key_expr(&entity).unwrap().to_string();
-    assert!(topic_key.contains("EMPTY_TYPE_NAME/EMPTY_SCHEMA_HASH"));
-
-    let liveliness = format::liveliness_key_expr(&entity, &ZenohId::default())
-        .unwrap()
-        .to_string();
-    assert!(liveliness.contains("EMPTY_TYPE_NAME/EMPTY_SCHEMA_HASH"));
-
-    let parsed = parse_liveliness(&liveliness).unwrap();
-    match parsed {
-        Entity::Endpoint(endpoint) => assert_eq!(endpoint.type_info, None),
-        Entity::Node(_) => panic!("expected endpoint"),
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -143,30 +120,22 @@ fn endpoint_liveliness_roundtrip_preserves_public_fields_for_all_endpoint_kinds(
         assert_eq!(ep.topic, topic);
         assert_eq!(ep.type_info, entity.type_info);
         assert_eq!(ep.qos, entity.qos);
-        assert_eq!(
-            ep.node.as_ref().unwrap().z_id,
-            entity.node.as_ref().unwrap().z_id
-        );
-        assert_eq!(
-            ep.node.as_ref().unwrap().id,
-            entity.node.as_ref().unwrap().id
-        );
-        assert_eq!(
-            ep.node.as_ref().unwrap().name,
-            entity.node.as_ref().unwrap().name
-        );
-        let expected_namespace = match entity.node.as_ref().unwrap().namespace.as_str() {
+        assert_eq!(ep.node.z_id, entity.node.z_id);
+        assert_eq!(ep.node.id, entity.node.id);
+        assert_eq!(ep.node.name, entity.node.name);
+        let expected_namespace = match entity.node.namespace.as_str() {
             "/" => "",
             namespace => namespace,
         };
-        assert_eq!(ep.node.as_ref().unwrap().namespace, expected_namespace);
+        assert_eq!(ep.node.namespace, expected_namespace);
     }
 }
 
 #[test]
-fn test_type_info_without_hash_roundtrip() {
+fn test_type_info_with_hash_roundtrip() {
+    let hash = SchemaHash([0xab; 32]);
     let mut entity = endpoint_entity(EndpointKind::Publisher, "/chatter");
-    entity.type_info = Some(TypeInfo::new("test_action::FeedbackMessage", None));
+    entity.type_info = TypeInfo::new("test_action::FeedbackMessage", hash);
     let zid = ZenohId::default();
 
     let ke = format::liveliness_key_expr(&entity, &zid).unwrap();
@@ -175,7 +144,7 @@ fn test_type_info_without_hash_roundtrip() {
     if let Entity::Endpoint(ep) = parsed {
         assert_eq!(
             ep.type_info,
-            Some(TypeInfo::new("test_action::FeedbackMessage", None))
+            TypeInfo::new("test_action::FeedbackMessage", hash)
         );
     } else {
         panic!("expected Endpoint entity");

--- a/crates/ros-z/examples/custom_message/navigation_types.rs
+++ b/crates/ros-z/examples/custom_message/navigation_types.rs
@@ -1,8 +1,4 @@
-use ros_z::{
-    Message, ServiceTypeInfo,
-    entity::{SchemaHash, TypeInfo},
-    message::Service,
-};
+use ros_z::{Message, ServiceTypeInfo, entity::TypeInfo, message::Service};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Message)]
@@ -32,7 +28,7 @@ impl ServiceTypeInfo for NavigateTo {
         )?;
         Ok(TypeInfo::new(
             "custom_msgs::NavigateTo",
-            Some(SchemaHash(ros_z_schema::compute_hash(&descriptor).0)),
+            ros_z_schema::compute_hash(&descriptor),
         ))
     }
 }

--- a/crates/ros-z/examples/service/add_two_ints.rs
+++ b/crates/ros-z/examples/service/add_two_ints.rs
@@ -1,8 +1,4 @@
-use ros_z::{
-    Message, ServiceTypeInfo,
-    entity::{SchemaHash, TypeInfo},
-    message::Service,
-};
+use ros_z::{Message, ServiceTypeInfo, entity::TypeInfo, message::Service};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Message)]
@@ -29,7 +25,7 @@ impl ServiceTypeInfo for AddTwoInts {
         )?;
         Ok(TypeInfo::new(
             "demo_nodes::AddTwoInts",
-            Some(SchemaHash(ros_z_schema::compute_hash(&descriptor).0)),
+            ros_z_schema::compute_hash(&descriptor),
         ))
     }
 }

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -18,6 +18,12 @@ pub struct DiscoveredTopicSchema {
     pub schema_hash: SchemaHash,
 }
 
+impl DiscoveredTopicSchema {
+    pub fn type_info(&self) -> TypeInfo {
+        TypeInfo::new(&self.root_name, self.schema_hash)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TopicSchemaCandidate {
     pub node_name: String,
@@ -53,49 +59,23 @@ pub(crate) fn collect_topic_schema_candidates_from_publishers(
     publishers: &[Arc<Entity>],
     qualified_topic: &str,
 ) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
-    let mut saw_missing_node_identity = false;
-    let mut saw_missing_type_info = false;
     let mut candidates = BTreeSet::new();
 
     for publisher in publishers {
         let Entity::Endpoint(endpoint) = &**publisher else {
             continue;
         };
-        let Some(node) = endpoint.node.as_ref() else {
-            saw_missing_node_identity = true;
-            continue;
-        };
-        let Some(type_info) = endpoint.type_info.as_ref() else {
-            saw_missing_type_info = true;
-            continue;
-        };
-        let Some(schema_hash) = type_info.hash else {
-            continue;
-        };
 
         candidates.insert(TopicSchemaCandidate {
-            node_name: node.name.clone(),
-            namespace: node.namespace.clone(),
-            type_name: type_info.name.clone(),
-            schema_hash,
+            node_name: endpoint.node.name.clone(),
+            namespace: endpoint.node.namespace.clone(),
+            type_name: endpoint.type_info.name.clone(),
+            schema_hash: endpoint.type_info.hash,
         });
     }
 
     if !candidates.is_empty() {
         return Ok(candidates.into_iter().collect());
-    }
-
-    if saw_missing_node_identity {
-        return Err(DynamicError::MissingNodeIdentity {
-            topic: qualified_topic.to_string(),
-        });
-    }
-
-    if saw_missing_type_info {
-        return Err(DynamicError::SchemaNotFound(format!(
-            "No publishers with type information found for topic: {}",
-            qualified_topic
-        )));
     }
 
     Err(DynamicError::SchemaNotFound(format!(
@@ -169,10 +149,6 @@ impl<'a> SchemaDiscovery<'a> {
     }
 }
 
-pub(crate) fn discovered_schema_type_info(discovered: &DiscoveredTopicSchema) -> TypeInfo {
-    TypeInfo::with_hash(&discovered.root_name, discovered.schema_hash)
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -183,15 +159,15 @@ mod tests {
     fn publisher(type_name: &str) -> Arc<Entity> {
         Arc::new(Entity::Endpoint(EndpointEntity {
             id: 1,
-            node: Some(NodeEntity {
+            node: NodeEntity {
                 z_id: Default::default(),
                 id: 2,
                 name: "talker".to_string(),
                 namespace: "/".to_string(),
-            }),
+            },
             kind: EndpointKind::Publisher,
             topic: "/chatter".to_string(),
-            type_info: Some(TypeInfo::with_hash(type_name, SchemaHash::zero())),
+            type_info: TypeInfo::new(type_name, SchemaHash::zero()),
             qos: Default::default(),
         }))
     }
@@ -216,5 +192,29 @@ mod tests {
         .expect("candidate");
 
         assert_eq!(candidates[0].type_name, "std_msgs::msg::dds_::String_");
+    }
+
+    #[test]
+    fn publisher_schema_candidates_use_strict_endpoint_type_info() {
+        let hash = SchemaHash([0x42; 32]);
+        let publisher = Arc::new(Entity::Endpoint(EndpointEntity {
+            id: 1,
+            node: NodeEntity {
+                z_id: Default::default(),
+                id: 2,
+                name: "talker".to_string(),
+                namespace: "/".to_string(),
+            },
+            kind: EndpointKind::Publisher,
+            topic: "/chatter".to_string(),
+            type_info: TypeInfo::new("std_msgs::String", hash),
+            qos: Default::default(),
+        }));
+
+        let candidates = collect_topic_schema_candidates_from_publishers(&[publisher], "/chatter")
+            .expect("candidate");
+
+        assert_eq!(candidates[0].type_name, "std_msgs::String");
+        assert_eq!(candidates[0].schema_hash, hash);
     }
 }

--- a/crates/ros-z/src/dynamic/mod.rs
+++ b/crates/ros-z/src/dynamic/mod.rs
@@ -99,7 +99,7 @@ pub use value::{
     DynamicNamedValue, DynamicValue, EnumPayloadValue, EnumValue, FromDynamic, IntoDynamic,
 };
 
-pub(crate) use discovery::{SchemaDiscovery, discovered_schema_type_info};
+pub(crate) use discovery::SchemaDiscovery;
 
 use crate::pubsub::{Publisher, PublisherBuilder, Subscriber, SubscriberBuilder};
 

--- a/crates/ros-z/src/dynamic/schema_service.rs
+++ b/crates/ros-z/src/dynamic/schema_service.rs
@@ -151,7 +151,7 @@ impl ServiceTypeInfo for GetSchema {
             "ros_z::GetSchemaResponse",
         )?;
 
-        Ok(TypeInfo::with_hash(
+        Ok(TypeInfo::new(
             descriptor.type_name.as_str(),
             ros_z_schema::compute_hash(&descriptor),
         ))
@@ -282,12 +282,10 @@ fn schema_service_server_builder(
 
     let entity = EndpointEntity {
         id: counter.increment(),
-        node: Some(node_entity),
+        node: node_entity,
         kind: EndpointKind::Service,
         topic: service_name.to_string(),
-        type_info: Some(
-            GetSchema::service_type_info().expect("schema service type info is static"),
-        ),
+        type_info: GetSchema::service_type_info().expect("schema service type info is static"),
         qos: Default::default(),
     };
 

--- a/crates/ros-z/src/entity.rs
+++ b/crates/ros-z/src/entity.rs
@@ -52,12 +52,8 @@ pub fn node_lv_token_key_expr(entity: &NodeEntity) -> Result<KeyExpr<'static>> {
 /// Get the global identifier for this endpoint.
 pub fn endpoint_global_id(entity: &EndpointEntity) -> EndpointGlobalId {
     use sha2::Digest;
-    let node = entity
-        .node
-        .as_ref()
-        .expect("endpoint_global_id requires endpoint node identity");
     let mut hasher = sha2::Sha256::new();
-    hasher.update(node.z_id.to_le_bytes());
+    hasher.update(entity.node.z_id.to_le_bytes());
     hasher.update(entity.id.to_le_bytes());
     let hash = hasher.finalize();
     let mut endpoint_global_id = [0u8; 16];
@@ -75,12 +71,7 @@ pub fn node_to_liveliness_key_expr(entity: &NodeEntity) -> Result<LivelinessKE> 
 
 /// Convert an EndpointEntity to a LivelinessKE using the default format
 pub fn endpoint_to_liveliness_key_expr(entity: &EndpointEntity) -> Result<LivelinessKE> {
-    let Some(node) = entity.node.as_ref() else {
-        return Err(zenoh::Error::from(
-            "endpoint liveliness requires node identity",
-        ));
-    };
-    ros_z_protocol::format::liveliness_key_expr(entity, &node.z_id)
+    ros_z_protocol::format::liveliness_key_expr(entity, &entity.node.z_id)
 }
 
 /// Convert an Entity to a LivelinessKE using the default format
@@ -124,10 +115,10 @@ mod tests {
     fn endpoint_entity(node: NodeEntity, id: usize) -> EndpointEntity {
         EndpointEntity {
             id,
-            node: Some(node),
+            node,
             kind: EndpointKind::Publisher,
             topic: "/topic".to_string(),
-            type_info: None,
+            type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
             qos: Default::default(),
         }
     }

--- a/crates/ros-z/src/graph/mod.rs
+++ b/crates/ros-z/src/graph/mod.rs
@@ -132,10 +132,7 @@ impl Graph {
     pub fn is_entity_local(&self, entity: &Entity) -> bool {
         match entity {
             Entity::Node(node) => node.z_id == self.zid,
-            Entity::Endpoint(endpoint) => endpoint
-                .node
-                .as_ref()
-                .is_some_and(|node| node.z_id == self.zid),
+            Entity::Endpoint(endpoint) => endpoint.node.z_id == self.zid,
         }
     }
 

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -187,10 +187,9 @@ impl Graph {
         data.visit_by_node(node_key, |ent| {
             if let Some(enp) = entity_get_endpoint(&ent)
                 && enp.entity_kind() == kind
-                && let Some(type_info) = &enp.type_info
             {
                 // Insert into set for automatic deduplication
-                res_set.insert((enp.topic.clone(), type_info.name.clone()));
+                res_set.insert((enp.topic.clone(), enp.type_info.name.clone()));
             }
         });
 

--- a/crates/ros-z/src/graph/state.rs
+++ b/crates/ros-z/src/graph/state.rs
@@ -96,9 +96,7 @@ impl GraphData {
                 {
                     Self::retain_entities_not_matching_key(slab, key_expr);
                 }
-                if let Some(node) = endpoint_entity.node.as_ref()
-                    && let Some(slab) = self.by_node.get_mut(&node_key(node))
-                {
+                if let Some(slab) = self.by_node.get_mut(&node_key(&endpoint_entity.node)) {
                     Self::retain_entities_not_matching_key(slab, key_expr);
                 }
             }
@@ -132,11 +130,9 @@ impl GraphData {
                     Self::insert_weak_entity(service_slab, weak.clone());
                 }
 
-                if let Some(node) = endpoint.node.as_ref() {
-                    // Index maps own their keys so parsed entities can remain immutable and shared by Arc.
-                    let node_slab = Self::get_or_create_slab(&mut self.by_node, node_key(node));
-                    Self::insert_weak_entity(node_slab, weak);
-                }
+                let node_slab =
+                    Self::get_or_create_slab(&mut self.by_node, node_key(&endpoint.node));
+                Self::insert_weak_entity(node_slab, weak);
             }
         }
     }
@@ -212,40 +208,22 @@ impl GraphData {
                     );
                 }
                 Entity::Endpoint(x) => {
-                    let node_desc = x
-                        .node
-                        .as_ref()
-                        .map(|node| format!("{}/{}", node.namespace, node.name))
-                        .unwrap_or_else(|| "<unavailable>".to_string());
+                    let node_desc = format!("{}/{}", x.node.namespace, x.node.name);
                     debug!(
                         "[GRF] Parsed endpoint: kind={:?}, topic={}, node={}",
                         x.kind, x.topic, node_desc
                     );
-                    let type_str = x
-                        .type_info
-                        .as_ref()
-                        .map(|t| t.name.as_str())
-                        .unwrap_or("unknown");
-                    if let Some(node) = x.node.as_ref() {
-                        let node_key = node_key(node);
-                        tracing::debug!(
-                            "parse: Storing Endpoint ({:?}) for node_key=({:?}, {:?}), topic={}, type={}, id={}",
-                            x.kind,
-                            node_key.0,
-                            node_key.1,
-                            x.topic,
-                            type_str,
-                            x.id
-                        );
-                    } else {
-                        tracing::debug!(
-                            "parse: Storing Endpoint ({:?}) without node identity, topic={}, type={}, id={}",
-                            x.kind,
-                            x.topic,
-                            type_str,
-                            x.id
-                        );
-                    }
+                    let type_str = x.type_info.name.as_str();
+                    let node_key = node_key(&x.node);
+                    tracing::debug!(
+                        "parse: Storing Endpoint ({:?}) for node_key=({:?}, {:?}), topic={}, type={}, id={}",
+                        x.kind,
+                        node_key.0,
+                        node_key.1,
+                        x.topic,
+                        type_str,
+                        x.id
+                    );
                 }
             }
             self.index_entity_arc(&arc);
@@ -370,7 +348,7 @@ impl GraphData {
                         && found_type.is_none()
                         && enp.kind == EndpointKind::Service
                     {
-                        found_type = enp.type_info.as_ref().map(|x| x.name.clone());
+                        found_type = Some(enp.type_info.name.clone());
                     }
                     true
                 } else {
@@ -397,9 +375,8 @@ impl GraphData {
                             enp.kind,
                             EndpointKind::Publisher | EndpointKind::Subscription
                         )
-                        && let Some(type_info) = &enp.type_info
                     {
-                        found_type = Some(type_info.name.clone());
+                        found_type = Some(enp.type_info.name.clone());
                     }
                     true
                 } else {

--- a/crates/ros-z/src/message.rs
+++ b/crates/ros-z/src/message.rs
@@ -169,10 +169,7 @@ pub trait Message: MessageSchema + Send + Sync + Sized + 'static {
 
     /// Type name plus schema hash advertised for this message.
     fn type_info() -> Result<TypeInfo, SchemaError> {
-        Ok(TypeInfo::with_hash(
-            &Self::type_name(),
-            Self::schema_hash()?,
-        ))
+        Ok(TypeInfo::new(Self::type_name(), Self::schema_hash()?))
     }
 }
 

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -7,7 +7,7 @@ use crate::{
     dynamic::{
         DiscoveredTopicSchema, DynamicCdrCodec, DynamicError, DynamicPayload,
         DynamicPublisherBuilder, DynamicSubscriberBuilder, Schema, SchemaDiscovery, SchemaService,
-        discovered_schema_type_info, schema_service::SchemaServiceNodeIdentity,
+        schema_service::SchemaServiceNodeIdentity,
     },
     entity::*,
     graph::Graph,
@@ -211,7 +211,7 @@ impl NodeBuilder {
 }
 
 fn typed_message_type_info<T: Message>(schema: &Schema) -> TypeInfo {
-    TypeInfo::with_hash(&T::type_name(), ros_z_schema::compute_hash(schema.as_ref()))
+    TypeInfo::new(T::type_name(), ros_z_schema::compute_hash(schema.as_ref()))
 }
 
 fn message_schema_build_error(
@@ -290,14 +290,10 @@ impl Node {
                 .map_err(|error| message_schema_build_error("publisher", topic, error))?;
         }
 
-        Ok(self.publisher_impl::<T, T::Codec>(topic, Some(typed_message_type_info::<T>(&schema))))
+        Ok(self.publisher_impl::<T, T::Codec>(topic, typed_message_type_info::<T>(&schema)))
     }
 
-    fn publisher_impl<T, S>(
-        &self,
-        topic: &str,
-        type_info: Option<TypeInfo>,
-    ) -> PublisherBuilder<T, S>
+    fn publisher_impl<T, S>(&self, topic: &str, type_info: TypeInfo) -> PublisherBuilder<T, S>
     where
         S: WireEncoder,
     {
@@ -305,7 +301,7 @@ impl Node {
         // to allow error handling in the Result type
         let entity = EndpointEntity {
             id: self.counter.increment(),
-            node: Some(self.entity.clone()),
+            node: self.entity.clone(),
             kind: EndpointKind::Publisher,
             topic: topic.to_string(),
             type_info,
@@ -341,14 +337,10 @@ impl Node {
             T::schema().map_err(|error| message_schema_build_error("subscriber", topic, error))?,
         );
 
-        Ok(self.subscriber_impl::<T, T::Codec>(topic, Some(typed_message_type_info::<T>(&schema))))
+        Ok(self.subscriber_impl::<T, T::Codec>(topic, typed_message_type_info::<T>(&schema)))
     }
 
-    fn subscriber_impl<T, S>(
-        &self,
-        topic: &str,
-        type_info: Option<TypeInfo>,
-    ) -> SubscriberBuilder<T, S>
+    fn subscriber_impl<T, S>(&self, topic: &str, type_info: TypeInfo) -> SubscriberBuilder<T, S>
     where
         S: WireDecoder,
     {
@@ -356,7 +348,7 @@ impl Node {
         // to allow error handling in the Result type
         let entity = EndpointEntity {
             id: self.counter.increment(),
-            node: Some(self.entity.clone()),
+            node: self.entity.clone(),
             kind: EndpointKind::Subscription,
             topic: topic.to_string(),
             type_info,
@@ -421,7 +413,7 @@ impl Node {
         let type_info =
             T::type_info().map_err(|error| message_schema_build_error("cache", topic, error))?;
         Ok(CacheBuilder::new(
-            self.subscriber_impl::<T, <T as Message>::Codec>(topic, Some(type_info)),
+            self.subscriber_impl::<T, <T as Message>::Codec>(topic, type_info),
             capacity,
         ))
     }
@@ -454,20 +446,20 @@ impl Node {
                 Ok(type_info)
             })
             .map_err(|error| service_type_info_build_error("server", name, error))?;
-        Ok(self.create_service_impl(name, Some(type_info)))
+        Ok(self.create_service_impl(name, type_info))
     }
 
     #[doc(hidden)]
     pub fn create_service_impl<T>(
         &self,
         name: &str,
-        type_info: Option<TypeInfo>,
+        type_info: TypeInfo,
     ) -> ServiceServerBuilder<T> {
         // Note: Service name qualification happens in ServiceServerBuilder::build()
         // to allow error handling in the Result type
         let entity = EndpointEntity {
             id: self.counter.increment(),
-            node: Some(self.entity.clone()),
+            node: self.entity.clone(),
             kind: EndpointKind::Service,
             topic: name.to_string(),
             type_info,
@@ -501,20 +493,20 @@ impl Node {
                 Ok(type_info)
             })
             .map_err(|error| service_type_info_build_error("client", name, error))?;
-        Ok(self.create_client_impl(name, Some(type_info)))
+        Ok(self.create_client_impl(name, type_info))
     }
 
     #[doc(hidden)]
     pub fn create_client_impl<T>(
         &self,
         name: &str,
-        type_info: Option<TypeInfo>,
+        type_info: TypeInfo,
     ) -> ServiceClientBuilder<T> {
         // Note: Service name qualification happens in ServiceClientBuilder::build()
         // to allow error handling in the Result type
         let entity = EndpointEntity {
             id: self.counter.increment(),
-            node: Some(self.entity.clone()),
+            node: self.entity.clone(),
             kind: EndpointKind::Client,
             topic: name.to_string(),
             type_info,
@@ -593,7 +585,9 @@ impl Node {
         &self.clock
     }
 
+    // ========================================================================
     // Dynamic Message API
+    // ========================================================================
 
     /// Create a dynamic publisher for the given topic.
     ///
@@ -620,7 +614,7 @@ impl Node {
     ///     )]),
     /// });
     ///
-    /// let type_info = TypeInfo::with_hash("std_msgs::String", ros_z_schema::compute_hash(schema.as_ref()));
+    /// let type_info = TypeInfo::new("std_msgs::String", ros_z_schema::compute_hash(schema.as_ref()));
     /// let publisher = node.dynamic_publisher("chatter", type_info, schema)?.build().await?;
     ///
     /// let mut message = DynamicStruct::default_for_schema(publisher.schema().unwrap())?;
@@ -631,7 +625,7 @@ impl Node {
     pub fn dynamic_publisher(
         &self,
         topic: &str,
-        mut type_info: TypeInfo,
+        type_info: TypeInfo,
         schema: Schema,
     ) -> Result<DynamicPublisherBuilder> {
         if let Err(error) = schema.validate() {
@@ -642,10 +636,6 @@ impl Node {
             return Err(message_schema_build_error("publisher", topic, error));
         }
 
-        if type_info.hash.is_none() {
-            type_info.hash = Some(ros_z_schema::compute_hash(schema.as_ref()));
-        }
-
         let should_register = registerable_schema_root(&type_info.name, schema.as_ref())
             .map_err(|error| message_schema_build_error("publisher", topic, error))?;
         if should_register {
@@ -653,7 +643,7 @@ impl Node {
                 .map_err(|error| message_schema_build_error("publisher", topic, error))?;
         }
 
-        Ok(self.dynamic_publisher_impl(topic, Some(type_info), schema))
+        Ok(self.dynamic_publisher_impl(topic, type_info, schema))
     }
 
     /// Discover the schema that publishers currently expose on a topic.
@@ -730,11 +720,7 @@ impl Node {
             discovered.schema_hash.to_hash_string()
         );
 
-        Ok(self.dynamic_subscriber_impl(
-            topic,
-            Some(discovered_schema_type_info(&discovered)),
-            discovered.schema,
-        ))
+        Ok(self.dynamic_subscriber_impl(topic, discovered.type_info(), discovered.schema))
     }
 
     /// Create a dynamic subscriber with a known schema.
@@ -766,14 +752,14 @@ impl Node {
     ///     )]),
     /// });
     ///
-    /// let type_info = TypeInfo::with_hash("std_msgs::String", ros_z_schema::compute_hash(schema.as_ref()));
-    /// let subscriber = node.dynamic_subscriber("chatter", Some(type_info), schema)?.build().await?;
+    /// let type_info = TypeInfo::new("std_msgs::String", ros_z_schema::compute_hash(schema.as_ref()));
+    /// let subscriber = node.dynamic_subscriber("chatter", type_info, schema)?.build().await?;
     /// let message = subscriber.recv().await?;
     /// ```
     pub fn dynamic_subscriber(
         &self,
         topic: &str,
-        type_info: Option<TypeInfo>,
+        type_info: TypeInfo,
         schema: Schema,
     ) -> Result<DynamicSubscriberBuilder> {
         if let Err(error) = schema.validate() {
@@ -786,7 +772,7 @@ impl Node {
     fn dynamic_publisher_impl(
         &self,
         topic: &str,
-        type_info: Option<TypeInfo>,
+        type_info: TypeInfo,
         schema: Schema,
     ) -> DynamicPublisherBuilder {
         self.publisher_impl::<DynamicPayload, DynamicCdrCodec>(topic, type_info)
@@ -796,7 +782,7 @@ impl Node {
     fn dynamic_subscriber_impl(
         &self,
         topic: &str,
-        type_info: Option<TypeInfo>,
+        type_info: TypeInfo,
         schema: Schema,
     ) -> DynamicSubscriberBuilder {
         self.subscriber_impl::<DynamicPayload, DynamicCdrCodec>(topic, type_info)

--- a/crates/ros-z/src/parameter/remote/types.rs
+++ b/crates/ros-z/src/parameter/remote/types.rs
@@ -174,7 +174,7 @@ macro_rules! impl_service {
                     <$req as crate::Message>::type_name(),
                     <$res as crate::Message>::type_name(),
                 )?;
-                Ok(TypeInfo::with_hash(
+                Ok(TypeInfo::new(
                     descriptor.type_name.as_str(),
                     ros_z_schema::compute_hash(&descriptor),
                 ))

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -238,9 +238,7 @@ where
     C: for<'a> WireEncoder<Input<'a> = &'a T> + 'static,
 {
     #[tracing::instrument(name = "pub_build", skip(self), fields(
-        topic = %self.entity.topic,
-        qos_reliability = ?self.entity.qos.reliability,
-        qos_durability = ?self.entity.qos.durability
+        topic = %self.entity.topic
     ))]
     pub async fn build(self) -> Result<Publisher<T, C>> {
         self.build_inner_async().await
@@ -254,23 +252,24 @@ where
         Option<Arc<TransientLocalCache>>,
         EndpointGlobalId,
     )> {
-        let Some(node) = self.entity.node.as_ref() else {
-            return Err(zenoh::Error::from("publisher build requires node identity"));
-        };
+        let entity = &mut self.entity;
         // Qualify the topic name as a ros-z graph name.
-        let qualified_topic =
-            topic_name::qualify_topic_name(&self.entity.topic, &node.namespace, &node.name)
-                .map_err(|e| zenoh::Error::from(format!("Failed to qualify topic: {}", e)))?;
+        let qualified_topic = topic_name::qualify_topic_name(
+            &entity.topic,
+            &entity.node.namespace,
+            &entity.node.name,
+        )
+        .map_err(|e| zenoh::Error::from(format!("Failed to qualify topic: {}", e)))?;
 
-        self.entity.topic = qualified_topic.clone();
+        entity.topic = qualified_topic.clone();
         debug!("[PUB] Qualified topic: {}", qualified_topic);
 
-        let topic_key_expr = ros_z_protocol::format::topic_key_expr(&self.entity)?;
+        let topic_key_expr = ros_z_protocol::format::topic_key_expr(entity)?;
         let data_key_expr = (*topic_key_expr).clone();
         debug!("[PUB] Key expression: {}", data_key_expr);
 
         if matches!(
-            self.entity.qos,
+            entity.qos,
             ros_z_protocol::qos::QosProfile {
                 durability: QosDurability::TransientLocal,
                 history: QosHistory::KeepAll,
@@ -282,9 +281,9 @@ where
             );
         }
 
-        let transient_local_cache = replay::transient_local_cache_capacity(&self.entity.qos)
+        let transient_local_cache = replay::transient_local_cache_capacity(&entity.qos)
             .map(|capacity| Arc::new(TransientLocalCache::new(capacity)));
-        let endpoint_global_id = endpoint_global_id(&self.entity);
+        let endpoint_global_id = endpoint_global_id(entity);
 
         Ok((
             data_key_expr,

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -587,7 +587,6 @@ fn replay_capable_publisher(entity: &Entity) -> Option<(EndpointGlobalId, usize)
     let QosHistory::KeepLast(depth) = endpoint.qos.history else {
         return None;
     };
-    endpoint.node.as_ref()?;
     Some((endpoint_global_id(endpoint), depth))
 }
 

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -125,28 +125,24 @@ where
     where
         F: Fn(Sample) + Send + Sync + 'static,
     {
-        let Some(node) = self.entity.node.as_ref() else {
-            return Err(zenoh::Error::from(
-                "subscriber build requires node identity",
-            ));
-        };
+        let entity = &mut self.entity;
         let qualified_topic =
-            qualify_topic_name(&self.entity.topic, &node.namespace, &node.name)
+            qualify_topic_name(&entity.topic, &entity.node.namespace, &entity.node.name)
                 .map_err(|e| zenoh::Error::from(format!("Failed to qualify topic: {}", e)))?;
 
-        self.entity.topic = qualified_topic.clone();
+        entity.topic = qualified_topic.clone();
         debug!("[{}] Qualified topic: {}", log_prefix, qualified_topic);
 
-        let topic_key_expr = ros_z_protocol::format::topic_key_expr(&self.entity)?;
+        let topic_key_expr = ros_z_protocol::format::topic_key_expr(entity)?;
         let key_expr = (*topic_key_expr).clone();
         debug!(
             "[{}] Key expression: {}, qos={:?}",
-            log_prefix, key_expr, self.entity.qos
+            log_prefix, key_expr, entity.qos
         );
 
         let callback: Arc<dyn Fn(Sample) + Send + Sync> = Arc::new(callback);
 
-        if !matches!(self.entity.qos.durability, QosDurability::TransientLocal) {
+        if !matches!(entity.qos.durability, QosDurability::TransientLocal) {
             let subscriber_callback = callback.clone();
             let mut subscriber = self
                 .session
@@ -158,15 +154,14 @@ where
             }
 
             let subscriber = subscriber.await?;
-            let liveliness_token = declare_liveliness(&self.session, &self.entity).await?;
+            let liveliness_token = declare_liveliness(&self.session, entity).await?;
             Ok(SubscriberResources {
                 _subscriber: subscriber,
                 _liveliness_token: liveliness_token,
                 _replay_guard: None,
             })
         } else {
-            let Some(live_capacity) =
-                replay::transient_local_replay_live_capacity(&self.entity.qos)
+            let Some(live_capacity) = replay::transient_local_replay_live_capacity(&entity.qos)
             else {
                 warn!(
                     "[{}] TransientLocal + KeepAll requested; replay coordination is disabled because history is unbounded",
@@ -183,7 +178,7 @@ where
                 }
 
                 let subscriber = subscriber.await?;
-                let liveliness_token = declare_liveliness(&self.session, &self.entity).await?;
+                let liveliness_token = declare_liveliness(&self.session, entity).await?;
                 return Ok(SubscriberResources {
                     _subscriber: subscriber,
                     _liveliness_token: liveliness_token,
@@ -209,7 +204,7 @@ where
             let subscriber = subscriber.await?;
 
             let (initial_replay_publishers, initial_replay_seen) = replay::initial_replay_plan(
-                replay::replay_capable_publishers(&self.graph, &self.entity.topic),
+                replay::replay_capable_publishers(&self.graph, &entity.topic),
             );
             for (publisher_global_id, _) in initial_replay_publishers {
                 replay::query_initial_transient_local_replay_async(
@@ -224,14 +219,14 @@ where
             coordinator.finish_initial_replay();
             let replay_task = replay::spawn_transient_local_replay_task(
                 self.graph.clone(),
-                self.entity.topic.clone(),
+                entity.topic.clone(),
                 coordinator,
                 self.session.clone(),
                 topic_key_expr.to_string(),
                 self.transient_local_replay_timeout,
                 initial_replay_seen,
             );
-            let liveliness_token = declare_liveliness(&self.session, &self.entity).await?;
+            let liveliness_token = declare_liveliness(&self.session, entity).await?;
             Ok(SubscriberResources {
                 _subscriber: subscriber,
                 _liveliness_token: liveliness_token,
@@ -262,12 +257,13 @@ where
             )
             .await?;
 
-        let endpoint_global_id = endpoint_global_id(&builder.entity);
+        let entity = builder.entity;
+        let endpoint_global_id = endpoint_global_id(&entity);
 
-        debug!("[SUB] Subscriber ready: topic={}", builder.entity.topic);
+        debug!("[SUB] Subscriber ready: topic={}", entity.topic);
 
         Ok(Subscriber {
-            entity: builder.entity,
+            entity,
             _resources: resources,
             queue,
             events_mgr: Arc::new(Mutex::new(EventsManager::new(endpoint_global_id))),

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -77,18 +77,19 @@ where
         service = %self.entity.topic
     ))]
     pub async fn build(mut self) -> Result<ServiceClient<T>> {
-        let Some(node) = self.entity.node.as_ref() else {
-            return Err(zenoh::Error::from("client build requires node identity"));
-        };
+        let entity = &mut self.entity;
         // Qualify the service name as a ros-z graph name.
-        let qualified_service =
-            topic_name::qualify_service_name(&self.entity.topic, &node.namespace, &node.name)
-                .map_err(|e| zenoh::Error::from(format!("Failed to qualify service: {}", e)))?;
+        let qualified_service = topic_name::qualify_service_name(
+            &entity.topic,
+            &entity.node.namespace,
+            &entity.node.name,
+        )
+        .map_err(|e| zenoh::Error::from(format!("Failed to qualify service: {}", e)))?;
 
-        self.entity.topic = qualified_service.clone();
+        entity.topic = qualified_service.clone();
         debug!("[CLN] Qualified service: {}", qualified_service);
 
-        let topic_key_expr = ros_z_protocol::format::topic_key_expr(&self.entity)?;
+        let topic_key_expr = ros_z_protocol::format::topic_key_expr(entity)?;
         let key_expr = (*topic_key_expr).clone();
         debug!("[CLN] Key expression: {}", key_expr);
 
@@ -99,20 +100,20 @@ where
             .consolidation(zenoh::query::ConsolidationMode::None)
             .await?;
         let liveliness_key_expr =
-            ros_z_protocol::format::liveliness_key_expr(&self.entity, &self.session.zid())?;
+            ros_z_protocol::format::liveliness_key_expr(entity, &self.session.zid())?;
         let lv_token = self
             .session
             .liveliness()
             .declare_token((*liveliness_key_expr).clone())
             .await?;
-        debug!("[CLN] Client ready: service={}", self.entity.topic);
+        debug!("[CLN] Client ready: service={}", entity.topic);
 
         Ok(ServiceClient {
             sequence_number: AtomicUsize::new(1), // Start at 1; zero is reserved for missing sequence values.
             inner,
             _lv_token: lv_token,
             endpoint_global_id: endpoint_global_id(&self.entity),
-            topic: self.entity.topic.clone(),
+            topic: self.entity.topic,
             clock: self.clock,
             _phantom_data: Default::default(),
         })
@@ -404,16 +405,17 @@ where
         handler: ServiceQueryHandler,
         queue: Option<Arc<BoundedQueue<Q>>>,
     ) -> Result<ServiceServer<T, Q>> {
-        let Some(node) = self.entity.node.as_ref() else {
-            return Err(zenoh::Error::from("service build requires node identity"));
-        };
-        let qualified_service =
-            topic_name::qualify_service_name(&self.entity.topic, &node.namespace, &node.name)
-                .map_err(|e| zenoh::Error::from(format!("Failed to qualify service: {}", e)))?;
+        let entity = &mut self.entity;
+        let qualified_service = topic_name::qualify_service_name(
+            &entity.topic,
+            &entity.node.namespace,
+            &entity.node.name,
+        )
+        .map_err(|e| zenoh::Error::from(format!("Failed to qualify service: {}", e)))?;
 
-        self.entity.topic = qualified_service;
+        entity.topic = qualified_service.clone();
 
-        let topic_key_expr = ros_z_protocol::format::topic_key_expr(&self.entity)?;
+        let topic_key_expr = ros_z_protocol::format::topic_key_expr(entity)?;
         let key_expr = (*topic_key_expr).clone();
         tracing::debug!("[SRV] KE: {key_expr}");
 
@@ -448,7 +450,7 @@ where
             .await?;
 
         let liveliness_key_expr =
-            ros_z_protocol::format::liveliness_key_expr(&self.entity, &self.session.zid())?;
+            ros_z_protocol::format::liveliness_key_expr(entity, &self.session.zid())?;
         let lv_token = self
             .session
             .liveliness()
@@ -719,7 +721,7 @@ mod tests {
                 AddTwoIntsRequest::type_name(),
                 AddTwoIntsResponse::type_name(),
             )?;
-            Ok(TypeInfo::with_hash(
+            Ok(TypeInfo::new(
                 descriptor.type_name.as_str(),
                 ros_z_schema::compute_hash(&descriptor),
             ))

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -44,7 +44,7 @@ impl ServiceTypeInfo for AddTwoInts {
         )?;
         Ok(TypeInfo::new(
             "test_msgs::AddTwoInts",
-            Some(SchemaHash(ros_z_schema::compute_hash(&descriptor).0)),
+            ros_z_schema::compute_hash(&descriptor),
         ))
     }
 }
@@ -296,10 +296,10 @@ mod tests {
         let topic = unique_graph_name("graph_readd_local_entity_topic");
         let entity = Entity::Endpoint(EndpointEntity {
             id: 4242,
-            node: Some(node.node_entity().clone()),
+            node: node.node_entity().clone(),
             kind: EndpointKind::Publisher,
             topic: topic.clone(),
-            type_info: None,
+            type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
             qos: Default::default(),
         });
 

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -10,42 +10,14 @@ use ros_z::{
     schema::{MessageSchema, SchemaBuilder},
     time::{Clock, Time},
 };
-use ros_z_schema::{PrimitiveTypeDef, SchemaError, SequenceLengthDef, TypeDef, TypeName};
 use ros_z_schema::{SchemaBundle, StructDef, TypeDefinition, TypeDefinitions};
+use ros_z_schema::{SchemaError, TypeDef, TypeName};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Message)]
 struct TestMessage {
     data: Vec<u8>,
     counter: u64,
-}
-
-impl Message for TestMessage {
-    type Codec = SerdeCdrCodec<Self>;
-
-    fn type_name() -> String {
-        "test_msgs::TestMessage".to_string()
-    }
-
-    fn schema_hash() -> Result<SchemaHash, SchemaError> {
-        Ok(SchemaHash::zero())
-    }
-}
-
-impl MessageSchema for TestMessage {
-    fn build_schema(builder: &mut SchemaBuilder) -> Result<TypeDef, SchemaError> {
-        builder.define_message_struct::<Self>(|fields| {
-            fields.field_with_shape(
-                "data",
-                TypeDef::Sequence {
-                    element: Box::new(TypeDef::Primitive(PrimitiveTypeDef::U8)),
-                    length: SequenceLengthDef::Dynamic,
-                },
-            );
-            fields.field_with_shape("counter", TypeDef::Primitive(PrimitiveTypeDef::U64));
-            Ok(())
-        })
-    }
 }
 
 fn topic_key_expr_for<T: Message>(node: &ros_z::node::Node, topic: &str) -> String {
@@ -58,13 +30,10 @@ fn topic_key_expr_for<T: Message>(node: &ros_z::node::Node, topic: &str) -> Stri
 
     let entity = EndpointEntity {
         id: 0,
-        node: Some(node.node_entity().clone()),
+        node: node.node_entity().clone(),
         kind: EndpointKind::Publisher,
         topic: qualified_topic,
-        type_info: Some(TypeInfo::with_hash(
-            &T::type_name(),
-            ros_z_schema::compute_hash(&T::schema().expect("schema should build")),
-        )),
+        type_info: T::type_info().expect("type info should be available"),
         qos: Default::default(),
     };
 
@@ -90,10 +59,7 @@ impl Message for CacheSchemaHashMessage {
     }
 
     fn type_info() -> Result<TypeInfo, SchemaError> {
-        Ok(TypeInfo::with_hash(
-            &Self::type_name(),
-            Self::schema_hash()?,
-        ))
+        Ok(TypeInfo::new(Self::type_name(), Self::schema_hash()?))
     }
 }
 
@@ -123,7 +89,7 @@ impl Message for AdvertisedTypeInfoSchemaMessage {
     }
 
     fn type_info() -> Result<TypeInfo, SchemaError> {
-        Ok(TypeInfo::with_hash(
+        Ok(TypeInfo::new(
             "test_msgs::AdvertisedTypeInfoSchemaMessageAlias",
             Self::schema_hash()?,
         ))
@@ -173,7 +139,7 @@ impl Message for InvalidSchemaManualTypeInfoMessage {
     }
 
     fn type_info() -> Result<TypeInfo, SchemaError> {
-        Ok(TypeInfo::new(&Self::type_name(), None))
+        Ok(TypeInfo::new(Self::type_name(), SchemaHash::zero()))
     }
 }
 
@@ -422,13 +388,14 @@ async fn dynamic_publisher_factory_rejects_schema_root_that_differs_from_type_in
         .build()
         .await
         .expect("Failed to create node");
-    let type_info = TypeInfo::new("test_msgs::AdvertisedDynamicRoot", None);
+    let schema = mismatched_dynamic_schema();
+    let type_info = TypeInfo::new(
+        "test_msgs::AdvertisedDynamicRoot",
+        ros_z_schema::compute_hash(schema.as_ref()),
+    );
 
-    let Err(error) = node.dynamic_publisher(
-        "/mismatched_dynamic_schema_root",
-        type_info,
-        mismatched_dynamic_schema(),
-    ) else {
+    let Err(error) = node.dynamic_publisher("/mismatched_dynamic_schema_root", type_info, schema)
+    else {
         panic!("mismatched schema root should fail dynamic publisher factory");
     };
     let message = error.to_string();
@@ -605,10 +572,10 @@ async fn create_cache_uses_schema_hash_method_when_type_info_is_available() {
             _ => None,
         })
         .expect("cache subscriber should be discoverable");
-    let advertised = endpoint.type_info.expect("cache subscriber type info");
+    let advertised = endpoint.type_info;
 
     assert_eq!(advertised.name, CacheSchemaHashMessage::type_name());
-    assert_eq!(advertised.hash, Some(expected_hash));
+    assert_eq!(advertised.hash, expected_hash);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -631,7 +598,7 @@ async fn publisher_schema_service_uses_schema_derived_key_when_type_info_diverge
         .expect("publisher should build");
 
     let advertised = AdvertisedTypeInfoSchemaMessage::type_info().unwrap();
-    let advertised_hash = advertised.hash.expect("type info should include a hash");
+    let advertised_hash = advertised.hash;
     let canonical_schema = AdvertisedTypeInfoSchemaMessage::schema().unwrap();
     let canonical_hash = ros_z_schema::compute_hash(&canonical_schema);
 
@@ -704,13 +671,13 @@ async fn typed_pubsub_advertises_canonical_schema_hash_when_schema_hash_override
                 _ => None,
             })
             .expect("endpoint should be discoverable");
-        let advertised = endpoint.type_info.expect("endpoint type info");
+        let advertised = endpoint.type_info;
 
         assert_eq!(
             advertised.name,
             AdvertisedTypeInfoSchemaMessage::type_name()
         );
-        assert_eq!(advertised.hash, Some(canonical_hash));
+        assert_eq!(advertised.hash, canonical_hash);
     }
 }
 
@@ -739,11 +706,7 @@ async fn dynamic_publisher_advertises_explicit_schema_hash() {
     let schema_hash = ros_z_schema::compute_hash(root_schema.as_ref());
 
     let _publisher = node
-        .dynamic_publisher(
-            topic,
-            TypeInfo::with_hash(&root_name, schema_hash),
-            root_schema,
-        )
+        .dynamic_publisher(topic, TypeInfo::new(&root_name, schema_hash), root_schema)
         .expect("dynamic publisher factory should succeed")
         .build()
         .await
@@ -760,7 +723,7 @@ async fn dynamic_publisher_advertises_explicit_schema_hash() {
             _ => None,
         })
         .expect("dynamic publisher should be discoverable");
-    let advertised = endpoint.type_info.expect("publisher type info");
+    let advertised = endpoint.type_info;
     let registered = node
         .schema_service()
         .expect("schema service")
@@ -769,62 +732,7 @@ async fn dynamic_publisher_advertises_explicit_schema_hash() {
         .expect("schema should be registered under root hash");
 
     assert_eq!(advertised.name, root_name);
-    assert_eq!(advertised.hash, Some(schema_hash));
-    assert_eq!(registered.schema_hash, schema_hash);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn dynamic_publisher_fills_missing_schema_hash_from_schema() {
-    let context = ContextBuilder::default()
-        .build()
-        .await
-        .expect("Failed to create context");
-    let node = context
-        .create_node("dynamic_inferred_schema_hash")
-        .build()
-        .await
-        .expect("Failed to create node");
-    let topic = "/dynamic_inferred_schema_hash";
-    let root_name = "test_msgs::DynamicInferredHash".to_string();
-    let root_type_name = TypeName::new(&root_name).unwrap();
-    let mut builder = SchemaBuilder::new();
-    let root = builder
-        .define_struct(root_type_name, |fields| {
-            fields.field::<String>("data")?;
-            Ok(())
-        })
-        .unwrap();
-    let root_schema = std::sync::Arc::new(builder.finish(root).unwrap());
-    let schema_hash = ros_z_schema::compute_hash(root_schema.as_ref());
-
-    let _publisher = node
-        .dynamic_publisher(topic, TypeInfo::new(&root_name, None), root_schema)
-        .expect("dynamic publisher factory should succeed")
-        .build()
-        .await
-        .expect("publisher should build");
-
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let endpoint = node
-        .graph()
-        .get_entities_by_topic(EntityKind::Publisher, topic)
-        .into_iter()
-        .find_map(|entity| match &*entity {
-            Entity::Endpoint(endpoint) => Some(endpoint.clone()),
-            _ => None,
-        })
-        .expect("dynamic publisher should be discoverable");
-    let advertised = endpoint.type_info.expect("publisher type info");
-    let registered = node
-        .schema_service()
-        .expect("schema service")
-        .get_schema(&root_name, &schema_hash)
-        .expect("schema lookup should succeed")
-        .expect("schema should be registered under inferred hash");
-
-    assert_eq!(advertised.name, root_name);
-    assert_eq!(advertised.hash, Some(schema_hash));
+    assert_eq!(advertised.hash, schema_hash);
     assert_eq!(registered.schema_hash, schema_hash);
 }
 

--- a/crates/ros-z/tests/service.rs
+++ b/crates/ros-z/tests/service.rs
@@ -3,7 +3,7 @@ use std::{thread, time::Duration};
 use ros_z::{
     ServiceTypeInfo,
     context::ContextBuilder,
-    entity::{SchemaHash, TypeInfo},
+    entity::TypeInfo,
     message::Service,
     schema::{MessageSchema, SchemaBuilder},
 };
@@ -38,7 +38,7 @@ impl ServiceTypeInfo for AddTwoInts {
         )?;
         Ok(TypeInfo::new(
             "test_msgs::AddTwoInts",
-            Some(SchemaHash(ros_z_schema::compute_hash(&descriptor).0)),
+            ros_z_schema::compute_hash(&descriptor),
         ))
     }
 }

--- a/crates/ros-z/tests/service_api_alignment.rs
+++ b/crates/ros-z/tests/service_api_alignment.rs
@@ -33,7 +33,7 @@ impl ServiceTypeInfo for AddTwoInts {
         )?;
         Ok(TypeInfo::new(
             "test_msgs::AddTwoInts",
-            Some(SchemaHash(ros_z_schema::compute_hash(&descriptor).0)),
+            SchemaHash(ros_z_schema::compute_hash(&descriptor).0),
         ))
     }
 }
@@ -55,8 +55,7 @@ fn generated_service_and_manual_descriptor_share_the_same_hash() {
     assert_eq!(
         AddTwoInts::service_type_info()
             .expect("generated type info")
-            .hash
-            .expect("generated hash"),
+            .hash,
         ros_z::entity::SchemaHash(ros_z_schema::compute_hash(&manual).0)
     );
 }

--- a/crates/ros-z/tests/type_info_test.rs
+++ b/crates/ros-z/tests/type_info_test.rs
@@ -17,7 +17,7 @@ fn type_info_exposes_schema_hash_as_the_public_hash_accessor() {
 #[test]
 fn type_info_uses_schema_hash() {
     let info = MockMessage::type_info().unwrap();
-    assert_eq!(info.hash, Some(MockMessage::schema_hash().unwrap()));
+    assert_eq!(info.hash, MockMessage::schema_hash().unwrap());
 }
 
 #[test]
@@ -116,7 +116,10 @@ fn type_info_module_exports_runtime_traits() {
     struct ServiceMarker;
     impl ServiceTypeInfo for ServiceMarker {
         fn service_type_info() -> Result<ros_z::TypeInfo, ros_z_schema::SchemaError> {
-            Ok(ros_z::TypeInfo::new("test_msgs::ServiceMarker", None))
+            Ok(ros_z::TypeInfo::new(
+                "test_msgs::ServiceMarker",
+                ros_z::SchemaHash::zero(),
+            ))
         }
     }
 


### PR DESCRIPTION
## Summary

- Stack on #2509 
- Require ros-z endpoint liveliness keys and runtime endpoint records to carry explicit schema hashes.
- Update graph, discovery, CLI, typed builders, dynamic endpoints, and hulk_ros_z callers to use strict type metadata.
- Remove placeholder and missing-hash handling from endpoint parsing and display paths.

## Reviewer Notes

- This is an intentional internal API break: `TypeInfo::new(name, hash)` is now the constructor.
- Dynamic publishers no longer manufacture missing hashes; callers must supply valid schema metadata.
- There is and was no path where this could be missing, this was a compatability left-over of upstream ros-z, as for example ROS2 Humble does not expose hashes on the liveliness wire.
- Please bear with the current error-handling noise in this PR; #2503 follows up to clean that up.