### PR TITLE
Fix `Time` `Message` schema impl

### DIFF
--- a/crates/ros-z/src/time.rs
+++ b/crates/ros-z/src/time.rs
@@ -47,8 +47,8 @@ impl crate::schema::MessageSchema for Time {
 fn duration_schema(builder: &mut crate::schema::SchemaBuilder) -> Result<TypeDef, SchemaError> {
     let name = TypeName::new("builtin_interfaces::Duration")?;
     builder.define_struct(name, |fields| {
-        fields.field::<i32>("sec")?;
-        fields.field::<u32>("nanosec")?;
+        fields.field::<u64>("secs")?;
+        fields.field::<u32>("nanos")?;
         Ok(())
     })
 }


### PR DESCRIPTION
## Why? What?

The `Message` impl for `ros_z::time::Time` is currently broken. The fields for the duration schema are both constructed with wrong field names and types. This PR fixes this and makes it consistent with the `Time` definition.