### PR TITLE
Port camera matrix calculator and intermediate nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4837,6 +4837,8 @@ dependencies = [
  "kinematics",
  "linear_algebra",
  "ros-z",
+ "tokio",
+ "types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6151,7 +6151,6 @@ dependencies = [
  "kinematics",
  "linear_algebra",
  "ros-z",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,10 +2331,12 @@ dependencies = [
  "coordinate_systems",
  "kinematics",
  "linear_algebra",
+ "nalgebra",
  "projection",
  "ros-z",
  "ros2",
  "serde",
+ "tokio",
  "types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,6 +5416,7 @@ dependencies = [
  "search_suggestor",
  "segment_filter",
  "stand_up",
+ "support_foot_estimator",
  "team_ball_receiver",
  "time_to_reach_kick_position",
  "tokio",
@@ -10629,6 +10630,22 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "support_foot_estimator"
+version = "0.1.0"
+dependencies = [
+ "booster",
+ "color-eyre",
+ "coordinate_systems",
+ "filtering",
+ "kinematics",
+ "linear_algebra",
+ "ros-z",
+ "serde",
+ "tokio",
+ "types",
+]
 
 [[package]]
 name = "svg_fmt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6144,7 +6144,9 @@ dependencies = [
  "booster",
  "color-eyre",
  "kinematics",
+ "linear_algebra",
  "ros-z",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
   "crates/nodes/search_suggestor",
   "crates/nodes/segment_filter",
   "crates/nodes/stand_up",
+  "crates/nodes/support_foot_estimator",
   "crates/nodes/team_ball_receiver",
   "crates/nodes/time_to_reach_kick_position",
   "crates/nodes/trigger",
@@ -338,6 +339,7 @@ smallvec = "1.14.0"
 source_analyzer = { path = "crates/source_analyzer" }
 splines = { version = "=4.2.0", features = ["serde"] }
 stand_up = { path = "crates/nodes/stand_up" }
+support_foot_estimator = { path = "crates/nodes/support_foot_estimator" }
 syn = { version = "2.0.98", features = ["extra-traits", "full"] }
 systemd = "0.10.0"
 team_ball_receiver = { path = "crates/nodes/team_ball_receiver" }

--- a/crates/hulk_ros_z/Cargo.toml
+++ b/crates/hulk_ros_z/Cargo.toml
@@ -55,6 +55,7 @@ safe_pose_checker = { workspace = true }
 search_suggestor = { workspace = true }
 segment_filter = { workspace = true }
 stand_up = { workspace = true }
+support_foot_estimator = { workspace = true }
 team_ball_receiver = { workspace = true }
 time_to_reach_kick_position = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }

--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -159,6 +159,7 @@ async fn spawn_all(ctx: Arc<Context>) -> Result<RunningStack> {
     join_set.spawn(search_suggestor::run(ctx.clone()));
     join_set.spawn(segment_filter::run(ctx.clone()));
     join_set.spawn(stand_up::run(ctx.clone()));
+    join_set.spawn(support_foot_estimator::run(ctx.clone()));
     join_set.spawn(team_ball_receiver::run(ctx.clone()));
     join_set.spawn(time_to_reach_kick_position::run(ctx.clone()));
     join_set.spawn(trigger::run(ctx.clone()));

--- a/crates/nodes/camera_matrix_calculator/Cargo.toml
+++ b/crates/nodes/camera_matrix_calculator/Cargo.toml
@@ -10,8 +10,10 @@ color-eyre = { workspace = true }
 coordinate_systems = { workspace = true }
 kinematics = { workspace = true }
 linear_algebra = { workspace = true }
+nalgebra = { workspace = true }
 projection = { workspace = true }
 ros-z = { workspace = true }
 ros2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true }
 types = { workspace = true }

--- a/crates/nodes/camera_matrix_calculator/src/lib.rs
+++ b/crates/nodes/camera_matrix_calculator/src/lib.rs
@@ -1,22 +1,23 @@
-use std::{future::pending, sync::Arc};
+use std::{f32::consts::FRAC_PI_2, sync::Arc};
 
 use color_eyre::Result;
 use serde::{Deserialize, Serialize};
 
-use coordinate_systems::{Camera, Ground, Robot};
-use kinematics::robot_kinematics::RobotKinematics;
-use linear_algebra::{Isometry3, Vector3};
+use coordinate_systems::{Camera, Ground, Head, Robot};
+use kinematics::{robot_dimensions::RobotDimensions, robot_kinematics::RobotKinematics};
+use linear_algebra::{IntoTransform, Isometry3, Vector3, vector};
 use projection::camera_matrix::CameraMatrix;
 use ros_z::{IntoEyreResultExt, prelude::*};
 use ros2::sensor_msgs::camera_info::CameraInfo;
 use types::parameters::CameraMatrixParameters;
 
+pub const ACTUAL_IMAGE_HEIGHT: f32 = 448.0;
+pub const ACTUAL_IMAGE_WIDTH: f32 = 544.0;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
 #[serde(deny_unknown_fields)]
 pub struct Parameters {
     pub camera_matrix_parameters: CameraMatrixParameters,
-    pub correction_in_robot: Vector3<Robot>,
-    pub correction_in_camera: Vector3<Camera>,
 }
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
@@ -26,41 +27,97 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await
         .into_eyre()?;
 
-    let _parameters = node
+    let parameters = node
         .bind_parameter_as::<Parameters>("camera_matrix_calculator")
         .into_eyre()?;
-    let _robot_kinematics_sub = node
+    let robot_kinematics_sub = node
         .subscriber::<RobotKinematics>("robot_kinematics")
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
-    let _robot_to_ground_sub = node
-        .subscriber::<Isometry3<Robot, Ground>>("robot_to_ground")
+    let robot_to_ground_cache = node
+        .create_cache::<Option<Isometry3<Robot, Ground>>>("robot_to_ground", 10)
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
-    let _camera_info_sub = node
-        .subscriber::<CameraInfo>("inputs/camera_info")
+    let camera_info_cache = node
+        .create_cache::<CameraInfo>("inputs/camera_info", 1)
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
-    let _uncalibrated_camera_matrix_pub = node
-        .publisher::<CameraMatrix>("uncalibrated_camera_matrix")
-        .into_eyre()?
-        .build()
-        .await
-        .into_eyre()?;
-    let _camera_matrix_pub = node
+
+    let camera_matrix_pub = node
         .publisher::<CameraMatrix>("camera_matrix")
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
 
-    pending::<()>().await;
+    loop {
+        let parameters = parameters.snapshot().typed().clone();
 
-    Ok(())
+        let robot_kinematics = robot_kinematics_sub
+            .recv_with_metadata()
+            .await
+            .into_eyre()?;
+
+        let time_stamp = robot_kinematics.source_time;
+
+        let maybe_robot_to_ground = robot_to_ground_cache.get_nearest(time_stamp);
+        let maybe_camera_info = camera_info_cache.get_nearest(time_stamp);
+
+        let (Some(maybe_robot_to_ground), Some(camera_info)) =
+            (maybe_robot_to_ground, maybe_camera_info)
+        else {
+            continue;
+        };
+        let Some(robot_to_ground) = *maybe_robot_to_ground else {
+            continue;
+        };
+
+        let camera_matrix = compute_camera_matrix(
+            &parameters.camera_matrix_parameters,
+            &robot_kinematics,
+            &robot_to_ground,
+            &camera_info,
+        );
+
+        camera_matrix_pub
+            .publish(&camera_matrix)
+            .await
+            .into_eyre()?;
+    }
+}
+
+fn compute_camera_matrix(
+    parameters: &CameraMatrixParameters,
+    robot_kinematics: &RobotKinematics,
+    robot_to_ground: &Isometry3<Robot, Ground>,
+    camera_info: &CameraInfo,
+) -> CameraMatrix {
+    // This is a hack, since the camera info currently received by the X5Receiver is wrong.
+    let image_size = vector!(ACTUAL_IMAGE_WIDTH, ACTUAL_IMAGE_HEIGHT);
+    let head_to_camera = head_to_camera(
+        parameters.camera_to_head_pitch.to_radians(),
+        RobotDimensions::HEAD_TO_CAMERA,
+    );
+
+    CameraMatrix::from_camera_info(
+        camera_info,
+        image_size,
+        robot_to_ground.inverse(),
+        robot_kinematics.head.head_to_robot.inverse(),
+        head_to_camera,
+    )
+}
+
+fn head_to_camera(camera_pitch: f32, head_to_camera: Vector3<Head>) -> Isometry3<Head, Camera> {
+    (nalgebra::Isometry3::rotation(nalgebra::Vector3::x() * -camera_pitch)
+        * nalgebra::Isometry3::rotation(nalgebra::Vector3::y() * -FRAC_PI_2)
+        * nalgebra::Isometry3::rotation(nalgebra::Vector3::x() * FRAC_PI_2)
+        * nalgebra::Isometry3::from(-head_to_camera.inner))
+    .framed_transform()
 }

--- a/crates/nodes/camera_matrix_calculator/src/lib.rs
+++ b/crates/nodes/camera_matrix_calculator/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{f32::consts::FRAC_PI_2, sync::Arc};
 
 use color_eyre::Result;
-use serde::{Deserialize, Serialize};
 
 use coordinate_systems::{Camera, Ground, Head, Robot};
 use kinematics::{robot_dimensions::RobotDimensions, robot_kinematics::RobotKinematics};
@@ -14,12 +13,6 @@ use types::parameters::CameraMatrixParameters;
 pub const ACTUAL_IMAGE_HEIGHT: f32 = 448.0;
 pub const ACTUAL_IMAGE_WIDTH: f32 = 544.0;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Message)]
-#[serde(deny_unknown_fields)]
-pub struct Parameters {
-    pub camera_matrix_parameters: CameraMatrixParameters,
-}
-
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx
         .create_node("camera_matrix_calculator")
@@ -28,7 +21,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
 
     let parameters = node
-        .bind_parameter_as::<Parameters>("camera_matrix_calculator")
+        .bind_parameter_as::<CameraMatrixParameters>("camera_matrix_calculator")
         .into_eyre()?;
     let robot_kinematics_sub = node
         .subscriber::<RobotKinematics>("robot_kinematics")
@@ -79,7 +72,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         };
 
         let camera_matrix = compute_camera_matrix(
-            &parameters.camera_matrix_parameters,
+            &parameters,
             &robot_kinematics,
             &robot_to_ground,
             &camera_info,

--- a/crates/nodes/ground_provider/Cargo.toml
+++ b/crates/nodes/ground_provider/Cargo.toml
@@ -12,3 +12,5 @@ coordinate_systems = { workspace = true }
 kinematics = { workspace = true }
 linear_algebra = { workspace = true }
 ros-z = { workspace = true }
+tokio = { workspace = true }
+types = { workspace = true }

--- a/crates/nodes/ground_provider/src/lib.rs
+++ b/crates/nodes/ground_provider/src/lib.rs
@@ -6,7 +6,7 @@ use booster::ImuState;
 use coordinate_systems::{Ground, Robot};
 use kinematics::robot_kinematics::RobotKinematics;
 use linear_algebra::{Isometry3, Orientation3, vector};
-use ros_z::{IntoEyreResultExt, prelude::*};
+use ros_z::{IntoEyreResultExt, prelude::*, qos::QosDurability};
 use types::support_foot::Side;
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
@@ -30,8 +30,12 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await
         .into_eyre()?;
     let support_foot_cache = node
-        .create_cache::<Side>("support_foot", 10)
+        .create_cache::<Option<Side>>("support_foot", 10)
         .into_eyre()?
+        .with_qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await
         .into_eyre()?;
@@ -63,11 +67,15 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             continue;
         };
 
-        let ground_to_robot = compute_ground_to_robot(
-            &imu_state.into_message(),
-            robot_kinematics.as_ref(),
-            support_foot.as_ref(),
-        );
+        let ground_to_robot = if let Some(support_foot) = *support_foot {
+            compute_ground_to_robot(
+                &imu_state.into_message(),
+                robot_kinematics.as_ref(),
+                &support_foot,
+            )
+        } else {
+            None
+        };
         let robot_to_ground = ground_to_robot.map(|ground_to_robot| ground_to_robot.inverse());
 
         ground_to_robot_pub

--- a/crates/nodes/ground_provider/src/lib.rs
+++ b/crates/nodes/ground_provider/src/lib.rs
@@ -22,14 +22,15 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await
         .into_eyre()?;
-    let _robot_kinematics_sub = node
-        .subscriber::<RobotKinematics>("robot_kinematics")
+
+    let robot_kinematics_cache = node
+        .create_cache::<RobotKinematics>("robot_kinematics", 10)
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
-    let _support_foot_sub = node
-        .subscriber::<ImuState>("support_foot")
+    let support_foot_cache = node
+        .create_cache::<Side>("support_foot", 10)
         .into_eyre()?
         .build()
         .await
@@ -49,27 +50,41 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
 
     loop {
-        tokio::select! {
-            imu_state = imu_state_sub.recv_with_metadata() => {
-                let imu_state = imu_state.into_eyre()?;
+        let imu_state = imu_state_sub.recv_with_metadata().await.into_eyre()?;
 
-                let fake_robot_kinematics = RobotKinematics::default();
-                let fake_support_foot = None;
+        let time_stamp = imu_state.source_time;
 
-                let ground_to_robot = compute_ground_to_robot(&imu_state, &fake_robot_kinematics, fake_support_foot);
-                let robot_to_ground = ground_to_robot.map(|ground_to_robot| ground_to_robot.inverse());
+        let maybe_robot_kinematics = robot_kinematics_cache.get_nearest(time_stamp);
+        let maybe_support_foot = support_foot_cache.get_nearest(time_stamp);
 
-                ground_to_robot_pub.publish(&ground_to_robot).await.into_eyre()?;
-                robot_to_ground_pub.publish(&robot_to_ground).await.into_eyre()?;
-            }
-        }
+        let (Some(robot_kinematics), Some(support_foot)) =
+            (maybe_robot_kinematics, maybe_support_foot)
+        else {
+            continue;
+        };
+
+        let ground_to_robot = compute_ground_to_robot(
+            &imu_state.into_message(),
+            robot_kinematics.as_ref(),
+            support_foot.as_ref(),
+        );
+        let robot_to_ground = ground_to_robot.map(|ground_to_robot| ground_to_robot.inverse());
+
+        ground_to_robot_pub
+            .publish(&ground_to_robot)
+            .await
+            .into_eyre()?;
+        robot_to_ground_pub
+            .publish(&robot_to_ground)
+            .await
+            .into_eyre()?;
     }
 }
 
 fn compute_ground_to_robot(
     imu_state: &ImuState,
     robot_kinematics: &RobotKinematics,
-    support_foot: Option<Side>,
+    support_foot: &Side,
 ) -> Option<Isometry3<Ground, Robot>> {
     struct LeftSoleHorizontal;
     struct RightSoleHorizontal;
@@ -116,9 +131,8 @@ fn compute_ground_to_robot(
     );
 
     let ground_to_robot = match support_foot {
-        Some(Side::Left) => left_sole_horizontal_to_robot * ground_to_left_sole,
-        Some(Side::Right) => right_sole_horizontal_to_robot * ground_to_right_sole,
-        None => return None,
+        Side::Left => left_sole_horizontal_to_robot * ground_to_left_sole,
+        Side::Right => right_sole_horizontal_to_robot * ground_to_right_sole,
     };
 
     Some(ground_to_robot)

--- a/crates/nodes/ground_provider/src/lib.rs
+++ b/crates/nodes/ground_provider/src/lib.rs
@@ -1,16 +1,24 @@
-use std::{future::pending, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
 
 use booster::ImuState;
 use coordinate_systems::{Ground, Robot};
 use kinematics::robot_kinematics::RobotKinematics;
-use linear_algebra::Isometry3;
+use linear_algebra::{Isometry3, Orientation3, vector};
 use ros_z::{IntoEyreResultExt, prelude::*};
+use types::support_foot::Side;
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx
         .create_node("ground_provider")
+        .build()
+        .await
+        .into_eyre()?;
+
+    let imu_state_sub = node
+        .subscriber::<ImuState>("inputs/imu_state")
+        .into_eyre()?
         .build()
         .await
         .into_eyre()?;
@@ -20,26 +28,98 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await
         .into_eyre()?;
-    let _imu_state_sub = node
-        .subscriber::<ImuState>("inputs/imu_state")
-        .into_eyre()?
-        .build()
-        .await
-        .into_eyre()?;
-    let _robot_to_ground_pub = node
-        .publisher::<Isometry3<Robot, Ground>>("robot_to_ground")
-        .into_eyre()?
-        .build()
-        .await
-        .into_eyre()?;
-    let _ground_to_robot_pub = node
-        .publisher::<Isometry3<Ground, Robot>>("ground_to_robot")
+    let _support_foot_sub = node
+        .subscriber::<ImuState>("support_foot")
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
 
-    pending::<()>().await;
+    let robot_to_ground_pub = node
+        .publisher::<Option<Isometry3<Robot, Ground>>>("robot_to_ground")
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
+    let ground_to_robot_pub = node
+        .publisher::<Option<Isometry3<Ground, Robot>>>("ground_to_robot")
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
 
-    Ok(())
+    loop {
+        tokio::select! {
+            imu_state = imu_state_sub.recv_with_metadata() => {
+                let imu_state = imu_state.into_eyre()?;
+
+                let fake_robot_kinematics = RobotKinematics::default();
+                let fake_support_foot = None;
+
+                let ground_to_robot = compute_ground_to_robot(&imu_state, &fake_robot_kinematics, fake_support_foot);
+                let robot_to_ground = ground_to_robot.map(|ground_to_robot| ground_to_robot.inverse());
+
+                ground_to_robot_pub.publish(&ground_to_robot).await.into_eyre()?;
+                robot_to_ground_pub.publish(&robot_to_ground).await.into_eyre()?;
+            }
+        }
+    }
+}
+
+fn compute_ground_to_robot(
+    imu_state: &ImuState,
+    robot_kinematics: &RobotKinematics,
+    support_foot: Option<Side>,
+) -> Option<Isometry3<Ground, Robot>> {
+    struct LeftSoleHorizontal;
+    struct RightSoleHorizontal;
+
+    let roll = imu_state.roll_pitch_yaw.x();
+    let pitch = imu_state.roll_pitch_yaw.y();
+
+    let imu_orientation = Orientation3::from_euler_angles(roll, pitch, 0.0).mirror();
+
+    let left_sole_horizontal_to_robot = Isometry3::from_parts(
+        robot_kinematics
+            .left_leg
+            .sole_to_robot
+            .translation()
+            .coords(),
+        imu_orientation,
+    );
+    let right_sole_horizontal_to_robot = Isometry3::from_parts(
+        robot_kinematics
+            .right_leg
+            .sole_to_robot
+            .translation()
+            .coords(),
+        imu_orientation,
+    );
+
+    let left_sole_in_robot = robot_kinematics.left_leg.sole_to_robot.translation();
+    let right_sole_in_robot = robot_kinematics.right_leg.sole_to_robot.translation();
+
+    let left_sole_to_right_sole = right_sole_in_robot - left_sole_in_robot;
+    let ground_to_left_sole = Isometry3::<Ground, LeftSoleHorizontal>::from(
+        vector![
+            left_sole_to_right_sole.x(),
+            left_sole_to_right_sole.y(),
+            0.0
+        ] / 2.0,
+    );
+    let ground_to_right_sole = Isometry3::<Ground, RightSoleHorizontal>::from(
+        -vector![
+            left_sole_to_right_sole.x(),
+            left_sole_to_right_sole.y(),
+            0.0
+        ] / 2.0,
+    );
+
+    let ground_to_robot = match support_foot {
+        Some(Side::Left) => left_sole_horizontal_to_robot * ground_to_left_sole,
+        Some(Side::Right) => right_sole_horizontal_to_robot * ground_to_right_sole,
+        None => return None,
+    };
+
+    Some(ground_to_robot)
 }

--- a/crates/nodes/kinematics_provider/Cargo.toml
+++ b/crates/nodes/kinematics_provider/Cargo.toml
@@ -11,4 +11,3 @@ color-eyre = { workspace = true }
 kinematics = { workspace = true }
 linear_algebra = { workspace = true }
 ros-z = { workspace = true }
-tokio = { workspace = true }

--- a/crates/nodes/kinematics_provider/Cargo.toml
+++ b/crates/nodes/kinematics_provider/Cargo.toml
@@ -9,4 +9,6 @@ homepage.workspace = true
 booster.workspace = true
 color-eyre = { workspace = true }
 kinematics = { workspace = true }
+linear_algebra = { workspace = true }
 ros-z = { workspace = true }
+tokio = { workspace = true }

--- a/crates/nodes/kinematics_provider/src/lib.rs
+++ b/crates/nodes/kinematics_provider/src/lib.rs
@@ -1,9 +1,28 @@
-use std::{future::pending, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
 
-use booster::MotorState;
-use kinematics::{joints::Joints, robot_kinematics::RobotKinematics};
+use booster::{JointsMotorState, MotorState};
+use kinematics::{
+    forward::{
+        head_to_neck, left_ankle_to_left_tibia, left_foot_to_left_ankle,
+        left_forearm_to_left_upper_arm, left_hip_to_left_pelvis, left_inner_shoulder_to_robot,
+        left_outer_shoulder_to_left_inner_shoulder, left_pelvis_to_robot, left_thigh_to_left_hip,
+        left_tibia_to_left_thigh, left_upper_arm_to_left_outer_shoulder, neck_to_robot,
+        right_ankle_to_right_tibia, right_foot_to_right_ankle, right_forearm_to_right_upper_arm,
+        right_hip_to_right_pelvis, right_inner_shoulder_to_robot,
+        right_outer_shoulder_to_right_inner_shoulder, right_pelvis_to_robot,
+        right_thigh_to_right_hip, right_tibia_to_right_thigh,
+        right_upper_arm_to_right_outer_shoulder,
+    },
+    joints::Joints,
+    robot_dimensions::RobotDimensions,
+    robot_kinematics::{
+        RobotHeadKinematics, RobotKinematics, RobotLeftArmKinematics, RobotLeftLegKinematics,
+        RobotRightArmKinematics, RobotRightLegKinematics, RobotTorsoKinematics,
+    },
+};
+use linear_algebra::Isometry3;
 use ros_z::{IntoEyreResultExt, prelude::*};
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
@@ -12,20 +31,133 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await
         .into_eyre()?;
-    let _serial_motor_states_sub = node
+    let serial_motor_states_sub = node
         .subscriber::<Joints<MotorState>>("inputs/serial_motor_states")
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
-    let _robot_kinematics_pub = node
+    let robot_kinematics_pub = node
         .publisher::<RobotKinematics>("robot_kinematics")
         .into_eyre()?
         .build()
         .await
         .into_eyre()?;
 
-    pending::<()>().await;
+    loop {
+        tokio::select! {
+            serial_motor_states = serial_motor_states_sub.recv_with_metadata() => {
+                let serial_motor_states = serial_motor_states.into_eyre()?;
 
-    Ok(())
+                let measured_positions = serial_motor_states.positions();
+                let robot_kinematics = compute_robot_kinematics(&measured_positions);
+
+                robot_kinematics_pub.publish(&robot_kinematics).await.into_eyre()?;
+            }
+        }
+    }
+}
+
+fn compute_robot_kinematics(motor_positions: &Joints) -> RobotKinematics {
+    // head
+    let neck_to_robot = neck_to_robot(&motor_positions.head);
+    let head_to_robot = neck_to_robot * head_to_neck(&motor_positions.head);
+    // torso
+    let torso_to_robot = Isometry3::from(RobotDimensions::ROBOT_TO_TORSO);
+    // left arm
+    let left_inner_shoulder_to_robot = left_inner_shoulder_to_robot(&motor_positions.left_arm);
+    let left_outer_shoulder_to_robot = left_inner_shoulder_to_robot
+        * left_outer_shoulder_to_left_inner_shoulder(&motor_positions.left_arm);
+    let left_upper_arm_to_robot = left_outer_shoulder_to_robot
+        * left_upper_arm_to_left_outer_shoulder(&motor_positions.left_arm);
+    let left_forearm_to_robot =
+        left_upper_arm_to_robot * left_forearm_to_left_upper_arm(&motor_positions.left_arm);
+
+    // right arm
+    let right_inner_shoulder_to_robot = right_inner_shoulder_to_robot(&motor_positions.right_arm);
+    let right_outer_shoulder_to_robot = right_inner_shoulder_to_robot
+        * right_outer_shoulder_to_right_inner_shoulder(&motor_positions.right_arm);
+    let right_upper_arm_to_robot = right_outer_shoulder_to_robot
+        * right_upper_arm_to_right_outer_shoulder(&motor_positions.right_arm);
+
+    let right_forearm_to_robot =
+        right_upper_arm_to_robot * right_forearm_to_right_upper_arm(&motor_positions.right_arm);
+
+    // left leg
+    let left_pelvis_to_robot = left_pelvis_to_robot(&motor_positions.left_leg);
+    let left_hip_to_robot =
+        left_pelvis_to_robot * left_hip_to_left_pelvis(&motor_positions.left_leg);
+    let left_thigh_to_robot = left_hip_to_robot * left_thigh_to_left_hip(&motor_positions.left_leg);
+    let left_tibia_to_robot =
+        left_thigh_to_robot * left_tibia_to_left_thigh(&motor_positions.left_leg);
+    let left_ankle_to_robot =
+        left_tibia_to_robot * left_ankle_to_left_tibia(&motor_positions.left_leg);
+    let left_foot_to_robot =
+        left_ankle_to_robot * left_foot_to_left_ankle(&motor_positions.left_leg);
+    let left_sole_to_robot =
+        left_foot_to_robot * Isometry3::from(RobotDimensions::LEFT_FOOT_TO_LEFT_SOLE);
+    // right leg
+    let right_pelvis_to_robot = right_pelvis_to_robot(&motor_positions.right_leg);
+    let right_hip_to_robot =
+        right_pelvis_to_robot * right_hip_to_right_pelvis(&motor_positions.right_leg);
+    let right_thigh_to_robot =
+        right_hip_to_robot * right_thigh_to_right_hip(&motor_positions.right_leg);
+    let right_tibia_to_robot =
+        right_thigh_to_robot * right_tibia_to_right_thigh(&motor_positions.right_leg);
+    let right_ankle_to_robot =
+        right_tibia_to_robot * right_ankle_to_right_tibia(&motor_positions.right_leg);
+    let right_foot_to_robot =
+        right_ankle_to_robot * right_foot_to_right_ankle(&motor_positions.right_leg);
+    let right_sole_to_robot =
+        right_foot_to_robot * Isometry3::from(RobotDimensions::RIGHT_FOOT_TO_RIGHT_SOLE);
+
+    let head = RobotHeadKinematics {
+        neck_to_robot,
+        head_to_robot,
+    };
+
+    let torso = RobotTorsoKinematics { torso_to_robot };
+
+    let left_arm = RobotLeftArmKinematics {
+        inner_shoulder_to_robot: left_inner_shoulder_to_robot,
+        outer_shoulder_to_robot: left_outer_shoulder_to_robot,
+        upper_arm_to_robot: left_upper_arm_to_robot,
+        forearm_to_robot: left_forearm_to_robot,
+    };
+
+    let right_arm = RobotRightArmKinematics {
+        inner_shoulder_to_robot: right_inner_shoulder_to_robot,
+        outer_shoulder_to_robot: right_outer_shoulder_to_robot,
+        upper_arm_to_robot: right_upper_arm_to_robot,
+        forearm_to_robot: right_forearm_to_robot,
+    };
+
+    let left_leg = RobotLeftLegKinematics {
+        pelvis_to_robot: left_pelvis_to_robot,
+        hip_to_robot: left_hip_to_robot,
+        thigh_to_robot: left_thigh_to_robot,
+        tibia_to_robot: left_tibia_to_robot,
+        ankle_to_robot: left_ankle_to_robot,
+        foot_to_robot: left_foot_to_robot,
+        sole_to_robot: left_sole_to_robot,
+    };
+
+    let right_leg = RobotRightLegKinematics {
+        pelvis_to_robot: right_pelvis_to_robot,
+        hip_to_robot: right_hip_to_robot,
+        thigh_to_robot: right_thigh_to_robot,
+        tibia_to_robot: right_tibia_to_robot,
+        ankle_to_robot: right_ankle_to_robot,
+        foot_to_robot: right_foot_to_robot,
+        sole_to_robot: right_sole_to_robot,
+    };
+
+    RobotKinematics {
+        head,
+        torso,
+        left_arm,
+        right_arm,
+        left_leg,
+        right_leg,
+    }
 }

--- a/crates/nodes/kinematics_provider/src/lib.rs
+++ b/crates/nodes/kinematics_provider/src/lib.rs
@@ -45,16 +45,18 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .into_eyre()?;
 
     loop {
-        tokio::select! {
-            serial_motor_states = serial_motor_states_sub.recv_with_metadata() => {
-                let serial_motor_states = serial_motor_states.into_eyre()?;
+        let serial_motor_states = serial_motor_states_sub
+            .recv_with_metadata()
+            .await
+            .into_eyre()?;
 
-                let measured_positions = serial_motor_states.positions();
-                let robot_kinematics = compute_robot_kinematics(&measured_positions);
+        let measured_positions = serial_motor_states.positions();
+        let robot_kinematics = compute_robot_kinematics(&measured_positions);
 
-                robot_kinematics_pub.publish(&robot_kinematics).await.into_eyre()?;
-            }
-        }
+        robot_kinematics_pub
+            .publish(&robot_kinematics)
+            .await
+            .into_eyre()?;
     }
 }
 

--- a/crates/nodes/support_foot_estimator/Cargo.toml
+++ b/crates/nodes/support_foot_estimator/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "support_foot_estimator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+booster.workspace = true
+color-eyre = { workspace = true }
+coordinate_systems = { workspace = true }
+filtering = { workspace = true }
+kinematics = { workspace = true }
+linear_algebra = { workspace = true }
+ros-z = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+types = { workspace = true }

--- a/crates/nodes/support_foot_estimator/src/lib.rs
+++ b/crates/nodes/support_foot_estimator/src/lib.rs
@@ -22,7 +22,7 @@ pub struct Parameters {
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx
-        .create_node("camera_matrix_calculator")
+        .create_node("support_foot_estimator")
         .build()
         .await
         .into_eyre()?;

--- a/crates/nodes/support_foot_estimator/src/lib.rs
+++ b/crates/nodes/support_foot_estimator/src/lib.rs
@@ -1,0 +1,154 @@
+use std::sync::Arc;
+
+use booster::{FallDownState, FallDownStateType, ImuState};
+use color_eyre::Result;
+use coordinate_systems::Robot;
+use linear_algebra::{Isometry3, Orientation3};
+use serde::{Deserialize, Serialize};
+
+use filtering::hysteresis::less_than_with_hysteresis;
+use kinematics::robot_kinematics::RobotKinematics;
+use ros_z::{IntoEyreResultExt, prelude::*, qos::QosDurability};
+use types::support_foot::Side;
+
+pub const ACTUAL_IMAGE_HEIGHT: f32 = 448.0;
+pub const ACTUAL_IMAGE_WIDTH: f32 = 544.0;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[serde(deny_unknown_fields)]
+pub struct Parameters {
+    pub switch_hysteresis: f32,
+}
+
+pub async fn run(ctx: Arc<Context>) -> Result<()> {
+    let node = ctx
+        .create_node("camera_matrix_calculator")
+        .build()
+        .await
+        .into_eyre()?;
+
+    let parameters = node
+        .bind_parameter_as::<Parameters>("support_foot_estimator")
+        .into_eyre()?;
+    let imu_state_sub = node
+        .subscriber::<ImuState>("inputs/imu_state")
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
+    let robot_kinematics_cache = node
+        .create_cache::<RobotKinematics>("robot_kinematics", 10)
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
+    let fall_down_state_cache = node
+        .create_cache::<FallDownState>("inputs/fall_down_state", 10)
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
+
+    let support_foot_pub = node
+        .publisher::<Option<Side>>("support_foot")
+        .into_eyre()?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
+        .build()
+        .await
+        .into_eyre()?;
+
+    let mut last_support_side = Side::default();
+    let mut last_maybe_support_side = None;
+
+    loop {
+        let parameters = parameters.snapshot().typed().clone();
+
+        let imu_state = imu_state_sub.recv_with_metadata().await.into_eyre()?;
+
+        let time_stamp = imu_state.source_time;
+
+        let maybe_robot_kinematics = robot_kinematics_cache.get_nearest(time_stamp);
+        let maybe_fall_down_state = fall_down_state_cache.get_nearest(time_stamp);
+
+        let (Some(robot_kinematics), Some(fall_down_state)) =
+            (maybe_robot_kinematics, maybe_fall_down_state)
+        else {
+            continue;
+        };
+
+        let current_support_side = estimate_support_side(
+            &parameters,
+            &imu_state,
+            &robot_kinematics,
+            last_support_side,
+        );
+
+        let support_side = if matches!(fall_down_state.fall_down_state, FallDownStateType::IsReady)
+        {
+            last_support_side = current_support_side;
+            Some(current_support_side)
+        } else {
+            None
+        };
+
+        if support_side != last_maybe_support_side {
+            support_foot_pub.publish(&support_side).await.into_eyre()?;
+        }
+
+        last_maybe_support_side = support_side;
+    }
+}
+
+fn estimate_support_side(
+    parameters: &Parameters,
+    imu_state: &ImuState,
+    robot_kinematics: &RobotKinematics,
+    last_support_side: Side,
+) -> Side {
+    struct Horizontal;
+
+    let imu_orientation = Orientation3::from_euler_angles(
+        imu_state.roll_pitch_yaw.x(),
+        imu_state.roll_pitch_yaw.y(),
+        imu_state.roll_pitch_yaw.z(),
+    )
+    .mirror();
+    let horizontal_to_robot = Isometry3::<Horizontal, Robot>::from(imu_orientation);
+    let robot_to_horizontal = horizontal_to_robot.inverse();
+
+    let left_sole_in_horizontal =
+        robot_to_horizontal * robot_kinematics.left_leg.sole_to_robot.translation();
+    let right_sole_in_horizontal =
+        robot_to_horizontal * robot_kinematics.right_leg.sole_to_robot.translation();
+    let height_difference = left_sole_in_horizontal.z() - right_sole_in_horizontal.z();
+
+    select_support_side(
+        height_difference,
+        last_support_side,
+        parameters.switch_hysteresis,
+    )
+}
+
+fn select_support_side(
+    height_difference: f32,
+    last_support_side: Side,
+    switch_hysteresis: f32,
+) -> Side {
+    let left_was_lower_last_time = last_support_side == Side::Left;
+
+    let left_sole_is_lower_than_right_sole = less_than_with_hysteresis(
+        left_was_lower_last_time,
+        height_difference,
+        0.0,
+        switch_hysteresis,
+    );
+
+    if left_sole_is_lower_than_right_sole {
+        Side::Left
+    } else {
+        Side::Right
+    }
+}

--- a/etc/parameters/ros_z/base/camera_matrix_calculator.json5
+++ b/etc/parameters/ros_z/base/camera_matrix_calculator.json5
@@ -4,6 +4,4 @@
     correction_in_robot: [0.0, 0.0, 0.0],
     correction_in_camera: [0.0, 0.0, 0.0],
   },
-  correction_in_robot: [0.0, 0.0, 0.0],
-  correction_in_camera: [0.0, 0.0, 0.0],
 }

--- a/etc/parameters/ros_z/base/camera_matrix_calculator.json5
+++ b/etc/parameters/ros_z/base/camera_matrix_calculator.json5
@@ -1,7 +1,5 @@
 {
-  camera_matrix_parameters: {
-    camera_to_head_pitch: -0.2125811028,
-    correction_in_robot: [0.0, 0.0, 0.0],
-    correction_in_camera: [0.0, 0.0, 0.0],
-  },
+  camera_to_head_pitch: -0.2125811028,
+  correction_in_robot: [0.0, 0.0, 0.0],
+  correction_in_camera: [0.0, 0.0, 0.0],
 }

--- a/etc/parameters/ros_z/base/support_foot_estimator.json5
+++ b/etc/parameters/ros_z/base/support_foot_estimator.json5
@@ -1,0 +1,3 @@
+{
+  switch_hysteresis: 0.008
+}


### PR DESCRIPTION
## Why? What?

Ports the nodes `kinematics_provider`,  `support_foot_estimator`, `ground_provider` and `camera_matrix_calculator`. 

- Depends on #2421 
- Part of #2426 

## ToDo / Known Issues

- [x] Use caches to match inputs
- [x] Support foot estimator
- [x] Camera matrix calculator

## How to Test

- Upload
- Use the twix ros z twix to view the output in the text panel or in rosz cli
