### PR TITLE
expose zenoh session from ros-z context

### DIFF
--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -477,7 +477,7 @@ impl ContextBuilder {
         let graph = Arc::new(Graph::new_with_options(&session, builder.graph_options).await?);
 
         Ok(Context {
-            session: Arc::new(session),
+            session,
             counter: Arc::new(GlobalCounter::default()),
             namespace: builder.namespace,
             graph,
@@ -503,7 +503,7 @@ impl ContextBuilder {
 /// ```
 #[derive(Clone)]
 pub struct Context {
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     // Global counter for the participants
     counter: Arc<GlobalCounter>,
     namespace: String,
@@ -544,6 +544,12 @@ impl Context {
     /// service clients/servers created from this context become invalid.
     pub fn shutdown(&self) -> Result<()> {
         self.session.close().wait()
+    }
+
+    /// Get a reference to the Zenoh session for advanced use cases. For most uses, this should not
+    /// be necessary.
+    pub fn session(&self) -> &Session {
+        &self.session
     }
 
     /// Get a reference to the graph for setting up event callbacks

--- a/crates/ros-z/src/dynamic/schema_service.rs
+++ b/crates/ros-z/src/dynamic/schema_service.rs
@@ -266,7 +266,7 @@ pub(crate) struct SchemaServiceNodeIdentity<'a> {
 }
 
 fn schema_service_server_builder(
-    session: Arc<Session>,
+    session: Session,
     node: SchemaServiceNodeIdentity<'_>,
     counter: &GlobalCounter,
     clock: &Clock,
@@ -302,7 +302,7 @@ fn schema_service_server_builder(
 
 impl SchemaService {
     pub(crate) async fn new(
-        session: Arc<Session>,
+        session: Session,
         node: SchemaServiceNodeIdentity<'_>,
         counter: &GlobalCounter,
         clock: &Clock,

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -33,7 +33,7 @@ use zenoh::{Result, Session, liveliness::LivelinessToken};
 /// ```
 pub struct Node {
     pub(crate) entity: NodeEntity,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     counter: Arc<GlobalCounter>,
     pub(crate) graph: Arc<Graph>,
     _lv_token: LivelinessToken,
@@ -58,7 +58,7 @@ impl std::fmt::Debug for Node {
 pub struct NodeBuilder {
     pub(crate) name: String,
     pub(crate) namespace: String,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     pub(crate) counter: Arc<GlobalCounter>,
     pub(crate) graph: Arc<Graph>,
     pub(crate) clock: Clock,
@@ -569,7 +569,7 @@ impl Node {
     }
 
     /// Get a reference to the underlying Zenoh session.
-    pub fn session(&self) -> &Arc<Session> {
+    pub fn session(&self) -> &Session {
         &self.session
     }
 

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -94,7 +94,7 @@ impl Drop for ReplayTaskGuard {
 }
 
 async fn spawn_transient_local_replay_queryable(
-    session: &Arc<Session>,
+    session: &Session,
     topic_key_expr: &ros_z_protocol::entity::TopicKE,
     endpoint_global_id: EndpointGlobalId,
     cache: Arc<TransientLocalCache>,
@@ -160,7 +160,7 @@ impl<T, C: WireEncoder> std::fmt::Debug for Publisher<T, C> {
 #[derive(Debug)]
 pub struct PublisherBuilder<T, C = <T as crate::Message>::Codec> {
     pub(crate) entity: EndpointEntity,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     pub(crate) graph: Arc<Graph>,
     pub(crate) clock: Clock,
     pub(crate) attachment: bool,

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -485,7 +485,7 @@ pub(crate) fn transient_local_replay_live_capacity(
 }
 
 async fn query_transient_local_replay(
-    session: &Arc<Session>,
+    session: &Session,
     topic_key_expr: &str,
     publisher_global_id: EndpointGlobalId,
     timeout: Duration,
@@ -538,7 +538,7 @@ async fn query_transient_local_replay(
 }
 
 pub(crate) async fn query_initial_transient_local_replay_async(
-    session: &Arc<Session>,
+    session: &Session,
     topic_key_expr: &str,
     publisher_global_id: EndpointGlobalId,
     timeout: Duration,
@@ -633,7 +633,7 @@ pub(crate) fn spawn_transient_local_replay_task(
     graph: Arc<Graph>,
     topic: String,
     coordinator: Arc<TransientLocalReplayCoordinator>,
-    session: Arc<Session>,
+    session: Session,
     topic_key_expr: String,
     timeout: Duration,
     initial_seen: HashSet<EndpointGlobalId>,

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -30,7 +30,7 @@ pub(super) fn subscriber_queue_capacity(qos: &ros_z_protocol::qos::QosProfile) -
 
 pub struct SubscriberBuilder<T, C = <T as crate::Message>::Codec> {
     pub(crate) entity: EndpointEntity,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     pub(crate) graph: Arc<Graph>,
     pub(crate) dyn_schema: Option<Schema>,
     pub(crate) schema_error: Option<SchemaError>,

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -27,7 +27,7 @@ use ros_z_schema::SchemaError;
 #[derive(Debug)]
 pub struct ServiceClientBuilder<T> {
     pub(crate) entity: EndpointEntity,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     pub(crate) clock: Clock,
     pub(crate) schema_error: Option<SchemaError>,
     pub(crate) _phantom_data: PhantomData<T>,
@@ -315,7 +315,7 @@ where
 #[derive(Debug)]
 pub struct ServiceServerBuilder<T> {
     pub(crate) entity: EndpointEntity,
-    pub(crate) session: Arc<Session>,
+    pub(crate) session: Session,
     pub(crate) clock: Clock,
     pub(crate) schema_error: Option<SchemaError>,
     pub(crate) _phantom_data: PhantomData<T>,


### PR DESCRIPTION
What it says... allows users to interact with the raw zenoh session

cleanup along the way: `zenoh::Session` is already cheaply clonable, we do not need an additional `Arc`