### PR TITLE
Port network and game controller filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6569,6 +6569,7 @@ dependencies = [
  "hsl_network_messages",
  "ros-z",
  "serde",
+ "tokio",
  "types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,7 +4318,9 @@ name = "game_controller_filter"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "hsl_network_messages",
  "ros-z",
+ "ros-z-streams",
  "serde",
  "types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,7 +4334,9 @@ dependencies = [
  "hsl_network_messages",
  "linear_algebra",
  "ros-z",
+ "ros-z-streams",
  "serde",
+ "tokio",
  "types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
  "color-eyre",
  "hsl_network_messages",
  "ros-z",
+ "ros-z-streams",
  "serde",
  "tokio",
  "types",

--- a/crates/nodes/ball_state_composer/src/lib.rs
+++ b/crates/nodes/ball_state_composer/src/lib.rs
@@ -41,7 +41,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _additional_last_ball_state_pub = node

--- a/crates/nodes/game_controller_filter/Cargo.toml
+++ b/crates/nodes/game_controller_filter/Cargo.toml
@@ -7,6 +7,8 @@ homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }
+hsl_network_messages = { workspace = true }
 ros-z = { workspace = true }
+ros-z-streams = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 types = { workspace = true }

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -1,14 +1,11 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use color_eyre::Result;
-use ros_z_streams::CreateFutureMapBuilder;
+use ros_z_streams::{CreateAnnouncingPublisher, CreateFutureMapBuilder};
 use serde::{Deserialize, Serialize};
 
 use hsl_network_messages::GameControllerStateMessage;
-use ros_z::{
-    prelude::*,
-    time::{Clock, Time},
-};
+use ros_z::{prelude::*, time::Time};
 use types::{
     field_dimensions::GlobalFieldSide,
     game_controller_state::GameControllerState,
@@ -39,8 +36,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let game_controller_state_pub = node
-        .publisher::<Option<GameControllerState>>("game_controller_state")?
-        .build()
+        .announcing_publisher::<Option<GameControllerState>>("game_controller_state")
         .await?;
     let game_controller_address_pub = node
         .publisher::<Option<SocketAddr>>("game_controller_address")?
@@ -55,7 +51,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
         let network_message = network_message_sub.recv().await?;
 
-        for (_, source_address, message) in
+        for (time, source_address, message) in
             network_message
                 .persistent
                 .iter()
@@ -67,9 +63,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     _ => None,
                 })
         {
-            game_controller_filter.update_game_controller_state(ctx.clock(), message);
+            let pending_annoucement = game_controller_state_pub.announce(*time).await?;
+            game_controller_filter.update_game_controller_state(time, message);
             game_controller_filter.alert_if_multiple_game_controllers(
-                ctx.clock(),
+                time,
                 parameters,
                 *source_address,
             );
@@ -84,7 +81,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 .max_by_key(|(_address, time)| *time)
                 .map(|(address, _time)| *address);
 
-            game_controller_state_pub
+            pending_annoucement
                 .publish(&game_controller_filter.game_controller_state)
                 .await?;
             game_controller_address_pub.publish(&last_address).await?;
@@ -101,17 +98,13 @@ pub struct GameControllerFilter {
 }
 
 impl GameControllerFilter {
-    fn update_game_controller_state(
-        &mut self,
-        clock: &Clock,
-        message: &GameControllerStateMessage,
-    ) {
+    fn update_game_controller_state(&mut self, time: &Time, message: &GameControllerStateMessage) {
         let game_state_changed = match &self.game_controller_state {
             Some(game_controller_state) => game_controller_state.game_state != message.game_state,
             None => true,
         };
         if game_state_changed {
-            self.last_game_state_change = Some(clock.now());
+            self.last_game_state_change = Some(*time);
         }
         self.game_controller_state = Some(GameControllerState {
             game_state: message.game_state,
@@ -135,14 +128,14 @@ impl GameControllerFilter {
 
     fn alert_if_multiple_game_controllers(
         &mut self,
-        clock: &Clock,
+        time: &Time,
         parameters: &Parameters,
         source_address: SocketAddr,
     ) {
-        self.last_contact.insert(source_address, clock.now());
+        self.last_contact.insert(source_address, *time);
 
         let recent_contacts = self.last_contact.iter().filter(|(_address, last_contact)| {
-            clock.now().duration_since(**last_contact)
+            time.duration_since(**last_contact)
                 < parameters.time_since_last_message_to_consider_ip_active
         });
         let collision_detected = recent_contacts.count() > 1;
@@ -150,7 +143,7 @@ impl GameControllerFilter {
         let alert_is_on_cooldown =
             self.last_collision_warning
                 .is_some_and(|last_collision_warning| {
-                    clock.now().duration_since(last_collision_warning)
+                    time.duration_since(last_collision_warning)
                         < parameters.collision_alert_cooldown
                 });
 
@@ -160,7 +153,7 @@ impl GameControllerFilter {
             //     .write_to_speakers(SpeakerRequest::PlaySound {
             //         sound: Sound::GameControllerCollision,
             //     });
-            self.last_collision_warning = Some(clock.now());
+            self.last_collision_warning = Some(*time);
         }
     }
 }

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -1,16 +1,20 @@
 use std::{
     collections::HashMap,
-    future::pending,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, SystemTime},
 };
 
 use color_eyre::Result;
+use ros_z_streams::CreateFutureMapBuilder;
 use serde::{Deserialize, Serialize};
 
-use ros_z::prelude::*;
-use types::{game_controller_state::GameControllerState, messages::IncomingMessage};
+use hsl_network_messages::GameControllerStateMessage;
+use ros_z::{prelude::*, time::Clock};
+use types::{
+    field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState,
+    messages::IncomingMessage,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
 #[serde(deny_unknown_fields)]
@@ -22,25 +26,140 @@ pub struct Parameters {
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("game_controller_filter").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("game_controller_filter")?;
-    let _network_message_sub = node
-        .subscriber::<IncomingMessage>("filtered_message")?
-        .build()
-        .await?;
-    let _last_contact_pub = node
+    let parameters = node.bind_parameter_as::<Parameters>("game_controller_filter")?;
+    let mut network_message_sub = node
+        .create_future_map_builder()
+        .create_future_subscriber::<IncomingMessage>("filtered_message", Duration::from_millis(1))
+        .await?
+        .build();
+    let last_contact_pub = node
         .publisher::<HashMap<SocketAddr, SystemTime>>("game_controller_address_contacts_times")?
         .build()
         .await?;
-    let _game_controller_state_pub = node
-        .publisher::<GameControllerState>("game_controller_state")?
+    let game_controller_state_pub = node
+        .publisher::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
-    let _game_controller_address_pub = node
-        .publisher::<SocketAddr>("game_controller_address")?
+    let game_controller_address_pub = node
+        .publisher::<Option<SocketAddr>>("game_controller_address")?
         .build()
         .await?;
 
-    pending::<()>().await;
+    let mut game_controller_filter = GameControllerFilter::default();
 
-    Ok(())
+    loop {
+        let parameters_snapshot = parameters.snapshot();
+        let parameters = parameters_snapshot.typed();
+
+        let network_message = network_message_sub.recv().await?;
+
+        for (_, source_address, message) in
+            network_message
+                .persistent
+                .iter()
+                .filter_map(|(time, message)| match message {
+                    (Some(IncomingMessage::GameController(source_address, message)),) => {
+                        Some((time, source_address, message))
+                    }
+                    _ => None,
+                })
+        {
+            game_controller_filter.update_game_controller_state(ctx.clock(), message);
+            game_controller_filter.alert_if_multiple_game_controllers(
+                ctx.clock(),
+                parameters,
+                *source_address,
+            );
+
+            last_contact_pub
+                .publish(&game_controller_filter.last_contact)
+                .await?;
+
+            let last_address = game_controller_filter
+                .last_contact
+                .iter()
+                .max_by_key(|(_address, time)| *time)
+                .map(|(address, _time)| *address);
+
+            game_controller_state_pub
+                .publish(&game_controller_filter.game_controller_state)
+                .await?;
+            game_controller_address_pub.publish(&last_address).await?;
+        }
+    }
+}
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct GameControllerFilter {
+    game_controller_state: Option<GameControllerState>,
+    last_game_state_change: Option<SystemTime>,
+
+    last_contact: HashMap<SocketAddr, SystemTime>,
+    last_collision_warning: Option<SystemTime>,
+}
+
+impl GameControllerFilter {
+    fn update_game_controller_state(
+        &mut self,
+        clock: &Clock,
+        message: &GameControllerStateMessage,
+    ) {
+        let game_state_changed = match &self.game_controller_state {
+            Some(game_controller_state) => game_controller_state.game_state != message.game_state,
+            None => true,
+        };
+        if game_state_changed {
+            self.last_game_state_change = Some(clock.now().to_wallclock());
+        }
+        self.game_controller_state = Some(GameControllerState {
+            game_state: message.game_state,
+            stopped: message.stopped,
+            game_phase: message.game_phase,
+            remaining_time_in_half: message.remaining_time_in_half,
+            kicking_team: message.kicking_team,
+            last_game_state_change: self.last_game_state_change.unwrap(),
+            penalties: message.hulks_team.clone().into(),
+            opponent_penalties: message.opponent_team.clone().into(),
+            sub_state: message.sub_state,
+            global_field_side: if message.hulks_team_is_home_after_coin_toss {
+                GlobalFieldSide::Home
+            } else {
+                GlobalFieldSide::Away
+            },
+            hulks_team: message.hulks_team.clone(),
+            opponent_team: message.opponent_team.clone(),
+        });
+    }
+
+    fn alert_if_multiple_game_controllers(
+        &mut self,
+        clock: &Clock,
+        parameters: &Parameters,
+        source_address: SocketAddr,
+    ) {
+        self.last_contact
+            .insert(source_address, clock.now().to_wallclock());
+
+        let recent_contacts = self.last_contact.iter().filter(|(_address, last_contact)| {
+            clock.now().duration_since((**last_contact).into())
+                < parameters.time_since_last_message_to_consider_ip_active
+        });
+        let collision_detected = recent_contacts.count() > 1;
+
+        let alert_is_on_cooldown =
+            self.last_collision_warning
+                .is_some_and(|last_collision_warning| {
+                    clock.now().duration_since(last_collision_warning.into())
+                        < parameters.collision_alert_cooldown
+                });
+
+        if collision_detected && !alert_is_on_cooldown {
+            // TODO: We currently do not have audio output implemented
+            //     hardware_interface
+            //     .write_to_speakers(SpeakerRequest::PlaySound {
+            //         sound: Sound::GameControllerCollision,
+            //     });
+            self.last_collision_warning = Some(clock.now().to_wallclock());
+        }
+    }
 }

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -5,12 +5,14 @@ use ros_z_streams::CreateFutureMapBuilder;
 use serde::{Deserialize, Serialize};
 
 use hsl_network_messages::GameControllerStateMessage;
-use ros_z::{prelude::*,
+use ros_z::{
+    prelude::*,
     time::{Clock, Time},
 };
 use types::{
-    field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState,
-    messages::IncomingMessage,
+    field_dimensions::GlobalFieldSide,
+    game_controller_state::GameControllerState,
+    messages::{IncomingMessage, StampedIncomingMessage},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
@@ -26,7 +28,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let parameters = node.bind_parameter_as::<Parameters>("game_controller_filter")?;
     let mut network_message_sub = node
         .create_future_map_builder()
-        .create_future_subscriber::<IncomingMessage>("filtered_message", Duration::from_millis(1))
+        .create_future_subscriber::<StampedIncomingMessage>(
+            "filtered_message",
+            Duration::from_millis(1),
+        )
         .await?
         .build();
     let last_contact_pub = node
@@ -55,9 +60,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 .persistent
                 .iter()
                 .filter_map(|(time, message)| match message {
-                    (Some(IncomingMessage::GameController(source_address, message)),) => {
-                        Some((time, source_address, message))
-                    }
+                    (Some(StampedIncomingMessage {
+                        incoming_message: IncomingMessage::GameController(source_address, message),
+                        ..
+                    }),) => Some((time, source_address, message)),
                     _ => None,
                 })
         {

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -1,14 +1,13 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use color_eyre::Result;
-use ros_z_streams::{CreateAnnouncingPublisher, CreateFutureMapBuilder};
 use serde::{Deserialize, Serialize};
 
 use hsl_network_messages::GameControllerStateMessage;
 use ros_z::{prelude::*, time::Time};
 use types::{
     field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState,
-    messages::IncomingMessage,
+    messages::IncomingMessage, time_wrapper::TimeWrapper,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
@@ -22,17 +21,17 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("game_controller_filter").build().await?;
 
     let parameters = node.bind_parameter_as::<Parameters>("game_controller_filter")?;
-    let mut network_message_sub = node
-        .create_future_map_builder()
-        .create_future_subscriber::<IncomingMessage>("filtered_message", Duration::from_millis(1))
-        .await?
-        .build();
+    let network_message_sub = node
+        .subscriber::<TimeWrapper<IncomingMessage>>("filtered_message")?
+        .build()
+        .await?;
     let last_contact_pub = node
         .publisher::<HashMap<SocketAddr, Time>>("game_controller_address_contacts_times")?
         .build()
         .await?;
     let game_controller_state_pub = node
-        .announcing_publisher::<Option<GameControllerState>>("game_controller_state")
+        .publisher::<TimeWrapper<Option<GameControllerState>>>("game_controller_state")?
+        .build()
         .await?;
     let game_controller_address_pub = node
         .publisher::<Option<SocketAddr>>("game_controller_address")?
@@ -47,40 +46,38 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
         let network_message = network_message_sub.recv().await?;
 
-        for (time, source_address, message) in
-            network_message
-                .persistent
-                .iter()
-                .filter_map(|(time, message)| match message {
-                    (Some(IncomingMessage::GameController(source_address, message)),) => {
-                        Some((time, source_address, message))
-                    }
-                    _ => None,
-                })
-        {
-            let pending_annoucement = game_controller_state_pub.announce(*time).await?;
-            game_controller_filter.update_game_controller_state(time, message);
-            game_controller_filter.alert_if_multiple_game_controllers(
-                time,
-                parameters,
-                *source_address,
-            );
+        let TimeWrapper {
+            time,
+            inner: IncomingMessage::GameController(source_address, message),
+        } = network_message
+        else {
+            continue;
+        };
 
-            last_contact_pub
-                .publish(&game_controller_filter.last_contact)
-                .await?;
+        game_controller_filter.update_game_controller_state(&time, &message);
+        game_controller_filter.alert_if_multiple_game_controllers(
+            &time,
+            parameters,
+            source_address,
+        );
 
-            let last_address = game_controller_filter
-                .last_contact
-                .iter()
-                .max_by_key(|(_address, time)| *time)
-                .map(|(address, _time)| *address);
+        last_contact_pub
+            .publish(&game_controller_filter.last_contact)
+            .await?;
 
-            pending_annoucement
-                .publish(&game_controller_filter.game_controller_state)
-                .await?;
-            game_controller_address_pub.publish(&last_address).await?;
-        }
+        let last_address = game_controller_filter
+            .last_contact
+            .iter()
+            .max_by_key(|(_address, time)| *time)
+            .map(|(address, _time)| *address);
+
+        let time_wrapper = TimeWrapper {
+            time,
+            inner: game_controller_filter.game_controller_state.clone(),
+        };
+
+        game_controller_state_pub.publish(&time_wrapper).await?;
+        game_controller_address_pub.publish(&last_address).await?;
     }
 }
 

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -1,16 +1,13 @@
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use color_eyre::Result;
 use ros_z_streams::CreateFutureMapBuilder;
 use serde::{Deserialize, Serialize};
 
 use hsl_network_messages::GameControllerStateMessage;
-use ros_z::{prelude::*, time::Clock};
+use ros_z::{prelude::*,
+    time::{Clock, Time},
+};
 use types::{
     field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState,
     messages::IncomingMessage,
@@ -33,7 +30,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?
         .build();
     let last_contact_pub = node
-        .publisher::<HashMap<SocketAddr, SystemTime>>("game_controller_address_contacts_times")?
+        .publisher::<HashMap<SocketAddr, Time>>("game_controller_address_contacts_times")?
         .build()
         .await?;
     let game_controller_state_pub = node
@@ -92,10 +89,9 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 #[derive(Default, Deserialize, Serialize)]
 pub struct GameControllerFilter {
     game_controller_state: Option<GameControllerState>,
-    last_game_state_change: Option<SystemTime>,
-
-    last_contact: HashMap<SocketAddr, SystemTime>,
-    last_collision_warning: Option<SystemTime>,
+    last_game_state_change: Option<Time>,
+    last_contact: HashMap<SocketAddr, Time>,
+    last_collision_warning: Option<Time>,
 }
 
 impl GameControllerFilter {
@@ -109,7 +105,7 @@ impl GameControllerFilter {
             None => true,
         };
         if game_state_changed {
-            self.last_game_state_change = Some(clock.now().to_wallclock());
+            self.last_game_state_change = Some(clock.now());
         }
         self.game_controller_state = Some(GameControllerState {
             game_state: message.game_state,
@@ -117,7 +113,7 @@ impl GameControllerFilter {
             game_phase: message.game_phase,
             remaining_time_in_half: message.remaining_time_in_half,
             kicking_team: message.kicking_team,
-            last_game_state_change: self.last_game_state_change.unwrap(),
+            last_game_state_change: self.last_game_state_change.unwrap().to_wallclock(),
             penalties: message.hulks_team.clone().into(),
             opponent_penalties: message.opponent_team.clone().into(),
             sub_state: message.sub_state,
@@ -137,8 +133,7 @@ impl GameControllerFilter {
         parameters: &Parameters,
         source_address: SocketAddr,
     ) {
-        self.last_contact
-            .insert(source_address, clock.now().to_wallclock());
+        self.last_contact.insert(source_address, clock.now());
 
         let recent_contacts = self.last_contact.iter().filter(|(_address, last_contact)| {
             clock.now().duration_since((**last_contact).into())
@@ -159,7 +154,7 @@ impl GameControllerFilter {
             //     .write_to_speakers(SpeakerRequest::PlaySound {
             //         sound: Sound::GameControllerCollision,
             //     });
-            self.last_collision_warning = Some(clock.now().to_wallclock());
+            self.last_collision_warning = Some(clock.now());
         }
     }
 }

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -136,7 +136,7 @@ impl GameControllerFilter {
         self.last_contact.insert(source_address, clock.now());
 
         let recent_contacts = self.last_contact.iter().filter(|(_address, last_contact)| {
-            clock.now().duration_since((**last_contact).into())
+            clock.now().duration_since(**last_contact)
                 < parameters.time_since_last_message_to_consider_ip_active
         });
         let collision_detected = recent_contacts.count() > 1;
@@ -144,7 +144,7 @@ impl GameControllerFilter {
         let alert_is_on_cooldown =
             self.last_collision_warning
                 .is_some_and(|last_collision_warning| {
-                    clock.now().duration_since(last_collision_warning.into())
+                    clock.now().duration_since(last_collision_warning)
                         < parameters.collision_alert_cooldown
                 });
 

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -7,9 +7,8 @@ use serde::{Deserialize, Serialize};
 use hsl_network_messages::GameControllerStateMessage;
 use ros_z::{prelude::*, time::Time};
 use types::{
-    field_dimensions::GlobalFieldSide,
-    game_controller_state::GameControllerState,
-    messages::{IncomingMessage, StampedIncomingMessage},
+    field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState,
+    messages::IncomingMessage,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
@@ -25,10 +24,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let parameters = node.bind_parameter_as::<Parameters>("game_controller_filter")?;
     let mut network_message_sub = node
         .create_future_map_builder()
-        .create_future_subscriber::<StampedIncomingMessage>(
-            "filtered_message",
-            Duration::from_millis(1),
-        )
+        .create_future_subscriber::<IncomingMessage>("filtered_message", Duration::from_millis(1))
         .await?
         .build();
     let last_contact_pub = node
@@ -56,10 +52,9 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 .persistent
                 .iter()
                 .filter_map(|(time, message)| match message {
-                    (Some(StampedIncomingMessage {
-                        incoming_message: IncomingMessage::GameController(source_address, message),
-                        ..
-                    }),) => Some((time, source_address, message)),
+                    (Some(IncomingMessage::GameController(source_address, message)),) => {
+                        Some((time, source_address, message))
+                    }
                     _ => None,
                 })
         {

--- a/crates/nodes/game_controller_state_filter/Cargo.toml
+++ b/crates/nodes/game_controller_state_filter/Cargo.toml
@@ -11,5 +11,7 @@ coordinate_systems = { workspace = true }
 hsl_network_messages = { workspace = true }
 linear_algebra = { workspace = true }
 ros-z = { workspace = true }
+ros-z-streams = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true }
 types = { workspace = true }

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -26,17 +26,17 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let parameters =
         node.bind_parameter_as::<GameStateFilterParameters>("game_controller_state_filter")?;
-    let field_dimensions_sub = node
-        .subscriber::<FieldDimensions>("field_dimensions")?
-        .qos(QosProfile {
+    let field_dimensions_cache = node
+        .create_cache::<FieldDimensions>("field_dimensions", 1)?
+        .with_qos(QosProfile {
             durability: QosDurability::TransientLocal,
             ..Default::default()
         })
         .build()
         .await?;
-    let player_number_sub = node
-        .subscriber::<PlayerNumber>("player_number")?
-        .qos(QosProfile {
+    let player_number_cache = node
+        .create_cache::<PlayerNumber>("player_number", 1)?
+        .with_qos(QosProfile {
             durability: QosDurability::TransientLocal,
             ..Default::default()
         })
@@ -65,8 +65,6 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let mut field_dimensions = None;
-    let mut player_number = None;
     let mut filtered_whistle = FilteredWhistle::default();
     let mut current_ball_state = None;
     let mut latest_ball_state = None;
@@ -89,16 +87,13 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     latest_ball_state = Some((received_source_time, actual_ball_state));
                 }
             }
-            received_field_dimensions = field_dimensions_sub.recv() => {
-                field_dimensions = Some(received_field_dimensions?)
-            }
-            received_player_number = player_number_sub.recv() => {
-                player_number = Some(received_player_number?)
-            }
             received_game_controller_state_wrapper = game_controller_state_sub.recv() => {
                 let game_controller_state_wrapper = received_game_controller_state_wrapper?;
 
-                let (Some(field_dimensions), Some(player_number)) = (field_dimensions, player_number) else {
+                let (Some(field_dimensions), Some(player_number)) = (
+                    field_dimensions_cache.get_latest(),
+                    player_number_cache.get_latest()
+                ) else {
                     continue;
                 };
 

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -79,8 +79,6 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let mut field_dimensions = None;
-    let mut player_number = None;
     let mut filtered_whistle = FilteredWhistle::default();
     let mut current_ball_state = None;
     let mut latest_ball_state = None;
@@ -92,14 +90,6 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         let parameters = parameters_snapshot.typed();
 
         tokio::select! {
-            received_field_dimensions = field_dimensions_sub.recv() => {
-                let received_field_dimensions = received_field_dimensions?;
-                field_dimensions = Some(received_field_dimensions);
-            }
-            received_player_number = player_number_sub.recv() => {
-                let received_player_number = received_player_number?;
-                player_number = Some(received_player_number);
-            }
             filtered_whistle_msg = filtered_whistle_sub.recv() => {
                 filtered_whistle = filtered_whistle_msg?;
             }
@@ -114,10 +104,8 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             game_controller_state = game_controller_state_sub.recv() => {
                 let game_controller_state = game_controller_state?;
 
-                let (Some(player_number), Some(field_dimensions)) = (player_number, field_dimensions) else {
-                    continue;
-                };
-
+                let field_dimensions = field_dimensions_sub.recv().await?;
+                let player_number = player_number_sub.recv().await?;
 
                 let Some(game_controller_state) = game_controller_state else {
                     continue;

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 
 use color_eyre::Result;
 
@@ -6,33 +6,17 @@ use coordinate_systems::Field;
 use hsl_network_messages::{GamePhase, GameState, Penalty, PlayerNumber, SubState, Team};
 use linear_algebra::{Point2, Vector2, distance};
 use ros_z::{prelude::*, qos::QosDurability, time::Time};
-use ros_z_streams::CreateFutureMapBuilder;
 use serde::{Deserialize, Serialize};
 use types::{
     field_dimensions::FieldDimensions, filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState, filtered_whistle::FilteredWhistle,
     game_controller_state::GameControllerState, parameters::GameStateFilterParameters,
-    players::Players, world_state::BallState,
+    players::Players, time_wrapper::TimeWrapper, world_state::BallState,
 };
 
 use crate::state::State;
 
 pub mod state;
-
-struct FilteredGameStates {
-    own: FilteredGameState,
-    opponent: FilteredGameState,
-}
-
-#[derive(Default, Deserialize, Serialize)]
-pub struct GameControllerStateFilter {
-    state: State,
-    opponent_state: State,
-    last_game_controller_state: Option<GameControllerState>,
-    whistle_in_set_ball_position: Option<Point2<Field>>,
-    last_time_hulk_was_penalized: Option<Time>,
-    last_time_opponent_was_penalized: Option<Time>,
-}
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx
@@ -59,14 +43,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let mut game_controller_state_sub = node
-        .create_future_map_builder()
-        .create_future_subscriber::<Option<GameControllerState>>(
-            "game_controller_state",
-            Duration::from_millis(1),
-        )
-        .await?
-        .build();
+    let game_controller_state_sub = node
+        .subscriber::<TimeWrapper<Option<GameControllerState>>>("game_controller_state")?
+        .build()
+        .await?;
     let filtered_whistle_sub = node
         .subscriber::<FilteredWhistle>("filtered_whistle")?
         .build()
@@ -81,7 +61,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let filtered_game_controller_state_pub = node
-        .publisher::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .publisher::<TimeWrapper<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
 
@@ -115,101 +95,141 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             received_player_number = player_number_sub.recv() => {
                 player_number = Some(received_player_number?)
             }
-            received_game_controller_state_item = game_controller_state_sub.recv() => {
-                let game_controller_state_item = received_game_controller_state_item?;
+            received_game_controller_state_wrapper = game_controller_state_sub.recv() => {
+                let game_controller_state_wrapper = received_game_controller_state_wrapper?;
 
                 let (Some(field_dimensions), Some(player_number)) = (field_dimensions, player_number) else {
                     continue;
                 };
 
-                for game_controller_state in game_controller_state_item.persistent.into_iter().filter_map(|(_, (maybe_game_controller_state,))| maybe_game_controller_state.flatten()) {
-                    let (new_own_penalties_last_cycle, new_opponent_penalties_last_cycle) = game_controller_state_filter
-                        .last_game_controller_state
-                        .as_ref()
-                        .map(|last| {
-                            (
-                                penalty_diff(last.penalties, game_controller_state.penalties),
-                                penalty_diff(
-                                    last.opponent_penalties,
-                                    game_controller_state.opponent_penalties,
-                                ),
+                let TimeWrapper { time, inner: Some(game_controller_state) } = game_controller_state_wrapper else { continue };
+
+                let filtered_game_controller_state =
+                    TimeWrapper {
+                        time,
+                        inner:
+                            game_controller_state_filter.compute_filtered_game_controller_state(
+                                node.clock().now(),
+                                parameters,
+                                &field_dimensions,
+                                &player_number,
+                                &game_controller_state,
+                                &latest_ball_state,
+                                &filtered_whistle,
+                                &current_ball_state
                             )
-                        })
-                        .unwrap_or_default();
-
-                    let did_receive_motion_in_set_penalty = new_own_penalties_last_cycle
-                        .iter()
-                        .chain(new_opponent_penalties_last_cycle.iter())
-                        .any(|(_, penalty)| matches!(penalty, Penalty::MotionInSet { .. }));
-
-
-                    let fake_detected_free_kick_kicking_team = None;
-
-                    let now = ctx.clock().now();
-
-                    let latest_ball_state = latest_ball_state.filter(|(ball_state_time, _)|{
-                        let is_not_in_penalty_kick =
-                            game_controller_state.sub_state != Some(SubState::PenaltyKick);
-
-                        if is_not_in_penalty_kick
-                            && now.duration_since(*ball_state_time)
-                                > parameters.duration_to_keep_observed_ball
-                        {
-                            return false;
-                        }
-                        true
-                    });
-
-                    let kicking_team = game_controller_state_filter.find_kicking_team(
-                        &now,
-                        parameters,
-                        &game_controller_state,
-                        &latest_ball_state,
-                        &new_own_penalties_last_cycle,
-                        &new_opponent_penalties_last_cycle,
-                        // detected_free_kick_kicking_team,
-                        fake_detected_free_kick_kicking_team,
-                        &filtered_whistle
-                    );
-
-                    let game_states = game_controller_state_filter.filter_game_states(
-                        &now,
-                        parameters,
-                        &field_dimensions,
-                        &player_number,
-                        &game_controller_state,
-                        &current_ball_state,
-                        &filtered_whistle,
-                        // visual_referee_proceed_to_ready,
-                        did_receive_motion_in_set_penalty,
-                        kicking_team,
-                    );
-
-                    let filtered_game_controller_state = FilteredGameControllerState {
-                        game_state: game_states.own,
-                        opponent_game_state: game_states.opponent,
-                        remaining_time_in_half: game_controller_state.remaining_time_in_half,
-                        game_phase: game_controller_state.game_phase,
-                        kicking_team,
-                        penalties: game_controller_state.penalties,
-                        remaining_number_of_messages: game_controller_state
-                        .hulks_team
-                        .remaining_amount_of_messages,
-                        sub_state: game_controller_state.sub_state,
-                        global_field_side: game_controller_state.global_field_side,
-                        new_own_penalties_last_cycle,
-                        new_opponent_penalties_last_cycle,
                     };
 
-                    whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await?;
-                    filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await?;
-                }
+                whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await?;
+                filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await?;
             }
         }
     }
 }
 
+struct FilteredGameStates {
+    own: FilteredGameState,
+    opponent: FilteredGameState,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct GameControllerStateFilter {
+    state: State,
+    opponent_state: State,
+    last_game_controller_state: Option<GameControllerState>,
+    whistle_in_set_ball_position: Option<Point2<Field>>,
+    last_time_hulk_was_penalized: Option<Time>,
+    last_time_opponent_was_penalized: Option<Time>,
+}
+
 impl GameControllerStateFilter {
+    #[allow(clippy::too_many_arguments)]
+    fn compute_filtered_game_controller_state(
+        &mut self,
+        now: Time,
+        parameters: &GameStateFilterParameters,
+        field_dimensions: &FieldDimensions,
+        player_number: &PlayerNumber,
+        game_controller_state: &GameControllerState,
+        latest_ball_state: &Option<(Time, BallState)>,
+        filtered_whistle: &FilteredWhistle,
+        current_ball_state: &Option<BallState>,
+    ) -> FilteredGameControllerState {
+        let (new_own_penalties_last_cycle, new_opponent_penalties_last_cycle) = self
+            .last_game_controller_state
+            .as_ref()
+            .map(|last| {
+                (
+                    penalty_diff(last.penalties, game_controller_state.penalties),
+                    penalty_diff(
+                        last.opponent_penalties,
+                        game_controller_state.opponent_penalties,
+                    ),
+                )
+            })
+            .unwrap_or_default();
+
+        let did_receive_motion_in_set_penalty = new_own_penalties_last_cycle
+            .iter()
+            .chain(new_opponent_penalties_last_cycle.iter())
+            .any(|(_, penalty)| matches!(penalty, Penalty::MotionInSet { .. }));
+
+        let fake_detected_free_kick_kicking_team = None;
+
+        let latest_ball_state = latest_ball_state.filter(|(ball_state_time, _)| {
+            let is_not_in_penalty_kick =
+                game_controller_state.sub_state != Some(SubState::PenaltyKick);
+
+            if is_not_in_penalty_kick
+                && now.duration_since(*ball_state_time) > parameters.duration_to_keep_observed_ball
+            {
+                return false;
+            }
+            true
+        });
+
+        let kicking_team = self.find_kicking_team(
+            &now,
+            parameters,
+            game_controller_state,
+            &latest_ball_state,
+            &new_own_penalties_last_cycle,
+            &new_opponent_penalties_last_cycle,
+            // detected_free_kick_kicking_team,
+            fake_detected_free_kick_kicking_team,
+            filtered_whistle,
+        );
+
+        let game_states = self.filter_game_states(
+            &now,
+            parameters,
+            field_dimensions,
+            player_number,
+            game_controller_state,
+            current_ball_state,
+            filtered_whistle,
+            // visual_referee_proceed_to_ready,
+            did_receive_motion_in_set_penalty,
+            kicking_team,
+        );
+
+        FilteredGameControllerState {
+            game_state: game_states.own,
+            opponent_game_state: game_states.opponent,
+            remaining_time_in_half: game_controller_state.remaining_time_in_half,
+            game_phase: game_controller_state.game_phase,
+            kicking_team,
+            penalties: game_controller_state.penalties,
+            remaining_number_of_messages: game_controller_state
+                .hulks_team
+                .remaining_amount_of_messages,
+            sub_state: game_controller_state.sub_state,
+            global_field_side: game_controller_state.global_field_side,
+            new_own_penalties_last_cycle,
+            new_opponent_penalties_last_cycle,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn filter_game_states(
         &mut self,

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -81,7 +81,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let mut field_dimensions = None;
     let mut player_number = None;
-    let mut filtered_whistle = None;
+    let mut filtered_whistle = FilteredWhistle::default();
     let mut current_ball_state = None;
     let mut latest_ball_state = None;
 
@@ -101,8 +101,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 player_number = Some(received_player_number);
             }
             filtered_whistle_msg = filtered_whistle_sub.recv() => {
-                let received_filtered_whistle = filtered_whistle_msg?;
-                filtered_whistle = Some(received_filtered_whistle);
+                filtered_whistle = filtered_whistle_msg?;
             }
             ball_state_msg = ball_state_sub.recv_with_metadata() => {
                 let received_ball_state = ball_state_msg?;
@@ -120,7 +119,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 };
 
 
-                let (Some(game_controller_state), Some(filtered_whistle)) = (game_controller_state, filtered_whistle) else {
+                let Some(game_controller_state) = game_controller_state else {
                     continue;
                 };
 

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -260,9 +260,11 @@ impl GameControllerStateFilter {
             did_receive_motion_in_set_penalty,
         );
 
-        if let (State::WhistleInSet { .. }, None) = (self.state, self.whistle_in_set_ball_position)
+        if let State::WhistleInSet { .. } = self.state
+            && self.whistle_in_set_ball_position.is_none()
+            && let Some(ball_state) = current_ball_state.as_ref()
         {
-            current_ball_state.map(|ball_state| ball_state.ball_in_field);
+            self.whistle_in_set_ball_position = Some(ball_state.ball_in_field);
         };
 
         let motion_in_set = matches!(

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -1,16 +1,37 @@
-use std::{future::pending, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use color_eyre::Result;
 
 use coordinate_systems::Field;
-use hsl_network_messages::PlayerNumber;
-use linear_algebra::Point2;
-use ros_z::{prelude::*, qos::QosDurability};
+use hsl_network_messages::{GamePhase, GameState, Penalty, PlayerNumber, SubState, Team};
+use linear_algebra::{Point2, Vector2, distance};
+use ros_z::{prelude::*, qos::QosDurability, time::Time};
+use serde::{Deserialize, Serialize};
 use types::{
     field_dimensions::FieldDimensions, filtered_game_controller_state::FilteredGameControllerState,
-    filtered_whistle::FilteredWhistle, game_controller_state::GameControllerState,
-    parameters::GameStateFilterParameters,
+    filtered_game_state::FilteredGameState, filtered_whistle::FilteredWhistle,
+    game_controller_state::GameControllerState, parameters::GameStateFilterParameters,
+    players::Players, world_state::BallState,
 };
+
+use crate::state::State;
+
+pub mod state;
+
+struct FilteredGameStates {
+    own: FilteredGameState,
+    opponent: FilteredGameState,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct GameControllerStateFilter {
+    state: State,
+    opponent_state: State,
+    last_game_controller_state: Option<GameControllerState>,
+    whistle_in_set_ball_position: Option<Point2<Field>>,
+    last_time_hulk_was_penalized: Option<Time>,
+    last_time_opponent_was_penalized: Option<Time>,
+}
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx
@@ -18,17 +39,9 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let _parameters =
+    let parameters =
         node.bind_parameter_as::<GameStateFilterParameters>("game_controller_state_filter")?;
-    let _filtered_whistle_sub = node
-        .subscriber::<FilteredWhistle>("filtered_whistle")?
-        .build()
-        .await?;
-    let _game_controller_state_sub = node
-        .subscriber::<Option<GameControllerState>>("game_controller_state")?
-        .build()
-        .await?;
-    let _field_dimensions_sub = node
+    let field_dimensions_sub = node
         .subscriber::<FieldDimensions>("field_dimensions")?
         .qos(QosProfile {
             durability: QosDurability::TransientLocal,
@@ -36,7 +49,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         })
         .build()
         .await?;
-    let _player_number_sub = node
+    let player_number_sub = node
         .subscriber::<PlayerNumber>("player_number")?
         .qos(QosProfile {
             durability: QosDurability::TransientLocal,
@@ -44,17 +57,505 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         })
         .build()
         .await?;
-
-    let _whistle_in_set_ball_position_pub = node
-        .publisher::<Point2<Field>>("whistle_in_set_ball_position")?
+    let game_controller_state_sub = node
+        .subscriber::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
-    let _filtered_game_controller_state_pub = node
+    let filtered_whistle_sub = node
+        .subscriber::<FilteredWhistle>("filtered_whistle")?
+        .build()
+        .await?;
+    let ball_state_sub = node
+        .subscriber::<Option<BallState>>("ball_state")
+        .into_eyre()?
+        .build()
+        .await
+        .into_eyre()?;
+
+    let whistle_in_set_ball_position_pub = node
+        .publisher::<Option<Point2<Field>>>("whistle_in_set_ball_position")?
+        .build()
+        .await?;
+    let filtered_game_controller_state_pub = node
         .publisher::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
 
-    pending::<()>().await;
+    let mut field_dimensions = None;
+    let mut player_number = None;
+    let mut filtered_whistle = None;
+    let mut current_ball_state = None;
+    let mut latest_ball_state = None;
 
-    Ok(())
+    let mut game_controller_state_filter = GameControllerStateFilter::new();
+
+    loop {
+        let parameters_snapshot = parameters.snapshot();
+        let parameters = parameters_snapshot.typed();
+
+        tokio::select! {
+            received_field_dimensions = field_dimensions_sub.recv() => {
+                let received_field_dimensions = received_field_dimensions.into_eyre()?;
+                field_dimensions = Some(received_field_dimensions);
+            }
+            received_player_number = player_number_sub.recv() => {
+                let received_player_number = received_player_number.into_eyre()?;
+                player_number = Some(received_player_number);
+            }
+            filtered_whistle_msg = filtered_whistle_sub.recv() => {
+                let received_filtered_whistle = filtered_whistle_msg.into_eyre()?;
+                filtered_whistle = Some(received_filtered_whistle);
+            }
+            ball_state_msg = ball_state_sub.recv_with_metadata() => {
+                let received_ball_state = ball_state_msg.into_eyre()?;
+                let received_source_time = received_ball_state.source_time;
+                current_ball_state = received_ball_state.into_message();
+                if let Some(actual_ball_state) = current_ball_state {
+                    latest_ball_state = Some((received_source_time, actual_ball_state));
+                }
+            }
+            game_controller_state = game_controller_state_sub.recv() => {
+                let game_controller_state = game_controller_state.into_eyre()?;
+
+                let (Some(player_number), Some(field_dimensions)) = (player_number, field_dimensions) else {
+                    continue;
+                };
+
+
+                let (Some(game_controller_state), Some(filtered_whistle)) = (game_controller_state, filtered_whistle) else {
+                    continue;
+                };
+
+                let (new_own_penalties_last_cycle, new_opponent_penalties_last_cycle) = game_controller_state_filter
+                    .last_game_controller_state
+                    .as_ref()
+                    .map(|last| {
+                        (
+                            penalty_diff(last.penalties, game_controller_state.penalties),
+                            penalty_diff(
+                                last.opponent_penalties,
+                                game_controller_state.opponent_penalties,
+                            ),
+                        )
+                    })
+                    .unwrap_or_default();
+
+                let did_receive_motion_in_set_penalty = new_own_penalties_last_cycle
+                    .iter()
+                    .chain(new_opponent_penalties_last_cycle.iter())
+                    .any(|(_, penalty)| matches!(penalty, Penalty::MotionInSet { .. }));
+
+
+                let fake_detected_free_kick_kicking_team = None;
+
+                let now = ctx.clock().now();
+
+                let latest_ball_state = latest_ball_state.filter(|(ball_state_time, _)|{
+                    let is_not_in_penalty_kick =
+                        game_controller_state.sub_state != Some(SubState::PenaltyKick);
+
+                    if is_not_in_penalty_kick
+                        && now.duration_since(*ball_state_time)
+                            > parameters.duration_to_keep_observed_ball
+                    {
+                        return false;
+                    }
+                    true
+                });
+
+                let kicking_team = game_controller_state_filter.find_kicking_team(
+                    &now,
+                    &parameters,
+                    &game_controller_state,
+                    &latest_ball_state,
+                    &new_own_penalties_last_cycle,
+                    &new_opponent_penalties_last_cycle,
+                    // detected_free_kick_kicking_team,
+                    fake_detected_free_kick_kicking_team,
+                    &filtered_whistle
+                );
+
+                let game_states = game_controller_state_filter.filter_game_states(
+                    &now,
+                    parameters,
+                    &field_dimensions,
+                    &player_number,
+                    &game_controller_state,
+                    &current_ball_state,
+                    &filtered_whistle,
+                    // visual_referee_proceed_to_ready,
+                    did_receive_motion_in_set_penalty,
+                    kicking_team,
+                );
+
+                let filtered_game_controller_state = FilteredGameControllerState {
+                    game_state: game_states.own,
+                    opponent_game_state: game_states.opponent,
+                    remaining_time_in_half: game_controller_state.remaining_time_in_half,
+                    game_phase: game_controller_state.game_phase,
+                    kicking_team,
+                    penalties: game_controller_state.penalties,
+                    remaining_number_of_messages: game_controller_state
+                        .hulks_team
+                        .remaining_amount_of_messages,
+                    sub_state: game_controller_state.sub_state,
+                    global_field_side: game_controller_state.global_field_side,
+                    new_own_penalties_last_cycle,
+                    new_opponent_penalties_last_cycle,
+                };
+
+                whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await.into_eyre()?;
+                filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await.into_eyre()?;
+            }
+        }
+    }
+}
+
+impl GameControllerStateFilter {
+    pub fn new() -> Self {
+        Self {
+            last_game_controller_state: None,
+            state: State::Initial,
+            opponent_state: State::Initial,
+            whistle_in_set_ball_position: None,
+            last_time_hulk_was_penalized: Default::default(),
+            last_time_opponent_was_penalized: Default::default(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn filter_game_states(
+        &mut self,
+        now: &Time,
+        parameters: &GameStateFilterParameters,
+        field_dimensions: &FieldDimensions,
+        player_number: &PlayerNumber,
+        game_controller_state: &GameControllerState,
+        current_ball_state: &Option<BallState>,
+        filtered_whistle: &FilteredWhistle,
+        did_receive_motion_in_set_penalty: bool,
+        filtered_kicking_team: Option<Team>,
+    ) -> FilteredGameStates {
+        let ball_detected_far_from_any_goal = ball_detected_far_from_any_goal(
+            current_ball_state,
+            field_dimensions,
+            parameters.whistle_acceptance_goal_distance,
+        );
+        self.state = next_filtered_state(
+            now,
+            self.state,
+            game_controller_state,
+            filtered_whistle.is_detected,
+            parameters,
+            ball_detected_far_from_any_goal,
+            did_receive_motion_in_set_penalty,
+        );
+        self.opponent_state = next_filtered_state(
+            now,
+            self.opponent_state,
+            game_controller_state,
+            filtered_whistle.is_detected,
+            parameters,
+            ball_detected_far_from_any_goal,
+            did_receive_motion_in_set_penalty,
+        );
+
+        if let (State::WhistleInSet { .. }, None) = (self.state, self.whistle_in_set_ball_position)
+        {
+            current_ball_state.map(|ball_state| ball_state.ball_in_field);
+        };
+
+        let motion_in_set = matches!(
+            game_controller_state.penalties[*player_number],
+            Some(Penalty::MotionInSet { .. })
+        );
+        if matches!(self.state, State::Playing) || motion_in_set {
+            self.whistle_in_set_ball_position = None;
+        }
+
+        let ball_detected_far_from_kick_off_point = current_ball_state
+            .map(|ball| {
+                let current_ball_position = ball.ball_in_field;
+                let reference_position = self.whistle_in_set_ball_position.unwrap_or_default();
+                distance(reference_position, current_ball_position)
+                    > parameters.distance_to_consider_ball_moved_in_kick_off
+            })
+            .unwrap_or(false);
+
+        let filtered_game_state = self.state.construct_filtered_game_state_for_team(
+            now,
+            game_controller_state,
+            Team::Hulks,
+            ball_detected_far_from_kick_off_point,
+            parameters,
+            filtered_kicking_team,
+        );
+
+        let filtered_opponent_game_state =
+            self.opponent_state.construct_filtered_game_state_for_team(
+                now,
+                game_controller_state,
+                Team::Opponent,
+                ball_detected_far_from_kick_off_point,
+                parameters,
+                filtered_kicking_team,
+            );
+
+        FilteredGameStates {
+            own: filtered_game_state,
+            opponent: filtered_opponent_game_state,
+        }
+    }
+
+    fn find_kicking_team(
+        &mut self,
+        now: &Time,
+        parameters: &GameStateFilterParameters,
+        game_controller_state: &GameControllerState,
+        latest_ball_state: &Option<(Time, BallState)>,
+        new_own_penalties_last_cycle: &HashMap<PlayerNumber, Penalty>,
+        new_opponent_penalties_last_cycle: &HashMap<PlayerNumber, Penalty>,
+        detected_free_kick_kicking_team: Option<Team>,
+        filtered_whistle: &FilteredWhistle,
+    ) -> Option<Team> {
+        let game_controller_state = game_controller_state;
+
+        if let Some(kicking_team) = game_controller_state.kicking_team {
+            return Some(kicking_team);
+        }
+
+        let ball_is_in_opponent_half = latest_ball_state
+            .map(|(_, ball_state)| ball_state.ball_in_field.x().is_sign_positive());
+
+        if !new_own_penalties_last_cycle.is_empty() {
+            self.last_time_hulk_was_penalized = Some(*now);
+        }
+
+        if self
+            .last_time_hulk_was_penalized
+            .is_some_and(|last_time_hulk_was_penalized| {
+                now.duration_since(last_time_hulk_was_penalized)
+                    > parameters.duration_to_keep_new_penalties
+            })
+        {
+            self.last_time_hulk_was_penalized = None;
+        }
+
+        if !new_opponent_penalties_last_cycle.is_empty() {
+            self.last_time_opponent_was_penalized = Some(*now);
+        }
+
+        if self
+            .last_time_opponent_was_penalized
+            .is_some_and(|last_time_opponent_was_penalized| {
+                now.duration_since(last_time_opponent_was_penalized)
+                    > parameters.duration_to_keep_new_penalties
+            })
+        {
+            self.last_time_opponent_was_penalized = None;
+        }
+
+        match game_controller_state {
+            GameControllerState {
+                sub_state: Some(SubState::CornerKick),
+                ..
+            } if ball_is_in_opponent_half? => Some(Team::Hulks),
+            GameControllerState {
+                sub_state: Some(SubState::CornerKick),
+                ..
+            } if !ball_is_in_opponent_half? => Some(Team::Opponent),
+            GameControllerState {
+                sub_state: Some(SubState::GoalKick),
+                ..
+            } if ball_is_in_opponent_half? => Some(Team::Opponent),
+            GameControllerState {
+                sub_state: Some(SubState::GoalKick),
+                ..
+            } if !ball_is_in_opponent_half? => Some(Team::Hulks),
+            GameControllerState {
+                sub_state: Some(SubState::PenaltyKick),
+                ..
+            } if ball_is_in_opponent_half? => Some(Team::Hulks),
+            GameControllerState {
+                sub_state: Some(SubState::PenaltyKick),
+                ..
+            } if !ball_is_in_opponent_half? => Some(Team::Opponent),
+            GameControllerState {
+                sub_state: Some(SubState::DirectFreeKick),
+                ..
+            } if self.last_time_hulk_was_penalized.is_some() => Some(Team::Opponent),
+            GameControllerState {
+                sub_state: Some(SubState::DirectFreeKick), //TODO: CHeck if direct free kick is right an no other substate
+                ..
+            } if self.last_time_opponent_was_penalized.is_some() => Some(Team::Hulks),
+            GameControllerState {
+                sub_state: Some(SubState::ThrowIn),
+                ..
+            } if detected_free_kick_kicking_team.is_some() => detected_free_kick_kicking_team,
+            GameControllerState {
+                game_state: GameState::Playing,
+                sub_state: None,
+                ..
+            } => match (filtered_whistle.is_detected, ball_is_in_opponent_half?) {
+                (true, false) => Some(Team::Opponent),
+                (true, true) => Some(Team::Hulks),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn next_filtered_state(
+    now: &Time,
+    current_state: State,
+    game_controller_state: &GameControllerState,
+    is_whistle_detected: bool,
+    parameters: &GameStateFilterParameters,
+    ball_detected_far_from_any_goal: bool,
+    did_receive_motion_in_set_penalty: bool,
+) -> State {
+    match (
+        current_state,
+        game_controller_state.game_state,
+        game_controller_state.stopped,
+    ) {
+        (_, _, true) => State::Stop,
+        (State::Stop, game_state, false) => State::from_game_state(game_state),
+        (State::Finished, GameState::Initial, _) => State::Initial,
+        (State::Finished, _, _) => match game_controller_state.game_phase {
+            GamePhase::PenaltyShootout { .. } => State::Set,
+            _ => State::Finished,
+        },
+        (
+            State::TentativeFinished {
+                time_when_finished_clicked,
+            },
+            GameState::Finished,
+            _,
+        ) if now.duration_since(time_when_finished_clicked)
+            >= parameters.tentative_finish_duration =>
+        {
+            State::Finished
+        }
+        (
+            State::TentativeFinished {
+                time_when_finished_clicked,
+            },
+            GameState::Finished,
+            _,
+        ) => State::TentativeFinished {
+            time_when_finished_clicked,
+        },
+        (State::TentativeFinished { .. }, game_state, _) => State::from_game_state(game_state),
+        (_, GameState::Finished, _) => State::TentativeFinished {
+            time_when_finished_clicked: *now,
+        },
+        (State::Initial | State::Ready, _, _)
+        | (State::Set, GameState::Initial | GameState::Ready | GameState::Playing, _)
+        | (
+            State::WhistleInSet { .. },
+            GameState::Initial | GameState::Ready | GameState::Playing,
+            _,
+        )
+        | (State::Playing, GameState::Initial | GameState::Ready | GameState::Set, _)
+        | (
+            State::WhistleInPlaying { .. },
+            GameState::Initial | GameState::Ready | GameState::Set,
+            _,
+        ) => State::from_game_state(game_controller_state.game_state),
+        (State::Set, GameState::Set, _) => {
+            if is_whistle_detected {
+                State::WhistleInSet {
+                    time_when_whistle_was_detected: *now,
+                }
+            } else {
+                State::Set
+            }
+        }
+        (State::WhistleInSet { .. }, GameState::Set, _) if did_receive_motion_in_set_penalty => {
+            State::Set
+        }
+        (
+            State::WhistleInSet {
+                time_when_whistle_was_detected,
+            },
+            GameState::Set,
+            _,
+        ) => {
+            if now.duration_since(time_when_whistle_was_detected)
+                < parameters.playing_message_delay + parameters.game_controller_controller_delay
+            {
+                State::WhistleInSet {
+                    time_when_whistle_was_detected,
+                }
+            } else {
+                State::Playing
+            }
+        }
+        (State::Playing, GameState::Playing, _) => {
+            if is_whistle_detected && !ball_detected_far_from_any_goal {
+                State::WhistleInPlaying {
+                    time_when_whistle_was_detected: *now,
+                }
+            } else {
+                State::Playing
+            }
+        }
+        (
+            State::WhistleInPlaying {
+                time_when_whistle_was_detected,
+            },
+            GameState::Playing,
+            _,
+        ) => {
+            if now.duration_since(time_when_whistle_was_detected)
+                < parameters.ready_message_delay + parameters.game_controller_controller_delay
+            {
+                State::WhistleInPlaying {
+                    time_when_whistle_was_detected,
+                }
+            } else {
+                State::Playing
+            }
+        }
+    }
+}
+
+fn ball_detected_far_from_any_goal(
+    maybe_ball_state: &Option<BallState>,
+    field_dimensions: &FieldDimensions,
+    whistle_acceptance_goal_distance: Vector2<Field>,
+) -> bool {
+    match maybe_ball_state {
+        Some(ball_state) => {
+            ball_state.ball_in_field.x().abs()
+                < field_dimensions.length / 2.0 - whistle_acceptance_goal_distance.x()
+                || ball_state.ball_in_field.y().abs()
+                    > field_dimensions.goal_inner_width / 2.0 + whistle_acceptance_goal_distance.y()
+        }
+        None => false,
+    }
+}
+
+fn penalty_diff(
+    last: Players<Option<Penalty>>,
+    current: Players<Option<Penalty>>,
+) -> HashMap<PlayerNumber, Penalty> {
+    let current_penalties = current
+        .iter()
+        .fold(HashMap::new(), |mut map, (player, penalty)| {
+            if let Some(penalty) = penalty {
+                map.insert(player, *penalty);
+            }
+            map
+        });
+    last.iter()
+        .fold(current_penalties, |mut map, (player, penalty)| {
+            if penalty.is_some() {
+                map.remove(&player);
+            }
+            map
+        })
 }

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use color_eyre::Result;
 
@@ -6,6 +6,7 @@ use coordinate_systems::Field;
 use hsl_network_messages::{GamePhase, GameState, Penalty, PlayerNumber, SubState, Team};
 use linear_algebra::{Point2, Vector2, distance};
 use ros_z::{prelude::*, qos::QosDurability, time::Time};
+use ros_z_streams::CreateFutureMapBuilder;
 use serde::{Deserialize, Serialize};
 use types::{
     field_dimensions::FieldDimensions, filtered_game_controller_state::FilteredGameControllerState,
@@ -57,10 +58,15 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         })
         .build()
         .await?;
-    let game_controller_state_sub = node
-        .subscriber::<Option<GameControllerState>>("game_controller_state")?
-        .build()
-        .await?;
+
+    let mut game_controller_state_sub = node
+        .create_future_map_builder()
+        .create_future_subscriber::<Option<GameControllerState>>(
+            "game_controller_state",
+            Duration::from_millis(1),
+        )
+        .await?
+        .build();
     let filtered_whistle_sub = node
         .subscriber::<FilteredWhistle>("filtered_whistle")?
         .build()
@@ -101,96 +107,94 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     latest_ball_state = Some((received_source_time, actual_ball_state));
                 }
             }
-            game_controller_state = game_controller_state_sub.recv() => {
-                let game_controller_state = game_controller_state?;
+            received_game_controller_state_item = game_controller_state_sub.recv() => {
+                let game_controller_state_item = received_game_controller_state_item?;
 
                 let field_dimensions = field_dimensions_sub.recv().await?;
                 let player_number = player_number_sub.recv().await?;
 
-                let Some(game_controller_state) = game_controller_state else {
-                    continue;
-                };
+                for game_controller_state in game_controller_state_item.persistent.into_iter().filter_map(|(_, (maybe_game_controller_state,))| maybe_game_controller_state.flatten()) {
+                    let (new_own_penalties_last_cycle, new_opponent_penalties_last_cycle) = game_controller_state_filter
+                        .last_game_controller_state
+                        .as_ref()
+                        .map(|last| {
+                            (
+                                penalty_diff(last.penalties, game_controller_state.penalties),
+                                penalty_diff(
+                                    last.opponent_penalties,
+                                    game_controller_state.opponent_penalties,
+                                ),
+                            )
+                        })
+                        .unwrap_or_default();
 
-                let (new_own_penalties_last_cycle, new_opponent_penalties_last_cycle) = game_controller_state_filter
-                    .last_game_controller_state
-                    .as_ref()
-                    .map(|last| {
-                        (
-                            penalty_diff(last.penalties, game_controller_state.penalties),
-                            penalty_diff(
-                                last.opponent_penalties,
-                                game_controller_state.opponent_penalties,
-                            ),
-                        )
-                    })
-                    .unwrap_or_default();
-
-                let did_receive_motion_in_set_penalty = new_own_penalties_last_cycle
-                    .iter()
-                    .chain(new_opponent_penalties_last_cycle.iter())
-                    .any(|(_, penalty)| matches!(penalty, Penalty::MotionInSet { .. }));
+                    let did_receive_motion_in_set_penalty = new_own_penalties_last_cycle
+                        .iter()
+                        .chain(new_opponent_penalties_last_cycle.iter())
+                        .any(|(_, penalty)| matches!(penalty, Penalty::MotionInSet { .. }));
 
 
-                let fake_detected_free_kick_kicking_team = None;
+                    let fake_detected_free_kick_kicking_team = None;
 
-                let now = ctx.clock().now();
+                    let now = ctx.clock().now();
 
-                let latest_ball_state = latest_ball_state.filter(|(ball_state_time, _)|{
-                    let is_not_in_penalty_kick =
-                        game_controller_state.sub_state != Some(SubState::PenaltyKick);
+                    let latest_ball_state = latest_ball_state.filter(|(ball_state_time, _)|{
+                        let is_not_in_penalty_kick =
+                            game_controller_state.sub_state != Some(SubState::PenaltyKick);
 
-                    if is_not_in_penalty_kick
-                        && now.duration_since(*ball_state_time)
-                            > parameters.duration_to_keep_observed_ball
-                    {
-                        return false;
-                    }
-                    true
-                });
+                        if is_not_in_penalty_kick
+                            && now.duration_since(*ball_state_time)
+                                > parameters.duration_to_keep_observed_ball
+                        {
+                            return false;
+                        }
+                        true
+                    });
 
-                let kicking_team = game_controller_state_filter.find_kicking_team(
-                    &now,
-                    parameters,
-                    &game_controller_state,
-                    &latest_ball_state,
-                    &new_own_penalties_last_cycle,
-                    &new_opponent_penalties_last_cycle,
-                    // detected_free_kick_kicking_team,
-                    fake_detected_free_kick_kicking_team,
-                    &filtered_whistle
-                );
+                    let kicking_team = game_controller_state_filter.find_kicking_team(
+                        &now,
+                        parameters,
+                        &game_controller_state,
+                        &latest_ball_state,
+                        &new_own_penalties_last_cycle,
+                        &new_opponent_penalties_last_cycle,
+                        // detected_free_kick_kicking_team,
+                        fake_detected_free_kick_kicking_team,
+                        &filtered_whistle
+                    );
 
-                let game_states = game_controller_state_filter.filter_game_states(
-                    &now,
-                    parameters,
-                    &field_dimensions,
-                    &player_number,
-                    &game_controller_state,
-                    &current_ball_state,
-                    &filtered_whistle,
-                    // visual_referee_proceed_to_ready,
-                    did_receive_motion_in_set_penalty,
-                    kicking_team,
-                );
+                    let game_states = game_controller_state_filter.filter_game_states(
+                        &now,
+                        parameters,
+                        &field_dimensions,
+                        &player_number,
+                        &game_controller_state,
+                        &current_ball_state,
+                        &filtered_whistle,
+                        // visual_referee_proceed_to_ready,
+                        did_receive_motion_in_set_penalty,
+                        kicking_team,
+                    );
 
-                let filtered_game_controller_state = FilteredGameControllerState {
-                    game_state: game_states.own,
-                    opponent_game_state: game_states.opponent,
-                    remaining_time_in_half: game_controller_state.remaining_time_in_half,
-                    game_phase: game_controller_state.game_phase,
-                    kicking_team,
-                    penalties: game_controller_state.penalties,
-                    remaining_number_of_messages: game_controller_state
+                    let filtered_game_controller_state = FilteredGameControllerState {
+                        game_state: game_states.own,
+                        opponent_game_state: game_states.opponent,
+                        remaining_time_in_half: game_controller_state.remaining_time_in_half,
+                        game_phase: game_controller_state.game_phase,
+                        kicking_team,
+                        penalties: game_controller_state.penalties,
+                        remaining_number_of_messages: game_controller_state
                         .hulks_team
                         .remaining_amount_of_messages,
-                    sub_state: game_controller_state.sub_state,
-                    global_field_side: game_controller_state.global_field_side,
-                    new_own_penalties_last_cycle,
-                    new_opponent_penalties_last_cycle,
-                };
+                        sub_state: game_controller_state.sub_state,
+                        global_field_side: game_controller_state.global_field_side,
+                        new_own_penalties_last_cycle,
+                        new_opponent_penalties_last_cycle,
+                    };
 
-                whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await?;
-                filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await?;
+                    whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await?;
+                    filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await?;
+                }
             }
         }
     }

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -23,7 +23,7 @@ struct FilteredGameStates {
     opponent: FilteredGameState,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct GameControllerStateFilter {
     state: State,
     opponent_state: State,
@@ -66,11 +66,9 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let ball_state_sub = node
-        .subscriber::<Option<BallState>>("ball_state")
-        .into_eyre()?
+        .subscriber::<Option<BallState>>("ball_state")?
         .build()
-        .await
-        .into_eyre()?;
+        .await?;
 
     let whistle_in_set_ball_position_pub = node
         .publisher::<Option<Point2<Field>>>("whistle_in_set_ball_position")?
@@ -87,7 +85,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let mut current_ball_state = None;
     let mut latest_ball_state = None;
 
-    let mut game_controller_state_filter = GameControllerStateFilter::new();
+    let mut game_controller_state_filter = GameControllerStateFilter::default();
 
     loop {
         let parameters_snapshot = parameters.snapshot();
@@ -95,19 +93,19 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
         tokio::select! {
             received_field_dimensions = field_dimensions_sub.recv() => {
-                let received_field_dimensions = received_field_dimensions.into_eyre()?;
+                let received_field_dimensions = received_field_dimensions?;
                 field_dimensions = Some(received_field_dimensions);
             }
             received_player_number = player_number_sub.recv() => {
-                let received_player_number = received_player_number.into_eyre()?;
+                let received_player_number = received_player_number?;
                 player_number = Some(received_player_number);
             }
             filtered_whistle_msg = filtered_whistle_sub.recv() => {
-                let received_filtered_whistle = filtered_whistle_msg.into_eyre()?;
+                let received_filtered_whistle = filtered_whistle_msg?;
                 filtered_whistle = Some(received_filtered_whistle);
             }
             ball_state_msg = ball_state_sub.recv_with_metadata() => {
-                let received_ball_state = ball_state_msg.into_eyre()?;
+                let received_ball_state = ball_state_msg?;
                 let received_source_time = received_ball_state.source_time;
                 current_ball_state = received_ball_state.into_message();
                 if let Some(actual_ball_state) = current_ball_state {
@@ -115,7 +113,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 }
             }
             game_controller_state = game_controller_state_sub.recv() => {
-                let game_controller_state = game_controller_state.into_eyre()?;
+                let game_controller_state = game_controller_state?;
 
                 let (Some(player_number), Some(field_dimensions)) = (player_number, field_dimensions) else {
                     continue;
@@ -165,7 +163,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
                 let kicking_team = game_controller_state_filter.find_kicking_team(
                     &now,
-                    &parameters,
+                    parameters,
                     &game_controller_state,
                     &latest_ball_state,
                     &new_own_penalties_last_cycle,
@@ -204,25 +202,14 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     new_opponent_penalties_last_cycle,
                 };
 
-                whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await.into_eyre()?;
-                filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await.into_eyre()?;
+                whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await?;
+                filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await?;
             }
         }
     }
 }
 
 impl GameControllerStateFilter {
-    pub fn new() -> Self {
-        Self {
-            last_game_controller_state: None,
-            state: State::Initial,
-            opponent_state: State::Initial,
-            whistle_in_set_ball_position: None,
-            last_time_hulk_was_penalized: Default::default(),
-            last_time_opponent_was_penalized: Default::default(),
-        }
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn filter_game_states(
         &mut self,
@@ -309,6 +296,7 @@ impl GameControllerStateFilter {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn find_kicking_team(
         &mut self,
         now: &Time,
@@ -320,8 +308,6 @@ impl GameControllerStateFilter {
         detected_free_kick_kicking_team: Option<Team>,
         filtered_whistle: &FilteredWhistle,
     ) -> Option<Team> {
-        let game_controller_state = game_controller_state;
-
         if let Some(kicking_team) = game_controller_state.kicking_team {
             return Some(kicking_team);
         }

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -47,12 +47,12 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .subscriber::<TimeWrapper<Option<GameControllerState>>>("game_controller_state")?
         .build()
         .await?;
-    let filtered_whistle_sub = node
-        .subscriber::<FilteredWhistle>("filtered_whistle")?
+    let filtered_whistle_cache = node
+        .create_cache::<FilteredWhistle>("filtered_whistle", 1)?
         .build()
         .await?;
-    let ball_state_sub = node
-        .subscriber::<Option<BallState>>("ball_state")?
+    let ball_state_cache = node
+        .create_cache::<Option<BallState>>("ball_state", 1)?
         .build()
         .await?;
 
@@ -65,60 +65,58 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let mut filtered_whistle = FilteredWhistle::default();
-    let mut current_ball_state = None;
-    let mut latest_ball_state = None;
-
+    let mut latest_known_ball_state = None;
     let mut game_controller_state_filter = GameControllerStateFilter::default();
 
     loop {
         let parameters_snapshot = parameters.snapshot();
         let parameters = parameters_snapshot.typed();
 
-        tokio::select! {
-            filtered_whistle_msg = filtered_whistle_sub.recv() => {
-                filtered_whistle = filtered_whistle_msg?;
-            }
-            ball_state_msg = ball_state_sub.recv_with_metadata() => {
-                let received_ball_state = ball_state_msg?;
-                let received_source_time = received_ball_state.source_time;
-                current_ball_state = received_ball_state.into_message();
-                if let Some(actual_ball_state) = current_ball_state {
-                    latest_ball_state = Some((received_source_time, actual_ball_state));
-                }
-            }
-            received_game_controller_state_wrapper = game_controller_state_sub.recv() => {
-                let game_controller_state_wrapper = received_game_controller_state_wrapper?;
+        let game_controller_state_wrapper = game_controller_state_sub.recv().await?;
 
-                let (Some(field_dimensions), Some(player_number)) = (
-                    field_dimensions_cache.get_latest(),
-                    player_number_cache.get_latest()
-                ) else {
-                    continue;
-                };
+        let (Some(field_dimensions), Some(player_number)) = (
+            field_dimensions_cache.get_latest(),
+            player_number_cache.get_latest(),
+        ) else {
+            continue;
+        };
 
-                let TimeWrapper { time, inner: Some(game_controller_state) } = game_controller_state_wrapper else { continue };
+        let filtered_whistle = filtered_whistle_cache.get_latest().unwrap_or_default();
 
-                let filtered_game_controller_state =
-                    TimeWrapper {
-                        time,
-                        inner:
-                            game_controller_state_filter.compute_filtered_game_controller_state(
-                                node.clock().now(),
-                                parameters,
-                                &field_dimensions,
-                                &player_number,
-                                &game_controller_state,
-                                &latest_ball_state,
-                                &filtered_whistle,
-                                &current_ball_state
-                            )
-                    };
+        let current_ball_state_time = ball_state_cache.latest_stamp();
+        let current_ball_state = ball_state_cache.get_latest().and_then(|maybe| *maybe);
+        if let Some((ball_state, time)) = current_ball_state_time.zip(current_ball_state) {
+            latest_known_ball_state = Some((ball_state, time))
+        };
 
-                whistle_in_set_ball_position_pub.publish(&game_controller_state_filter.whistle_in_set_ball_position).await?;
-                filtered_game_controller_state_pub.publish(&filtered_game_controller_state).await?;
-            }
-        }
+        let TimeWrapper {
+            time,
+            inner: Some(game_controller_state),
+        } = game_controller_state_wrapper
+        else {
+            continue;
+        };
+
+        let filtered_game_controller_state = TimeWrapper {
+            time,
+            inner: game_controller_state_filter.compute_filtered_game_controller_state(
+                node.clock().now(),
+                parameters,
+                &field_dimensions,
+                &player_number,
+                &game_controller_state,
+                &latest_known_ball_state,
+                &filtered_whistle,
+                &current_ball_state,
+            ),
+        };
+
+        whistle_in_set_ball_position_pub
+            .publish(&game_controller_state_filter.whistle_in_set_ball_position)
+            .await?;
+        filtered_game_controller_state_pub
+            .publish(&filtered_game_controller_state)
+            .await?;
     }
 }
 
@@ -146,7 +144,7 @@ impl GameControllerStateFilter {
         field_dimensions: &FieldDimensions,
         player_number: &PlayerNumber,
         game_controller_state: &GameControllerState,
-        latest_ball_state: &Option<(Time, BallState)>,
+        latest_known_ball_state: &Option<(Time, BallState)>,
         filtered_whistle: &FilteredWhistle,
         current_ball_state: &Option<BallState>,
     ) -> FilteredGameControllerState {
@@ -171,7 +169,7 @@ impl GameControllerStateFilter {
 
         let fake_detected_free_kick_kicking_team = None;
 
-        let latest_ball_state = latest_ball_state.filter(|(ball_state_time, _)| {
+        let latest_ball_state = latest_known_ball_state.filter(|(ball_state_time, _)| {
             let is_not_in_penalty_kick =
                 game_controller_state.sub_state != Some(SubState::PenaltyKick);
 

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -25,7 +25,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _game_controller_state_sub = node
-        .subscriber::<GameControllerState>("game_controller_state")?
+        .subscriber::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
     let _field_dimensions_sub = node

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -85,6 +85,8 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
+    let mut field_dimensions = None;
+    let mut player_number = None;
     let mut filtered_whistle = FilteredWhistle::default();
     let mut current_ball_state = None;
     let mut latest_ball_state = None;
@@ -107,11 +109,18 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     latest_ball_state = Some((received_source_time, actual_ball_state));
                 }
             }
+            received_field_dimensions = field_dimensions_sub.recv() => {
+                field_dimensions = Some(received_field_dimensions?)
+            }
+            received_player_number = player_number_sub.recv() => {
+                player_number = Some(received_player_number?)
+            }
             received_game_controller_state_item = game_controller_state_sub.recv() => {
                 let game_controller_state_item = received_game_controller_state_item?;
 
-                let field_dimensions = field_dimensions_sub.recv().await?;
-                let player_number = player_number_sub.recv().await?;
+                let (Some(field_dimensions), Some(player_number)) = (field_dimensions, player_number) else {
+                    continue;
+                };
 
                 for game_controller_state in game_controller_state_item.persistent.into_iter().filter_map(|(_, (maybe_game_controller_state,))| maybe_game_controller_state.flatten()) {
                     let (new_own_penalties_last_cycle, new_opponent_penalties_last_cycle) = game_controller_state_filter

--- a/crates/nodes/game_controller_state_filter/src/state.rs
+++ b/crates/nodes/game_controller_state_filter/src/state.rs
@@ -1,0 +1,94 @@
+use std::time::Duration;
+
+use hsl_network_messages::{GamePhase, GameState, Team};
+use ros_z::time::Time;
+use serde::{Deserialize, Serialize};
+use types::{
+    filtered_game_state::FilteredGameState, game_controller_state::GameControllerState,
+    parameters::GameStateFilterParameters,
+};
+
+#[derive(Clone, Copy, Deserialize, Serialize)]
+pub enum State {
+    Initial,
+    Ready,
+    Set,
+    Stop,
+    WhistleInSet {
+        time_when_whistle_was_detected: Time,
+    },
+    Playing,
+    WhistleInPlaying {
+        time_when_whistle_was_detected: Time,
+    },
+    TentativeFinished {
+        time_when_finished_clicked: Time,
+    },
+    Finished,
+}
+
+impl State {
+    pub fn from_game_state(game_state: GameState) -> Self {
+        match game_state {
+            GameState::Initial => State::Initial,
+            GameState::Ready => State::Ready,
+            GameState::Set => State::Set,
+            GameState::Playing => State::Playing,
+            GameState::Finished => State::Finished,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn construct_filtered_game_state_for_team(
+        &self,
+        now: &Time,
+        game_controller_state: &GameControllerState,
+        team: Team,
+        ball_detected_far_from_kick_off_point: bool,
+        config: &GameStateFilterParameters,
+        filtered_kicking_team: Option<Team>,
+    ) -> FilteredGameState {
+        let is_in_sub_state = game_controller_state.sub_state.is_some();
+        let opponent_is_kicking_team = filtered_kicking_team != Some(team);
+
+        match self {
+            State::Initial => FilteredGameState::Initial,
+            State::Ready => FilteredGameState::Ready,
+            State::Set => FilteredGameState::Set,
+            State::Stop => FilteredGameState::Stop,
+            State::WhistleInSet {
+                time_when_whistle_was_detected,
+            } => {
+                let kick_off_grace_period = is_in_grace_period(
+                    now,
+                    *time_when_whistle_was_detected,
+                    config.kick_off_grace_period + config.game_controller_controller_delay,
+                );
+                let opponent_kick_off = opponent_is_kicking_team
+                    && kick_off_grace_period
+                    && !ball_detected_far_from_kick_off_point;
+                let opponent_sub_state = opponent_is_kicking_team && is_in_sub_state;
+
+                FilteredGameState::Playing {
+                    ball_is_free: !opponent_kick_off && !opponent_sub_state,
+                    kick_off: !is_in_sub_state,
+                }
+            }
+            State::Playing => FilteredGameState::Playing {
+                ball_is_free: !(is_in_sub_state && opponent_is_kicking_team),
+                kick_off: false,
+            },
+            State::WhistleInPlaying { .. } => FilteredGameState::Ready,
+            State::Finished => match game_controller_state.game_phase {
+                GamePhase::PenaltyShootout { .. } => FilteredGameState::Set,
+                _ => FilteredGameState::Finished,
+            },
+            // is hack @schluis
+            State::TentativeFinished { .. } => FilteredGameState::Set,
+        }
+    }
+}
+
+fn is_in_grace_period(now: &Time, start_time: Time, grace_period: Duration) -> bool {
+    now.duration_since(start_time) < grace_period
+}

--- a/crates/nodes/game_controller_state_filter/src/state.rs
+++ b/crates/nodes/game_controller_state_filter/src/state.rs
@@ -8,8 +8,9 @@ use types::{
     parameters::GameStateFilterParameters,
 };
 
-#[derive(Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Deserialize, Serialize)]
 pub enum State {
+    #[default]
     Initial,
     Ready,
     Set,

--- a/crates/nodes/localization/src/lib.rs
+++ b/crates/nodes/localization/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let _parameters = node.bind_parameter_as::<Parameters>("localization")?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _primary_state_sub = node

--- a/crates/nodes/look_around/src/lib.rs
+++ b/crates/nodes/look_around/src/lib.rs
@@ -19,7 +19,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _current_mode_pub = node

--- a/crates/nodes/message_filter/Cargo.toml
+++ b/crates/nodes/message_filter/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 color-eyre = { workspace = true }
 hsl_network_messages = { workspace = true }
 ros-z = { workspace = true }
+ros-z-streams = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
 types = { workspace = true }

--- a/crates/nodes/message_filter/Cargo.toml
+++ b/crates/nodes/message_filter/Cargo.toml
@@ -10,4 +10,5 @@ color-eyre = { workspace = true }
 hsl_network_messages = { workspace = true }
 ros-z = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true }
 types = { workspace = true }

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -4,6 +4,7 @@ use color_eyre::Result;
 
 use hsl_network_messages::{HulkMessage, PlayerNumber, StateMessage};
 use ros_z::{prelude::*, qos::QosDurability};
+use ros_z_streams::CreateAnnouncingPublisher;
 use types::messages::IncomingMessage;
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
@@ -22,16 +23,18 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let filtered_message_pub = node
-        .publisher::<IncomingMessage>("filtered_message")?
-        .build()
+        .announcing_publisher::<IncomingMessage>("filtered_message")
         .await?;
 
     let mut player_number = None;
 
     loop {
         tokio::select! {
-            message = message_sub.recv(), if player_number.is_some() => {
-                let message = match message? {
+            message = message_sub.recv_with_metadata(), if player_number.is_some() => {
+                let received_message = message?;
+
+                let pending_accouncement = filtered_message_pub.announce(received_message.source_time).await?;
+                let message = match received_message.into_message(){
                     IncomingMessage::GameController(source_address, message) => Some(
                         IncomingMessage::GameController(source_address, message.clone()),
                     ),
@@ -42,7 +45,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 };
 
                 if let Some(message) = message {
-                    filtered_message_pub.publish(&message).await?;
+                    pending_accouncement.publish(&message).await?;
                 }
             }
             new_player_number = player_number_sub.recv() => {

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -37,7 +37,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 let pending_accouncement = filtered_message_pub.announce(stamped_message.time).await?;
 
                 let should_filter_message_out = matches!(stamped_message.incoming_message, IncomingMessage::Hsl(
-                        message @ HulkMessage::State(StateMessage { player_number, .. }),
+                        HulkMessage::State(StateMessage { player_number, .. }),
                     ) if player_number == current_player_number);
 
                 if !should_filter_message_out {

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -5,7 +5,7 @@ use color_eyre::Result;
 use hsl_network_messages::{HulkMessage, PlayerNumber, StateMessage};
 use ros_z::{prelude::*, qos::QosDurability};
 use ros_z_streams::CreateAnnouncingPublisher;
-use types::messages::IncomingMessage;
+use types::messages::{IncomingMessage, StampedIncomingMessage};
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("message_filter").build().await?;
@@ -19,34 +19,29 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let message_sub = node
-        .subscriber::<IncomingMessage>("inputs/message")?
+        .subscriber::<StampedIncomingMessage>("inputs/message")?
         .build()
         .await?;
     let filtered_message_pub = node
-        .announcing_publisher::<IncomingMessage>("filtered_message")
+        .announcing_publisher::<StampedIncomingMessage>("filtered_message")
         .await?;
 
     let mut player_number = None;
 
     loop {
         tokio::select! {
-            message = message_sub.recv_with_metadata() => {
-                let received_message = message?;
-
+            received_stamped_message = message_sub.recv() => {
                 let Some(current_player_number) = player_number else {continue;};
-                let pending_accouncement = filtered_message_pub.announce(received_message.source_time).await?;
-                let message = match received_message.into_message(){
-                    IncomingMessage::GameController(source_address, message) => Some(
-                        IncomingMessage::GameController(source_address, message.clone()),
-                    ),
-                    IncomingMessage::Hsl(
-                        message @ HulkMessage::State(StateMessage { player_number, .. }),
-                    ) if player_number != current_player_number => Some(IncomingMessage::Hsl(message)),
-                    _ => None,
-                };
+                let stamped_message = received_stamped_message?;
 
-                if let Some(message) = message {
-                    pending_accouncement.publish(&message).await?;
+                let pending_accouncement = filtered_message_pub.announce(stamped_message.time).await?;
+
+                let should_filter_message_out = matches!(stamped_message.incoming_message, IncomingMessage::Hsl(
+                        message @ HulkMessage::State(StateMessage { player_number, .. }),
+                    ) if player_number == current_player_number);
+
+                if !should_filter_message_out {
+                    pending_accouncement.publish(&stamped_message).await?;
                 }
             }
             received_player_number = player_number_sub.recv() => {

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     loop {
         tokio::select! {
             message = message_sub.recv(), if player_number.is_some() => {
-                let message = match message.into_eyre()? {
+                let message = match message? {
                     IncomingMessage::GameController(source_address, message) => Some(
                         IncomingMessage::GameController(source_address, message.clone()),
                     ),
@@ -42,7 +42,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 };
 
                 if let Some(message) = message {
-                    filtered_message_pub.publish(&message).await.into_eyre()?;
+                    filtered_message_pub.publish(&message).await?;
                 }
             }
             new_player_number = player_number_sub.recv() => {

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -30,9 +30,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     loop {
         tokio::select! {
-            message = message_sub.recv_with_metadata(), if player_number.is_some() => {
+            message = message_sub.recv_with_metadata() => {
                 let received_message = message?;
 
+                let Some(current_player_number) = player_number else {continue;};
                 let pending_accouncement = filtered_message_pub.announce(received_message.source_time).await?;
                 let message = match received_message.into_message(){
                     IncomingMessage::GameController(source_address, message) => Some(
@@ -40,7 +41,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     ),
                     IncomingMessage::Hsl(
                         message @ HulkMessage::State(StateMessage { player_number, .. }),
-                    ) if player_number != player_number => Some(IncomingMessage::Hsl(message)),
+                    ) if player_number != current_player_number => Some(IncomingMessage::Hsl(message)),
                     _ => None,
                 };
 
@@ -48,8 +49,8 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                     pending_accouncement.publish(&message).await?;
                 }
             }
-            new_player_number = player_number_sub.recv() => {
-                player_number = Some(new_player_number);
+            received_player_number = player_number_sub.recv() => {
+                player_number = Some(received_player_number?);
             }
         }
     }

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -4,7 +4,6 @@ use color_eyre::Result;
 
 use hsl_network_messages::{HulkMessage, PlayerNumber, StateMessage};
 use ros_z::{prelude::*, qos::QosDurability};
-use ros_z_streams::CreateAnnouncingPublisher;
 use types::{messages::IncomingMessage, time_wrapper::TimeWrapper};
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
@@ -23,7 +22,8 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let filtered_message_pub = node
-        .announcing_publisher::<IncomingMessage>("filtered_message")
+        .publisher::<TimeWrapper<IncomingMessage>>("filtered_message")?
+        .build()
         .await?;
 
     let mut player_number = None;
@@ -34,14 +34,17 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 let Some(current_player_number) = player_number else {continue;};
                 let time_wrapped_message = received_time_wrapped_message?;
 
-                let pending_accouncement = filtered_message_pub.announce(time_wrapped_message.time).await?;
-
                 let should_filter_message_out = matches!(time_wrapped_message.inner, IncomingMessage::Hsl(
                         HulkMessage::State(StateMessage { player_number, .. }),
                     ) if player_number == current_player_number);
 
                 if !should_filter_message_out {
-                    pending_accouncement.publish(&time_wrapped_message.inner).await?;
+                    filtered_message_pub.publish(
+                        &TimeWrapper {
+                            time: time_wrapped_message.time,
+                            inner: time_wrapped_message.inner
+                        }
+                    ).await?;
                 }
             }
             received_player_number = player_number_sub.recv() => {

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -5,7 +5,7 @@ use color_eyre::Result;
 use hsl_network_messages::{HulkMessage, PlayerNumber, StateMessage};
 use ros_z::{prelude::*, qos::QosDurability};
 use ros_z_streams::CreateAnnouncingPublisher;
-use types::messages::{IncomingMessage, StampedIncomingMessage};
+use types::{messages::IncomingMessage, time_wrapper::TimeWrapper};
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("message_filter").build().await?;
@@ -19,29 +19,29 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let message_sub = node
-        .subscriber::<StampedIncomingMessage>("inputs/message")?
+        .subscriber::<TimeWrapper<IncomingMessage>>("inputs/message")?
         .build()
         .await?;
     let filtered_message_pub = node
-        .announcing_publisher::<StampedIncomingMessage>("filtered_message")
+        .announcing_publisher::<IncomingMessage>("filtered_message")
         .await?;
 
     let mut player_number = None;
 
     loop {
         tokio::select! {
-            received_stamped_message = message_sub.recv() => {
+            received_time_wrapped_message = message_sub.recv() => {
                 let Some(current_player_number) = player_number else {continue;};
-                let stamped_message = received_stamped_message?;
+                let time_wrapped_message = received_time_wrapped_message?;
 
-                let pending_accouncement = filtered_message_pub.announce(stamped_message.time).await?;
+                let pending_accouncement = filtered_message_pub.announce(time_wrapped_message.time).await?;
 
-                let should_filter_message_out = matches!(stamped_message.incoming_message, IncomingMessage::Hsl(
+                let should_filter_message_out = matches!(time_wrapped_message.inner, IncomingMessage::Hsl(
                         HulkMessage::State(StateMessage { player_number, .. }),
                     ) if player_number == current_player_number);
 
                 if !should_filter_message_out {
-                    pending_accouncement.publish(&stamped_message).await?;
+                    pending_accouncement.publish(&time_wrapped_message.inner).await?;
                 }
             }
             received_player_number = player_number_sub.recv() => {

--- a/crates/nodes/message_filter/src/lib.rs
+++ b/crates/nodes/message_filter/src/lib.rs
@@ -1,15 +1,15 @@
-use std::{future::pending, sync::Arc};
+use std::sync::Arc;
 
 use color_eyre::Result;
 
-use hsl_network_messages::PlayerNumber;
+use hsl_network_messages::{HulkMessage, PlayerNumber, StateMessage};
 use ros_z::{prelude::*, qos::QosDurability};
 use types::messages::IncomingMessage;
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("message_filter").build().await?;
 
-    let _player_number_sub = node
+    let player_number_sub = node
         .subscriber::<PlayerNumber>("player_number")?
         .qos(QosProfile {
             durability: QosDurability::TransientLocal,
@@ -17,16 +17,37 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         })
         .build()
         .await?;
-    let _message_sub = node
+    let message_sub = node
         .subscriber::<IncomingMessage>("inputs/message")?
         .build()
         .await?;
-    let _filtered_message_pub = node
+    let filtered_message_pub = node
         .publisher::<IncomingMessage>("filtered_message")?
         .build()
         .await?;
 
-    pending::<()>().await;
+    let mut player_number = None;
 
-    Ok(())
+    loop {
+        tokio::select! {
+            message = message_sub.recv(), if player_number.is_some() => {
+                let message = match message.into_eyre()? {
+                    IncomingMessage::GameController(source_address, message) => Some(
+                        IncomingMessage::GameController(source_address, message.clone()),
+                    ),
+                    IncomingMessage::Hsl(
+                        message @ HulkMessage::State(StateMessage { player_number, .. }),
+                    ) if player_number != player_number => Some(IncomingMessage::Hsl(message)),
+                    _ => None,
+                };
+
+                if let Some(message) = message {
+                    filtered_message_pub.publish(&message).await.into_eyre()?;
+                }
+            }
+            new_player_number = player_number_sub.recv() => {
+                player_number = Some(new_player_number);
+            }
+        }
+    }
 }

--- a/crates/nodes/message_receiver/src/lib.rs
+++ b/crates/nodes/message_receiver/src/lib.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use hsl_network::endpoint::{Endpoint, Ports};
 use ros_z::prelude::*;
-use types::messages::IncomingMessage;
+use types::messages::StampedIncomingMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
 #[serde(deny_unknown_fields)]
@@ -18,7 +18,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let parameters = node.bind_parameter_as::<Parameters>("message_receiver")?;
     let message_pub = node
-        .publisher::<IncomingMessage>("inputs/message")?
+        .publisher::<StampedIncomingMessage>("inputs/message")?
         .build()
         .await?;
 
@@ -30,6 +30,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             message = endpoint.read() => {
                 let message = message?;
 
+                let message = StampedIncomingMessage{ time: ctx.clock().now(), incoming_message: message };
                 message_pub.publish(&message).await?;
             }
         }

--- a/crates/nodes/message_receiver/src/lib.rs
+++ b/crates/nodes/message_receiver/src/lib.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use hsl_network::endpoint::{Endpoint, Ports};
 use ros_z::prelude::*;
-use types::messages::StampedIncomingMessage;
+use types::{messages::IncomingMessage, time_wrapper::TimeWrapper};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
 #[serde(deny_unknown_fields)]
@@ -18,7 +18,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let parameters = node.bind_parameter_as::<Parameters>("message_receiver")?;
     let message_pub = node
-        .publisher::<StampedIncomingMessage>("inputs/message")?
+        .publisher::<TimeWrapper<IncomingMessage>>("inputs/message")?
         .build()
         .await?;
 
@@ -30,7 +30,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             message = endpoint.read() => {
                 let message = message?;
 
-                let message = StampedIncomingMessage{ time: ctx.clock().now(), incoming_message: message };
+                let message = TimeWrapper{ time: ctx.clock().now(), inner: message };
                 message_pub.publish(&message).await?;
             }
         }

--- a/crates/nodes/obstacle_receiver/src/lib.rs
+++ b/crates/nodes/obstacle_receiver/src/lib.rs
@@ -12,7 +12,7 @@ use types::{
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("obstacle_receiver").build().await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _ground_to_field_sub = node

--- a/crates/nodes/primary_state_filter/src/lib.rs
+++ b/crates/nodes/primary_state_filter/src/lib.rs
@@ -35,7 +35,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _is_safe_pose_sub = node.subscriber::<bool>("is_safe_pose")?.build().await?;

--- a/crates/nodes/rule_obstacle_composer/src/lib.rs
+++ b/crates/nodes/rule_obstacle_composer/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _ball_state_sub = node.subscriber::<BallState>("ball_state")?.build().await?;

--- a/crates/nodes/search_suggestor/src/lib.rs
+++ b/crates/nodes/search_suggestor/src/lib.rs
@@ -43,7 +43,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _network_message_sub = node

--- a/crates/nodes/team_ball_receiver/src/lib.rs
+++ b/crates/nodes/team_ball_receiver/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let _parameters = node.bind_parameter_as::<Parameters>("team_ball_receiver")?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _network_message_sub = node

--- a/crates/nodes/world_state_composer/src/lib.rs
+++ b/crates/nodes/world_state_composer/src/lib.rs
@@ -33,7 +33,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _ball_sub = node.subscriber::<BallState>("ball_state")?.build().await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _ground_to_field_sub = node

--- a/crates/nodes/world_to_field_provider/src/lib.rs
+++ b/crates/nodes/world_to_field_provider/src/lib.rs
@@ -10,7 +10,7 @@ use types::game_controller_state::GameControllerState;
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("world_to_field_provider").build().await?;
     let _game_controller_state_sub = node
-        .subscriber::<GameControllerState>("game_controller_state")?
+        .subscriber::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
     let _world_to_field_pub = node

--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -176,11 +176,15 @@ impl<T> CacheInner<T> {
         }
     }
 
-    pub fn oldest_stamp(&self) -> Option<Time> {
+    pub fn get_latest(&self) -> Option<Arc<T>> {
+        self.entries.values().next_back()?.back().cloned()
+    }
+
+    pub fn earliest_stamp(&self) -> Option<Time> {
         self.entries.keys().next().copied()
     }
 
-    pub fn newest_stamp(&self) -> Option<Time> {
+    pub fn latest_stamp(&self) -> Option<Time> {
         self.entries.keys().next_back().copied()
     }
 
@@ -315,14 +319,18 @@ impl<T> Cache<T> {
         inner.get_nearest(t)
     }
 
+    pub fn get_latest(&self) -> Option<Arc<T>> {
+        self.inner.read().get_latest()
+    }
+
     /// Timestamp of the oldest cached message, or `None` if empty.
     pub fn oldest_stamp(&self) -> Option<Time> {
-        self.inner.read().oldest_stamp()
+        self.inner.read().earliest_stamp()
     }
 
     /// Timestamp of the newest cached message, or `None` if empty.
     pub fn newest_stamp(&self) -> Option<Time> {
-        self.inner.read().newest_stamp()
+        self.inner.read().latest_stamp()
     }
 
     /// Number of messages currently in the cache.

--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -324,12 +324,12 @@ impl<T> Cache<T> {
     }
 
     /// Timestamp of the oldest cached message, or `None` if empty.
-    pub fn oldest_stamp(&self) -> Option<Time> {
+    pub fn earliest_stamp(&self) -> Option<Time> {
         self.inner.read().earliest_stamp()
     }
 
     /// Timestamp of the newest cached message, or `None` if empty.
-    pub fn newest_stamp(&self) -> Option<Time> {
+    pub fn latest_stamp(&self) -> Option<Time> {
         self.inner.read().latest_stamp()
     }
 

--- a/crates/ros-z/tests/pubsub_qos.rs
+++ b/crates/ros-z/tests/pubsub_qos.rs
@@ -382,7 +382,7 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                if let Some(stamp) = cache.newest_stamp() {
+                if let Some(stamp) = cache.latest_stamp() {
                     let message = cache.get_before(stamp).expect("stamp came from cache");
                     assert_eq!(message.as_str(), "cached");
                     break;

--- a/crates/types/src/filtered_whistle.rs
+++ b/crates/types/src/filtered_whistle.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(
     Clone,
+    Copy,
     Debug,
     Default,
     Deserialize,

--- a/crates/types/src/messages.rs
+++ b/crates/types/src/messages.rs
@@ -1,16 +1,10 @@
 use std::net::SocketAddr;
 
-use ros_z::{Message, time::Time};
+use ros_z::Message;
 use serde::{Deserialize, Serialize};
 
 use hsl_network_messages::{GameControllerReturnMessage, GameControllerStateMessage, HulkMessage};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
-
-#[derive(Debug, Serialize, Deserialize, Message)]
-pub struct StampedIncomingMessage {
-    pub time: Time,
-    pub incoming_message: IncomingMessage,
-}
 
 #[derive(
     Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect, Message,

--- a/crates/types/src/messages.rs
+++ b/crates/types/src/messages.rs
@@ -1,10 +1,16 @@
 use std::net::SocketAddr;
 
-use ros_z::Message;
+use ros_z::{Message, time::Time};
 use serde::{Deserialize, Serialize};
 
 use hsl_network_messages::{GameControllerReturnMessage, GameControllerStateMessage, HulkMessage};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
+
+#[derive(Debug, Serialize, Deserialize, Message)]
+pub struct StampedIncomingMessage {
+    pub time: Time,
+    pub incoming_message: IncomingMessage,
+}
 
 #[derive(
     Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect, Message,


### PR DESCRIPTION
## Why? What?

This PR ports the `message_filter`, `game_controller_filter` and `game_controller_state_filter`.

- Part of #2426
- Depends on #2522  
- Depends on #2521 
- Depends on #2534 
- Depends on #2535 

## Discussion

- [x] Do the inputs of message filter and game controller state filter need to be future queues/maps?

## How to Test

- Upload
- Use the twix ros z twix to view the output in the text panel or in rosz cli