### PR TITLE
refactor: make ros-z endpoint factories fallible

### DIFF
--- a/crates/hulk_ros_z/src/nodes/active_vision.rs
+++ b/crates/hulk_ros_z/src/nodes/active_vision.rs
@@ -27,31 +27,37 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _ball_sub = node
         .subscriber::<BallState>("ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _rule_ball_sub = node
         .subscriber::<BallState>("rule_ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _obstacles_sub = node
         .subscriber::<Vec<Obstacle>>("obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_field_sub = node
         .subscriber::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _position_of_interest_pub = node
         .publisher::<Point2<Ground>>("position_of_interest")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/ball_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/ball_filter.rs
@@ -33,46 +33,55 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _historic_camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _integrated_odometry_sub = node
         .subscriber::<Odometer>("odometer")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _detected_objects_sub = node
         .subscriber::<Vec<Object<RobocupObjectLabel>>>("detected_objects")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filter_state_pub = node
         .publisher::<BallFiltering>("ball_filter_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _best_ball_hypothesis_pub = node
         .publisher::<BallHypothesis>("best_ball_hypothesis")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_balls_in_image_pub = node
         .publisher::<Vec<Circle<Pixel>>>("filtered_balls_in_image")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ball_percepts_pub = node
         .publisher::<Vec<BallPercept>>("ball_percepts")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ball_position_pub = node
         .publisher::<BallPosition<Ground>>("ball_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _hypothetical_ball_positions_pub = node
         .publisher::<Vec<HypotheticalBallPosition<Ground>>>("hypothetical_ball_positions")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/ball_state_composer.rs
+++ b/crates/hulk_ros_z/src/nodes/ball_state_composer.rs
@@ -33,41 +33,49 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _ball_position_sub = node
         .subscriber::<BallPosition<Ground>>("ball_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_field_sub = node
         .subscriber::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _team_ball_sub = node
         .subscriber::<BallPosition<Field>>("team_ball")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _additional_last_ball_state_pub = node
         .publisher::<LastBallState>("last_ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ball_state_pub = node
         .publisher::<BallState>("ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _rule_ball_state_pub = node
         .publisher::<BallState>("rule_ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/behavior_node.rs
+++ b/crates/hulk_ros_z/src/nodes/behavior_node.rs
@@ -25,31 +25,37 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _world_state_sub = node
         .subscriber::<WorldState>("world_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _behavior_trace_pub = node
         .publisher::<NodeTrace>("behavior/trace")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _behavior_tree_layout_pub = node
         .publisher::<NodeTrace>("behavior/tree_layout")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _time_since_last_switch_pub = node
         .publisher::<Duration>("behavior/time_since_last_switch")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _path_obstacles_output_pub = node
         .publisher::<Vec<PathObstacle>>("path_obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _motion_command_pub = node
         .publisher::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/button_event_handler.rs
+++ b/crates/hulk_ros_z/src/nodes/button_event_handler.rs
@@ -15,11 +15,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _maybe_button_event_sub = node
         .subscriber::<ButtonEventMsg>("button_event")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _buttons_pub = node
         .publisher::<Buttons<Option<ButtonPressType>>>("buttons")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/button_event_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/button_event_receiver.rs
@@ -8,7 +8,12 @@ use crate::IntoEyreResultExt;
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("button_event_receiver").build().await.into_eyre()?;
-    let _button_event_pub = node.publisher::<ButtonEventMsg>("button_event").build().await.into_eyre()?;
+    let _button_event_pub = node
+        .publisher::<ButtonEventMsg>("button_event")
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
 
     pending::<()>().await;
 

--- a/crates/hulk_ros_z/src/nodes/camera_matrix_calculator.rs
+++ b/crates/hulk_ros_z/src/nodes/camera_matrix_calculator.rs
@@ -32,26 +32,31 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _robot_kinematics_sub = node
         .subscriber::<RobotKinematics>("robot_kinematics")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _robot_to_ground_sub = node
         .subscriber::<Isometry3<Robot, Ground>>("robot_to_ground")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _image_left_raw_camera_info_sub = node
         .subscriber::<CameraInfo>("image_left_raw_camera_info")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _uncalibrated_camera_matrix_pub = node
         .publisher::<CameraMatrix>("uncalibrated_camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _camera_matrix_pub = node
         .publisher::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/command_sender.rs
+++ b/crates/hulk_ros_z/src/nodes/command_sender.rs
@@ -27,11 +27,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _collected_target_joint_positions_sub = node
         .subscriber::<Joints<f32>>("collected_target_joint_positions")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _low_command_pub = node
         .publisher::<LowCommand>("low_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/fake_odometry.rs
+++ b/crates/hulk_ros_z/src/nodes/fake_odometry.rs
@@ -10,6 +10,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("fake_odometry").build().await.into_eyre()?;
     let _current_odometry_to_last_odometry_pub = node
         .publisher::<na::Isometry2<f32>>("current_odometry_to_last_odometry")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/fall_down_state_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/fall_down_state_receiver.rs
@@ -14,6 +14,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _fall_down_state_pub = node
         .publisher::<FallDownState>("fall_down_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/field_border_detection.rs
+++ b/crates/hulk_ros_z/src/nodes/field_border_detection.rs
@@ -32,21 +32,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _image_segments_sub = node
         .subscriber::<ImageSegments>("image_segments")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _field_border_points_pub = node
         .publisher::<Vec<Point2<Pixel>>>("field_border_points")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _field_border_pub = node
         .publisher::<FieldBorder>("field_border")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/game_controller_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/game_controller_filter.rs
@@ -32,21 +32,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _network_message_sub = node
         .subscriber::<IncomingMessage>("filtered_message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _last_contact_pub = node
         .publisher::<HashMap<SocketAddr, SystemTime>>("game_controller_address_contacts_times")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _game_controller_state_pub = node
         .publisher::<GameControllerState>("game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _game_controller_address_pub = node
         .publisher::<SocketAddr>("game_controller_address")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/game_controller_state_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/game_controller_state_filter.rs
@@ -34,21 +34,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _filtered_whistle_sub = node
         .subscriber::<FilteredWhistle>("filtered_whistle")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _game_controller_state_sub = node
         .subscriber::<GameControllerState>("game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _whistle_in_set_ball_position_pub = node
         .publisher::<Point2<Field>>("whistle_in_set_ball_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_pub = node
         .publisher::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/ground_provider.rs
+++ b/crates/hulk_ros_z/src/nodes/ground_provider.rs
@@ -17,21 +17,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _robot_kinematics_sub = node
         .subscriber::<RobotKinematics>("robot_kinematics")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _imu_state_sub = node
         .subscriber::<ImuState>("imu_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _robot_to_ground_pub = node
         .publisher::<Isometry3<Robot, Ground>>("robot_to_ground")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_robot_pub = node
         .publisher::<Isometry3<Ground, Robot>>("ground_to_robot")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/head_motion.rs
+++ b/crates/hulk_ros_z/src/nodes/head_motion.rs
@@ -23,26 +23,31 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _look_around_target_joints_sub = node
         .subscriber::<HeadJoints<f32>>("look_around_target_joints")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _look_at_sub = node
         .subscriber::<HeadJoints<f32>>("look_at")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _motor_states_sub = node
         .subscriber::<Joints<MotorState>>("serial_motor_states")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _head_joints_command_pub = node
         .publisher::<HeadJoints<f32>>("head_joints_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/image_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/image_receiver.rs
@@ -45,9 +45,15 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await
         .into_eyre()?;
-    let image_pub = node.publisher::<Image>("image").build().await.into_eyre()?;
+    let image_pub = node
+        .publisher::<Image>("image")
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
     let ycbcr422_image_pub = node
         .publisher::<YCbCr422Image>("ycbcr422_image")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/image_segmenter.rs
+++ b/crates/hulk_ros_z/src/nodes/image_segmenter.rs
@@ -38,16 +38,19 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _image_sub = node
         .subscriber::<YCbCr422Image>("ycbcr422_image")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _image_segments_pub = node
         .publisher::<ImageSegments>("image_segments")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/inference.rs
+++ b/crates/hulk_ros_z/src/nodes/inference.rs
@@ -26,31 +26,37 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _image_sub = node
         .subscriber::<Image>("image")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _inference_duration_pub = node
         .publisher::<Duration>("inference_duration")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _post_processing_duration_pub = node
         .publisher::<Duration>("post_processing_duration")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _non_maximum_suppression_duration_pub = node
         .publisher::<Duration>("non_maximum_suppression_duration")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _detected_objects_pub = node
         .publisher::<Vec<Object<RobocupObjectLabel>>>("detected_objects")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _detected_poses_pub = node
         .publisher::<Vec<Pose<YOLOObjectLabel>>>("detected_poses")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/kick.rs
+++ b/crates/hulk_ros_z/src/nodes/kick.rs
@@ -25,6 +25,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/kinematics_provider.rs
+++ b/crates/hulk_ros_z/src/nodes/kinematics_provider.rs
@@ -15,11 +15,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _serial_motor_states_sub = node
         .subscriber::<Joints<MotorState>>("serial_motor_states")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _robot_kinematics_pub = node
         .publisher::<RobotKinematics>("robot_kinematics")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/led_handler.rs
+++ b/crates/hulk_ros_z/src/nodes/led_handler.rs
@@ -10,6 +10,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("led_handler").build().await.into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/line_detection.rs
+++ b/crates/hulk_ros_z/src/nodes/line_detection.rs
@@ -49,21 +49,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_segments_sub = node
         .subscriber::<FilteredSegments>("filtered_segments")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _image_sub = node
         .subscriber::<YCbCr422Image>("ycbcr422_image")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _lines_in_image_pub = node
         .publisher::<Vec<LineSegment<Pixel>>>("lines_in_image")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
@@ -75,11 +79,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _filtered_segments_output_pub = node
         .publisher::<Vec<GenericSegment>>("line_detection/filtered_segments")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _line_data_pub = node
         .publisher::<LineData>("line_data")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/localization.rs
+++ b/crates/hulk_ros_z/src/nodes/localization.rs
@@ -59,71 +59,85 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _odometer_sub = node
         .subscriber::<Odometer>("odometer")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _fall_down_state_sub = node
         .subscriber::<FallDownState>("fall_down_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _imu_state_sub = node
         .subscriber::<ImuState>("imu_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _line_data_sub = node
         .subscriber::<LineData>("line_data")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _correspondence_lines_pub = node
         .publisher::<Vec<LineSegment<Field>>>("localization/correspondence_lines")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _fit_errors_pub = node
         .publisher::<Vec<Vec<Vec<Vec<f32>>>>>("localization/fit_errors")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _measured_lines_in_field_pub = node
         .publisher::<Vec<LineSegment<Field>>>("localization/measured_lines_in_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _pose_hypotheses_pub = node
         .publisher::<Vec<ScoredPose>>("localization/pose_hypotheses")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _updates_pub = node
         .publisher::<Vec<Vec<Update>>>("localization/updates")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _gyro_movement_pub = node
         .publisher::<f32>("localization/gyro_movement")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_field_pub = node
         .publisher::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _is_localization_converged_pub = node
         .publisher::<bool>("is_localization_converged")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/look_around.rs
+++ b/crates/hulk_ros_z/src/nodes/look_around.rs
@@ -26,21 +26,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _current_mode_pub = node
         .publisher::<LookAroundMode>("look_around_mode")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _look_around_target_joints_pub = node
         .publisher::<HeadJoints<f32>>("look_around_target_joints")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/look_at.rs
+++ b/crates/hulk_ros_z/src/nodes/look_at.rs
@@ -28,26 +28,31 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_robot_sub = node
         .subscriber::<Isometry3<Ground, Robot>>("ground_to_robot")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _serial_motor_states_sub = node
         .subscriber::<Joints<MotorState>>("serial_motor_states")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _look_at_pub = node
         .publisher::<HeadJoints<f32>>("look_at")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/message_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/message_filter.rs
@@ -26,11 +26,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _message_sub = node
         .subscriber::<IncomingMessage>("message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_message_pub = node
         .publisher::<IncomingMessage>("filtered_message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/message_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/message_receiver.rs
@@ -14,6 +14,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _message_pub = node
         .publisher::<IncomingMessage>("message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/microphone_recorder.rs
+++ b/crates/hulk_ros_z/src/nodes/microphone_recorder.rs
@@ -14,6 +14,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _samples_pub = node
         .publisher::<Samples>("samples")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/motor_commands_collector.rs
+++ b/crates/hulk_ros_z/src/nodes/motor_commands_collector.rs
@@ -14,11 +14,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _head_target_joints_positions_sub = node
         .subscriber::<HeadJoints<f32>>("head_joints_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _collected_target_joint_positions_pub = node
         .publisher::<Joints<f32>>("collected_target_joint_positions")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/obstacle_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/obstacle_filter.rs
@@ -38,46 +38,55 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _network_robot_obstacles_sub = node
         .subscriber::<Vec<Point2<Ground>>>("network_robot_obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _current_odometry_to_last_odometry_sub = node
         .subscriber::<na::Isometry2<f32>>("current_odometry_to_last_odometry")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _current_ground_to_field_sub = node
         .subscriber::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _fall_down_state_sub = node
         .subscriber::<FallDownState>("fall_down_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _detected_objects_sub = node
         .subscriber::<Vec<Object<RobocupObjectLabel>>>("detected_objects")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _obstacle_filter_hypotheses_pub = node
         .publisher::<Vec<Hypothesis>>("obstacle_filter_hypotheses")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _obstacles_pub = node
         .publisher::<Vec<Obstacle>>("obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/obstacle_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/obstacle_receiver.rs
@@ -18,21 +18,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_field_sub = node
         .subscriber::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _network_message_sub = node
         .subscriber::<IncomingMessage>("filtered_message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _network_robot_obstacles_pub = node
         .publisher::<Vec<Point2<Ground>>>("network_robot_obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/odometer_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/odometer_receiver.rs
@@ -14,6 +14,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _odometer_pub = node
         .publisher::<Odometer>("odometer")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/primary_state_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/primary_state_filter.rs
@@ -32,21 +32,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _buttons_sub = node
         .subscriber::<Buttons<Option<ButtonPressType>>>("buttons")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _is_safe_pose_sub = node
         .subscriber::<bool>("is_safe_pose")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _primary_state_pub = node
         .publisher::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/robot_mode_handler.rs
+++ b/crates/hulk_ros_z/src/nodes/robot_mode_handler.rs
@@ -29,11 +29,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _buttons_sub = node
         .subscriber::<Buttons<Option<ButtonPressType>>>("buttons")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/rotate_head.rs
+++ b/crates/hulk_ros_z/src/nodes/rotate_head.rs
@@ -27,6 +27,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _head_joints_sub = node
         .subscriber::<HeadJoints<f32>>("head_joints_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/rule_obstacle_composer.rs
+++ b/crates/hulk_ros_z/src/nodes/rule_obstacle_composer.rs
@@ -32,16 +32,19 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ball_state_sub = node
         .subscriber::<BallState>("ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _rule_obstacles_pub = node
         .publisher::<Vec<RuleObstacle>>("rule_obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/safe_pose_checker.rs
+++ b/crates/hulk_ros_z/src/nodes/safe_pose_checker.rs
@@ -33,36 +33,43 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _imu_state_sub = node
         .subscriber::<ImuState>("imu_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _serial_motor_states_sub = node
         .subscriber::<Joints<MotorState>>("serial_motor_states")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _joint_position_difference_to_safe_pub = node
         .publisher::<Joints>("joint_position_difference_to_safe")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _joint_velocities_difference_to_safe_pub = node
         .publisher::<Joints>("joint_velocities_difference_to_safe")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _angular_velocities_difference_to_safe_pub = node
         .publisher::<Vector3<Robot>>("angular_velocities_difference_to_safe")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _linear_accelerations_difference_to_safe_pub = node
         .publisher::<Vector3<Robot>>("linear_accelerations_difference_to_safe")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _is_safe_pose_pub = node
         .publisher::<bool>("is_safe_pose")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/search_suggestor.rs
+++ b/crates/hulk_ros_z/src/nodes/search_suggestor.rs
@@ -35,31 +35,37 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _ball_position_sub = node
         .subscriber::<BallPosition<Ground>>("ball_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _hypothetical_ball_positions_sub = node
         .subscriber::<Vec<HypotheticalBallPosition<Ground>>>("hypothetical_ball_positions")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_field_sub = node
         .subscriber::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _network_message_sub = node
         .subscriber::<IncomingMessage>("filtered_message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
@@ -72,6 +78,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _suggested_search_position_pub = node
         .publisher::<Point2<Field>>("suggested_search_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/segment_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/segment_filter.rs
@@ -16,16 +16,19 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _field_border_sub = node
         .subscriber::<FieldBorder>("field_border")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _image_segments_sub = node
         .subscriber::<ImageSegments>("image_segments")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_segments_pub = node
         .publisher::<FilteredSegments>("filtered_segments")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/sensor_data_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/sensor_data_receiver.rs
@@ -15,16 +15,19 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _imu_state_pub = node
         .publisher::<ImuState>("imu_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _serial_motor_states_pub = node
         .publisher::<Joints<MotorState>>("serial_motor_states")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _parallel_motor_states_pub = node
         .publisher::<Joints<MotorState>>("parallel_motor_states")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/stand_up.rs
+++ b/crates/hulk_ros_z/src/nodes/stand_up.rs
@@ -16,6 +16,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/team_ball_receiver.rs
+++ b/crates/hulk_ros_z/src/nodes/team_ball_receiver.rs
@@ -29,21 +29,25 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _network_message_sub = node
         .subscriber::<IncomingMessage>("filtered_message")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _team_balls_pub = node
         .publisher::<Players<Option<BallPosition<Field>>>>("team_balls")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _team_ball_pub = node
         .publisher::<BallPosition<Field>>("team_ball")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/time_to_reach_kick_position.rs
+++ b/crates/hulk_ros_z/src/nodes/time_to_reach_kick_position.rs
@@ -14,11 +14,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _ball_state_sub = node
         .subscriber::<BallState>("ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _time_to_reach_kick_position_pub = node
         .publisher::<Duration>("time_to_reach_kick_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/walking.rs
+++ b/crates/hulk_ros_z/src/nodes/walking.rs
@@ -28,11 +28,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _step_pub = node
         .publisher::<Step>("additional_outputs/walking_step")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/whistle_detection.rs
+++ b/crates/hulk_ros_z/src/nodes/whistle_detection.rs
@@ -29,6 +29,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _samples_sub = node
         .subscriber::<Samples>("samples")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
@@ -40,11 +41,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     //     .into_eyre()?;
     let _detection_infos_pub = node
         .publisher::<Vec<DetectionInfo>>("detection_infos")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _detected_whistle_pub = node
         .publisher::<Whistle>("detected_whistle")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/whistle_filter.rs
+++ b/crates/hulk_ros_z/src/nodes/whistle_filter.rs
@@ -26,11 +26,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _detected_whistle_sub = node
         .subscriber::<Whistle>("detected_whistle")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_whistle_pub = node
         .publisher::<FilteredWhistle>("filtered_whistle")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/world_state_composer.rs
+++ b/crates/hulk_ros_z/src/nodes/world_state_composer.rs
@@ -36,61 +36,73 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _fall_down_state_sub = node
         .subscriber::<FallDownState>("fall_down_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ball_sub = node
         .subscriber::<BallState>("ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _ground_to_field_sub = node
         .subscriber::<Isometry2<Ground, Field>>("ground_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _hypothetical_ball_position_sub = node
         .subscriber::<Vec<HypotheticalBallPosition<Ground>>>("hypothetical_ball_positions")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _obstacles_sub = node
         .subscriber::<Vec<Obstacle>>("obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _position_of_interest_sub = node
         .subscriber::<Point2<Ground>>("position_of_interest")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _rule_ball_sub = node
         .subscriber::<BallState>("rule_ball_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _rule_obstacles_sub = node
         .subscriber::<Vec<RuleObstacle>>("rule_obstacles")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _suggested_search_position_sub = node
         .subscriber::<Point2<Field>>("suggested_search_position")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _world_state_pub = node
         .publisher::<WorldState>("world_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/hulk_ros_z/src/nodes/world_to_field_provider.rs
+++ b/crates/hulk_ros_z/src/nodes/world_to_field_provider.rs
@@ -16,11 +16,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
     let _game_controller_state_sub = node
         .subscriber::<GameControllerState>("game_controller_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
     let _world_to_field_pub = node
         .publisher::<Isometry2<World, Field>>("world_to_field")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;

--- a/crates/ros-z-cli/src/commands/schema.rs
+++ b/crates/ros-z-cli/src/commands/schema.rs
@@ -31,6 +31,7 @@ pub async fn run(
     let client = app
         .node()
         .create_service_client::<GetSchema>(&service_name)
+        .map_err(display_error)?
         .build()
         .await
         .map_err(display_error)?;

--- a/crates/ros-z-cli/tests/e2e.rs
+++ b/crates/ros-z-cli/tests/e2e.rs
@@ -363,9 +363,9 @@ impl GraphFixture {
             .await?;
         let topic = "/cli_e2e/telemetry".to_string();
         let service = "/cli_e2e/add_two_ints".to_string();
-        let publisher = node.publisher::<Telemetry>(&topic).build().await?;
+        let publisher = node.publisher::<Telemetry>(&topic)?.build().await?;
         let service_server = node
-            .create_service_server::<AddTwoInts>(&service)
+            .create_service_server::<AddTwoInts>(&service)?
             .build()
             .await?;
 
@@ -398,7 +398,7 @@ impl PublishingFixture {
             .with_namespace("/cli_e2e")
             .build()
             .await?;
-        let publisher = node.publisher::<Telemetry>(topic).build().await?;
+        let publisher = node.publisher::<Telemetry>(topic)?.build().await?;
 
         Ok(Self {
             topic: topic.to_string(),
@@ -675,7 +675,7 @@ async fn schema_resolves_string_publisher_schema() -> TestResult {
         .build()
         .await?;
     let _publisher = node
-        .publisher::<String>("/cli_e2e/schema_string")
+        .publisher::<String>("/cli_e2e/schema_string")?
         .build()
         .await?;
     let node_fqn = "/cli_e2e/string_schema_fixture";

--- a/crates/ros-z-streams/src/announce.rs
+++ b/crates/ros-z-streams/src/announce.rs
@@ -83,9 +83,12 @@ impl CreateAnnouncingPublisher for Node {
         for<'de> T::Codec: WireEncoder<Input<'de> = &'de T>,
     {
         Box::pin(async move {
-            let data_publisher = self.publisher(topic).build().await?;
-            let announcement_publisher =
-                Arc::new(self.publisher(&format!("{topic}/announce")).build().await?);
+            let data_publisher = self.publisher(topic)?.build().await?;
+            let announcement_publisher = Arc::new(
+                self.publisher(&format!("{topic}/announce"))?
+                    .build()
+                    .await?,
+            );
 
             Ok(AnnouncingPublisher {
                 data_publisher,
@@ -183,11 +186,13 @@ mod tests {
             .expect("create announcing publisher");
         let announcement_subscriber = node
             .subscriber::<Announcement>("alignment/topic/announce")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("create announcement subscriber");
         let data_subscriber = node
             .subscriber::<String>("alignment/topic")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("create data subscriber");

--- a/crates/ros-z-streams/src/future_queue.rs
+++ b/crates/ros-z-streams/src/future_queue.rs
@@ -302,9 +302,9 @@ impl CreateFutureQueue for Node {
         T: Message + 'a,
         for<'de> T::Codec: WireDecoder<Input<'de> = &'de [u8], Output = T>,
     {
-        let data_subscriber = self.subscriber(topic).build().await?;
+        let data_subscriber = self.subscriber(topic)?.build().await?;
         let announcement_subscriber = self
-            .subscriber(&format!("{}/announce", topic))
+            .subscriber(&format!("{}/announce", topic))?
             .build()
             .await?;
 
@@ -344,11 +344,13 @@ mod tests {
             .expect("create node");
         let data_publisher = node
             .publisher::<String>("queue/payload_first")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("create data publisher");
         let announcement_publisher = node
             .publisher::<Announcement>("queue/payload_first/announce")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("create announcement publisher");
@@ -413,6 +415,7 @@ mod tests {
             .expect("create node");
         let announcement_publisher = node
             .publisher::<Announcement>("queue/safe_time_order/announce")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("create announcement publisher");

--- a/crates/ros-z/README.md
+++ b/crates/ros-z/README.md
@@ -29,7 +29,7 @@ use ros_z::prelude::*;
 # async fn demo() -> zenoh::Result<()> {
 let context = ContextBuilder::default().build().await?;
 let node = context.create_node("talker").build().await?;
-let publisher = node.publisher::<String>("/chatter").build().await?;
+let publisher = node.publisher::<String>("/chatter")?.build().await?;
 
 publisher.publish(&"hello".to_owned()).await?;
 # Ok(())
@@ -38,6 +38,7 @@ publisher.publish(&"hello".to_owned()).await?;
 
 Builders that create runtime resources are async. Build contexts, nodes,
 publishers, subscribers, services, and caches inside a Tokio-compatible runtime.
+Endpoint factory methods validate schema/type metadata immediately and return `Result<Builder>`; `.build().await` only creates runtime Zenoh resources.
 
 ## Examples
 

--- a/crates/ros-z/examples/custom_message/navigation_client.rs
+++ b/crates/ros-z/examples/custom_message/navigation_client.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("navigation_client").build().await?;
     let service_client = node
-        .create_service_client::<NavigateTo>("navigate_to")
+        .create_service_client::<NavigateTo>("navigate_to")?
         .build()
         .await?;
 

--- a/crates/ros-z/examples/custom_message/navigation_server.rs
+++ b/crates/ros-z/examples/custom_message/navigation_server.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("navigation_server").build().await?;
     let mut service_server = node
-        .create_service_server::<NavigateTo>("navigate_to")
+        .create_service_server::<NavigateTo>("navigate_to")?
         .build()
         .await?;
 

--- a/crates/ros-z/examples/custom_message/status_publisher.rs
+++ b/crates/ros-z/examples/custom_message/status_publisher.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
         .build()
         .await?;
     let publisher = node
-        .publisher::<RobotStatus>("robot_status")
+        .publisher::<RobotStatus>("robot_status")?
         .build()
         .await?;
 

--- a/crates/ros-z/examples/custom_message/status_subscriber.rs
+++ b/crates/ros-z/examples/custom_message/status_subscriber.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
         .build()
         .await?;
     let subscriber = node
-        .subscriber::<RobotStatus>("robot_status")
+        .subscriber::<RobotStatus>("robot_status")?
         .build()
         .await?;
 

--- a/crates/ros-z/examples/pubsub/listener.rs
+++ b/crates/ros-z/examples/pubsub/listener.rs
@@ -6,7 +6,7 @@ async fn main() -> Result<()> {
 
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("listener").build().await?;
-    let subscriber = node.subscriber::<String>("chatter").build().await?;
+    let subscriber = node.subscriber::<String>("chatter")?.build().await?;
 
     println!("Listening for String messages on /chatter...");
     while let Ok(received) = subscriber.recv_with_metadata().await {

--- a/crates/ros-z/examples/pubsub/talker.rs
+++ b/crates/ros-z/examples/pubsub/talker.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
 
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("talker").build().await?;
-    let publisher = node.publisher::<String>("chatter").build().await?;
+    let publisher = node.publisher::<String>("chatter")?.build().await?;
 
     let mut count = 1_u64;
     loop {

--- a/crates/ros-z/examples/service/client.rs
+++ b/crates/ros-z/examples/service/client.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("add_two_ints_client").build().await?;
     let service_client = node
-        .create_service_client::<AddTwoInts>("add_two_ints")
+        .create_service_client::<AddTwoInts>("add_two_ints")?
         .build()
         .await?;
 

--- a/crates/ros-z/examples/service/server.rs
+++ b/crates/ros-z/examples/service/server.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("add_two_ints_server").build().await?;
     let mut service_server = node
-        .create_service_server::<AddTwoInts>("add_two_ints")
+        .create_service_server::<AddTwoInts>("add_two_ints")?
         .build()
         .await?;
 

--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -27,7 +27,7 @@
 //! let node = context.create_node("cache_demo").build().await?;
 //!
 //! // Zero-config: indexed by Zenoh transport timestamp
-//! let cache = node.create_cache::<String>("/chatter", 200).build().await?;
+//! let cache = node.create_cache::<String>("/chatter", 200)?.build().await?;
 //!
 //! let now = Time::from_wallclock(std::time::SystemTime::now());
 //! let window = cache.get_interval(now - Duration::from_millis(100), now);

--- a/crates/ros-z/src/dynamic/schema_query.rs
+++ b/crates/ros-z/src/dynamic/schema_query.rs
@@ -115,6 +115,7 @@ pub(crate) async fn query_schema(
 
     let client = node
         .create_service_client::<GetSchema>(&service_name)
+        .map_err(|e| DynamicError::SerializationError(e.to_string()))?
         .build()
         .await
         .map_err(|e| DynamicError::SerializationError(e.to_string()))?;

--- a/crates/ros-z/src/dynamic/schema_service.rs
+++ b/crates/ros-z/src/dynamic/schema_service.rs
@@ -295,7 +295,6 @@ fn schema_service_server_builder(
         entity,
         session,
         clock: clock.clone(),
-        schema_error: None,
         _phantom_data: Default::default(),
     }
 }

--- a/crates/ros-z/src/lib.rs
+++ b/crates/ros-z/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! let context = ContextBuilder::default().build().await?;
 //! let node = context.create_node("talker").build().await?;
-//! let publisher = node.publisher::<String>("/chatter").build().await?;
+//! let publisher = node.publisher::<String>("/chatter")?.build().await?;
 //! publisher.publish(&"hello".to_owned()).await?;
 //! ```
 //!

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -214,6 +214,26 @@ fn typed_message_type_info<T: Message>(schema: &Schema) -> TypeInfo {
     TypeInfo::with_hash(&T::type_name(), ros_z_schema::compute_hash(schema.as_ref()))
 }
 
+fn message_schema_build_error(
+    endpoint_kind: &str,
+    name: &str,
+    error: impl std::fmt::Display,
+) -> zenoh::Error {
+    zenoh::Error::from(format!(
+        "failed to build message schema for {endpoint_kind} '{name}': {error}"
+    ))
+}
+
+fn service_type_info_build_error(
+    endpoint_kind: &str,
+    name: &str,
+    error: impl std::fmt::Display,
+) -> zenoh::Error {
+    zenoh::Error::from(format!(
+        "failed to build service type info for {endpoint_kind} '{name}': {error}"
+    ))
+}
+
 fn registerable_schema_root(
     root_name: &str,
     schema: &ros_z_schema::SchemaBundle,
@@ -252,33 +272,25 @@ impl Node {
     /// - Absolute topics (starting with '/') are used as-is
     /// - Private topics (starting with '~') are expanded to `/<namespace>/<node_name>/<topic>`
     /// - Relative topics are expanded to `/<namespace>/<topic>`
-    pub fn publisher<T>(&self, topic: &str) -> PublisherBuilder<T>
+    pub fn publisher<T>(&self, topic: &str) -> Result<PublisherBuilder<T>>
     where
         T: Message,
         T::Codec: WireEncoder,
     {
         debug!("[NOD] Creating publisher: topic={}", topic);
-        match T::schema().map(Arc::new) {
-            Ok(schema) => {
-                let type_name = T::type_name();
-                let type_info = typed_message_type_info::<T>(&schema);
-                let builder = self.publisher_impl::<T, T::Codec>(topic, Some(type_info));
-                match registerable_schema_root(&type_name, schema.as_ref()).and_then(
-                    |should_register| {
-                        if should_register {
-                            self.register_schema_with_service(&type_name, Arc::clone(&schema))?;
-                        }
-                        Ok(())
-                    },
-                ) {
-                    Ok(()) => builder,
-                    Err(error) => builder.schema_error(error),
-                }
-            }
-            Err(error) => self
-                .publisher_impl::<T, T::Codec>(topic, None)
-                .schema_error(error),
+
+        let schema = Arc::new(
+            T::schema().map_err(|error| message_schema_build_error("publisher", topic, error))?,
+        );
+        let type_name = T::type_name();
+        let should_register = registerable_schema_root(&type_name, schema.as_ref())
+            .map_err(|error| message_schema_build_error("publisher", topic, error))?;
+        if should_register {
+            self.register_schema_with_service(&type_name, Arc::clone(&schema))
+                .map_err(|error| message_schema_build_error("publisher", topic, error))?;
         }
+
+        Ok(self.publisher_impl::<T, T::Codec>(topic, Some(typed_message_type_info::<T>(&schema))))
     }
 
     fn publisher_impl<T, S>(
@@ -307,7 +319,6 @@ impl Node {
             attachment: true,
             shm_config: self.shm_config.clone(),
             dyn_schema: None,
-            schema_error: None,
             _phantom_data: Default::default(),
         }
     }
@@ -320,19 +331,18 @@ impl Node {
     /// - Absolute topics (starting with '/') are used as-is
     /// - Private topics (starting with '~') are expanded to `/<namespace>/<node_name>/<topic>`
     /// - Relative topics are expanded to `/<namespace>/<topic>`
-    pub fn subscriber<T>(&self, topic: &str) -> SubscriberBuilder<T>
+    pub fn subscriber<T>(&self, topic: &str) -> Result<SubscriberBuilder<T>>
     where
         T: Message,
         T::Codec: WireDecoder,
     {
         debug!("[NOD] Creating subscriber: topic={}", topic);
-        match T::schema().map(Arc::new) {
-            Ok(schema) => self
-                .subscriber_impl::<T, T::Codec>(topic, Some(typed_message_type_info::<T>(&schema))),
-            Err(error) => self
-                .subscriber_impl::<T, T::Codec>(topic, None)
-                .schema_error(error),
-        }
+
+        let schema = Arc::new(
+            T::schema().map_err(|error| message_schema_build_error("subscriber", topic, error))?,
+        );
+
+        Ok(self.subscriber_impl::<T, T::Codec>(topic, Some(typed_message_type_info::<T>(&schema))))
     }
 
     fn subscriber_impl<T, S>(
@@ -358,7 +368,6 @@ impl Node {
             session: self.session.clone(),
             graph: self.graph.clone(),
             dyn_schema: None,
-            schema_error: None,
             locality: None,
             transient_local_replay_timeout: DEFAULT_TRANSIENT_LOCAL_REPLAY_TIMEOUT,
             _phantom_data: Default::default(),
@@ -388,7 +397,7 @@ impl Node {
     /// let node = context.create_node("cache_demo").build().await?;
     ///
     /// // Zero-config (Zenoh transport timestamp)
-    /// let cache = node.create_cache::<String>("/chatter", 200).build().await?;
+    /// let cache = node.create_cache::<String>("/chatter", 200)?.build().await?;
     ///
     /// // Pull messages from the last 100 ms
     /// let now = Time::from_wallclock(std::time::SystemTime::now());
@@ -400,7 +409,7 @@ impl Node {
         &self,
         topic: &str,
         capacity: usize,
-    ) -> CacheBuilder<T, <T as Message>::Codec>
+    ) -> Result<CacheBuilder<T, <T as Message>::Codec>>
     where
         T: Message,
         for<'a> <T as Message>::Codec: WireDecoder<Input<'a> = &'a [u8], Output = T>,
@@ -409,15 +418,13 @@ impl Node {
             "[NOD] Creating cache: topic={}, capacity={}",
             topic, capacity
         );
-        let sub_builder = match T::schema().and_then(|_| T::type_info()) {
-            Ok(type_info) => {
-                self.subscriber_impl::<T, <T as Message>::Codec>(topic, Some(type_info))
-            }
-            Err(error) => self
-                .subscriber_impl::<T, <T as Message>::Codec>(topic, None)
-                .schema_error(error),
-        };
-        CacheBuilder::new(sub_builder, capacity)
+        T::schema().map_err(|error| message_schema_build_error("cache", topic, error))?;
+        let type_info =
+            T::type_info().map_err(|error| message_schema_build_error("cache", topic, error))?;
+        Ok(CacheBuilder::new(
+            self.subscriber_impl::<T, <T as Message>::Codec>(topic, Some(type_info)),
+            capacity,
+        ))
     }
 
     /// Create a periodic timer tied to this node's clock.
@@ -437,18 +444,18 @@ impl Node {
     /// - Absolute service names (starting with '/') are used as-is
     /// - Private service names (starting with '~') are expanded to `/<namespace>/<node_name>/<service>`
     /// - Relative service names are expanded to `/<namespace>/<service>`
-    pub fn create_service_server<T>(&self, name: &str) -> ServiceServerBuilder<T>
+    pub fn create_service_server<T>(&self, name: &str) -> Result<ServiceServerBuilder<T>>
     where
         T: Service + ServiceTypeInfo,
     {
         debug!("[NOD] Creating service server: name={}", name);
-        match T::service_type_info().and_then(|type_info| {
-            Self::validate_service_message_schemas::<T>()?;
-            Ok(type_info)
-        }) {
-            Ok(type_info) => self.create_service_impl(name, Some(type_info)),
-            Err(error) => self.create_service_impl(name, None).schema_error(error),
-        }
+        let type_info = T::service_type_info()
+            .and_then(|type_info| {
+                Self::validate_service_message_schemas::<T>()?;
+                Ok(type_info)
+            })
+            .map_err(|error| service_type_info_build_error("server", name, error))?;
+        Ok(self.create_service_impl(name, Some(type_info)))
     }
 
     #[doc(hidden)]
@@ -471,7 +478,6 @@ impl Node {
             entity,
             session: self.session.clone(),
             clock: self.clock.clone(),
-            schema_error: None,
             _phantom_data: Default::default(),
         }
     }
@@ -485,18 +491,18 @@ impl Node {
     /// - Absolute service names (starting with '/') are used as-is
     /// - Private service names (starting with '~') are expanded to `/<namespace>/<node_name>/<service>`
     /// - Relative service names are expanded to `/<namespace>/<service>`
-    pub fn create_service_client<T>(&self, name: &str) -> ServiceClientBuilder<T>
+    pub fn create_service_client<T>(&self, name: &str) -> Result<ServiceClientBuilder<T>>
     where
         T: Service + ServiceTypeInfo,
     {
         debug!("[NOD] Creating service client: name={}", name);
-        match T::service_type_info().and_then(|type_info| {
-            Self::validate_service_message_schemas::<T>()?;
-            Ok(type_info)
-        }) {
-            Ok(type_info) => self.create_client_impl(name, Some(type_info)),
-            Err(error) => self.create_client_impl(name, None).schema_error(error),
-        }
+        let type_info = T::service_type_info()
+            .and_then(|type_info| {
+                Self::validate_service_message_schemas::<T>()?;
+                Ok(type_info)
+            })
+            .map_err(|error| service_type_info_build_error("client", name, error))?;
+        Ok(self.create_client_impl(name, Some(type_info)))
     }
 
     #[doc(hidden)]
@@ -519,7 +525,6 @@ impl Node {
             entity,
             session: self.session.clone(),
             clock: self.clock.clone(),
-            schema_error: None,
             _phantom_data: Default::default(),
         }
     }
@@ -589,9 +594,7 @@ impl Node {
         &self.clock
     }
 
-    // ========================================================================
     // Dynamic Message API
-    // ========================================================================
 
     /// Create a dynamic publisher for the given topic.
     ///
@@ -619,7 +622,7 @@ impl Node {
     /// });
     ///
     /// let type_info = TypeInfo::with_hash("std_msgs::String", ros_z_schema::compute_hash(schema.as_ref()));
-    /// let publisher = node.dynamic_publisher("chatter", type_info, schema).build().await?;
+    /// let publisher = node.dynamic_publisher("chatter", type_info, schema)?.build().await?;
     ///
     /// let mut message = DynamicStruct::default_for_schema(publisher.schema().unwrap())?;
     /// message.set("data", "Hello, world!")?;
@@ -631,37 +634,27 @@ impl Node {
         topic: &str,
         mut type_info: TypeInfo,
         schema: Schema,
-    ) -> DynamicPublisherBuilder {
-        let mut build_error = schema.validate().err().map(|error| {
+    ) -> Result<DynamicPublisherBuilder> {
+        if let Err(error) = schema.validate() {
             warn!(
                 "[NOD] Failed to validate schema {}: {}",
                 type_info.name, error
             );
-            error.to_string()
-        });
-
-        if build_error.is_none() {
-            if type_info.hash.is_none() {
-                type_info.hash = Some(ros_z_schema::compute_hash(schema.as_ref()));
-            }
-
-            if let Err(error) = registerable_schema_root(&type_info.name, schema.as_ref()).and_then(
-                |should_register| {
-                    if should_register {
-                        self.register_schema_with_service(&type_info.name, Arc::clone(&schema))?;
-                    }
-                    Ok(())
-                },
-            ) {
-                build_error = Some(error.to_string());
-            }
+            return Err(message_schema_build_error("publisher", topic, error));
         }
 
-        let builder = self.dynamic_publisher_impl(topic, Some(type_info), schema);
-        match build_error {
-            Some(error) => builder.schema_error(error),
-            None => builder,
+        if type_info.hash.is_none() {
+            type_info.hash = Some(ros_z_schema::compute_hash(schema.as_ref()));
         }
+
+        let should_register = registerable_schema_root(&type_info.name, schema.as_ref())
+            .map_err(|error| message_schema_build_error("publisher", topic, error))?;
+        if should_register {
+            self.register_schema_with_service(&type_info.name, Arc::clone(&schema))
+                .map_err(|error| message_schema_build_error("publisher", topic, error))?;
+        }
+
+        Ok(self.dynamic_publisher_impl(topic, Some(type_info), schema))
     }
 
     /// Discover the schema that publishers currently expose on a topic.
@@ -775,7 +768,7 @@ impl Node {
     /// });
     ///
     /// let type_info = TypeInfo::with_hash("std_msgs::String", ros_z_schema::compute_hash(schema.as_ref()));
-    /// let subscriber = node.dynamic_subscriber("chatter", Some(type_info), schema).build().await?;
+    /// let subscriber = node.dynamic_subscriber("chatter", Some(type_info), schema)?.build().await?;
     /// let message = subscriber.recv().await?;
     /// ```
     pub fn dynamic_subscriber(
@@ -783,13 +776,12 @@ impl Node {
         topic: &str,
         type_info: Option<TypeInfo>,
         schema: Schema,
-    ) -> DynamicSubscriberBuilder {
-        let schema_error = schema.validate().err();
-        let builder = self.dynamic_subscriber_impl(topic, type_info, schema);
-        match schema_error {
-            Some(error) => builder.schema_error(error),
-            None => builder,
+    ) -> Result<DynamicSubscriberBuilder> {
+        if let Err(error) = schema.validate() {
+            return Err(message_schema_build_error("subscriber", topic, error));
         }
+
+        Ok(self.dynamic_subscriber_impl(topic, type_info, schema))
     }
 
     fn dynamic_publisher_impl(

--- a/crates/ros-z/src/parameter/remote/client.rs
+++ b/crates/ros-z/src/parameter/remote/client.rs
@@ -149,6 +149,7 @@ impl RemoteParameterClient {
     pub async fn subscribe_events(&self) -> Result<Subscriber<NodeParameterEvent>> {
         self.node
             .subscriber::<NodeParameterEvent>(&self.events_topic())
+            .map_err(map_remote_err)?
             .qos(QosProfile {
                 reliability: QosReliability::Reliable,
                 durability: QosDurability::TransientLocal,
@@ -179,6 +180,7 @@ impl RemoteParameterClient {
     {
         self.node
             .create_service_client::<S>(service_name)
+            .map_err(map_remote_err)?
             .build()
             .await
             .map_err(map_remote_err)

--- a/crates/ros-z/src/parameter/remote/services.rs
+++ b/crates/ros-z/src/parameter/remote/services.rs
@@ -37,6 +37,9 @@ where
     pub async fn register(node: &Node, inner: Arc<NodeParametersInner<T>>) -> Result<Self> {
         let event_publisher = node
             .publisher::<NodeParameterEvent>("~parameter/events")
+            .map_err(|err| ParameterError::RemoteError {
+                message: err.to_string(),
+            })?
             .qos(QosProfile {
                 reliability: QosReliability::Reliable,
                 durability: QosDurability::TransientLocal,
@@ -127,6 +130,9 @@ where
     S: Service + ServiceTypeInfo,
 {
     node.create_service_server::<S>(name)
+        .map_err(|err| ParameterError::RemoteError {
+            message: err.to_string(),
+        })?
         .build_with_callback(move |query| handler(&query))
         .await
         .map_err(|err| ParameterError::RemoteError {

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -168,7 +168,6 @@ pub struct PublisherBuilder<T, C = <T as crate::Message>::Codec> {
     /// Schema for dynamic message publishing.
     /// When set, the schema will be registered with the schema service.
     pub(crate) dyn_schema: Option<Schema>,
-    pub(crate) schema_error: Option<String>,
     pub(crate) _phantom_data: PhantomData<(T, C)>,
 }
 
@@ -199,7 +198,7 @@ impl<T, C> PublisherBuilder<T, C> {
     /// let provider = Arc::new(ShmProviderBuilder::new(20 * 1024 * 1024).build()?);
     /// let config = ShmConfig::new(provider).with_threshold(5_000);
     ///
-    /// let publisher = node.publisher::<String>("topic")
+    /// let publisher = node.publisher::<String>("topic")?
     ///     .shm_config(config)
     ///     .build()
     ///     .await?;
@@ -223,7 +222,7 @@ impl<T, C> PublisherBuilder<T, C> {
     /// # let context = ros_z::context::ContextBuilder::default().with_shm_enabled()?.build().await?;
     /// # let node = context.create_node("test").build().await?;
     /// // Context has SHM enabled, but disable for this publisher
-    /// let publisher = node.publisher::<String>("small_messages")
+    /// let publisher = node.publisher::<String>("small_messages")?
     ///     .without_shm()
     ///     .build()
     ///     .await?;
@@ -238,11 +237,6 @@ impl<T, C> PublisherBuilder<T, C> {
     /// Set the dynamic schema for runtime-typed publishers.
     pub fn dynamic_schema(mut self, schema: Schema) -> Self {
         self.dyn_schema = Some(schema);
-        self
-    }
-
-    pub(crate) fn schema_error(mut self, error: impl std::fmt::Display) -> Self {
-        self.schema_error = Some(error.to_string());
         self
     }
 }
@@ -269,13 +263,6 @@ where
         Option<Arc<TransientLocalCache>>,
         EndpointGlobalId,
     )> {
-        if let Some(error) = self.schema_error.take() {
-            return Err(zenoh::Error::from(format!(
-                "failed to build message schema for publisher '{}': {}",
-                self.entity.topic, error
-            )));
-        }
-
         let Some(node) = self.entity.node.as_ref() else {
             return Err(zenoh::Error::from("publisher build requires node identity"));
         };

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -19,7 +19,6 @@ use crate::qos::QosProfile;
 use crate::queue::BoundedQueue;
 use crate::topic_name::qualify_topic_name;
 use ros_z_protocol::qos::{QosDurability, QosHistory};
-use ros_z_schema::SchemaError;
 
 pub(super) fn subscriber_queue_capacity(qos: &ros_z_protocol::qos::QosProfile) -> usize {
     match qos.history {
@@ -33,7 +32,6 @@ pub struct SubscriberBuilder<T, C = <T as crate::Message>::Codec> {
     pub(crate) session: Arc<Session>,
     pub(crate) graph: Arc<Graph>,
     pub(crate) dyn_schema: Option<Schema>,
-    pub(crate) schema_error: Option<SchemaError>,
     pub(crate) locality: Option<zenoh::sample::Locality>,
     pub(crate) transient_local_replay_timeout: Duration,
     pub(crate) _phantom_data: PhantomData<(T, C)>,
@@ -73,7 +71,7 @@ where
     /// use zenoh::sample::Locality;
     ///
     /// let subscriber = node
-    ///     .subscriber::<String>("/topic")
+    ///     .subscriber::<String>("/topic")?
     ///     .locality(Locality::Remote)  // Only receive from remote publishers
     ///     .build()
     ///     .await?;
@@ -91,11 +89,6 @@ where
     /// Set the dynamic schema for runtime-typed messages.
     pub fn dynamic_schema(mut self, schema: Schema) -> Self {
         self.dyn_schema = Some(schema);
-        self
-    }
-
-    pub(crate) fn schema_error(mut self, error: SchemaError) -> Self {
-        self.schema_error = Some(error);
         self
     }
 
@@ -132,13 +125,6 @@ where
     where
         F: Fn(Sample) + Send + Sync + 'static,
     {
-        if let Some(error) = self.schema_error.take() {
-            return Err(zenoh::Error::from(format!(
-                "failed to build message schema for subscriber '{}': {}",
-                self.entity.topic, error
-            )));
-        }
-
         let Some(node) = self.entity.node.as_ref() else {
             return Err(zenoh::Error::from(
                 "subscriber build requires node identity",

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -22,14 +22,12 @@ use crate::{
     queue::BoundedQueue,
     time::Clock,
 };
-use ros_z_schema::SchemaError;
 
 #[derive(Debug)]
 pub struct ServiceClientBuilder<T> {
     pub(crate) entity: EndpointEntity,
     pub(crate) session: Arc<Session>,
     pub(crate) clock: Clock,
-    pub(crate) schema_error: Option<SchemaError>,
     pub(crate) _phantom_data: PhantomData<T>,
 }
 
@@ -79,13 +77,6 @@ where
         service = %self.entity.topic
     ))]
     pub async fn build(mut self) -> Result<ServiceClient<T>> {
-        if let Some(error) = self.schema_error.take() {
-            return Err(zenoh::Error::from(format!(
-                "failed to build service type info for client '{}': {}",
-                self.entity.topic, error
-            )));
-        }
-
         let Some(node) = self.entity.node.as_ref() else {
             return Err(zenoh::Error::from("client build requires node identity"));
         };
@@ -317,22 +308,7 @@ pub struct ServiceServerBuilder<T> {
     pub(crate) entity: EndpointEntity,
     pub(crate) session: Arc<Session>,
     pub(crate) clock: Clock,
-    pub(crate) schema_error: Option<SchemaError>,
     pub(crate) _phantom_data: PhantomData<T>,
-}
-
-impl<T> ServiceClientBuilder<T> {
-    pub(crate) fn schema_error(mut self, error: SchemaError) -> Self {
-        self.schema_error = Some(error);
-        self
-    }
-}
-
-impl<T> ServiceServerBuilder<T> {
-    pub(crate) fn schema_error(mut self, error: SchemaError) -> Self {
-        self.schema_error = Some(error);
-        self
-    }
 }
 
 impl<T> ServiceClientBuilder<T> {
@@ -428,13 +404,6 @@ where
         handler: ServiceQueryHandler,
         queue: Option<Arc<BoundedQueue<Q>>>,
     ) -> Result<ServiceServer<T, Q>> {
-        if let Some(error) = self.schema_error.take() {
-            return Err(zenoh::Error::from(format!(
-                "failed to build service type info for server '{}': {}",
-                self.entity.topic, error
-            )));
-        }
-
         let Some(node) = self.entity.node.as_ref() else {
             return Err(zenoh::Error::from("service build requires node identity"));
         };
@@ -776,6 +745,7 @@ mod tests {
 
         let mut server = server_node
             .create_service_server::<AddTwoInts>("raw_query_add_two_ints")
+            .expect("service server factory should succeed")
             .build()
             .await
             .expect("Failed to create service server");

--- a/crates/ros-z/src/shm.rs
+++ b/crates/ros-z/src/shm.rs
@@ -52,7 +52,7 @@
 //! let provider = Arc::new(ShmProviderBuilder::new(20_000_000).build()?);
 //! let config = ShmConfig::new(provider).with_threshold(10_000);
 //!
-//! let publisher = node.publisher::<String>("topic")
+//! let publisher = node.publisher::<String>("topic")?
 //!     .shm_config(config)
 //!     .build()
 //!     .await?;

--- a/crates/ros-z/tests/communication_pubsub_alignment.rs
+++ b/crates/ros-z/tests/communication_pubsub_alignment.rs
@@ -23,11 +23,13 @@ async fn publisher_message_id_is_reserved_and_observable() {
 
     let publisher = node
         .publisher::<AlignmentMessage>("/alignment_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher");
     let subscriber = node
         .subscriber::<AlignmentMessage>("/alignment_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -71,11 +73,13 @@ async fn publisher_direct_publish_attaches_publication_id() {
 
     let publisher = node
         .publisher::<AlignmentMessage>("/alignment_direct_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher");
     let subscriber = node
         .subscriber::<AlignmentMessage>("/alignment_direct_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");

--- a/crates/ros-z/tests/extended_type_info.rs
+++ b/crates/ros-z/tests/extended_type_info.rs
@@ -302,6 +302,7 @@ async fn discovery_uses_schema_service_for_standard_compatible_types() {
 
     let publisher = pub_node
         .publisher::<TelemetryLite>("/extended_standard_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");
@@ -378,6 +379,7 @@ async fn schema_service_round_trips_recursive_bundle() {
 
     let publisher = pub_node
         .publisher::<RecursiveTrace>("/recursive_trace_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");
@@ -463,6 +465,7 @@ async fn extended_discovery_should_fail_when_the_publisher_disabled_the_schema_s
 
     let publisher = pub_node
         .publisher::<RobotEnvelope>("/extended_robot_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");
@@ -518,6 +521,7 @@ async fn extended_only_types_use_schema_service_when_enabled() {
 
     let publisher = pub_node
         .publisher::<RobotEnvelope>("/extended_robot_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");
@@ -618,6 +622,7 @@ async fn type_description_discovery_works_across_namespaces_for_extended_types()
 
     let publisher = pub_node
         .publisher::<RobotEnvelope>("/extended_robot_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");
@@ -687,6 +692,7 @@ async fn top_level_enums_are_discoverable_through_the_schema_service() {
 
     let publisher = pub_node
         .publisher::<RobotState>("/robot_state_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -338,12 +338,12 @@ mod tests {
         };
 
         let _publisher = pub_node
-            .publisher::<String>(&topic)
+            .publisher::<String>(&topic)?
             .qos(pub_qos)
             .build()
             .await?;
         let _subscriber = sub_node
-            .subscriber::<String>(&topic)
+            .subscriber::<String>(&topic)?
             .qos(sub_qos)
             .build()
             .await?;
@@ -385,12 +385,12 @@ mod tests {
         };
 
         let _publisher = pub_node
-            .publisher::<String>(&topic)
+            .publisher::<String>(&topic)?
             .qos(pub_qos)
             .build()
             .await?;
         let _subscriber = sub_node
-            .subscriber::<String>(&topic)
+            .subscriber::<String>(&topic)?
             .qos(sub_qos)
             .build()
             .await?;
@@ -413,7 +413,7 @@ mod tests {
         let (_ctx, node) = setup_test_node("test_graph_node").await?;
         let topic_name = unique_graph_name("test_graph_topic_names_and_types");
 
-        let _pub = node.publisher::<String>(&topic_name).build().await?;
+        let _pub = node.publisher::<String>(&topic_name)?.build().await?;
         assert!(
             wait_for_publishers(&node, &topic_name, 1, 1_000).await?,
             "Expected graph to discover publisher for {topic_name}"
@@ -436,7 +436,7 @@ mod tests {
         let service_name = unique_graph_name("test_graph_service_names_and_types");
 
         let _service = node
-            .create_service_server::<AddTwoInts>(&service_name)
+            .create_service_server::<AddTwoInts>(&service_name)?
             .build()
             .await?;
         assert!(
@@ -465,7 +465,7 @@ mod tests {
 
         assert_eq!(count, 0, "Expected 0 publishers on non-existent topic");
 
-        let _pub = node.publisher::<String>(&topic_name).build().await?;
+        let _pub = node.publisher::<String>(&topic_name)?.build().await?;
 
         assert!(wait_for_publishers(&node, &topic_name, 1, 1_000).await?);
 
@@ -487,7 +487,7 @@ mod tests {
         let count = graph.count(EntityKind::Subscription, &topic_name);
         assert_eq!(count, 0, "Expected 0 subscribers on non-existent topic");
 
-        let _sub = node.subscriber::<String>(&topic_name).build().await?;
+        let _sub = node.subscriber::<String>(&topic_name)?.build().await?;
 
         assert!(wait_for_subscribers(&node, &topic_name, 1, 1_000).await?);
 
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(count, 0, "Expected 0 clients on non-existent service");
 
         let _client = node
-            .create_service_client::<AddTwoInts>(&service_name)
+            .create_service_client::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(count, 0, "Expected 0 services on non-existent service");
 
         let _service = node
-            .create_service_server::<AddTwoInts>(&service_name)
+            .create_service_server::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -552,7 +552,7 @@ mod tests {
         let service_name = unique_graph_name("graph_service_by_node");
 
         let _service = node
-            .create_service_server::<AddTwoInts>(&service_name)
+            .create_service_server::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -578,7 +578,7 @@ mod tests {
         let service_name = unique_graph_name("graph_client_by_node");
 
         let _client = node
-            .create_service_client::<AddTwoInts>(&service_name)
+            .create_service_client::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -616,7 +616,7 @@ mod tests {
         assert_eq!(count_pubs, 0, "Expected 0 publishers initially");
         assert_eq!(count_subs, 0, "Expected 0 subscribers initially");
 
-        let pub_handle = node.publisher::<String>(&topic_name).build().await?;
+        let pub_handle = node.publisher::<String>(&topic_name)?.build().await?;
 
         assert!(wait_for_publishers(&node, &topic_name, 1, 1_000).await?);
 
@@ -626,7 +626,7 @@ mod tests {
             "Expected at least 1 publisher after creation"
         );
 
-        let sub_handle = node.subscriber::<String>(&topic_name).build().await?;
+        let sub_handle = node.subscriber::<String>(&topic_name)?.build().await?;
 
         assert!(wait_for_subscribers(&node, &topic_name, 1, 1_000).await?);
 
@@ -686,8 +686,8 @@ mod tests {
 
         let topic_name = unique_graph_name("test_multi_node_pub");
 
-        let _pub1 = node1.publisher::<String>(&topic_name).build().await?;
-        let _pub2 = node2.publisher::<String>(&topic_name).build().await?;
+        let _pub1 = node1.publisher::<String>(&topic_name)?.build().await?;
+        let _pub2 = node2.publisher::<String>(&topic_name)?.build().await?;
 
         assert!(
             wait_for_publishers(&node1, &topic_name, 2, 1_000).await?,
@@ -715,8 +715,8 @@ mod tests {
 
         let topic_name = unique_graph_name("test_multi_node_sub");
 
-        let _sub1 = node1.subscriber::<String>(&topic_name).build().await?;
-        let _sub2 = node2.subscriber::<String>(&topic_name).build().await?;
+        let _sub1 = node1.subscriber::<String>(&topic_name)?.build().await?;
+        let _sub2 = node2.subscriber::<String>(&topic_name)?.build().await?;
 
         assert!(
             wait_for_subscribers(&node1, &topic_name, 2, 1_000).await?,
@@ -746,11 +746,11 @@ mod tests {
         let service_name2 = unique_graph_name("graph_multi_node_service_2");
 
         let _srv1 = node1
-            .create_service_server::<AddTwoInts>(&service_name1)
+            .create_service_server::<AddTwoInts>(&service_name1)?
             .build()
             .await?;
         let _srv2 = node2
-            .create_service_server::<AddTwoInts>(&service_name2)
+            .create_service_server::<AddTwoInts>(&service_name2)?
             .build()
             .await?;
 
@@ -787,15 +787,15 @@ mod tests {
         let service_name = unique_graph_name("graph_multi_node_client");
 
         let _srv = node1
-            .create_service_server::<AddTwoInts>(&service_name)
+            .create_service_server::<AddTwoInts>(&service_name)?
             .build()
             .await?;
         let _client1 = node1
-            .create_service_client::<AddTwoInts>(&service_name)
+            .create_service_client::<AddTwoInts>(&service_name)?
             .build()
             .await?;
         let _client2 = node2
-            .create_service_client::<AddTwoInts>(&service_name)
+            .create_service_client::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -814,7 +814,7 @@ mod tests {
         let service_name = unique_graph_name("graph_service_available");
 
         let client = node
-            .create_service_client::<AddTwoInts>(&service_name)
+            .create_service_client::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -823,7 +823,7 @@ mod tests {
         assert_eq!(count, 0, "Expected 0 services before creating server");
 
         let service = node
-            .create_service_server::<AddTwoInts>(&service_name)
+            .create_service_server::<AddTwoInts>(&service_name)?
             .build()
             .await?;
 
@@ -847,8 +847,8 @@ mod tests {
         let (_ctx, node) = setup_test_node("test_graph_node").await?;
         let topic_name = unique_graph_name("graph_entities_by_topic");
 
-        let _pub = node.publisher::<String>(&topic_name).build().await?;
-        let _sub = node.subscriber::<String>(&topic_name).build().await?;
+        let _pub = node.publisher::<String>(&topic_name)?.build().await?;
+        let _sub = node.subscriber::<String>(&topic_name)?.build().await?;
 
         assert!(wait_for_publishers(&node, &topic_name, 1, 1_000).await?);
         assert!(wait_for_subscribers(&node, &topic_name, 1, 1_000).await?);

--- a/crates/ros-z/tests/nalgebra_field_type_info.rs
+++ b/crates/ros-z/tests/nalgebra_field_type_info.rs
@@ -383,6 +383,7 @@ async fn nalgebra_fields_roundtrip_via_standard_discovery() {
 
     let publisher = pub_node
         .publisher::<MathSnapshot>("/math_snapshot")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");
@@ -455,6 +456,7 @@ async fn single_schema_discovery_works_with_basic_nalgebra_fields() {
 
     let publisher = pub_node
         .publisher::<MathCommand>("/math_command")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("publisher");

--- a/crates/ros-z/tests/parameter_integration.rs
+++ b/crates/ros-z/tests/parameter_integration.rs
@@ -423,7 +423,7 @@ async fn remote_v1_services_work() -> TestResult {
     let snapshot_client = client_node
         .create_service_client::<GetNodeParametersSnapshotSrv>(
             "/motion/walk_publisher/parameter/get_snapshot",
-        )
+        )?
         .build()
         .await?;
     let snapshot = snapshot_client.call_async(&Default::default()).await?;
@@ -432,7 +432,7 @@ async fn remote_v1_services_work() -> TestResult {
     assert!(snapshot.value_json.contains("threshold"));
 
     let set_client = client_node
-        .create_service_client::<SetNodeParameterSrv>("/motion/walk_publisher/parameter/set")
+        .create_service_client::<SetNodeParameterSrv>("/motion/walk_publisher/parameter/set")?
         .build()
         .await?;
     let set_response = set_client
@@ -448,7 +448,7 @@ async fn remote_v1_services_work() -> TestResult {
     let value_client = client_node
         .create_service_client::<GetNodeParameterValueSrv>(
             "/motion/walk_publisher/parameter/get_value",
-        )
+        )?
         .build()
         .await?;
     let value_response = value_client
@@ -494,7 +494,7 @@ async fn bound_parameters_expose_type_info_and_schema_lookup() -> TestResult {
     let type_info_client = client_node
         .create_service_client::<GetNodeParameterTypeInfoSrv>(
             "/motion/walk_publisher/parameter/get_type_info",
-        )
+        )?
         .build()
         .await?;
     let type_info = type_info_client.call_async(&Default::default()).await?;

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -219,9 +219,9 @@ async fn node_builder_can_disable_schema_service_explicitly() -> zenoh::Result<(
 async fn raw_subscriber_receives_sample_payload() -> zenoh::Result<()> {
     let context = ContextBuilder::default().build().await?;
     let node = context.create_node("raw_subscriber_node").build().await?;
-    let publisher = node.publisher::<TestMessage>("/raw_topic").build().await?;
+    let publisher = node.publisher::<TestMessage>("/raw_topic")?.build().await?;
     let mut subscriber = node
-        .subscriber::<TestMessage>("/raw_topic")
+        .subscriber::<TestMessage>("/raw_topic")?
         .raw()
         .build()
         .await?;
@@ -240,56 +240,130 @@ async fn raw_subscriber_receives_sample_payload() -> zenoh::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn typed_pubsub_builders_return_schema_errors() {
+async fn typed_pubsub_factories_return_schema_errors() {
     let context = ContextBuilder::default()
         .build()
         .await
         .expect("Failed to create context");
     let node = context
-        .create_node("invalid_schema_builders")
+        .create_node("invalid_schema_factories")
         .build()
         .await
         .expect("Failed to create node");
 
-    let publisher = node
-        .publisher::<InvalidSchemaMessage>("/invalid_schema_publisher")
-        .build()
-        .await;
-    assert!(publisher.is_err());
+    let Err(publisher_error) = node.publisher::<InvalidSchemaMessage>("/invalid_schema_publisher")
+    else {
+        panic!("invalid schema should fail publisher factory");
+    };
+    assert!(
+        publisher_error
+            .to_string()
+            .contains("failed to build message schema for publisher")
+    );
 
-    let subscriber = node
-        .subscriber::<InvalidSchemaMessage>("/invalid_schema_subscriber")
-        .build()
-        .await;
-    assert!(subscriber.is_err());
+    let Err(subscriber_error) =
+        node.subscriber::<InvalidSchemaMessage>("/invalid_schema_subscriber")
+    else {
+        panic!("invalid schema should fail subscriber factory");
+    };
+    assert!(
+        subscriber_error
+            .to_string()
+            .contains("failed to build message schema for subscriber")
+    );
 
-    let cache = node
-        .create_cache::<InvalidSchemaMessage>("/invalid_schema_cache", 1)
-        .build()
-        .await;
-    assert!(cache.is_err());
+    let Err(cache_error) = node.create_cache::<InvalidSchemaMessage>("/invalid_schema_cache", 1)
+    else {
+        panic!("invalid schema should fail cache factory");
+    };
+    assert!(
+        cache_error
+            .to_string()
+            .contains("failed to build message schema for cache")
+    );
 
-    let manual_publisher = node
-        .publisher::<InvalidSchemaManualTypeInfoMessage>("/invalid_manual_schema_publisher")
-        .build()
-        .await;
-    assert!(manual_publisher.is_err());
+    let Err(manual_publisher_error) =
+        node.publisher::<InvalidSchemaManualTypeInfoMessage>("/invalid_manual_schema_publisher")
+    else {
+        panic!("invalid schema should fail publisher factory even with manual type info");
+    };
+    assert!(
+        manual_publisher_error
+            .to_string()
+            .contains("failed to build message schema for publisher")
+    );
 
-    let manual_subscriber = node
-        .subscriber::<InvalidSchemaManualTypeInfoMessage>("/invalid_manual_schema_subscriber")
-        .build()
-        .await;
-    assert!(manual_subscriber.is_err());
+    let Err(manual_subscriber_error) =
+        node.subscriber::<InvalidSchemaManualTypeInfoMessage>("/invalid_manual_schema_subscriber")
+    else {
+        panic!("invalid schema should fail subscriber factory even with manual type info");
+    };
+    assert!(
+        manual_subscriber_error
+            .to_string()
+            .contains("failed to build message schema for subscriber")
+    );
 
-    let manual_cache = node
-        .create_cache::<InvalidSchemaManualTypeInfoMessage>("/invalid_manual_schema_cache", 1)
-        .build()
-        .await;
-    assert!(manual_cache.is_err());
+    let Err(manual_cache_error) =
+        node.create_cache::<InvalidSchemaManualTypeInfoMessage>("/invalid_manual_schema_cache", 1)
+    else {
+        panic!("invalid schema should fail cache factory even with manual type info");
+    };
+    assert!(
+        manual_cache_error
+            .to_string()
+            .contains("failed to build message schema for cache")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn typed_publisher_rejects_schema_root_that_differs_from_type_name() {
+async fn publisher_factory_returns_schema_error_when_message_schema_invalid() {
+    let context = ContextBuilder::default()
+        .build()
+        .await
+        .expect("Failed to create context");
+    let node = context
+        .create_node("invalid_publisher_schema")
+        .build()
+        .await
+        .expect("Failed to create node");
+
+    let Err(error) = node.publisher::<InvalidSchemaMessage>("/invalid_schema") else {
+        panic!("invalid schema should fail publisher factory");
+    };
+
+    assert!(
+        error
+            .to_string()
+            .contains("failed to build message schema for publisher")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn subscriber_factory_returns_schema_error_when_message_schema_invalid() {
+    let context = ContextBuilder::default()
+        .build()
+        .await
+        .expect("Failed to create context");
+    let node = context
+        .create_node("invalid_subscriber_schema")
+        .build()
+        .await
+        .expect("Failed to create node");
+
+    let Err(error) = node.subscriber::<InvalidSchemaMessage>("/invalid_schema") else {
+        panic!("invalid schema should fail subscriber factory");
+    };
+
+    assert!(
+        error
+            .to_string()
+            .contains("failed to build message schema for subscriber")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn typed_publisher_factory_rejects_schema_root_that_differs_from_type_name() {
     let context = ContextBuilder::default()
         .build()
         .await
@@ -300,20 +374,20 @@ async fn typed_publisher_rejects_schema_root_that_differs_from_type_name() {
         .await
         .expect("Failed to create node");
 
-    let error = node
-        .publisher::<MismatchedRootSchemaMessage>("/mismatched_schema_root")
-        .build()
-        .await
-        .expect_err("mismatched schema root should fail publisher build");
+    let Err(error) = node.publisher::<MismatchedRootSchemaMessage>("/mismatched_schema_root")
+    else {
+        panic!("mismatched schema root should fail publisher factory");
+    };
     let message = error.to_string();
 
+    assert!(message.contains("failed to build message schema for publisher"));
     assert!(message.contains("schema root"));
     assert!(message.contains("test_msgs::AdvertisedRoot"));
     assert!(message.contains("test_msgs::ActualRoot"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn dynamic_publisher_rejects_schema_root_that_differs_from_type_info() {
+async fn dynamic_publisher_factory_rejects_schema_root_that_differs_from_type_info() {
     let context = ContextBuilder::default()
         .build()
         .await
@@ -325,17 +399,16 @@ async fn dynamic_publisher_rejects_schema_root_that_differs_from_type_info() {
         .expect("Failed to create node");
     let type_info = TypeInfo::new("test_msgs::AdvertisedDynamicRoot", None);
 
-    let error = node
-        .dynamic_publisher(
-            "/mismatched_dynamic_schema_root",
-            type_info,
-            mismatched_dynamic_schema(),
-        )
-        .build()
-        .await
-        .expect_err("mismatched schema root should fail dynamic publisher build");
+    let Err(error) = node.dynamic_publisher(
+        "/mismatched_dynamic_schema_root",
+        type_info,
+        mismatched_dynamic_schema(),
+    ) else {
+        panic!("mismatched schema root should fail dynamic publisher factory");
+    };
     let message = error.to_string();
 
+    assert!(message.contains("failed to build message schema for publisher"));
     assert!(message.contains("schema root"));
     assert!(message.contains("test_msgs::AdvertisedDynamicRoot"));
     assert!(message.contains("test_msgs::ActualDynamicRoot"));
@@ -355,12 +428,14 @@ async fn test_basic_pubsub() {
 
     let publisher = node
         .publisher::<TestMessage>("/test_topic")
+        .expect("publisher factory should succeed")
         .build()
         .await
         .unwrap();
 
     let subscriber = node
         .subscriber::<TestMessage>("/test_topic")
+        .expect("subscriber factory should succeed")
         .build()
         .await
         .unwrap();
@@ -400,7 +475,7 @@ async fn transient_local_build_waits_for_initial_replay() -> zenoh::Result<()> {
     };
 
     let publisher = pub_node
-        .publisher::<TestMessage>(topic)
+        .publisher::<TestMessage>(topic)?
         .qos(qos)
         .build()
         .await?;
@@ -411,7 +486,7 @@ async fn transient_local_build_waits_for_initial_replay() -> zenoh::Result<()> {
     publisher.publish(&message).await?;
 
     let subscriber = sub_node
-        .subscriber::<TestMessage>(topic)
+        .subscriber::<TestMessage>(topic)?
         .qos(qos)
         .build()
         .await?;
@@ -441,12 +516,14 @@ async fn test_multiple_messages() {
 
     let publisher = node
         .publisher::<TestMessage>("/multi_topic")
+        .expect("publisher factory should succeed")
         .build()
         .await
         .unwrap();
 
     let subscriber = node
         .subscriber::<TestMessage>("/multi_topic")
+        .expect("subscriber factory should succeed")
         .build()
         .await
         .unwrap();
@@ -485,6 +562,7 @@ async fn create_cache_uses_schema_hash_method_when_type_info_is_available() {
 
     let _cache = node
         .create_cache::<CacheSchemaHashMessage>(topic, 4)
+        .expect("cache factory should succeed")
         .build()
         .await
         .expect("cache should build");
@@ -522,6 +600,7 @@ async fn publisher_schema_service_uses_schema_derived_key_when_type_info_diverge
 
     let _publisher = node
         .publisher::<AdvertisedTypeInfoSchemaMessage>("/advertised_schema_service")
+        .expect("publisher factory should succeed")
         .build()
         .await
         .expect("publisher should build");
@@ -570,11 +649,13 @@ async fn typed_pubsub_advertises_canonical_schema_hash_when_schema_hash_override
 
     let _publisher = node
         .publisher::<AdvertisedTypeInfoSchemaMessage>(topic)
+        .expect("publisher factory should succeed")
         .build()
         .await
         .expect("publisher should build");
     let _subscriber = node
         .subscriber::<AdvertisedTypeInfoSchemaMessage>(topic)
+        .expect("subscriber factory should succeed")
         .build()
         .await
         .expect("subscriber should build");
@@ -638,6 +719,7 @@ async fn dynamic_publisher_advertises_explicit_schema_hash() {
             TypeInfo::with_hash(&root_name, schema_hash),
             root_schema,
         )
+        .expect("dynamic publisher factory should succeed")
         .build()
         .await
         .expect("publisher should build");
@@ -667,6 +749,61 @@ async fn dynamic_publisher_advertises_explicit_schema_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn dynamic_publisher_fills_missing_schema_hash_from_schema() {
+    let context = ContextBuilder::default()
+        .build()
+        .await
+        .expect("Failed to create context");
+    let node = context
+        .create_node("dynamic_inferred_schema_hash")
+        .build()
+        .await
+        .expect("Failed to create node");
+    let topic = "/dynamic_inferred_schema_hash";
+    let root_name = "test_msgs::DynamicInferredHash".to_string();
+    let root_type_name = TypeName::new(&root_name).unwrap();
+    let mut builder = SchemaBuilder::new();
+    let root = builder
+        .define_struct(root_type_name, |fields| {
+            fields.field::<String>("data")?;
+            Ok(())
+        })
+        .unwrap();
+    let root_schema = std::sync::Arc::new(builder.finish(root).unwrap());
+    let schema_hash = ros_z_schema::compute_hash(root_schema.as_ref());
+
+    let _publisher = node
+        .dynamic_publisher(topic, TypeInfo::new(&root_name, None), root_schema)
+        .expect("dynamic publisher factory should succeed")
+        .build()
+        .await
+        .expect("publisher should build");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let endpoint = node
+        .graph()
+        .get_entities_by_topic(EntityKind::Publisher, topic)
+        .into_iter()
+        .find_map(|entity| match &*entity {
+            Entity::Endpoint(endpoint) => Some(endpoint.clone()),
+            _ => None,
+        })
+        .expect("dynamic publisher should be discoverable");
+    let advertised = endpoint.type_info.expect("publisher type info");
+    let registered = node
+        .schema_service()
+        .expect("schema service")
+        .get_schema(&root_name, &schema_hash)
+        .expect("schema lookup should succeed")
+        .expect("schema should be registered under inferred hash");
+
+    assert_eq!(advertised.name, root_name);
+    assert_eq!(advertised.hash, Some(schema_hash));
+    assert_eq!(registered.schema_hash, schema_hash);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_recv_with_metadata_preserves_receive_context() {
     let context = ContextBuilder::default()
         .build()
@@ -680,12 +817,14 @@ async fn test_recv_with_metadata_preserves_receive_context() {
 
     let publisher = node
         .publisher::<TestMessage>("/metadata_topic")
+        .expect("publisher factory should succeed")
         .build()
         .await
         .unwrap();
 
     let subscriber = node
         .subscriber::<TestMessage>("/metadata_topic")
+        .expect("subscriber factory should succeed")
         .build()
         .await
         .unwrap();
@@ -723,12 +862,14 @@ async fn test_large_payload() {
 
     let publisher = node
         .publisher::<TestMessage>("/large_topic")
+        .expect("publisher factory should succeed")
         .build()
         .await
         .unwrap();
 
     let subscriber = node
         .subscriber::<TestMessage>("/large_topic")
+        .expect("subscriber factory should succeed")
         .build()
         .await
         .unwrap();
@@ -768,11 +909,13 @@ async fn test_logical_clock_is_used_for_attachment_timestamps() {
 
     let publisher = node
         .publisher::<TestMessage>("/sim_clock")
+        .expect("publisher factory should succeed")
         .build()
         .await
         .unwrap();
     let mut subscriber = node
         .subscriber::<TestMessage>("/sim_clock")
+        .expect("subscriber factory should succeed")
         .raw()
         .build()
         .await
@@ -820,6 +963,7 @@ async fn test_vec_u8_pubsub() {
 
             let publisher = node
                 .publisher::<Vec<u8>>("zbuf_topic")
+                .expect("publisher factory should succeed")
                 .build()
                 .await
                 .expect("Failed to create publisher");
@@ -850,6 +994,7 @@ async fn test_vec_u8_pubsub() {
 
             let subscriber = node
                 .subscriber::<Vec<u8>>("zbuf_topic")
+                .expect("subscriber factory should succeed")
                 .build()
                 .await
                 .expect("Failed to create subscriber");

--- a/crates/ros-z/tests/pubsub_qos.rs
+++ b/crates/ros-z/tests/pubsub_qos.rs
@@ -73,13 +73,17 @@ mod tests {
         );
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
         let receive_task = tokio::spawn(collect_messages(subscriber, 5, Duration::from_secs(5)));
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
@@ -110,10 +114,14 @@ mod tests {
             QosHistory::KeepLast(NonZeroUsize::new(10).unwrap()),
         );
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -153,13 +161,17 @@ mod tests {
         );
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
         let receive_task = tokio::spawn(collect_messages(subscriber, 5, Duration::from_secs(5)));
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
@@ -193,11 +205,15 @@ mod tests {
             ..Default::default()
         };
 
-        let publisher = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let publisher = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
         publisher.publish(&"cached".into()).await?;
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -220,13 +236,17 @@ mod tests {
             ..Default::default()
         };
 
-        let publisher = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let publisher = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
         for data in ["one", "two", "three"] {
             publisher.publish(&data.into()).await?;
         }
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -252,14 +272,18 @@ mod tests {
             ..Default::default()
         };
 
-        let publisher = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let publisher = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         for data in ["cached-1", "cached-2", "cached-3"] {
             publisher.publish(&data.into()).await?;
         }
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -292,7 +316,7 @@ mod tests {
         };
 
         let publisher = pub_node
-            .publisher::<String>(topic)
+            .publisher::<String>(topic)?
             .qos(qos)
             .attachment(false)
             .build()
@@ -302,7 +326,7 @@ mod tests {
         }
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -330,11 +354,15 @@ mod tests {
             ..Default::default()
         };
 
-        let publisher = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let publisher = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
         publisher.publish(&"cached".into()).await?;
 
         let cache = cache_node
-            .create_cache::<String>(topic, 1)
+            .create_cache::<String>(topic, 1)?
             .with_qos(qos)
             .build()
             .await?;
@@ -376,12 +404,16 @@ mod tests {
         };
 
         let early_subscriber = early_sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .raw()
             .build()
             .await?;
-        let publisher = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let publisher = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
         publisher.publish(&"cached".into()).await?;
 
         let mut early_subscriber = early_subscriber;
@@ -389,7 +421,7 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(2), early_subscriber.recv()).await??;
 
         let late_subscriber = late_sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .raw()
             .build()
@@ -420,10 +452,14 @@ mod tests {
             QosHistory::KeepLast(NonZeroUsize::new(10).unwrap()),
         );
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -456,13 +492,17 @@ mod tests {
         );
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
         let receive_task = tokio::spawn(collect_messages(subscriber, 10, Duration::from_secs(5)));
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         tokio::time::sleep(Duration::from_millis(2000)).await;
 
@@ -495,7 +535,7 @@ mod tests {
             QosHistory::KeepLast(NonZeroUsize::new(1).unwrap()),
         );
 
-        let pub_handle = node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = node.publisher::<String>(topic)?.qos(qos).build().await?;
         let message = "Test message".to_string();
 
         let publish_result =
@@ -526,13 +566,17 @@ mod tests {
         );
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
         let receive_task = tokio::spawn(collect_messages(subscriber, 2, Duration::from_secs(4)));
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
@@ -562,10 +606,14 @@ mod tests {
             QosHistory::KeepLast(NonZeroUsize::new(10).unwrap()),
         );
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
@@ -618,13 +666,17 @@ mod tests {
         };
 
         let subscriber = sub_node
-            .subscriber::<String>(topic)
+            .subscriber::<String>(topic)?
             .qos(qos)
             .build()
             .await?;
         let receive_task = tokio::spawn(collect_messages(subscriber, 2, Duration::from_secs(4)));
 
-        let pub_handle = pub_node.publisher::<String>(topic).qos(qos).build().await?;
+        let pub_handle = pub_node
+            .publisher::<String>(topic)?
+            .qos(qos)
+            .build()
+            .await?;
 
         tokio::time::sleep(Duration::from_millis(1000)).await;
 

--- a/crates/ros-z/tests/service.rs
+++ b/crates/ros-z/tests/service.rs
@@ -105,7 +105,7 @@ impl Service for InvalidResponseSchemaService {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn typed_service_builders_return_schema_errors() {
+async fn typed_service_factories_return_schema_errors() {
     let context = ContextBuilder::default()
         .disable_multicast_scouting()
         .with_json("connect/endpoints", json!([]))
@@ -118,21 +118,29 @@ async fn typed_service_builders_return_schema_errors() {
         .await
         .expect("Failed to create node");
 
-    let server = node
-        .create_service_server::<InvalidServiceTypeInfo>("invalid_service")
-        .build()
-        .await;
-    assert!(server.is_err());
+    let Err(server_error) = node.create_service_server::<InvalidServiceTypeInfo>("invalid_service")
+    else {
+        panic!("invalid service type info should fail server factory");
+    };
+    assert!(
+        server_error
+            .to_string()
+            .contains("failed to build service type info for server")
+    );
 
-    let client = node
-        .create_service_client::<InvalidServiceTypeInfo>("invalid_service")
-        .build()
-        .await;
-    assert!(client.is_err());
+    let Err(client_error) = node.create_service_client::<InvalidServiceTypeInfo>("invalid_service")
+    else {
+        panic!("invalid service type info should fail client factory");
+    };
+    assert!(
+        client_error
+            .to_string()
+            .contains("failed to build service type info for client")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn typed_service_builders_validate_request_and_response_schemas() {
+async fn typed_service_factories_validate_request_and_response_schemas() {
     let context = ContextBuilder::default()
         .disable_multicast_scouting()
         .with_json("connect/endpoints", json!([]))
@@ -145,33 +153,49 @@ async fn typed_service_builders_validate_request_and_response_schemas() {
         .await
         .expect("Failed to create node");
 
-    let server = node
-        .create_service_server::<InvalidRequestSchemaService>("invalid_service_message_schema")
-        .build()
-        .await;
-    assert!(server.is_err());
+    let Err(server_error) =
+        node.create_service_server::<InvalidRequestSchemaService>("invalid_service_message_schema")
+    else {
+        panic!("invalid request schema should fail server factory");
+    };
+    assert!(
+        server_error
+            .to_string()
+            .contains("failed to build service type info for server")
+    );
 
-    let client = node
-        .create_service_client::<InvalidRequestSchemaService>("invalid_service_message_schema")
-        .build()
-        .await;
-    assert!(client.is_err());
+    let Err(client_error) =
+        node.create_service_client::<InvalidRequestSchemaService>("invalid_service_message_schema")
+    else {
+        panic!("invalid request schema should fail client factory");
+    };
+    assert!(
+        client_error
+            .to_string()
+            .contains("failed to build service type info for client")
+    );
 
-    let response_server = node
-        .create_service_server::<InvalidResponseSchemaService>(
-            "invalid_service_response_message_schema",
-        )
-        .build()
-        .await;
-    assert!(response_server.is_err());
+    let Err(response_server_error) = node.create_service_server::<InvalidResponseSchemaService>(
+        "invalid_service_response_message_schema",
+    ) else {
+        panic!("invalid response schema should fail server factory");
+    };
+    assert!(
+        response_server_error
+            .to_string()
+            .contains("failed to build service type info for server")
+    );
 
-    let response_client = node
-        .create_service_client::<InvalidResponseSchemaService>(
-            "invalid_service_response_message_schema",
-        )
-        .build()
-        .await;
-    assert!(response_client.is_err());
+    let Err(response_client_error) = node.create_service_client::<InvalidResponseSchemaService>(
+        "invalid_service_response_message_schema",
+    ) else {
+        panic!("invalid response schema should fail client factory");
+    };
+    assert!(
+        response_client_error
+            .to_string()
+            .contains("failed to build service type info for client")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -195,6 +219,7 @@ async fn test_basic_service_request_response() {
             let mut server = handle
                 .block_on(
                     node.create_service_server::<AddTwoInts>("add_two_ints")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create server");
@@ -222,6 +247,7 @@ async fn test_basic_service_request_response() {
             let client = handle
                 .block_on(
                     node.create_service_client::<AddTwoInts>("add_two_ints")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create client");
@@ -262,6 +288,7 @@ async fn test_async_service_request_response() {
 
         let mut server = node
             .create_service_server::<AddTwoInts>("async_add")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("Failed to create server");
@@ -291,6 +318,7 @@ async fn test_async_service_request_response() {
 
         let client = node
             .create_service_client::<AddTwoInts>("async_add")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("Failed to create client");
@@ -333,6 +361,7 @@ async fn test_multiple_service_requests() {
             let mut server = handle
                 .block_on(
                     node.create_service_server::<AddTwoInts>("multi_add")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create server");
@@ -362,6 +391,7 @@ async fn test_multiple_service_requests() {
             let client = handle
                 .block_on(
                     node.create_service_client::<AddTwoInts>("multi_add")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create client");
@@ -407,6 +437,7 @@ async fn test_blocking_call_waits_for_service_response() {
             let mut server = handle
                 .block_on(
                     node.create_service_server::<AddTwoInts>("blocking_call")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create server");
@@ -432,6 +463,7 @@ async fn test_blocking_call_waits_for_service_response() {
             let client = handle
                 .block_on(
                     node.create_service_client::<AddTwoInts>("blocking_call")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create client");
@@ -471,6 +503,7 @@ async fn test_blocking_call_with_timeout_can_exceed_old_builder_timeout() {
             let mut server = handle
                 .block_on(
                     node.create_service_server::<AddTwoInts>("builder_timeout_queue")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create server");
@@ -494,6 +527,7 @@ async fn test_blocking_call_with_timeout_can_exceed_old_builder_timeout() {
 
     let client = node
         .create_service_client::<AddTwoInts>("builder_timeout_queue")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create client");
@@ -531,6 +565,7 @@ async fn test_async_call_with_timeout_can_exceed_old_builder_timeout() {
 
         let mut server = node
             .create_service_server::<AddTwoInts>("builder_timeout_async")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("Failed to create server");
@@ -559,6 +594,7 @@ async fn test_async_call_with_timeout_can_exceed_old_builder_timeout() {
 
         let client = node
             .create_service_client::<AddTwoInts>("builder_timeout_async")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("Failed to create client");
@@ -595,6 +631,7 @@ async fn test_blocking_call_with_timeout_reports_early_completion_when_no_server
 
     let client = node
         .create_service_client::<AddTwoInts>("blocking_timeout")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create client");
@@ -640,6 +677,7 @@ async fn test_blocking_call_with_timeout_returns_response_before_deadline() {
             let mut server = handle
                 .block_on(
                     node.create_service_server::<AddTwoInts>("blocking_timeout_success")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create server");
@@ -660,6 +698,7 @@ async fn test_blocking_call_with_timeout_returns_response_before_deadline() {
 
     let client = node
         .create_service_client::<AddTwoInts>("blocking_timeout_success")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create client");
@@ -703,6 +742,7 @@ async fn test_blocking_call_with_timeout_reports_real_timeout_while_waiting_for_
             let mut server = handle
                 .block_on(
                     node.create_service_server::<AddTwoInts>("blocking_timeout_waiting")
+                        .expect("endpoint factory should succeed")
                         .build(),
                 )
                 .expect("Failed to create server");
@@ -723,6 +763,7 @@ async fn test_blocking_call_with_timeout_reports_real_timeout_while_waiting_for_
 
     let client = node
         .create_service_client::<AddTwoInts>("blocking_timeout_waiting")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create client");
@@ -762,6 +803,7 @@ async fn test_blocking_call_with_timeout_reports_early_completion_without_reply(
         .await
         .expect("Failed to create node")
         .create_service_server::<AddTwoInts>("blocking_early_completion")
+        .expect("endpoint factory should succeed")
         .build_with_callback(move |_query| {
             // Intentionally end the query without producing a successful reply sample.
         })
@@ -778,6 +820,7 @@ async fn test_blocking_call_with_timeout_reports_early_completion_without_reply(
 
     let client = node
         .create_service_client::<AddTwoInts>("blocking_early_completion")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create client");

--- a/crates/ros-z/tests/service_api_alignment.rs
+++ b/crates/ros-z/tests/service_api_alignment.rs
@@ -80,6 +80,7 @@ async fn blocking_and_async_service_calls_share_the_same_api_names() {
 
         let mut server = node
             .create_service_server::<AddTwoInts>("service_api_alignment")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("Failed to create service server");
@@ -108,6 +109,7 @@ async fn blocking_and_async_service_calls_share_the_same_api_names() {
     let client = Arc::new(
         client_node
             .create_service_client::<AddTwoInts>("service_api_alignment")
+            .expect("endpoint factory should succeed")
             .build()
             .await
             .expect("Failed to create service client"),

--- a/crates/ros-z/tests/shm.rs
+++ b/crates/ros-z/tests/shm.rs
@@ -25,12 +25,14 @@ async fn test_shm_pubsub_large_message() {
 
     let publisher = node
         .publisher::<Vec<u8>>("shm_test_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher");
 
     let subscriber = node
         .subscriber::<Vec<u8>>("shm_test_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -81,12 +83,14 @@ async fn test_shm_pubsub_small_message() {
 
     let publisher = node
         .publisher::<Vec<u8>>("small_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher");
 
     let subscriber = node
         .subscriber::<Vec<u8>>("small_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -135,12 +139,14 @@ async fn test_shm_threshold_boundary() {
 
     let publisher = node
         .publisher::<Vec<u8>>("boundary_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher");
 
     let subscriber = node
         .subscriber::<Vec<u8>>("boundary_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -192,12 +198,14 @@ async fn test_shm_config_hierarchy_node_override() {
 
     let publisher = node
         .publisher::<Vec<u8>>("hierarchy_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher");
 
     let subscriber = node
         .subscriber::<Vec<u8>>("hierarchy_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -240,6 +248,7 @@ async fn test_without_shm() {
 
     let publisher = node
         .publisher::<Vec<u8>>("no_shm_topic")
+        .expect("endpoint factory should succeed")
         .without_shm() // Explicitly disable SHM
         .build()
         .await
@@ -247,6 +256,7 @@ async fn test_without_shm() {
 
     let subscriber = node
         .subscriber::<Vec<u8>>("no_shm_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -295,6 +305,7 @@ async fn test_publisher_shm_override() {
 
     let publisher = node
         .publisher::<Vec<u8>>("pub_shm_topic")
+        .expect("endpoint factory should succeed")
         .shm_config(pub_shm_config)
         .build()
         .await
@@ -302,6 +313,7 @@ async fn test_publisher_shm_override() {
 
     let subscriber = node
         .subscriber::<Vec<u8>>("pub_shm_topic")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber");
@@ -345,6 +357,7 @@ async fn test_multiple_publishers_different_thresholds() {
     // Publisher 1: uses context default
     let pub1 = node
         .publisher::<Vec<u8>>("topic1")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create publisher 1");
@@ -357,6 +370,7 @@ async fn test_multiple_publishers_different_thresholds() {
     );
     let pub2 = node
         .publisher::<Vec<u8>>("topic2")
+        .expect("endpoint factory should succeed")
         .shm_config(ShmConfig::new(provider2).with_threshold(1_000))
         .build()
         .await
@@ -364,12 +378,14 @@ async fn test_multiple_publishers_different_thresholds() {
 
     let sub1 = node
         .subscriber::<Vec<u8>>("topic1")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber 1");
 
     let sub2 = node
         .subscriber::<Vec<u8>>("topic2")
+        .expect("endpoint factory should succeed")
         .build()
         .await
         .expect("Failed to create subscriber 2");


### PR DESCRIPTION
## Summary

- Currently, builders have a weird intermediate failed state, storing an error string.

This PR changes that:

- Make ros-z publisher, subscriber, cache, service, and dynamic endpoint factories return `Result<Builder>`.
- Remove deferred schema-error state from endpoint builders so builders only represent valid endpoint metadata.
- Migrate workspace call sites, examples, docs, and tests to handle factory-time schema/type-info errors.

## Reviewer Notes

- This PR leaves some error-handling noise in place. #2503 follows up to clean that up, so please focus this review on builder invariants and call-site handling.

## How to test (ci does that as well)

- `cargo fmt --all`
- `cargo check --workspace --all-targets`
- `cargo nextest run -p ros-z -p ros-z-cli -p ros-z-streams`
