### PR TITLE
Only publish global parameters on change

### DIFF
--- a/crates/nodes/global_parameter_provider/src/lib.rs
+++ b/crates/nodes/global_parameter_provider/src/lib.rs
@@ -45,9 +45,11 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await
         .into_eyre()?;
 
+    let mut parameters_receiver = parameters.subscribe();
     loop {
-        let parameters_snapshot = parameters.snapshot();
-        let parameters = parameters_snapshot.typed();
+        let _ = parameters_receiver.changed().await;
+        let parameters = parameters_receiver.borrow_and_update().clone();
+        let parameters = parameters.typed();
 
         player_number_pub
             .publish(&parameters.player_number)


### PR DESCRIPTION
## Why? What?

Currently, the global parameters are published every loop iteration. Since it is a TransientLocal Publisher, it can simply only publish when the parameters changes, and subscribers still always receive the most up to date value.

## How to Test

- `cargo run --bin hulk_ros_z -- --robot 42 --location base`
- Play around with `rosz parameter get/set field_dimensions`