### PR TITLE
Pepsi zweigleisig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7589,7 +7589,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.25.0"
+version = "7.26.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/repository/src/upload.rs
+++ b/crates/repository/src/upload.rs
@@ -49,12 +49,12 @@ impl Repository {
     }
 }
 
-pub fn get_hulk_binary(profile: &str) -> String {
+pub fn get_hulk_binary(profile: &str, binary_name: &str) -> String {
     // the target directory is "debug" with --profile dev...
     let profile_directory = match profile {
         "dev" => "debug",
         other => other,
     };
 
-    format!("target/aarch64-unknown-linux-gnu/{profile_directory}/hulk_booster")
+    format!("target/aarch64-unknown-linux-gnu/{profile_directory}/{binary_name}")
 }

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -13,7 +13,6 @@ chown -R booster:booster /home/booster/hulk/logs
   --env RUST_BACKTRACE=1 \
   --user $(id -u booster) \
   hulk \
-  /home/booster/hulk/bin/hulk_booster \
-    --log-path "${INTERNAL_LOG_PATH}" \
+  /home/booster/hulk/bin/hulk_booster --log-path "${INTERNAL_LOG_PATH}" \
   > >(tee "${INTERNAL_LOG_PATH}/hulk.out") \
   2> >(tee "${INTERNAL_LOG_PATH}/hulk.err")

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.25.0"
+version = "7.26.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -263,7 +263,7 @@ async fn gammaray_robot(
             .ssh_to_robot()?
             .arg("sudo sed")
             .arg("--in-place")
-            .arg("'s#hulk_booster .*#hulk_ros_z --robot number --location lab --parameter-root etc/parameters/ros_z --router tcp/127.0.0.1:7447 \\\\#'")
+            .arg(format!("'s#hulk_booster .*#hulk_ros_z --robot {} --location lab --parameter-root etc/parameters/ros_z --router tcp/127.0.0.1:7447 \\\\#'", team_robot.number))
             .arg("/usr/bin/launch-hulk")
             .ssh_with_log("hacking launch-hulk", &progress_bar).await?;
     }

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -37,6 +37,10 @@ pub struct Arguments {
     /// e.g. rust-trt-inference-image.tar
     #[arg(short, long)]
     image_file: Option<PathBuf>,
+
+    /// Use old booster binary
+    #[arg(long)]
+    old: bool,
 }
 
 static PACKAGES: [&str; 2] = ["zenohd", "zenoh-bridge-dds"];
@@ -69,6 +73,7 @@ pub async fn gammaray(arguments: Arguments, repository: &Repository) -> Result<(
                     arguments.image_file.as_deref(),
                     &team,
                     setup_path,
+                    arguments.old,
                 )
             },
         )
@@ -85,6 +90,7 @@ async fn gammaray_robot(
     image_file: Option<&Path>,
     team: &Team,
     setup: &Path,
+    old: bool,
 ) -> Result<()> {
     let robot = Robot::try_new_with_ping(robot.ip).await?;
 

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -258,6 +258,16 @@ async fn gammaray_robot(
         .rsync_with_log("uploading binaries", &progress_bar)
         .await?;
 
+    if !old {
+        robot
+            .ssh_to_robot()?
+            .arg("sudo sed")
+            .arg("--in-place")
+            .arg("'s#hulk_booster .*#hulk_ros_z --robot number --location lab --parameter-root etc/parameters/ros_z --router tcp/127.0.0.1:7447 \\\\#'")
+            .arg("/usr/bin/launch-hulk")
+            .ssh_with_log("hacking launch-hulk", &progress_bar).await?;
+    }
+
     robot
         .ssh_to_robot()?
         .arg("sudo systemctl daemon-reload")

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -28,6 +28,9 @@ pub struct Arguments {
     pub environment: EnvironmentArguments,
     #[command(flatten, next_help_heading = "Cargo Options")]
     pub build: build::Arguments,
+    /// Use old booster binary
+    #[arg(long)]
+    pub old: bool,
 }
 
 #[derive(Args)]
@@ -98,13 +101,17 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
         .wrap_err("failed to configure repository")?;
 
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
-    let hulk_binary = get_hulk_binary(arguments.build.profile());
+    let binary_name = match arguments.old {
+        true => "hulk_booster",
+        false => "hulk_ros_z",
+    };
+    let hulk_binary = get_hulk_binary(arguments.build.profile(), binary_name);
 
     let cargo_arguments = cargo::Arguments {
         manifest: Some(
             repository
                 .root
-                .join("crates/hulk_booster/Cargo.toml")
+                .join(format!("crates/{binary_name}/Cargo.toml"))
                 .into_os_string(),
         ),
         environment: arguments.environment,

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -13,6 +13,7 @@ use tempfile::tempdir;
 
 use crate::{
     cargo::{self, CargoCommand, build, cargo, environment::EnvironmentArguments},
+    gammaray::CommandExt,
     progress_indicator::{ProgressIndicator, Task},
 };
 
@@ -25,6 +26,9 @@ pub struct Arguments {
     pub environment: EnvironmentArguments,
     #[command(flatten, next_help_heading = "Cargo Options")]
     pub build: build::Arguments,
+    /// Use old booster binary
+    #[arg(long)]
+    pub old: bool,
 }
 
 #[derive(Args)]
@@ -52,6 +56,7 @@ async fn upload_with_progress(
     arguments: &UploadArguments,
     progress: &Task,
     repository: &Repository,
+    binary_name: &str,
 ) -> Result<()> {
     progress.set_message("Pinging Robot...");
     let robot = Robot::try_new_with_ping(robot_address.ip).await?;
@@ -72,6 +77,17 @@ async fn upload_with_progress(
             );
         }
     }
+
+    robot
+        .ssh_to_robot()?
+        .arg("grep")
+        .arg(binary_name)
+        .arg("/usr/bin/launch-hulk")
+        .ssh_with_log("checking launch-hulk", &progress.progress)
+        .await
+        .wrap_err_with(|| {
+            format!("launch-hulk was not set up to launch {binary_name}, gammaray needed")
+        })?;
 
     progress.set_message("Stopping HULK...");
     robot

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -105,13 +105,17 @@ async fn upload_with_progress(
 
 pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()> {
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
-    let hulk_binary = get_hulk_binary(arguments.build.profile());
+    let binary_name = match arguments.old {
+        true => "hulk_booster",
+        false => "hulk_ros_z",
+    };
+    let hulk_binary = get_hulk_binary(arguments.build.profile(), binary_name);
 
     let cargo_arguments = cargo::Arguments {
         manifest: Some(
             repository
                 .root
-                .join("crates/hulk_booster/Cargo.toml")
+                .join(format!("crates/{binary_name}/Cargo.toml"))
                 .into_os_string(),
         ),
         environment: arguments.environment,
@@ -148,6 +152,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
                         upload_arguments,
                         &progress,
                         repository,
+                        binary_name,
                     )
                     .await
                     .as_ref(),


### PR DESCRIPTION
## Why? What?

This PR modifies pepsi to upload the new hulk_ros_z binary by default and adds an `--old` flag to upload and gammaray to use the old `hulk_booster` instead.

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

To use this with a robot, it first needs to be gammarayed to the correct state, uploading then needs to take the same `--old` flag.

Attempting to `gammaray --old` and then `upload` or first `gammaray` and then `upload --old` will result in an error.