### PR TITLE
Publish global parameters atleast once

### DIFF
--- a/crates/nodes/global_parameter_provider/src/lib.rs
+++ b/crates/nodes/global_parameter_provider/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Parameters {
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("global_parameter_provider").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("global")?;
+    let node_parameters = node.bind_parameter_as::<Parameters>("global")?;
 
     let player_number_pub = node
         .publisher::<PlayerNumber>("player_number")?
@@ -37,7 +37,14 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let mut parameters_receiver = parameters.subscribe();
+    let parameters_snapshot = node_parameters.snapshot();
+    let parameters = parameters_snapshot.typed();
+    player_number_pub.publish(&parameters.player_number).await?;
+    field_dimensions_pub
+        .publish(&parameters.field_dimensions)
+        .await?;
+
+    let mut parameters_receiver = node_parameters.subscribe();
     loop {
         let _ = parameters_receiver.changed().await;
         let parameters = parameters_receiver.borrow_and_update().clone();


### PR DESCRIPTION
## Why? What?

Currently, the transient local publisher of the global parameters only publish once the parameters have been changed. This PR makes them publish once before waiting. 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
