### PR TITLE
feat(ros-z-debug): add debug adapter crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9377,6 +9377,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ros-z-debug"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
+ "parking_lot",
+ "ros-z",
+ "ros-z-schema",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "ros-z-derive"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
   "crates/ros-z",
   "crates/ros-z-cdr",
   "crates/ros-z-cli",
+  "crates/ros-z-debug",
   "crates/ros-z-derive",
   "crates/ros-z-protocol",
   "crates/ros-z-schema",
@@ -313,6 +314,7 @@ robot = { path = "crates/robot" }
 robot_mode_handler = { path = "crates/nodes/robot_mode_handler" }
 ros-z = { path = "crates/ros-z", features = ["nalgebra"] }
 ros-z-cdr = { path = "crates/ros-z-cdr" }
+ros-z-debug = { path = "crates/ros-z-debug" }
 ros-z-derive = { path = "crates/ros-z-derive" }
 ros-z-protocol = { path = "crates/ros-z-protocol" }
 ros-z-schema = { path = "crates/ros-z-schema" }

--- a/crates/ros-z-debug/Cargo.toml
+++ b/crates/ros-z-debug/Cargo.toml
@@ -11,8 +11,9 @@ parking_lot = { workspace = true }
 ros-z = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "sync"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
 ros-z-schema = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "time"] }

--- a/crates/ros-z-debug/Cargo.toml
+++ b/crates/ros-z-debug/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ros-z-debug"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+arc-swap = { workspace = true }
+parking_lot = { workspace = true }
+ros-z = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
+tokio-util = { workspace = true }
+
+[dev-dependencies]
+ros-z-schema = { workspace = true }

--- a/crates/ros-z-debug/src/error.rs
+++ b/crates/ros-z-debug/src/error.rs
@@ -1,0 +1,33 @@
+use ros_z::topic_name::TopicNameError;
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error(transparent)]
+    RosZ(#[from] ros_z::Error),
+
+    #[error("invalid topic selector '{selector}': {source}")]
+    InvalidTopicSelector {
+        selector: String,
+        #[source]
+        source: TopicNameError,
+    },
+
+    #[error(
+        "private topic selector '{selector}' requires target node context; debug topic selectors currently resolve against a target namespace only"
+    )]
+    UnsupportedPrivateTopicSelector { selector: String },
+
+    #[error("invalid target namespace '{target_namespace}': {source}")]
+    InvalidTargetNamespace {
+        target_namespace: String,
+        #[source]
+        source: TopicNameError,
+    },
+
+    #[error("invalid retention policy: {0}")]
+    InvalidRetention(String),
+}

--- a/crates/ros-z-debug/src/event.rs
+++ b/crates/ros-z-debug/src/event.rs
@@ -1,0 +1,86 @@
+use std::collections::VecDeque;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum DebugEvent {
+    /// The subscription status snapshot changed.
+    StatusChanged,
+    /// A new sample was retained as the latest value.
+    ValueUpdated,
+    /// A non-terminal diagnostic message was recorded.
+    Diagnostic(String),
+}
+
+pub struct EventBuffer {
+    capacity: usize,
+    events: VecDeque<DebugEvent>,
+}
+
+impl EventBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            events: VecDeque::new(),
+        }
+    }
+
+    pub fn push(&mut self, event: DebugEvent) {
+        if self.capacity == 0 {
+            return;
+        }
+
+        if self.events.len() == self.capacity {
+            self.events.pop_front();
+        }
+
+        self.events.push_back(event);
+    }
+
+    pub fn drain(&mut self) -> Vec<DebugEvent> {
+        self.events.drain(..).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DebugEvent, EventBuffer};
+
+    #[test]
+    fn drain_returns_and_clears_events() {
+        let mut buffer = EventBuffer::new(2);
+        buffer.push(DebugEvent::StatusChanged);
+        buffer.push(DebugEvent::Diagnostic("schema unavailable".to_string()));
+
+        let drained = buffer.drain();
+        assert_eq!(drained.len(), 2);
+        assert!(matches!(drained[0], DebugEvent::StatusChanged));
+        assert!(
+            matches!(&drained[1], DebugEvent::Diagnostic(message) if message == "schema unavailable")
+        );
+        assert!(buffer.drain().is_empty());
+    }
+
+    #[test]
+    fn capacity_zero_stores_nothing() {
+        let mut buffer = EventBuffer::new(0);
+
+        buffer.push(DebugEvent::ValueUpdated);
+
+        assert!(buffer.drain().is_empty());
+    }
+
+    #[test]
+    fn push_drops_oldest_event_when_capacity_is_exceeded() {
+        let mut buffer = EventBuffer::new(2);
+        buffer.push(DebugEvent::StatusChanged);
+        buffer.push(DebugEvent::ValueUpdated);
+        buffer.push(DebugEvent::Diagnostic("decode failed".to_string()));
+
+        let drained = buffer.drain();
+        assert_eq!(drained.len(), 2);
+        assert!(matches!(drained[0], DebugEvent::ValueUpdated));
+        assert!(
+            matches!(&drained[1], DebugEvent::Diagnostic(message) if message == "decode failed")
+        );
+    }
+}

--- a/crates/ros-z-debug/src/history.rs
+++ b/crates/ros-z-debug/src/history.rs
@@ -31,6 +31,10 @@ impl<T> TimestampIndex<T> {
     }
 
     fn get_interval(&self, start: Time, end: Time) -> Vec<Arc<T>> {
+        if start > end {
+            return Vec::new();
+        }
+
         self.entries
             .range(start..=end)
             .flat_map(|(_, values)| values.iter().cloned())

--- a/crates/ros-z-debug/src/history.rs
+++ b/crates/ros-z-debug/src/history.rs
@@ -1,0 +1,270 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
+
+use ros_z::time::Time;
+
+use crate::{RetentionPolicy, SampleRecord};
+
+pub struct TimeIndexedHistory<V> {
+    entries: TimestampIndex<SampleRecord<V>>,
+    policy: RetentionPolicy,
+}
+
+struct TimestampIndex<T> {
+    entries: BTreeMap<Time, VecDeque<Arc<T>>>,
+    len: usize,
+}
+
+impl<T> TimestampIndex<T> {
+    fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            len: 0,
+        }
+    }
+
+    fn insert(&mut self, timestamp: Time, value: Arc<T>) {
+        self.entries.entry(timestamp).or_default().push_back(value);
+        self.len += 1;
+    }
+
+    fn get_interval(&self, start: Time, end: Time) -> Vec<Arc<T>> {
+        self.entries
+            .range(start..=end)
+            .flat_map(|(_, values)| values.iter().cloned())
+            .collect()
+    }
+
+    fn latest_stamp(&self) -> Option<Time> {
+        self.entries.keys().next_back().copied()
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn remove_older_than(&mut self, minimum: Time) {
+        let mut older = std::mem::take(&mut self.entries);
+        let mut retained = older.split_off(&minimum);
+        self.len = retained.values().map(VecDeque::len).sum();
+        std::mem::swap(&mut self.entries, &mut retained);
+    }
+
+    fn pop_oldest(&mut self) -> Option<Arc<T>> {
+        let oldest_timestamp = *self.entries.keys().next()?;
+        let values = self.entries.get_mut(&oldest_timestamp)?;
+        let value = values.pop_front()?;
+        self.len -= 1;
+
+        if values.is_empty() {
+            self.entries.remove(&oldest_timestamp);
+        }
+
+        Some(value)
+    }
+}
+
+impl<V> TimeIndexedHistory<V> {
+    pub fn new(policy: RetentionPolicy) -> Self {
+        Self {
+            entries: TimestampIndex::new(),
+            policy,
+        }
+    }
+
+    pub fn insert(&mut self, record: Arc<SampleRecord<V>>) {
+        let source_time = record.source_time;
+        self.entries.insert(source_time, record);
+
+        self.evict();
+    }
+
+    pub fn window(&self, start: Time, end: Time) -> Vec<Arc<SampleRecord<V>>> {
+        self.entries.get_interval(start, end)
+    }
+
+    fn evict(&mut self) {
+        let Some(newest_source_time) = self.entries.latest_stamp() else {
+            return;
+        };
+
+        let (duration, max_samples) = match self.policy {
+            RetentionPolicy::LatestOnly => {
+                self.entries.remove_older_than(newest_source_time);
+                return;
+            }
+            RetentionPolicy::TimeWindow(window) => (window.duration(), window.max_samples()),
+        };
+
+        let minimum_source_time = newest_source_time.saturating_sub(duration);
+        self.entries.remove_older_than(minimum_source_time);
+
+        if let Some(max_samples) = max_samples {
+            while self.entries.len() > max_samples.get() {
+                self.entries.pop_oldest();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use ros_z::time::Time;
+
+    use super::TimeIndexedHistory;
+    use crate::{
+        DEFAULT_TIME_WINDOW_MAX_SAMPLES, RetentionPolicy, SampleMetadata, SampleRecord,
+        TopicSelector,
+    };
+
+    fn test_type_info() -> ros_z::TypeInfo {
+        ros_z::TypeInfo::new("test_msgs::DebugValue", ros_z::SchemaHash::zero())
+    }
+
+    fn test_publication_id() -> ros_z::pubsub::PublicationId {
+        ros_z::pubsub::Received {
+            message: (),
+            transport_time: None,
+            source_time: Time::zero(),
+            sequence_number: 1,
+            source_global_id: [7; 16],
+        }
+        .publication_id()
+    }
+
+    fn test_metadata() -> Arc<SampleMetadata> {
+        Arc::new(SampleMetadata {
+            requested_topic: TopicSelector::new("debug").unwrap(),
+            resolved_topic: "/debug".to_string(),
+            type_info: test_type_info(),
+        })
+    }
+
+    fn record(value: i32, source_time_nanos: i64) -> Arc<SampleRecord<i32>> {
+        Arc::new(SampleRecord {
+            value,
+            source_time: Time::from_nanos(source_time_nanos),
+            transport_time: None,
+            publication_id: test_publication_id(),
+            metadata: test_metadata(),
+        })
+    }
+
+    #[test]
+    fn time_window_eviction_uses_source_time() {
+        let mut history =
+            TimeIndexedHistory::new(RetentionPolicy::time_window(Duration::from_secs(1)).unwrap());
+
+        history.insert(record(1, 0));
+        history.insert(record(2, 2_000_000_000));
+
+        let values = history.window(Time::from_nanos(0), Time::from_nanos(2_000_000_000));
+        assert_eq!(
+            values.iter().map(|record| record.value).collect::<Vec<_>>(),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn max_samples_evicts_oldest_after_time_eviction() {
+        let mut history = TimeIndexedHistory::new(
+            RetentionPolicy::time_window_with_max_samples(
+                Duration::from_secs(10),
+                std::num::NonZeroUsize::new(2).unwrap(),
+            )
+            .unwrap(),
+        );
+
+        history.insert(record(1, 1));
+        history.insert(record(2, 2));
+        history.insert(record(3, 3));
+
+        let values = history.window(Time::from_nanos(0), Time::from_nanos(10));
+        assert_eq!(
+            values.iter().map(|record| record.value).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+    }
+
+    #[test]
+    fn duplicate_timestamps_preserve_insertion_order() {
+        let mut history =
+            TimeIndexedHistory::new(RetentionPolicy::time_window(Duration::from_secs(10)).unwrap());
+
+        history.insert(record(1, 5));
+        history.insert(record(2, 5));
+
+        let values = history.window(Time::from_nanos(5), Time::from_nanos(5));
+        assert_eq!(
+            values.iter().map(|record| record.value).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn latest_only_retains_only_latest_source_time_records() {
+        let mut history = TimeIndexedHistory::new(RetentionPolicy::LatestOnly);
+
+        history.insert(record(1, 1));
+        history.insert(record(2, 3));
+        history.insert(record(3, 2));
+
+        let values = history.window(Time::from_nanos(0), Time::from_nanos(3));
+        assert_eq!(
+            values.iter().map(|record| record.value).collect::<Vec<_>>(),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn latest_only_preserves_duplicate_newest_timestamp_order() {
+        let mut history = TimeIndexedHistory::new(RetentionPolicy::LatestOnly);
+
+        history.insert(record(1, 1));
+        history.insert(record(2, 3));
+        history.insert(record(3, 3));
+
+        let values = history.window(Time::from_nanos(0), Time::from_nanos(3));
+        assert_eq!(
+            values.iter().map(|record| record.value).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+    }
+
+    #[test]
+    fn time_window_eviction_uses_newest_source_time_for_out_of_order_inserts() {
+        let mut history =
+            TimeIndexedHistory::new(RetentionPolicy::time_window(Duration::from_secs(1)).unwrap());
+
+        history.insert(record(1, 2_000_000_000));
+        history.insert(record(2, 0));
+
+        let values = history.window(Time::from_nanos(0), Time::from_nanos(2_000_000_000));
+        assert_eq!(
+            values.iter().map(|record| record.value).collect::<Vec<_>>(),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn default_time_window_retention_bounds_stalled_source_timestamps() {
+        let mut history =
+            TimeIndexedHistory::new(RetentionPolicy::time_window(Duration::from_secs(10)).unwrap());
+
+        for value in 0..=DEFAULT_TIME_WINDOW_MAX_SAMPLES {
+            history.insert(record(value as i32, 5));
+        }
+
+        let values = history.window(Time::from_nanos(5), Time::from_nanos(5));
+        assert_eq!(values.len(), DEFAULT_TIME_WINDOW_MAX_SAMPLES);
+        assert_eq!(values.first().map(|record| record.value), Some(1));
+        assert_eq!(
+            values.last().map(|record| record.value),
+            Some(DEFAULT_TIME_WINDOW_MAX_SAMPLES as i32)
+        );
+    }
+}

--- a/crates/ros-z-debug/src/lib.rs
+++ b/crates/ros-z-debug/src/lib.rs
@@ -1,0 +1,55 @@
+//! Read-only subscription helpers for `ros-z` debug tooling.
+//!
+//! `SubscriptionManager` owns debug subscriptions and keeps the latest sample,
+//! optional time-window history, status, and small event buffers. Relative topic
+//! selectors resolve against [`ManagerOptions::target_namespace`], then the
+//! manager subscribes to the absolute topic name through `ros-z`.
+//!
+//! ```rust
+//! use std::sync::Arc;
+//!
+//! use ros_z::context::ContextBuilder;
+//! use ros_z_debug::{ManagerOptions, RetentionPolicy, SubscriptionManager};
+//!
+//! # async fn demo() -> ros_z_debug::Result<()> {
+//! let context = ContextBuilder::default().build().await?;
+//! let node = Arc::new(context.create_node("debug").build().await?);
+//! let options = ManagerOptions::with_target_namespace("/robot_1")?;
+//!
+//! let manager = SubscriptionManager::new(node, options);
+//! let handle = manager
+//!     .subscribe_typed::<String>("status")
+//!     .retention(RetentionPolicy::LatestOnly)
+//!     .build()
+//!     .await?;
+//!
+//! let latest = handle.latest();
+//! # let _ = latest;
+//! # Ok(())
+//! # }
+//! ```
+
+mod error;
+mod event;
+mod history;
+mod manager;
+mod retention;
+mod sample;
+mod status;
+mod subscription;
+mod topic;
+
+pub use error::{Error, Result};
+pub use event::DebugEvent;
+pub use manager::{
+    DynamicSubscriptionBuilder, ManagerOptions, SubscriptionManager, TypedSubscriptionBuilder,
+};
+pub use retention::{DEFAULT_TIME_WINDOW_MAX_SAMPLES, RetentionPolicy, RetentionWindow};
+pub use ros_z::dynamic::{
+    ByteRenderPolicy, DynamicJsonRenderPolicy as JsonRenderPolicy, NonFiniteFloatRenderPolicy,
+    dynamic_payload_to_json, dynamic_value_to_json,
+};
+pub use sample::{SampleMetadata, SampleRecord};
+pub use status::{SubscriptionStatus, SubscriptionStatusSnapshot};
+pub use subscription::{JsonSubscriptionHandle, SubscriptionHandle};
+pub use topic::{ProjectedTopic, ProjectedTopicScope, TopicProjection, TopicSelector};

--- a/crates/ros-z-debug/src/manager.rs
+++ b/crates/ros-z-debug/src/manager.rs
@@ -1,0 +1,536 @@
+use std::{error::Error as _, fmt::Write as _, marker::PhantomData, sync::Arc, time::Duration};
+
+use parking_lot::Mutex;
+use ros_z::{Message, dynamic::DynamicPayload, node::Node};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    JsonRenderPolicy, JsonSubscriptionHandle, Result, RetentionPolicy, SampleMetadata,
+    SampleRecord, SubscriptionHandle, SubscriptionStatus, SubscriptionStatusSnapshot,
+    TopicSelector,
+    subscription::{ManagedSubscription, SubscriptionState},
+    topic::normalize_target_namespace,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ManagerOptions {
+    /// Namespace used to resolve relative topic selectors.
+    ///
+    /// This names the robot or target namespace being inspected, not the
+    /// namespace of the debug node that owns the subscriptions.
+    target_namespace: String,
+}
+
+impl Default for ManagerOptions {
+    fn default() -> Self {
+        Self {
+            target_namespace: "/".to_string(),
+        }
+    }
+}
+
+impl ManagerOptions {
+    /// Create options with a validated target namespace.
+    pub fn with_target_namespace(target_namespace: impl Into<String>) -> Result<Self> {
+        let mut options = Self::default();
+        options.set_target_namespace(target_namespace)?;
+        Ok(options)
+    }
+
+    /// Namespace used to resolve relative topic selectors.
+    pub fn target_namespace(&self) -> &str {
+        &self.target_namespace
+    }
+
+    /// Update the target namespace after validating it as a ROS namespace.
+    pub fn set_target_namespace(
+        &mut self,
+        target_namespace: impl Into<String>,
+    ) -> Result<&mut Self> {
+        let target_namespace = target_namespace.into();
+        self.target_namespace = normalize_target_namespace(&target_namespace)?;
+        Ok(self)
+    }
+}
+
+/// Owns debug subscriptions created from a `ros-z` node.
+///
+/// Handles returned by this manager retain the latest sample, optional history,
+/// status, and queued debug events. Dropping the manager closes subscriptions it
+/// can still reach; dropping the last handle for a subscription also cancels its
+/// receive task.
+pub struct SubscriptionManager {
+    node: Arc<Node>,
+    options: ManagerOptions,
+    subscriptions: SubscriptionRegistry,
+}
+
+impl SubscriptionManager {
+    /// Create a manager for subscriptions owned by `node`.
+    pub fn new(node: Arc<Node>, options: ManagerOptions) -> Self {
+        Self {
+            node,
+            options,
+            subscriptions: SubscriptionRegistry::default(),
+        }
+    }
+
+    /// Start building a typed debug subscription.
+    ///
+    /// Relative topics resolve against [`ManagerOptions::target_namespace`].
+    /// The default retention policy is [`RetentionPolicy::LatestOnly`].
+    pub fn subscribe_typed<T>(&self, topic: impl Into<String>) -> TypedSubscriptionBuilder<'_, T> {
+        TypedSubscriptionBuilder {
+            manager: self,
+            topic: topic.into(),
+            retention: RetentionPolicy::LatestOnly,
+            value: PhantomData,
+        }
+    }
+
+    /// Start building a dynamic debug subscription.
+    ///
+    /// Relative topics resolve against [`ManagerOptions::target_namespace`].
+    /// Dynamic subscriptions discover the schema from visible publishers during
+    /// `build()` or `build_json()`, using a five second timeout.
+    pub fn subscribe_dynamic(&self, topic: impl Into<String>) -> DynamicSubscriptionBuilder<'_> {
+        DynamicSubscriptionBuilder {
+            manager: self,
+            topic: topic.into(),
+            retention: RetentionPolicy::LatestOnly,
+        }
+    }
+
+    pub(crate) fn node(&self) -> &Arc<Node> {
+        &self.node
+    }
+
+    /// Namespace used to resolve relative topic selectors.
+    pub fn target_namespace(&self) -> &str {
+        self.options.target_namespace()
+    }
+
+    pub(crate) fn close(&self) {
+        self.subscriptions.close_all();
+    }
+}
+
+impl Drop for SubscriptionManager {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct SubscriptionRegistry {
+    subscriptions: Mutex<Vec<std::sync::Weak<dyn ManagedSubscription>>>,
+}
+
+impl SubscriptionRegistry {
+    pub(crate) fn register<V>(&self, state: &Arc<SubscriptionState<V>>)
+    where
+        V: Send + Sync + 'static,
+    {
+        let state: Arc<dyn ManagedSubscription> = state.clone();
+        let mut subscriptions = self.subscriptions.lock();
+        subscriptions.retain(|subscription| subscription.strong_count() > 0);
+        subscriptions.push(Arc::downgrade(&state));
+    }
+
+    pub(crate) fn close_all(&self) {
+        self.subscriptions.lock().retain(|subscription| {
+            if let Some(subscription) = subscription.upgrade() {
+                subscription.close();
+                true
+            } else {
+                false
+            }
+        });
+    }
+}
+
+/// Builder for typed debug subscriptions.
+pub struct TypedSubscriptionBuilder<'a, T> {
+    pub(crate) manager: &'a SubscriptionManager,
+    pub(crate) topic: String,
+    pub(crate) retention: RetentionPolicy,
+    value: PhantomData<T>,
+}
+
+impl<T> TypedSubscriptionBuilder<'_, T> {
+    /// Configure how many samples the handle retains.
+    pub fn retention(mut self, retention: RetentionPolicy) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    /// Manager that will own the subscription.
+    pub fn manager(&self) -> &SubscriptionManager {
+        self.manager
+    }
+
+    /// Topic selector requested by the caller.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    /// Configured retention policy.
+    pub fn retention_policy(&self) -> RetentionPolicy {
+        self.retention
+    }
+
+    /// Build the typed subscription and spawn its receive task.
+    pub async fn build(self) -> Result<SubscriptionHandle<T>>
+    where
+        T: Message + Send + Sync + 'static,
+        T::Codec: Send + Sync,
+    {
+        let retention = self.retention;
+        let requested_topic = TopicSelector::new(self.topic)?;
+        let resolved_topic = requested_topic.resolve(self.manager.target_namespace())?;
+        let subscriber = self
+            .manager
+            .node()
+            .subscriber::<T>(&resolved_topic)?
+            .build()
+            .await?;
+        let type_info = subscriber.entity().type_info.clone();
+        let metadata = Arc::new(SampleMetadata {
+            requested_topic,
+            resolved_topic: resolved_topic.clone(),
+            type_info: type_info.clone(),
+        });
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::with_metadata(
+                SubscriptionStatus::WaitingForFirstSample,
+                resolved_topic,
+                type_info,
+            ),
+            retention,
+        ));
+        let handle = state.handle();
+        self.manager.subscriptions.register(&state);
+
+        let receive_task = tokio::spawn(receive_typed_loop(
+            subscriber,
+            Arc::downgrade(&state),
+            state.cancellation_token(),
+            metadata,
+        ));
+        state.set_receive_task(receive_task.abort_handle());
+
+        Ok(handle)
+    }
+}
+
+/// Builder for dynamic debug subscriptions.
+///
+/// Dynamic builders use publisher discovery to find one consistent schema for
+/// the resolved topic. Building fails if no matching publisher/schema can be
+/// discovered within five seconds.
+pub struct DynamicSubscriptionBuilder<'a> {
+    pub(crate) manager: &'a SubscriptionManager,
+    pub(crate) topic: String,
+    pub(crate) retention: RetentionPolicy,
+}
+
+impl DynamicSubscriptionBuilder<'_> {
+    /// Configure how many samples the handle retains.
+    pub fn retention(mut self, retention: RetentionPolicy) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    /// Manager that will own the subscription.
+    pub fn manager(&self) -> &SubscriptionManager {
+        self.manager
+    }
+
+    /// Topic selector requested by the caller.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    /// Configured retention policy.
+    pub fn retention_policy(&self) -> RetentionPolicy {
+        self.retention
+    }
+
+    /// Build a dynamic payload subscription and spawn its receive task.
+    ///
+    /// Schema discovery requires at least one visible publisher on the resolved
+    /// topic, consistent type metadata, and a reachable schema service.
+    pub async fn build(self) -> Result<SubscriptionHandle<DynamicPayload>> {
+        self.build_dynamic_payload().await
+    }
+
+    /// Build a dynamic JSON subscription with `policy`.
+    ///
+    /// Schema discovery has the same requirements as [`Self::build`].
+    pub async fn build_json(self, policy: JsonRenderPolicy) -> Result<JsonSubscriptionHandle> {
+        let dynamic = self.build_dynamic_payload().await?;
+        Ok(JsonSubscriptionHandle::new(dynamic, policy))
+    }
+
+    async fn build_dynamic_payload(self) -> Result<SubscriptionHandle<DynamicPayload>> {
+        let retention = self.retention;
+        let requested_topic = TopicSelector::new(self.topic)?;
+        let resolved_topic = requested_topic.resolve(self.manager.target_namespace())?;
+        let subscriber = self
+            .manager
+            .node()
+            .dynamic_subscriber_auto(&resolved_topic, Duration::from_secs(5))
+            .await?
+            .build()
+            .await?;
+        let type_info = subscriber.entity().type_info.clone();
+        let metadata = Arc::new(SampleMetadata {
+            requested_topic,
+            resolved_topic: resolved_topic.clone(),
+            type_info: type_info.clone(),
+        });
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::with_metadata(
+                SubscriptionStatus::WaitingForFirstSample,
+                resolved_topic,
+                type_info,
+            ),
+            retention,
+        ));
+        let handle = state.handle();
+        self.manager.subscriptions.register(&state);
+
+        let receive_task = tokio::spawn(receive_dynamic_loop(
+            subscriber,
+            Arc::downgrade(&state),
+            state.cancellation_token(),
+            metadata,
+        ));
+        state.set_receive_task(receive_task.abort_handle());
+
+        Ok(handle)
+    }
+}
+
+async fn receive_typed_loop<T>(
+    subscriber: ros_z::pubsub::Subscriber<T>,
+    state: std::sync::Weak<SubscriptionState<T>>,
+    cancellation: CancellationToken,
+    metadata: Arc<SampleMetadata>,
+) where
+    T: Message,
+    T::Codec: Send + Sync,
+{
+    loop {
+        let received = tokio::select! {
+            result = subscriber.recv_with_metadata() => result,
+            _ = cancellation.cancelled() => break,
+        };
+
+        let Some(state) = state.upgrade() else {
+            break;
+        };
+
+        match received {
+            Ok(received) => {
+                let publication_id = received.publication_id();
+                state.store_latest(Arc::new(SampleRecord {
+                    value: received.message,
+                    source_time: received.source_time,
+                    transport_time: received.transport_time,
+                    publication_id,
+                    metadata: Arc::clone(&metadata),
+                }));
+            }
+            Err(error) => {
+                let message = receive_error_diagnostic(&error, &metadata);
+                let status = classify_receive_error(&error, message);
+                state.set_receive_error(status);
+            }
+        }
+    }
+}
+
+async fn receive_dynamic_loop(
+    subscriber: ros_z::pubsub::Subscriber<DynamicPayload, ros_z::dynamic::DynamicCdrCodec>,
+    state: std::sync::Weak<SubscriptionState<DynamicPayload>>,
+    cancellation: CancellationToken,
+    metadata: Arc<SampleMetadata>,
+) {
+    loop {
+        let received = tokio::select! {
+            result = subscriber.recv_with_metadata() => result,
+            _ = cancellation.cancelled() => break,
+        };
+
+        let Some(state) = state.upgrade() else {
+            break;
+        };
+
+        match received {
+            Ok(received) => {
+                let publication_id = received.publication_id();
+                state.store_latest(Arc::new(SampleRecord {
+                    value: received.message,
+                    source_time: received.source_time,
+                    transport_time: received.transport_time,
+                    publication_id,
+                    metadata: Arc::clone(&metadata),
+                }));
+            }
+            Err(error) => {
+                let message = receive_error_diagnostic(&error, &metadata);
+                let status = classify_receive_error(&error, message);
+                state.set_receive_error(status);
+            }
+        }
+    }
+}
+
+fn receive_error_diagnostic(error: &ros_z::Error, metadata: &SampleMetadata) -> String {
+    let mut message = format!(
+        "{} while receiving '{}' as {}",
+        error, metadata.resolved_topic, metadata.type_info.name
+    );
+    let mut source = error.source();
+
+    while let Some(error) = source {
+        let _ = write!(message, ": {error}");
+        source = error.source();
+    }
+
+    message
+}
+
+fn classify_receive_error(error: &ros_z::Error, message: String) -> SubscriptionStatus {
+    if matches!(
+        error,
+        ros_z::Error::Wire(source) if matches!(
+            source.as_ref(),
+            ros_z::error::WireError::MissingSampleAttachment
+                | ros_z::error::WireError::SampleAttachmentDecode { .. }
+        )
+    ) {
+        SubscriptionStatus::protocol_error(message)
+    } else {
+        SubscriptionStatus::decode_error(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{
+        ManagerOptions, SubscriptionRegistry, classify_receive_error, receive_error_diagnostic,
+    };
+    use crate::{
+        Error, RetentionPolicy, SampleMetadata, SubscriptionStatus, SubscriptionStatusSnapshot,
+        TopicSelector, subscription::SubscriptionState,
+    };
+
+    struct TestPayload;
+
+    fn test_metadata() -> SampleMetadata {
+        SampleMetadata {
+            requested_topic: TopicSelector::new("debug").unwrap(),
+            resolved_topic: "/debug".to_string(),
+            type_info: ros_z::TypeInfo::new("test_msgs::DebugValue", ros_z::SchemaHash::zero()),
+        }
+    }
+
+    #[test]
+    fn manager_options_reject_invalid_target_namespace() {
+        let error = ManagerOptions::with_target_namespace("123invalid").unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidTargetNamespace { ref target_namespace, .. }
+                if target_namespace == "123invalid"
+        ));
+    }
+
+    #[test]
+    fn manager_options_normalize_valid_target_namespace() {
+        let options = ManagerOptions::with_target_namespace("alpha/").unwrap();
+
+        assert_eq!(options.target_namespace(), "/alpha");
+    }
+
+    #[test]
+    fn classify_missing_sample_attachment_as_protocol_error() {
+        let error = ros_z::Error::from(ros_z::error::WireError::MissingSampleAttachment);
+
+        assert!(matches!(
+            classify_receive_error(&error, "missing attachment".to_string()),
+            SubscriptionStatus::ProtocolError { ref message } if message == "missing attachment"
+        ));
+    }
+
+    #[test]
+    fn classify_wire_decode_errors_as_decode_errors() {
+        let error = ros_z::Error::from(ros_z::error::WireError::Decode {
+            type_name: "test_msgs::DebugValue".to_string(),
+            source: Box::new(std::io::Error::other("failed to deserialize cdr payload")),
+        });
+
+        assert!(matches!(
+            classify_receive_error(&error, "decode failed".to_string()),
+            SubscriptionStatus::DecodeError { ref message } if message == "decode failed"
+        ));
+    }
+
+    #[test]
+    fn receive_error_diagnostic_includes_source_chain_and_metadata() {
+        let error = ros_z::Error::from(ros_z::error::WireError::Decode {
+            type_name: "test_msgs::DebugValue".to_string(),
+            source: Box::new(std::io::Error::other("failed to deserialize cdr payload")),
+        });
+
+        let message = receive_error_diagnostic(&error, &test_metadata());
+
+        assert!(message.contains("/debug"));
+        assert!(message.contains("test_msgs::DebugValue"));
+        assert!(message.contains("failed to deserialize cdr payload"));
+    }
+
+    #[test]
+    fn registry_prunes_dropped_subscriptions_on_register() {
+        let registry = SubscriptionRegistry::default();
+        let first = Arc::new(SubscriptionState::<TestPayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        registry.register(&first);
+        drop(first);
+
+        let second = Arc::new(SubscriptionState::<TestPayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        registry.register(&second);
+
+        assert_eq!(registry.subscriptions.lock().len(), 1);
+    }
+
+    #[test]
+    fn registry_closes_subscriptions_while_handles_remain_alive() {
+        let registry = SubscriptionRegistry::default();
+        let state = Arc::new(SubscriptionState::<TestPayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let handle = state.handle();
+        registry.register(&state);
+        drop(state);
+
+        registry.close_all();
+
+        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert!(matches!(
+            handle.drain_events().as_slice(),
+            [crate::DebugEvent::StatusChanged]
+        ));
+    }
+}

--- a/crates/ros-z-debug/src/manager.rs
+++ b/crates/ros-z-debug/src/manager.rs
@@ -20,12 +20,15 @@ pub struct ManagerOptions {
     /// This names the robot or target namespace being inspected, not the
     /// namespace of the debug node that owns the subscriptions.
     target_namespace: String,
+    /// Timeout used while querying schema services for dynamic subscriptions.
+    schema_discovery_timeout: Duration,
 }
 
 impl Default for ManagerOptions {
     fn default() -> Self {
         Self {
             target_namespace: "/".to_string(),
+            schema_discovery_timeout: Duration::from_secs(5),
         }
     }
 }
@@ -43,7 +46,12 @@ impl ManagerOptions {
         &self.target_namespace
     }
 
-    /// Update the target namespace after validating it as a ROS namespace.
+    /// Timeout used while querying schema services for dynamic subscriptions.
+    pub fn schema_discovery_timeout(&self) -> Duration {
+        self.schema_discovery_timeout
+    }
+
+    /// Update the target namespace after validating it as a graph namespace.
     pub fn set_target_namespace(
         &mut self,
         target_namespace: impl Into<String>,
@@ -51,6 +59,12 @@ impl ManagerOptions {
         let target_namespace = target_namespace.into();
         self.target_namespace = normalize_target_namespace(&target_namespace)?;
         Ok(self)
+    }
+
+    /// Update the timeout used while querying schema services for dynamic subscriptions.
+    pub fn set_schema_discovery_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.schema_discovery_timeout = timeout;
+        self
     }
 }
 
@@ -94,7 +108,7 @@ impl SubscriptionManager {
     /// Relative topics resolve against [`ManagerOptions::target_namespace`].
     /// Dynamic subscriptions discover the schema from currently visible
     /// publishers during `build()` or `build_json()`. Schema service queries use
-    /// a five second timeout.
+    /// [`ManagerOptions::schema_discovery_timeout`].
     pub fn subscribe_dynamic(&self, topic: impl Into<String>) -> DynamicSubscriptionBuilder<'_> {
         DynamicSubscriptionBuilder {
             manager: self,
@@ -229,7 +243,8 @@ impl<T> TypedSubscriptionBuilder<'_, T> {
 ///
 /// Dynamic builders use currently visible publishers to find one consistent
 /// schema for the resolved topic. Building fails if no matching publisher/schema
-/// is visible, or if schema service queries do not complete within five seconds.
+/// is visible, or if schema service queries do not complete within the manager's
+/// configured discovery timeout.
 pub struct DynamicSubscriptionBuilder<'a> {
     pub(crate) manager: &'a SubscriptionManager,
     pub(crate) topic: String,
@@ -281,7 +296,10 @@ impl DynamicSubscriptionBuilder<'_> {
         let subscriber = self
             .manager
             .node()
-            .dynamic_subscriber_auto(&resolved_topic, Duration::from_secs(5))
+            .dynamic_subscriber_auto(
+                &resolved_topic,
+                self.manager.options.schema_discovery_timeout(),
+            )
             .await?
             .build()
             .await?;

--- a/crates/ros-z-debug/src/manager.rs
+++ b/crates/ros-z-debug/src/manager.rs
@@ -443,12 +443,12 @@ mod tests {
 
     #[test]
     fn manager_options_reject_invalid_target_namespace() {
-        let error = ManagerOptions::with_target_namespace("123invalid").unwrap_err();
+        let error = ManagerOptions::with_target_namespace("alpha%bad").unwrap_err();
 
         assert!(matches!(
             error,
             Error::InvalidTargetNamespace { ref target_namespace, .. }
-                if target_namespace == "123invalid"
+                if target_namespace == "alpha%bad"
         ));
     }
 

--- a/crates/ros-z-debug/src/manager.rs
+++ b/crates/ros-z-debug/src/manager.rs
@@ -92,8 +92,9 @@ impl SubscriptionManager {
     /// Start building a dynamic debug subscription.
     ///
     /// Relative topics resolve against [`ManagerOptions::target_namespace`].
-    /// Dynamic subscriptions discover the schema from visible publishers during
-    /// `build()` or `build_json()`, using a five second timeout.
+    /// Dynamic subscriptions discover the schema from currently visible
+    /// publishers during `build()` or `build_json()`. Schema service queries use
+    /// a five second timeout.
     pub fn subscribe_dynamic(&self, topic: impl Into<String>) -> DynamicSubscriptionBuilder<'_> {
         DynamicSubscriptionBuilder {
             manager: self,
@@ -226,9 +227,9 @@ impl<T> TypedSubscriptionBuilder<'_, T> {
 
 /// Builder for dynamic debug subscriptions.
 ///
-/// Dynamic builders use publisher discovery to find one consistent schema for
-/// the resolved topic. Building fails if no matching publisher/schema can be
-/// discovered within five seconds.
+/// Dynamic builders use currently visible publishers to find one consistent
+/// schema for the resolved topic. Building fails if no matching publisher/schema
+/// is visible, or if schema service queries do not complete within five seconds.
 pub struct DynamicSubscriptionBuilder<'a> {
     pub(crate) manager: &'a SubscriptionManager,
     pub(crate) topic: String,
@@ -259,8 +260,8 @@ impl DynamicSubscriptionBuilder<'_> {
 
     /// Build a dynamic payload subscription and spawn its receive task.
     ///
-    /// Schema discovery requires at least one visible publisher on the resolved
-    /// topic, consistent type metadata, and a reachable schema service.
+    /// Schema discovery requires at least one currently visible publisher on the
+    /// resolved topic, consistent type metadata, and a reachable schema service.
     pub async fn build(self) -> Result<SubscriptionHandle<DynamicPayload>> {
         self.build_dynamic_payload().await
     }

--- a/crates/ros-z-debug/src/manager.rs
+++ b/crates/ros-z-debug/src/manager.rs
@@ -496,25 +496,6 @@ mod tests {
     }
 
     #[test]
-    fn registry_prunes_dropped_subscriptions_on_register() {
-        let registry = SubscriptionRegistry::default();
-        let first = Arc::new(SubscriptionState::<TestPayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
-            RetentionPolicy::LatestOnly,
-        ));
-        registry.register(&first);
-        drop(first);
-
-        let second = Arc::new(SubscriptionState::<TestPayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
-            RetentionPolicy::LatestOnly,
-        ));
-        registry.register(&second);
-
-        assert_eq!(registry.subscriptions.lock().len(), 1);
-    }
-
-    #[test]
     fn registry_closes_subscriptions_while_handles_remain_alive() {
         let registry = SubscriptionRegistry::default();
         let state = Arc::new(SubscriptionState::<TestPayload>::new(

--- a/crates/ros-z-debug/src/retention.rs
+++ b/crates/ros-z-debug/src/retention.rs
@@ -1,0 +1,114 @@
+use std::{num::NonZeroUsize, time::Duration};
+
+use crate::{Error, Result};
+
+/// Default sample cap used by [`RetentionPolicy::time_window`].
+pub const DEFAULT_TIME_WINDOW_MAX_SAMPLES: usize = 4096;
+
+/// Sample retention policy for a debug subscription handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum RetentionPolicy {
+    /// Keep only the latest sample.
+    LatestOnly,
+    /// Keep samples inside a source-time window.
+    TimeWindow(RetentionWindow),
+}
+
+/// Source-time retention window configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RetentionWindow {
+    duration: Duration,
+    max_samples: Option<NonZeroUsize>,
+}
+
+impl RetentionWindow {
+    /// Source-time duration retained from the newest sample.
+    pub fn duration(self) -> Duration {
+        self.duration
+    }
+
+    /// Optional cap for the number of retained samples.
+    pub fn max_samples(self) -> Option<NonZeroUsize> {
+        self.max_samples
+    }
+}
+
+impl RetentionPolicy {
+    /// Retain samples whose source time is inside `duration` from the newest sample.
+    ///
+    /// This also caps retained samples to [`DEFAULT_TIME_WINDOW_MAX_SAMPLES`] so
+    /// stalled or repeated source timestamps cannot grow memory without bound.
+    pub fn time_window(duration: Duration) -> Result<Self> {
+        Self::time_window_inner(duration, Some(default_time_window_max_samples()))
+    }
+
+    /// Retain samples inside `duration`, capped to `max_samples` newest entries.
+    pub fn time_window_with_max_samples(
+        duration: Duration,
+        max_samples: NonZeroUsize,
+    ) -> Result<Self> {
+        Self::time_window_inner(duration, Some(max_samples))
+    }
+
+    fn time_window_inner(duration: Duration, max_samples: Option<NonZeroUsize>) -> Result<Self> {
+        if duration.is_zero() {
+            return Err(Error::InvalidRetention(
+                "time window duration must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(Self::TimeWindow(RetentionWindow {
+            duration,
+            max_samples,
+        }))
+    }
+}
+
+fn default_time_window_max_samples() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_TIME_WINDOW_MAX_SAMPLES)
+        .expect("default time-window retention cap must be non-zero")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{num::NonZeroUsize, time::Duration};
+
+    use super::{DEFAULT_TIME_WINDOW_MAX_SAMPLES, RetentionPolicy};
+
+    #[test]
+    fn time_window_rejects_zero_duration() {
+        let error = RetentionPolicy::time_window(Duration::ZERO).unwrap_err();
+
+        assert!(error.to_string().contains("duration"));
+    }
+
+    #[test]
+    fn time_window_retains_non_zero_duration() {
+        let policy = RetentionPolicy::time_window(Duration::from_secs(1)).unwrap();
+
+        let RetentionPolicy::TimeWindow(window) = policy else {
+            panic!("expected time window retention");
+        };
+        assert_eq!(window.duration(), Duration::from_secs(1));
+        assert_eq!(
+            window.max_samples(),
+            NonZeroUsize::new(DEFAULT_TIME_WINDOW_MAX_SAMPLES)
+        );
+    }
+
+    #[test]
+    fn time_window_with_max_samples_uses_non_zero_cap() {
+        let policy = RetentionPolicy::time_window_with_max_samples(
+            Duration::from_secs(1),
+            NonZeroUsize::new(2).unwrap(),
+        )
+        .unwrap();
+
+        let RetentionPolicy::TimeWindow(window) = policy else {
+            panic!("expected time window retention");
+        };
+        assert_eq!(window.duration(), Duration::from_secs(1));
+        assert_eq!(window.max_samples(), NonZeroUsize::new(2));
+    }
+}

--- a/crates/ros-z-debug/src/sample.rs
+++ b/crates/ros-z-debug/src/sample.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use ros_z::{TypeInfo, time::Time};
+
+/// Metadata fixed for all samples received through one debug subscription.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct SampleMetadata {
+    /// Topic selector originally requested by the caller.
+    pub requested_topic: crate::TopicSelector,
+    /// Absolute topic name used for the underlying subscription.
+    pub resolved_topic: String,
+    /// Type metadata discovered or declared for this subscription.
+    pub type_info: TypeInfo,
+}
+
+/// A retained subscription sample with transport metadata and shared subscription metadata.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct SampleRecord<V> {
+    /// Decoded typed value or dynamic payload.
+    pub value: V,
+    /// Source timestamp reported by the publisher.
+    pub source_time: Time,
+    /// Zenoh transport timestamp, when present on the received sample.
+    pub transport_time: Option<Time>,
+    /// Stable publication identity derived from source id and sequence number.
+    pub publication_id: ros_z::pubsub::PublicationId,
+    /// Metadata shared by all samples received through the same subscription.
+    pub metadata: Arc<SampleMetadata>,
+}

--- a/crates/ros-z-debug/src/status.rs
+++ b/crates/ros-z-debug/src/status.rs
@@ -1,0 +1,117 @@
+use ros_z::TypeInfo;
+
+/// Current lifecycle state for a debug subscription.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SubscriptionStatus {
+    /// The subscription has been created and is waiting for its first sample.
+    WaitingForFirstSample,
+    /// At least one sample has been received and retained.
+    Ready,
+    /// A transport or sample metadata error prevented normal receive handling.
+    ProtocolError { message: String },
+    /// A received payload could not be decoded as the expected type.
+    DecodeError { message: String },
+    /// The subscription was closed and will not accept further samples or errors.
+    Closed,
+}
+
+impl SubscriptionStatus {
+    /// Create a protocol error status with a diagnostic message.
+    pub fn protocol_error(message: impl Into<String>) -> Self {
+        Self::ProtocolError {
+            message: message.into(),
+        }
+    }
+
+    /// Create a decode error status with a diagnostic message.
+    pub fn decode_error(message: impl Into<String>) -> Self {
+        Self::DecodeError {
+            message: message.into(),
+        }
+    }
+
+    /// Return the diagnostic message for error states.
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            Self::ProtocolError { message } | Self::DecodeError { message } => Some(message),
+            Self::WaitingForFirstSample | Self::Ready | Self::Closed => None,
+        }
+    }
+
+    pub(crate) fn is_same_kind(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+/// Point-in-time subscription status and resolved metadata.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SubscriptionStatusSnapshot {
+    status: SubscriptionStatus,
+    resolved_topic: Option<String>,
+    type_info: Option<TypeInfo>,
+}
+
+impl SubscriptionStatusSnapshot {
+    #[cfg(test)]
+    pub(crate) fn new(status: SubscriptionStatus) -> Self {
+        Self {
+            status,
+            resolved_topic: None,
+            type_info: None,
+        }
+    }
+
+    pub(crate) fn with_metadata(
+        status: SubscriptionStatus,
+        resolved_topic: String,
+        type_info: TypeInfo,
+    ) -> Self {
+        Self {
+            status,
+            resolved_topic: Some(resolved_topic),
+            type_info: Some(type_info),
+        }
+    }
+
+    /// Return the lifecycle status at the time this snapshot was taken.
+    pub fn status(&self) -> &SubscriptionStatus {
+        &self.status
+    }
+
+    /// Return the diagnostic message for error states.
+    pub fn message(&self) -> Option<&str> {
+        self.status.message()
+    }
+
+    /// Return the resolved absolute topic once subscription metadata is known.
+    pub fn resolved_topic(&self) -> Option<&str> {
+        self.resolved_topic.as_deref()
+    }
+
+    /// Return the resolved type metadata once subscription metadata is known.
+    pub fn type_info(&self) -> Option<&TypeInfo> {
+        self.type_info.as_ref()
+    }
+
+    pub(crate) fn set_status(&mut self, status: SubscriptionStatus) {
+        self.status = status;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SubscriptionStatus, SubscriptionStatusSnapshot};
+
+    #[test]
+    fn error_status_carries_message_in_variant() {
+        let snapshot = SubscriptionStatusSnapshot::new(SubscriptionStatus::decode_error(
+            "failed to decode sample",
+        ));
+
+        assert_eq!(snapshot.message(), Some("failed to decode sample"));
+        assert_eq!(snapshot.resolved_topic(), None);
+        assert_eq!(snapshot.type_info(), None);
+    }
+}

--- a/crates/ros-z-debug/src/subscription.rs
+++ b/crates/ros-z-debug/src/subscription.rs
@@ -357,6 +357,21 @@ mod tests {
     }
 
     #[test]
+    fn time_window_handle_returns_empty_for_inverted_window() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+        ));
+        state.store_latest(sample_record_at(NonClonePayload(1), Time::from_nanos(1)));
+
+        let records = state
+            .handle()
+            .window(Time::from_nanos(2), Time::from_nanos(1));
+
+        assert!(records.is_empty());
+    }
+
+    #[test]
     fn latest_only_handle_returns_empty_window_but_keeps_latest() {
         let state = Arc::new(SubscriptionState::new(
             SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),

--- a/crates/ros-z-debug/src/subscription.rs
+++ b/crates/ros-z-debug/src/subscription.rs
@@ -1,0 +1,577 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+use parking_lot::Mutex;
+use ros_z::dynamic::DynamicPayload;
+use ros_z::time::Time;
+use serde_json::Value;
+use tokio::task::AbortHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    DebugEvent, JsonRenderPolicy, RetentionPolicy, SampleRecord, SubscriptionStatus,
+    SubscriptionStatusSnapshot, dynamic_payload_to_json, event::EventBuffer,
+    history::TimeIndexedHistory,
+};
+
+pub(crate) trait ManagedSubscription: Send + Sync {
+    fn close(&self);
+}
+
+/// Handle for reading retained subscription state.
+///
+/// Cloning the handle keeps the subscription alive. Dropping the last handle
+/// cancels the receive task.
+pub struct SubscriptionHandle<V> {
+    state: Arc<SubscriptionState<V>>,
+}
+
+impl<V> Clone for SubscriptionHandle<V> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl<V> SubscriptionHandle<V> {
+    /// Return the current status snapshot.
+    pub fn status(&self) -> SubscriptionStatusSnapshot {
+        self.state.status()
+    }
+
+    /// Return the latest retained sample, if one has arrived.
+    pub fn latest(&self) -> Option<Arc<SampleRecord<V>>> {
+        self.state.latest()
+    }
+
+    /// Return retained samples whose source time falls inside `[start, end]`.
+    ///
+    /// Handles with [`RetentionPolicy::LatestOnly`] return an empty window.
+    pub fn window(&self, start: Time, end: Time) -> Vec<Arc<SampleRecord<V>>> {
+        self.state.window(start, end)
+    }
+
+    /// Drain queued status/value/diagnostic events.
+    pub fn drain_events(&self) -> Vec<DebugEvent> {
+        self.state.drain_events()
+    }
+}
+
+/// Handle that renders retained dynamic payloads as JSON on demand.
+pub struct JsonSubscriptionHandle {
+    dynamic: SubscriptionHandle<DynamicPayload>,
+    policy: JsonRenderPolicy,
+}
+
+impl JsonSubscriptionHandle {
+    pub(crate) fn new(
+        dynamic: SubscriptionHandle<DynamicPayload>,
+        policy: JsonRenderPolicy,
+    ) -> Self {
+        Self { dynamic, policy }
+    }
+
+    /// Return the current status snapshot.
+    pub fn status(&self) -> SubscriptionStatusSnapshot {
+        self.dynamic.status()
+    }
+
+    /// Render the latest retained dynamic payload as JSON.
+    pub fn latest_json(&self) -> Option<Value> {
+        self.dynamic
+            .latest()
+            .map(|record| dynamic_payload_to_json(&record.value, self.policy))
+    }
+
+    /// Render retained dynamic payloads in `[start, end]` as JSON.
+    pub fn window_json(&self, start: Time, end: Time) -> Vec<Value> {
+        self.dynamic
+            .window(start, end)
+            .iter()
+            .map(|record| dynamic_payload_to_json(&record.value, self.policy))
+            .collect()
+    }
+
+    /// Drain queued status/value/diagnostic events.
+    pub fn drain_events(&self) -> Vec<DebugEvent> {
+        self.dynamic.drain_events()
+    }
+}
+
+pub(crate) struct SubscriptionState<V> {
+    latest: ArcSwapOption<SampleRecord<V>>,
+    history: Option<Mutex<TimeIndexedHistory<V>>>,
+    meta: Mutex<SubscriptionMeta>,
+    cancellation_token: CancellationToken,
+}
+
+struct SubscriptionMeta {
+    status: SubscriptionStatusSnapshot,
+    events: EventBuffer,
+    receive_task: Option<AbortHandle>,
+}
+
+impl<V> SubscriptionState<V> {
+    pub(crate) fn new(status: SubscriptionStatusSnapshot, retention: RetentionPolicy) -> Self {
+        let history = match retention {
+            RetentionPolicy::LatestOnly => None,
+            RetentionPolicy::TimeWindow(_) => Some(Mutex::new(TimeIndexedHistory::new(retention))),
+        };
+
+        Self {
+            latest: ArcSwapOption::empty(),
+            history,
+            meta: Mutex::new(SubscriptionMeta {
+                status,
+                events: EventBuffer::new(256),
+                receive_task: None,
+            }),
+            cancellation_token: CancellationToken::new(),
+        }
+    }
+
+    pub(crate) fn handle(self: &Arc<Self>) -> SubscriptionHandle<V> {
+        SubscriptionHandle {
+            state: Arc::clone(self),
+        }
+    }
+
+    pub(crate) fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
+    }
+
+    pub(crate) fn set_receive_task(&self, abort_handle: AbortHandle) {
+        let mut meta = self.meta.lock();
+        if meta.status.status() == &SubscriptionStatus::Closed {
+            drop(meta);
+            abort_handle.abort();
+            return;
+        }
+
+        if let Some(previous) = meta.receive_task.replace(abort_handle) {
+            previous.abort();
+        }
+    }
+
+    pub(crate) fn close(&self) {
+        let mut meta = self.meta.lock();
+        if meta.status.status() == &SubscriptionStatus::Closed {
+            return;
+        }
+        meta.status.set_status(SubscriptionStatus::Closed);
+        meta.events.push(DebugEvent::StatusChanged);
+        let receive_task = meta.receive_task.take();
+        drop(meta);
+
+        self.cancellation_token.cancel();
+        if let Some(receive_task) = receive_task {
+            receive_task.abort();
+        }
+    }
+
+    pub(crate) fn store_latest(&self, record: Arc<SampleRecord<V>>) {
+        let mut meta = self.meta.lock();
+        if meta.status.status() == &SubscriptionStatus::Closed {
+            return;
+        }
+
+        if let Some(history) = &self.history {
+            history.lock().insert(Arc::clone(&record));
+        }
+        self.latest.store(Some(record));
+
+        let status_changed = meta.status.status() != &SubscriptionStatus::Ready;
+        meta.status.set_status(SubscriptionStatus::Ready);
+        if status_changed {
+            meta.events.push(DebugEvent::StatusChanged);
+        }
+        meta.events.push(DebugEvent::ValueUpdated);
+    }
+
+    pub(crate) fn set_receive_error(&self, status: SubscriptionStatus) {
+        let mut meta = self.meta.lock();
+        if meta.status.status() == &SubscriptionStatus::Closed {
+            return;
+        }
+
+        let status_changed = !meta.status.status().is_same_kind(&status);
+        let message = status.message().map(str::to_owned);
+        meta.status.set_status(status);
+        if status_changed {
+            meta.events.push(DebugEvent::StatusChanged);
+        }
+        if let Some(message) = message {
+            meta.events.push(DebugEvent::Diagnostic(message));
+        }
+    }
+
+    fn status(&self) -> SubscriptionStatusSnapshot {
+        self.meta.lock().status.clone()
+    }
+
+    fn latest(&self) -> Option<Arc<SampleRecord<V>>> {
+        self.latest.load_full()
+    }
+
+    fn window(&self, start: Time, end: Time) -> Vec<Arc<SampleRecord<V>>> {
+        self.history
+            .as_ref()
+            .map_or_else(Vec::new, |history| history.lock().window(start, end))
+    }
+
+    fn drain_events(&self) -> Vec<DebugEvent> {
+        self.meta.lock().events.drain()
+    }
+}
+
+impl<V> Drop for SubscriptionState<V> {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+        if let Some(receive_task) = self.meta.lock().receive_task.take() {
+            receive_task.abort();
+        }
+    }
+}
+
+impl<V> ManagedSubscription for SubscriptionState<V>
+where
+    V: Send + Sync,
+{
+    fn close(&self) {
+        SubscriptionState::close(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use ros_z::{
+        dynamic::{DynamicPayload, DynamicValue, PrimitiveTypeDef, SchemaBundle, TypeDef},
+        time::Time,
+    };
+
+    use super::{JsonSubscriptionHandle, SubscriptionState};
+    use crate::{
+        DebugEvent, JsonRenderPolicy, RetentionPolicy, SampleMetadata, SampleRecord,
+        SubscriptionStatus, SubscriptionStatusSnapshot, TopicSelector,
+    };
+
+    struct NonClonePayload(u32);
+
+    fn test_type_info() -> ros_z::TypeInfo {
+        ros_z::TypeInfo::new("test_msgs::DebugValue", ros_z::SchemaHash::zero())
+    }
+
+    fn test_publication_id() -> ros_z::pubsub::PublicationId {
+        ros_z::pubsub::Received {
+            message: (),
+            transport_time: None,
+            source_time: Time::zero(),
+            sequence_number: 1,
+            source_global_id: [7; 16],
+        }
+        .publication_id()
+    }
+
+    fn test_metadata() -> Arc<SampleMetadata> {
+        Arc::new(SampleMetadata {
+            requested_topic: TopicSelector::new("camera").unwrap(),
+            resolved_topic: "/camera".to_string(),
+            type_info: test_type_info(),
+        })
+    }
+
+    fn sample_record_at(
+        value: NonClonePayload,
+        source_time: Time,
+    ) -> Arc<SampleRecord<NonClonePayload>> {
+        Arc::new(SampleRecord {
+            value,
+            source_time,
+            transport_time: None,
+            publication_id: test_publication_id(),
+            metadata: test_metadata(),
+        })
+    }
+
+    fn sample_record(value: NonClonePayload) -> Arc<SampleRecord<NonClonePayload>> {
+        sample_record_at(value, Time::zero())
+    }
+
+    fn dynamic_payload(value: i32) -> DynamicPayload {
+        DynamicPayload::new(
+            Arc::new(SchemaBundle {
+                root: TypeDef::Primitive(PrimitiveTypeDef::I32),
+                definitions: Default::default(),
+            }),
+            DynamicValue::Int32(value),
+        )
+        .unwrap()
+    }
+
+    fn dynamic_record_at(value: i32, source_time: Time) -> Arc<SampleRecord<DynamicPayload>> {
+        Arc::new(SampleRecord {
+            value: dynamic_payload(value),
+            source_time,
+            transport_time: None,
+            publication_id: test_publication_id(),
+            metadata: test_metadata(),
+        })
+    }
+
+    #[test]
+    fn latest_returns_arc_record_without_cloning_payload() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let record = sample_record(NonClonePayload(7));
+
+        state.store_latest(Arc::clone(&record));
+
+        let latest = state.handle().latest().unwrap();
+        assert!(Arc::ptr_eq(&record, &latest));
+        assert_eq!(latest.value.0, 7);
+    }
+
+    #[test]
+    fn time_window_handle_returns_stored_records_in_window() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+        ));
+        let first = sample_record_at(NonClonePayload(1), Time::from_nanos(1));
+        let second = sample_record_at(NonClonePayload(2), Time::from_nanos(2));
+
+        state.store_latest(Arc::clone(&first));
+        state.store_latest(Arc::clone(&second));
+
+        let records = state
+            .handle()
+            .window(Time::from_nanos(1), Time::from_nanos(2));
+        assert_eq!(records.len(), 2);
+        assert!(Arc::ptr_eq(&records[0], &first));
+        assert!(Arc::ptr_eq(&records[1], &second));
+    }
+
+    #[test]
+    fn latest_only_handle_returns_empty_window_but_keeps_latest() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let record = sample_record_at(NonClonePayload(3), Time::from_nanos(3));
+
+        state.store_latest(Arc::clone(&record));
+
+        assert!(
+            state
+                .handle()
+                .window(Time::from_nanos(0), Time::from_nanos(10))
+                .is_empty()
+        );
+        assert!(Arc::ptr_eq(&record, &state.handle().latest().unwrap()));
+    }
+
+    #[test]
+    fn drain_events_returns_and_clears_events() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+
+        state.store_latest(sample_record(NonClonePayload(1)));
+
+        let events = state.handle().drain_events();
+        assert!(matches!(
+            &events[..],
+            [DebugEvent::StatusChanged, DebugEvent::ValueUpdated]
+        ));
+        assert!(state.handle().drain_events().is_empty());
+    }
+
+    #[test]
+    fn status_becomes_ready_after_storing_latest() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+
+        state.store_latest(sample_record(NonClonePayload(1)));
+
+        assert_eq!(state.handle().status().status(), &SubscriptionStatus::Ready);
+    }
+
+    #[test]
+    fn recovery_from_error_emits_status_changed_and_value_updated() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        state.set_receive_error(SubscriptionStatus::decode_error(
+            "failed to deserialize sample",
+        ));
+        state.handle().drain_events();
+
+        state.store_latest(sample_record(NonClonePayload(1)));
+
+        let events = state.handle().drain_events();
+        assert!(matches!(
+            events.as_slice(),
+            [DebugEvent::StatusChanged, DebugEvent::ValueUpdated]
+        ));
+    }
+
+    #[test]
+    fn close_sets_closed_status_and_emits_event() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let handle = state.handle();
+
+        state.close();
+
+        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert!(matches!(
+            handle.drain_events().as_slice(),
+            [DebugEvent::StatusChanged]
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_aborts_registered_receive_task() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let task = tokio::spawn(std::future::pending::<()>());
+        state.set_receive_task(task.abort_handle());
+
+        state.close();
+
+        assert!(task.await.unwrap_err().is_cancelled());
+    }
+
+    #[test]
+    fn store_latest_after_close_keeps_closed_terminal() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let handle = state.handle();
+
+        state.close();
+        state.store_latest(sample_record(NonClonePayload(1)));
+
+        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert!(handle.latest().is_none());
+        assert!(matches!(
+            handle.drain_events().as_slice(),
+            [DebugEvent::StatusChanged]
+        ));
+    }
+
+    #[test]
+    fn receive_error_after_close_keeps_closed_terminal() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let handle = state.handle();
+
+        state.close();
+        state.set_receive_error(SubscriptionStatus::decode_error("late decode failure"));
+
+        let status = handle.status();
+        assert_eq!(status.status(), &SubscriptionStatus::Closed);
+        assert_eq!(status.message(), None);
+        assert!(matches!(
+            handle.drain_events().as_slice(),
+            [DebugEvent::StatusChanged]
+        ));
+    }
+
+    #[test]
+    fn close_is_idempotent() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let handle = state.handle();
+
+        state.close();
+        state.close();
+
+        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert!(matches!(
+            handle.drain_events().as_slice(),
+            [DebugEvent::StatusChanged]
+        ));
+    }
+
+    #[test]
+    fn json_handle_projects_latest_dynamic_payload() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        state.store_latest(dynamic_record_at(42, Time::zero()));
+        let handle = JsonSubscriptionHandle::new(state.handle(), JsonRenderPolicy::default());
+
+        assert_eq!(handle.latest_json(), Some(serde_json::json!(42)));
+    }
+
+    #[test]
+    fn json_handle_drains_underlying_dynamic_events() {
+        let state = Arc::new(SubscriptionState::<DynamicPayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        state.store_latest(dynamic_record_at(1, Time::zero()));
+        let handle = JsonSubscriptionHandle::new(state.handle(), JsonRenderPolicy::default());
+
+        let events = handle.drain_events();
+
+        assert!(matches!(
+            &events[..],
+            [DebugEvent::StatusChanged, DebugEvent::ValueUpdated]
+        ));
+        assert!(handle.drain_events().is_empty());
+    }
+
+    #[test]
+    fn json_handle_projects_dynamic_payload_window() {
+        let state = Arc::new(SubscriptionState::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+        ));
+        state.store_latest(dynamic_record_at(1, Time::from_nanos(1)));
+        state.store_latest(dynamic_record_at(2, Time::from_nanos(2)));
+        let handle = JsonSubscriptionHandle::new(state.handle(), JsonRenderPolicy::default());
+
+        assert_eq!(
+            handle.window_json(Time::from_nanos(1), Time::from_nanos(2)),
+            vec![serde_json::json!(1), serde_json::json!(2)]
+        );
+    }
+
+    #[test]
+    fn dropping_last_handle_cancels_subscription_state() {
+        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
+            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            RetentionPolicy::LatestOnly,
+        ));
+        let cancellation = state.cancellation_token();
+        let handle = state.handle();
+
+        drop(state);
+        assert!(!cancellation.is_cancelled());
+
+        drop(handle);
+
+        assert!(cancellation.is_cancelled());
+    }
+}

--- a/crates/ros-z-debug/src/topic.rs
+++ b/crates/ros-z-debug/src/topic.rs
@@ -7,8 +7,9 @@ const TARGET_NODE_PLACEHOLDER: &str = "debug_target";
 /// Validated topic selector used by debug subscriptions.
 ///
 /// Relative selectors resolve against a target namespace. Absolute selectors
-/// are used as-is after validation. Private `~` selectors are rejected because
-/// the debug manager has target namespace context, not target node context.
+/// are used as-is through `ros-z` topic qualification. Private `~` selectors are
+/// rejected because the debug manager has target namespace context, not target
+/// node context.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TopicSelector(String);
 
@@ -234,14 +235,6 @@ mod tests {
     #[test]
     fn invalid_relative_selector_is_rejected_during_construction() {
         let error = TopicSelector::new("123invalid").unwrap_err();
-
-        assert!(error.source().is_some());
-        assert!(error.to_string().contains("invalid component '123invalid'"));
-    }
-
-    #[test]
-    fn invalid_absolute_selector_is_rejected_during_construction() {
-        let error = TopicSelector::new("/123invalid").unwrap_err();
 
         assert!(error.source().is_some());
         assert!(error.to_string().contains("invalid component '123invalid'"));

--- a/crates/ros-z-debug/src/topic.rs
+++ b/crates/ros-z-debug/src/topic.rs
@@ -1,0 +1,291 @@
+use ros_z::topic_name::qualify_topic_name;
+
+use crate::{Error, Result};
+
+const TARGET_NODE_PLACEHOLDER: &str = "debug_target";
+
+/// Validated topic selector used by debug subscriptions.
+///
+/// Relative selectors resolve against a target namespace. Absolute selectors
+/// are used as-is after validation. Private `~` selectors are rejected because
+/// the debug manager has target namespace context, not target node context.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TopicSelector(String);
+
+/// Topic name projected for display in a UI or debug tool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedTopic {
+    /// Display label for the topic under the active namespace context.
+    pub display_name: String,
+    /// Absolute topic name used for subscription.
+    pub resolved_topic: String,
+    /// Relationship between the topic and the active namespace.
+    pub scope: ProjectedTopicScope,
+}
+
+/// Scope used when projecting a topic for display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProjectedTopicScope {
+    /// Topic is inside the active namespace and can be displayed relatively.
+    RelativeToActiveNamespace,
+    /// Topic is outside the active namespace and should be treated as fully qualified.
+    FullyQualified,
+}
+
+/// Projects absolute or relative topic names for display under an active namespace.
+pub struct TopicProjection;
+
+impl TopicSelector {
+    /// Validate and store a topic selector.
+    pub fn new(selector: impl Into<String>) -> Result<Self> {
+        let selector = selector.into();
+
+        if selector.starts_with('~') {
+            return Err(Error::UnsupportedPrivateTopicSelector { selector });
+        }
+
+        resolve_topic_name(&selector, "/")?;
+
+        Ok(Self(selector))
+    }
+
+    /// Return the original selector string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Return whether this selector is absolute.
+    pub fn is_absolute(&self) -> bool {
+        self.0.starts_with('/')
+    }
+
+    /// Resolve this selector against `target_namespace`.
+    pub fn resolve(&self, target_namespace: &str) -> Result<String> {
+        resolve_topic_name(&self.0, target_namespace)
+    }
+}
+
+impl TopicProjection {
+    /// Project topic names for display under `active_namespace`.
+    ///
+    /// Topics inside the active namespace display without that namespace prefix.
+    /// Other absolute topics keep their leading `/` so callers can distinguish
+    /// global topics from active-namespace topics.
+    pub fn project<Topic>(
+        active_namespace: &str,
+        topics: impl IntoIterator<Item = Topic>,
+    ) -> Result<Vec<ProjectedTopic>>
+    where
+        Topic: AsRef<str>,
+    {
+        let active_namespace = normalize_target_namespace(active_namespace)?;
+        topics
+            .into_iter()
+            .map(|topic| {
+                let resolved_topic = resolve_topic_name(topic.as_ref(), &active_namespace)?;
+                let (display_name, scope) = display_name(&active_namespace, &resolved_topic);
+
+                Ok(ProjectedTopic {
+                    display_name,
+                    resolved_topic,
+                    scope,
+                })
+            })
+            .collect::<Result<Vec<_>>>()
+    }
+}
+
+fn resolve_topic_name(selector: &str, target_namespace: &str) -> Result<String> {
+    if selector.starts_with('~') {
+        return Err(Error::UnsupportedPrivateTopicSelector {
+            selector: selector.to_string(),
+        });
+    }
+
+    let namespace = if selector.starts_with('/') {
+        "/".to_string()
+    } else {
+        normalize_target_namespace(target_namespace)?
+    };
+
+    qualify_topic_name(selector, &namespace, TARGET_NODE_PLACEHOLDER).map_err(|error| {
+        Error::InvalidTopicSelector {
+            selector: selector.to_string(),
+            source: error,
+        }
+    })
+}
+
+pub(crate) fn normalize_target_namespace(target_namespace: &str) -> Result<String> {
+    let normalized_namespace = normalize_namespace(target_namespace);
+    validate_target_namespace(target_namespace, &normalized_namespace)?;
+    Ok(normalized_namespace)
+}
+
+fn validate_target_namespace(target_namespace: &str, normalized_namespace: &str) -> Result<()> {
+    qualify_topic_name(
+        "ros_z_debug_namespace_probe",
+        normalized_namespace,
+        TARGET_NODE_PLACEHOLDER,
+    )
+    .map(|_| ())
+    .map_err(|error| Error::InvalidTargetNamespace {
+        target_namespace: target_namespace.to_string(),
+        source: error,
+    })
+}
+
+fn normalize_namespace(namespace: &str) -> String {
+    let namespace = namespace.trim_matches('/');
+    if namespace.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{namespace}")
+    }
+}
+
+fn display_name(active_namespace: &str, resolved_topic: &str) -> (String, ProjectedTopicScope) {
+    if active_namespace == "/" {
+        return (
+            resolved_topic.trim_start_matches('/').to_string(),
+            ProjectedTopicScope::RelativeToActiveNamespace,
+        );
+    }
+
+    let namespace_prefix = format!("{active_namespace}/");
+    if let Some(relative_name) = resolved_topic.strip_prefix(&namespace_prefix) {
+        (
+            relative_name.to_string(),
+            ProjectedTopicScope::RelativeToActiveNamespace,
+        )
+    } else {
+        (
+            resolved_topic.to_string(),
+            ProjectedTopicScope::FullyQualified,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use super::{ProjectedTopicScope, TopicProjection, TopicSelector};
+    use crate::Error;
+
+    #[test]
+    fn relative_selector_resolves_under_target_namespace() {
+        let selector = TopicSelector::new("my_data/foo").unwrap();
+
+        assert_eq!(selector.resolve("alpha").unwrap(), "/alpha/my_data/foo");
+    }
+
+    #[test]
+    fn relative_selector_trims_trailing_slash() {
+        let selector = TopicSelector::new("foo/").unwrap();
+
+        assert_eq!(selector.resolve("alpha").unwrap(), "/alpha/foo");
+    }
+
+    #[test]
+    fn target_namespace_trims_trailing_slash() {
+        let selector = TopicSelector::new("foo").unwrap();
+
+        assert_eq!(selector.resolve("/alpha/").unwrap(), "/alpha/foo");
+    }
+
+    #[test]
+    fn absolute_selector_ignores_namespace() {
+        let selector = TopicSelector::new("/diagnostics").unwrap();
+
+        assert_eq!(selector.resolve("alpha").unwrap(), "/diagnostics");
+    }
+
+    #[test]
+    fn absolute_selector_does_not_validate_target_namespace() {
+        let selector = TopicSelector::new("/diagnostics").unwrap();
+
+        assert_eq!(selector.resolve("123invalid/").unwrap(), "/diagnostics");
+    }
+
+    #[test]
+    fn relative_selector_reports_invalid_target_namespace() {
+        let selector = TopicSelector::new("diagnostics").unwrap();
+
+        let error = selector.resolve("123invalid").unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid target namespace '123invalid'")
+        );
+    }
+
+    #[test]
+    fn private_selector_rejection_explains_missing_target_node() {
+        let error = TopicSelector::new("~private").unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::UnsupportedPrivateTopicSelector { ref selector } if selector == "~private"
+        ));
+    }
+
+    #[test]
+    fn invalid_relative_selector_is_rejected_during_construction() {
+        let error = TopicSelector::new("123invalid").unwrap_err();
+
+        assert!(error.source().is_some());
+        assert!(error.to_string().contains("invalid component '123invalid'"));
+    }
+
+    #[test]
+    fn invalid_absolute_selector_is_rejected_during_construction() {
+        let error = TopicSelector::new("/123invalid").unwrap_err();
+
+        assert!(error.source().is_some());
+        assert!(error.to_string().contains("invalid component '123invalid'"));
+    }
+
+    #[test]
+    fn projection_displays_active_namespace_topics_as_relative() {
+        let projected = TopicProjection::project("alpha", ["/alpha/foo", "/beta/foo"]).unwrap();
+
+        assert!(projected.iter().any(|topic| topic.display_name == "foo"
+            && topic.resolved_topic == "/alpha/foo"
+            && topic.scope == ProjectedTopicScope::RelativeToActiveNamespace));
+        assert!(
+            projected
+                .iter()
+                .any(|topic| topic.display_name == "/beta/foo"
+                    && topic.resolved_topic == "/beta/foo"
+                    && topic.scope == ProjectedTopicScope::FullyQualified)
+        );
+    }
+
+    #[test]
+    fn projection_canonicalizes_relative_topics_with_trailing_slash() {
+        let projected = TopicProjection::project("alpha", ["foo/"]).unwrap();
+
+        assert_eq!(projected[0].display_name, "foo");
+        assert_eq!(projected[0].resolved_topic, "/alpha/foo");
+    }
+
+    #[test]
+    fn projection_preserves_duplicate_resolved_topics() {
+        let projected = TopicProjection::project("alpha", ["/alpha/foo", "/alpha/foo"]).unwrap();
+
+        let duplicated = projected
+            .iter()
+            .filter(|topic| topic.display_name == "foo")
+            .collect::<Vec<_>>();
+        assert_eq!(duplicated.len(), 2);
+    }
+
+    #[test]
+    fn projection_rejects_invalid_relative_topics_using_ros_z_validation() {
+        let error = TopicProjection::project("alpha", ["123invalid"]).unwrap_err();
+
+        assert!(error.to_string().contains("invalid component '123invalid'"));
+    }
+}

--- a/crates/ros-z-debug/src/topic.rs
+++ b/crates/ros-z-debug/src/topic.rs
@@ -213,12 +213,12 @@ mod tests {
     fn relative_selector_reports_invalid_target_namespace() {
         let selector = TopicSelector::new("diagnostics").unwrap();
 
-        let error = selector.resolve("123invalid").unwrap_err();
+        let error = selector.resolve("alpha%bad").unwrap_err();
 
         assert!(
             error
                 .to_string()
-                .contains("invalid target namespace '123invalid'")
+                .contains("invalid target namespace 'alpha%bad'")
         );
     }
 
@@ -234,10 +234,10 @@ mod tests {
 
     #[test]
     fn invalid_relative_selector_is_rejected_during_construction() {
-        let error = TopicSelector::new("123invalid").unwrap_err();
+        let error = TopicSelector::new("foo%bar").unwrap_err();
 
         assert!(error.source().is_some());
-        assert!(error.to_string().contains("invalid component '123invalid'"));
+        assert!(error.to_string().contains("invalid component 'foo%bar'"));
     }
 
     #[test]
@@ -277,8 +277,8 @@ mod tests {
 
     #[test]
     fn projection_rejects_invalid_relative_topics_using_ros_z_validation() {
-        let error = TopicProjection::project("alpha", ["123invalid"]).unwrap_err();
+        let error = TopicProjection::project("alpha", ["foo%bar"]).unwrap_err();
 
-        assert!(error.to_string().contains("invalid component '123invalid'"));
+        assert!(error.to_string().contains("invalid component 'foo%bar'"));
     }
 }

--- a/crates/ros-z-debug/tests/integration.rs
+++ b/crates/ros-z-debug/tests/integration.rs
@@ -79,11 +79,32 @@ async fn typed_subscription_receives_latest_sample() {
             assert_eq!(record.value, "hello");
             assert_eq!(record.metadata.resolved_topic, "/debug_text");
             assert_eq!(record.publication_id.sequence_number(), 0);
-            return;
+            break;
         }
         assert!(
             tokio::time::Instant::now() < deadline,
             "timed out waiting for sample"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    publisher
+        .publish(&"goodbye".to_string())
+        .await
+        .expect("second publish should work");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(record) = handle.latest()
+            && record.value == "goodbye"
+        {
+            assert_eq!(record.metadata.resolved_topic, "/debug_text");
+            assert_eq!(record.publication_id.sequence_number(), 1);
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for latest sample replacement"
         );
         tokio::time::sleep(Duration::from_millis(10)).await;
     }

--- a/crates/ros-z-debug/tests/integration.rs
+++ b/crates/ros-z-debug/tests/integration.rs
@@ -1,0 +1,222 @@
+use std::{sync::Arc, time::Duration};
+
+use ros_z::prelude::*;
+use ros_z_debug::{ManagerOptions, RetentionPolicy, SubscriptionManager};
+
+#[allow(dead_code)]
+fn typed_subscription_builder_can_be_named<'a, T>(
+    builder: ros_z_debug::TypedSubscriptionBuilder<'a, T>,
+) -> ros_z_debug::TypedSubscriptionBuilder<'a, T> {
+    builder
+}
+
+#[allow(dead_code)]
+fn dynamic_subscription_builder_can_be_named<'a>(
+    builder: ros_z_debug::DynamicSubscriptionBuilder<'a>,
+) -> ros_z_debug::DynamicSubscriptionBuilder<'a> {
+    builder
+}
+
+fn string_message_schema() -> ros_z::dynamic::Schema {
+    use ros_z_schema::{
+        FieldDef, SchemaBundle, StructDef, TypeDef, TypeDefinition, TypeDefinitions, TypeName,
+    };
+
+    let name = TypeName::new("test_msgs::StringMessage").expect("valid type name");
+    Arc::new(SchemaBundle {
+        root: TypeDef::Named(name.clone()),
+        definitions: TypeDefinitions::from([(
+            name,
+            TypeDefinition::Struct(StructDef {
+                fields: vec![FieldDef::new("data", TypeDef::String)],
+            }),
+        )]),
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_subscription_receives_latest_sample() {
+    let context = ContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_json("connect/endpoints", serde_json::json!([]))
+        .build()
+        .await
+        .expect("context should build");
+    let publisher_node = context
+        .create_node("typed_pub")
+        .build()
+        .await
+        .expect("publisher node");
+    let subscriber_node = Arc::new(
+        context
+            .create_node("typed_sub")
+            .build()
+            .await
+            .expect("subscriber node"),
+    );
+    let publisher = publisher_node
+        .publisher::<String>("debug_text")
+        .expect("publisher builder")
+        .build()
+        .await
+        .expect("publisher");
+    let manager = SubscriptionManager::new(subscriber_node, ManagerOptions::default());
+    let handle = manager
+        .subscribe_typed::<String>("debug_text")
+        .retention(RetentionPolicy::LatestOnly)
+        .build()
+        .await
+        .expect("subscription should build");
+
+    publisher
+        .publish(&"hello".to_string())
+        .await
+        .expect("publish should work");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(record) = handle.latest() {
+            assert_eq!(record.value, "hello");
+            assert_eq!(record.metadata.resolved_topic, "/debug_text");
+            assert_eq!(record.publication_id.sequence_number(), 0);
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for sample"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_subscription_resolves_relative_topic_against_target_namespace() {
+    let context = ContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_json("connect/endpoints", serde_json::json!([]))
+        .build()
+        .await
+        .expect("context should build");
+    let publisher_node = context
+        .create_node("target_namespace_pub")
+        .build()
+        .await
+        .expect("publisher node");
+    let subscriber_node = Arc::new(
+        context
+            .create_node("target_namespace_sub")
+            .build()
+            .await
+            .expect("subscriber node"),
+    );
+    let publisher = publisher_node
+        .publisher::<String>("/alpha/debug_text")
+        .expect("publisher builder")
+        .build()
+        .await
+        .expect("publisher");
+    let options = ManagerOptions::with_target_namespace("/alpha").expect("valid target namespace");
+    let manager = SubscriptionManager::new(subscriber_node, options);
+    let handle = manager
+        .subscribe_typed::<String>("debug_text")
+        .retention(RetentionPolicy::LatestOnly)
+        .build()
+        .await
+        .expect("subscription should build");
+
+    publisher
+        .publish(&"hello target".to_string())
+        .await
+        .expect("publish should work");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(record) = handle.latest() {
+            assert_eq!(record.value, "hello target");
+            assert_eq!(record.metadata.resolved_topic, "/alpha/debug_text");
+            assert_eq!(record.publication_id.sequence_number(), 0);
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for target namespace sample"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_subscription_renders_json_view() {
+    use ros_z::dynamic::{DynamicPayload, DynamicStruct};
+
+    let context = ContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_json("connect/endpoints", serde_json::json!([]))
+        .build()
+        .await
+        .expect("context should build");
+    let publisher_node = context
+        .create_node("dynamic_pub")
+        .build()
+        .await
+        .expect("publisher node");
+    let subscriber_node = Arc::new(
+        context
+            .create_node("dynamic_sub")
+            .build()
+            .await
+            .expect("subscriber node"),
+    );
+    let schema = string_message_schema();
+    let type_info = ros_z::TypeInfo::new(
+        "test_msgs::StringMessage",
+        ros_z_schema::compute_hash(schema.as_ref()).expect("schema hash"),
+    );
+    let publisher = publisher_node
+        .dynamic_publisher("debug_dynamic", type_info, schema.clone())
+        .expect("dynamic publisher builder")
+        .build()
+        .await
+        .expect("dynamic publisher");
+    let manager = SubscriptionManager::new(subscriber_node, ManagerOptions::default());
+    let json = manager
+        .subscribe_dynamic("debug_dynamic")
+        .retention(RetentionPolicy::LatestOnly)
+        .build_json(Default::default())
+        .await
+        .expect("dynamic json subscription should build");
+    let mut message = DynamicStruct::default_for_schema(&schema).expect("default dynamic struct");
+    message.set("data", "hello").expect("set field");
+    let payload = DynamicPayload::from_struct(message).expect("dynamic payload");
+
+    publisher
+        .publish(&payload)
+        .await
+        .expect("publish should work");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(value) = json.latest_json() {
+            assert_eq!(value, serde_json::json!({ "data": "hello" }));
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for dynamic sample"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[test]
+fn namespace_projection_keeps_global_topics_qualified() {
+    let projected = ros_z_debug::TopicProjection::project("alpha", ["/alpha/foo", "/diagnostics"])
+        .expect("topics should project");
+
+    assert!(projected.iter().any(|topic| topic.display_name == "foo"));
+    assert!(
+        projected
+            .iter()
+            .any(|topic| topic.display_name == "/diagnostics")
+    );
+}

--- a/crates/ros-z/README.md
+++ b/crates/ros-z/README.md
@@ -20,6 +20,7 @@ C/C++ runtime dependencies.
 - `ros-z-derive`: `#[derive(Message)]` support for typed messages.
 - `ros-z-streams`: future queues and maps for timestamped sensor-fusion streams.
 - `ros-z-cli`: graph, schema, topic, and parameter inspection commands.
+- `ros-z-debug`: read-only debug subscriptions with retained samples and JSON views.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Add `ros-z-debug`, a read-only subscription manager crate for typed and dynamic debug subscriptions.
- Retain latest samples and optional source-time windows with status snapshots, events, and topic/type metadata.
- Harden the debug API by validating target namespaces through existing `ros-z` topic qualification, preserving topic validation sources, rejecting private selectors without node context, pruning dead registry refs, returning empty inverted history windows, and reporting receive error source chains with topic/type context.
- Make dynamic schema discovery timeout configurable through `ManagerOptions`.
- Clarify that dynamic debug subscriptions use currently visible publishers; the discovery timeout applies to schema service queries, not waiting for future publishers.

## Scope
- Introduces the first usable debug subscription layer for Twix-facing work.
- Does not replace direct `ros-z` subscribers for normal application receive loops.
- Keeps reconnect orchestration, runtime namespace retargeting, graph-driven topic discovery, pending dynamic subscriptions, and stricter global topic-name validation out of the initial API contract.
- Keeps the timestamp index private to `ros-z-debug`; it does not promote a new `ros_z::time_index` public API.

## Future Work
- Pending dynamic subscriptions that wait for publisher/schema availability instead of failing during build.
- Runtime target-namespace retargeting for switching inspected robots.
- Reconnect behavior that rebuilds managed subscriptions after connection changes.
- Graph-driven topic discovery and projection for Twix topic lists.
- A Twix backend/facade layer that uses `ros-z-debug` for read-only robot data.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run -p ros-z-debug`
- [x] `cargo clippy -p ros-z-debug --all-targets --locked -- -D warnings`
- [x] `cargo test --doc -p ros-z-debug`