### PR TITLE
Update flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv/
 .vs/
 .vscode/
+result
 
 /.wiki/
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,111 +1,45 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1778106249,
+        "narHash": "sha256-cM/AuKy5tMhwOOQIbha8ZRRMHVfNf7cv2aljIw+qoCg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6d015ea29630b7ad2402841386da2cb617a470a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1698420672,
-        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
-    "nixgl": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1685908677,
-        "narHash": "sha256-E4zUPEUFyVWjVm45zICaHRpfGepfkE9Z2OECV9HXfA4=",
-        "owner": "guibou",
-        "repo": "nixGL",
-        "rev": "489d6b095ab9d289fe11af0219a9ff00fe87c7c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "guibou",
-        "repo": "nixGL",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704842529,
-        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1660551188,
-        "narHash": "sha256-a1LARMMYQ8DPx1BgoI/UN4bXe12hhZkCNqdxNi6uS0g=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "441dc5d512153039f19ef198e662e4f3dbb9fd65",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1701068326,
-        "narHash": "sha256-vmMceA+q6hG1yrjb+MP8T0YFDQIrW3bl45e7z24IEts=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -117,10 +51,9 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
-        "nixgl": "nixgl",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -15,24 +15,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1778869304,
@@ -52,23 +34,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,119 +1,108 @@
 {
-  description = "Dev environment for HULKs";
+  description = "Dev Environment for HULKs";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nix-community/naersk";
-    nixgl.url = "github:guibou/nixGL";
+    crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, flake-utils, naersk, nixgl }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ nixgl.overlay ];
-          };
-          naersk' = pkgs.callPackage naersk { };
-          nao_sdk_version = "5.9.0";
-          nao_sdk_environment_path = "$HOME/.naosdk/${nao_sdk_version}/environment-setup-corei7-64-aldebaran-linux";
-          buildInputs = with pkgs;[
-            # Tools
-            cargo
-            cmake
-            llvmPackages.clang
-            pkg-config
-            python312
-            rsync
-            rustc
-            rustfmt
+  outputs = { self, nixpkgs, flake-utils, crane }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        craneLibrary = crane.mkLib pkgs;
 
-            # Libs
-            alsa-lib
-            hdf5
-            libGL
-            libogg
-            libxkbcommon
-            luajit
-            openssl
-            opusfile
-            pkgs.nixgl.auto.nixGLDefault
-            rustPlatform.bindgenHook
-            systemdLibs
-            wayland
-            xorg.libX11
-            xorg.libXcursor
-            xorg.libXi
-            xorg.libXrandr
+        src = pkgs.lib.cleanSourceWith {
+          src = craneLibrary.path ./.;
+          filter = path: type:
+            (builtins.match ".*/(crates|tools)/.*" path != null) ||
+            (craneLibrary.filterCargoSources path type);
+        };
+
+        baseNativeBuildInputs = with pkgs; [ pkg-config rustPlatform.bindgenHook ];
+        baseBuildInputs = with pkgs; [ openssl ];
+        guiLibraries = with pkgs; [ libGL libxkbcommon wayland libx11 udev ];
+
+        workspaceCargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+        workspaceVersion = workspaceCargoToml.workspace.package.version;
+
+        mkCrate = { name, package ? name, cargoToml, extraLibraries ? [] }:
+          let
+            localCargoToml = fromTOML (builtins.readFile cargoToml);
+
+            # Crane currently cannot resolve `version = { workspace = true }`.
+            # Resolve the version by checking the local Cargo.toml first, then falling back to the workspace root
+            resolvedVersion =
+              if localCargoToml.package ? version && builtins.isString localCargoToml.package.version then
+                localCargoToml.package.version
+              else
+                workspaceVersion;
+
+            arguments = {
+              inherit src;
+              pname = name;
+              version = resolvedVersion;
+              nativeBuildInputs = baseNativeBuildInputs ++ pkgs.lib.optional (extraLibraries != []) pkgs.makeWrapper;
+              buildInputs = baseBuildInputs ++ extraLibraries;
+              cargoExtraArgs = "-p ${package} --bin ${name}";
+            };
+
+            cargoArtifacts = craneLibrary.buildDepsOnly arguments;
+          in
+          craneLibrary.buildPackage (arguments // {
+            inherit cargoArtifacts;
+            postInstall = pkgs.lib.optionalString (extraLibraries != [])  ''
+              if [ -f $out/bin/${name} ]; then
+                wrapProgram $out/bin/${name} \
+                  --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath extraLibraries}
+              fi
+            '';
+          });
+      in
+      {
+        packages = {
+          pepsi = mkCrate {
+            name = "pepsi";
+            cargoToml = ./tools/pepsi/Cargo.toml;
+          };
+
+          twix = mkCrate {
+            name = "twix";
+            cargoToml = ./tools/twix/Cargo.toml;
+            extraLibraries = guiLibraries;
+          };
+
+          rosz = mkCrate {
+            name = "rosz";
+            package = "ros-z-cli";
+            cargoToml = ./crates/ros-z-cli/Cargo.toml;
+          };
+
+          default = self.packages.${system}.pepsi;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [
+            self.packages.${system}.pepsi
+            self.packages.${system}.twix
+            self.packages.${system}.rosz
           ];
 
-          mktool = manifest_path:
-            let
-              manifest = (pkgs.lib.importTOML manifest_path).package;
-            in
-            naersk'.buildPackage {
-              name = manifest.name;
-              version = manifest.version;
-              src = ./.;
-              inherit buildInputs;
-              cargoBuildOptions = x: x ++ [ "-p" manifest.name ];
-              cargoTestOptions = x: x ++ [ "-p" manifest.name ];
-            };
+          packages = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            rustfmt
+            clippy
+            rsync
+            openssh
+          ];
 
-          mktool_wrapper_gui = tool:
-            let
-              binary_name = pkgs.lib.strings.removeSuffix "-${tool.version}" tool.name;
-              wrapper = pkgs.writeShellScriptBin "${tool.name}-wrapper" ''
-                ${pkgs.nixgl.auto.nixGLDefault}/bin/nixGL ${tool}/bin/${binary_name} $@
-              '';
-            in
-            {
-              type = "app";
-              program = "${wrapper}/bin/${tool.name}-wrapper";
-            };
-        in
-        {
-          packages.twix = mktool ./tools/twix/Cargo.toml;
-          packages.pepsi = mktool ./tools/pepsi/Cargo.toml;
-          packages.fanta = mktool ./tools/fanta/Cargo.toml;
-          packages.annotato = mktool ./tools/annotato/Cargo.toml;
-          packages.behavior_simulator = mktool ./tools/behavior_simulator/Cargo.toml;
-
-          # Needed for non-nixos systems
-          apps.twix = mktool_wrapper_gui self.packages.${system}.twix;
-
-          # Needed for non-nixos systems
-          apps.annotato  = mktool_wrapper_gui self.packages.${system}.annotato;
-
-          devShells = {
-            tools = pkgs.mkShell
-              rec {
-                inherit buildInputs;
-                env = {
-                  LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
-                  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-                };
-              };
-
-            robot = (pkgs.buildFHSUserEnv {
-              name = "hulk-robot-dev-env";
-              targetPkgs = pkgs: ([ ]);
-              extraOutputsToInstall = [ "dev" ];
-              runScript = "bash";
-              profile = ''
-                if [[ ! -f "${nao_sdk_environment_path}" ]]; then
-                  echo "ERROR: nao sdk v${nao_sdk_version} not found! Please install it."
-                  exit 1
-                fi
-                echo "Unsetting LD_LIBRARY_PATH..."
-                unset LD_LIBRARY_PATH
-                echo "Sourcing nao sdk v${nao_sdk_version}..."
-                source ${nao_sdk_environment_path}
-              '';
-            }).env;
+          env = {
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath guiLibraries;
           };
-        }
-      );
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,108 +1,82 @@
 {
-  description = "Dev Environment for HULKs";
+  description = "Development environment and tools for HULKs";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, flake-utils, crane }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        craneLibrary = crane.mkLib pkgs;
+  outputs = { nixpkgs, crane, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      craneLibrary = crane.mkLib pkgs;
 
-        src = pkgs.lib.cleanSourceWith {
-          src = craneLibrary.path ./.;
-          filter = path: type:
-            (builtins.match ".*/(crates|tools)/.*" path != null) ||
-            (craneLibrary.filterCargoSources path type);
+      src = pkgs.lib.fileset.toSource {
+        root = ./.;
+        fileset = pkgs.lib.fileset.unions [
+          (craneLibrary.fileset.commonCargoSources ./.)
+          ./crates/hsl_network_messages/headers/RoboCupGameControlData.hpp
+          ./tools/pepsi/src/install-podman.sh
+        ];
+      };
+
+      guiLibraries = with pkgs; [ libGL libxkbcommon wayland libx11 ];
+      workspaceVersion =
+        (fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
+      mkCrate = {
+        name,
+        cargoToml,
+        package ? name,
+        nativeBuildInputs ? [ ],
+        libraries ? [ ],
+      }:
+        let
+          packageVersion =
+            (fromTOML (builtins.readFile cargoToml)).package.version;
+          version = if builtins.isString packageVersion then packageVersion else workspaceVersion;
+        in
+        craneLibrary.buildPackage {
+          inherit src version;
+          pname = name;
+          strictDeps = true;
+          nativeBuildInputs =
+            nativeBuildInputs ++ pkgs.lib.optional (libraries != [ ]) pkgs.makeWrapper;
+          buildInputs = libraries;
+          cargoExtraArgs = "--locked -p ${package} --bin ${name}";
+          doCheck = false;
+          postInstall = pkgs.lib.optionalString (libraries != [ ]) ''
+            wrapProgram "$out/bin/${name}" \
+              --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath libraries}
+          '';
         };
 
-        baseNativeBuildInputs = with pkgs; [ pkg-config rustPlatform.bindgenHook ];
-        baseBuildInputs = with pkgs; [ openssl ];
-        guiLibraries = with pkgs; [ libGL libxkbcommon wayland libx11 udev ];
+      pepsi = mkCrate {
+        name = "pepsi";
+        cargoToml = ./tools/pepsi/Cargo.toml;
+      };
 
-        workspaceCargoToml = fromTOML (builtins.readFile ./Cargo.toml);
-        workspaceVersion = workspaceCargoToml.workspace.package.version;
+      twix = mkCrate {
+        name = "twix";
+        cargoToml = ./tools/twix/Cargo.toml;
+        nativeBuildInputs = with pkgs; [ pkg-config rustPlatform.bindgenHook ];
+        libraries = guiLibraries;
+      };
 
-        mkCrate = { name, package ? name, cargoToml, extraLibraries ? [] }:
-          let
-            localCargoToml = fromTOML (builtins.readFile cargoToml);
+      rosz = mkCrate {
+        name = "rosz";
+        package = "ros-z-cli";
+        cargoToml = ./crates/ros-z-cli/Cargo.toml;
+      };
+    in
+    {
+      packages.${system} = { inherit pepsi twix rosz; };
 
-            # Crane currently cannot resolve `version = { workspace = true }`.
-            # Resolve the version by checking the local Cargo.toml first, then falling back to the workspace root
-            resolvedVersion =
-              if localCargoToml.package ? version && builtins.isString localCargoToml.package.version then
-                localCargoToml.package.version
-              else
-                workspaceVersion;
-
-            arguments = {
-              inherit src;
-              pname = name;
-              version = resolvedVersion;
-              nativeBuildInputs = baseNativeBuildInputs ++ pkgs.lib.optional (extraLibraries != []) pkgs.makeWrapper;
-              buildInputs = baseBuildInputs ++ extraLibraries;
-              cargoExtraArgs = "-p ${package} --bin ${name}";
-            };
-
-            cargoArtifacts = craneLibrary.buildDepsOnly arguments;
-          in
-          craneLibrary.buildPackage (arguments // {
-            inherit cargoArtifacts;
-            postInstall = pkgs.lib.optionalString (extraLibraries != [])  ''
-              if [ -f $out/bin/${name} ]; then
-                wrapProgram $out/bin/${name} \
-                  --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath extraLibraries}
-              fi
-            '';
-          });
-      in
-      {
-        packages = {
-          pepsi = mkCrate {
-            name = "pepsi";
-            cargoToml = ./tools/pepsi/Cargo.toml;
-          };
-
-          twix = mkCrate {
-            name = "twix";
-            cargoToml = ./tools/twix/Cargo.toml;
-            extraLibraries = guiLibraries;
-          };
-
-          rosz = mkCrate {
-            name = "rosz";
-            package = "ros-z-cli";
-            cargoToml = ./crates/ros-z-cli/Cargo.toml;
-          };
-
-          default = self.packages.${system}.pepsi;
-        };
-
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [
-            self.packages.${system}.pepsi
-            self.packages.${system}.twix
-            self.packages.${system}.rosz
-          ];
-
-          packages = with pkgs; [
-            cargo
-            rustc
-            rust-analyzer
-            rustfmt
-            clippy
-            rsync
-            openssh
-          ];
-
-          env = {
-            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath guiLibraries;
-          };
-        };
-      }
-    );
+      devShells.${system}.default = craneLibrary.devShell {
+        inputsFrom = [ pepsi twix rosz ];
+        packages = with pkgs; [ rust-analyzer rsync openssh ];
+        env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath guiLibraries;
+      };
+    };
 }


### PR DESCRIPTION
## Why? What?

Updates the `flake.nix` of the root. While not-complete, it provides `pepsi`, `rosz`, and `twix`, which are arguably the most important tools right now.
However, more importantly, the flake can be used to generate a deterministic development environment.

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

- Port remaining cli tools

## How to Test

- `nix build|run .#pepsi|rosz|twix`
- `nix develop`
