### PR TITLE
Add closest to ball logic

### DIFF
--- a/crates/nodes/behavior_node/src/conditions.rs
+++ b/crates/nodes/behavior_node/src/conditions.rs
@@ -4,6 +4,7 @@ use linear_algebra::{point, vector};
 use types::{
     filtered_game_controller_state::FilteredGameControllerState, primary_state::PrimaryState,
 };
+use voronoi::Ownership;
 
 use crate::node::Blackboard;
 
@@ -91,9 +92,53 @@ pub fn is_close_to_ball_aligned(blackboard: &mut Blackboard) -> bool {
     is_close_and_aligned
 }
 
-pub fn is_closest_to_ball(_blackboard: &mut Blackboard) -> bool {
-    // TODO
-    true
+pub fn is_closest_to_ball(blackboard: &mut Blackboard) -> bool {
+    let own_player_number = blackboard.world_state.robot.player_number;
+
+    let raw_is_closest =
+        if let (Some(ball), Some(voronoi_map)) = (&blackboard.ball, &blackboard.voronoi_map) {
+            let ownership_at_ball = voronoi_map.ownership_at(ball.position);
+            match ownership_at_ball {
+                Some(Ownership::Robot(player_number)) if player_number == own_player_number => true,
+                Some(Ownership::Blocked) => voronoi_map
+                    .nearest_non_blocked_ownership(ball.position)
+                    .is_some_and(|ownership| ownership == Ownership::Robot(own_player_number)),
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+    let now = blackboard.world_state.now;
+    if raw_is_closest {
+        blackboard.closest_to_ball_entered_area_since =
+            blackboard.closest_to_ball_entered_area_since.or(Some(now));
+        blackboard.closest_to_ball_left_area_since = None;
+    } else {
+        blackboard.closest_to_ball_left_area_since =
+            blackboard.closest_to_ball_left_area_since.or(Some(now));
+        blackboard.closest_to_ball_entered_area_since = None;
+    }
+
+    let is_closest = if blackboard.last_closest_to_ball {
+        raw_is_closest
+            || blackboard
+                .closest_to_ball_left_area_since
+                .is_some_and(|since| {
+                    now.duration_since(since) < blackboard.parameters.closest_to_ball_exit_duration
+                })
+    } else {
+        raw_is_closest
+            && blackboard
+                .closest_to_ball_entered_area_since
+                .is_some_and(|since| {
+                    now.duration_since(since)
+                        >= blackboard.parameters.closest_to_ball_enter_duration
+                })
+    };
+
+    blackboard.last_closest_to_ball = is_closest;
+    is_closest
 }
 
 pub fn is_fallen(blackboard: &mut Blackboard) -> bool {

--- a/crates/nodes/behavior_node/src/node.rs
+++ b/crates/nodes/behavior_node/src/node.rs
@@ -57,6 +57,9 @@ pub struct Blackboard {
     pub last_motion_type: Option<MotionType>,
     pub last_sent_game_controller_return_message_time: Option<Time>,
     pub last_sent_hsl_message_time: Option<Time>,
+    pub last_closest_to_ball: bool,
+    pub closest_to_ball_entered_area_since: Option<Time>,
+    pub closest_to_ball_left_area_since: Option<Time>,
 
     pub is_injected_motion_command: bool,
     pub walk_position: Option<Point2<Ground>>,
@@ -200,6 +203,9 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         last_motion_type: None,
         last_sent_game_controller_return_message_time: None,
         last_sent_hsl_message_time: None,
+        last_closest_to_ball: false,
+        closest_to_ball_entered_area_since: None,
+        closest_to_ball_left_area_since: None,
 
         is_injected_motion_command: false,
         walk_position: None,

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -97,6 +97,8 @@ pub struct BehaviorParameters {
     pub substates: SubstatesParameters,
     pub voronoi: VoronoiParameters,
     pub hsl_network: HslNetworkParameters,
+    pub closest_to_ball_enter_duration: Duration,
+    pub closest_to_ball_exit_duration: Duration,
 }
 
 #[derive(

--- a/crates/voronoi/src/lib.rs
+++ b/crates/voronoi/src/lib.rs
@@ -381,6 +381,11 @@ impl VoronoiGrid {
         None
     }
 
+    pub fn nearest_non_blocked_ownership(&self, point: Point2<Field>) -> Option<Ownership> {
+        self.nearest_non_blocked_cell_index(point)
+            .map(|index| self.tiles[index])
+    }
+
     fn index_from_xy(&self, x: usize, y: usize) -> usize {
         y * (self.width_tiles) + x
     }
@@ -408,6 +413,10 @@ impl VoronoiGrid {
                 }
             }
         }
+    }
+
+    pub fn ownership_at(&self, point: Point2<Field>) -> Option<Ownership> {
+        self.point_to_index(point).map(|index| self.tiles[index])
     }
 }
 

--- a/crates/world_state/src/behavior/condition.rs
+++ b/crates/world_state/src/behavior/condition.rs
@@ -4,6 +4,7 @@ use linear_algebra::{point, vector};
 use types::{
     filtered_game_controller_state::FilteredGameControllerState, primary_state::PrimaryState,
 };
+use voronoi::Ownership;
 
 use crate::behavior::node::Blackboard;
 
@@ -91,9 +92,60 @@ pub fn is_close_to_ball_aligned(blackboard: &mut Blackboard) -> bool {
     is_close_and_aligned
 }
 
-pub fn is_closest_to_ball(_blackboard: &mut Blackboard) -> bool {
-    // TODO
-    true
+pub fn is_closest_to_ball(blackboard: &mut Blackboard) -> bool {
+    let own_player_number = blackboard.world_state.robot.player_number;
+
+    let raw_is_closest =
+        if let (Some(ball), Some(voronoi_map)) = (&blackboard.ball, &blackboard.voronoi_map) {
+            let ownership_at_ball = voronoi_map.ownership_at(ball.position);
+            match ownership_at_ball {
+                Some(Ownership::Robot(player_number)) if player_number == own_player_number => true,
+                Some(Ownership::Blocked) => voronoi_map
+                    .nearest_non_blocked_ownership(ball.position)
+                    .is_some_and(|ownership| ownership == Ownership::Robot(own_player_number)),
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+    let now = blackboard.world_state.now;
+    if raw_is_closest {
+        blackboard.closest_to_ball_entered_area_since = blackboard
+            .closest_to_ball_entered_area_since
+            .or(Some(now.to_wallclock()));
+        blackboard.closest_to_ball_left_area_since = None;
+    } else {
+        blackboard.closest_to_ball_left_area_since = blackboard
+            .closest_to_ball_left_area_since
+            .or(Some(now.to_wallclock()));
+        blackboard.closest_to_ball_entered_area_since = None;
+    }
+
+    let is_closest = if blackboard.last_closest_to_ball {
+        raw_is_closest
+            || blackboard
+                .closest_to_ball_left_area_since
+                .is_some_and(|since| {
+                    now.to_wallclock()
+                        .duration_since(since)
+                        .expect("time ran backwards")
+                        < blackboard.parameters.closest_to_ball_exit_duration
+                })
+    } else {
+        raw_is_closest
+            && blackboard
+                .closest_to_ball_entered_area_since
+                .is_some_and(|since| {
+                    now.to_wallclock()
+                        .duration_since(since)
+                        .expect("time ran backwards")
+                        >= blackboard.parameters.closest_to_ball_enter_duration
+                })
+    };
+
+    blackboard.last_closest_to_ball = is_closest;
+    is_closest
 }
 
 pub fn is_fallen(blackboard: &mut Blackboard) -> bool {

--- a/crates/world_state/src/behavior/node.rs
+++ b/crates/world_state/src/behavior/node.rs
@@ -47,6 +47,9 @@ pub struct Behavior {
     pub static_layout: NodeTrace,
     pub last_sent_game_controller_return_message_time: Option<SystemTime>,
     pub last_sent_hsl_message_time: Option<SystemTime>,
+    pub last_closest_to_ball: bool,
+    pub closest_to_ball_entered_area_since: Option<SystemTime>,
+    pub closest_to_ball_left_area_since: Option<SystemTime>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,6 +79,9 @@ pub struct Blackboard {
     pub last_motion_command: MotionCommand,
     pub last_motion_switch_time: SystemTime,
     pub last_motion_type: Option<MotionType>,
+    pub last_closest_to_ball: bool,
+    pub closest_to_ball_entered_area_since: Option<SystemTime>,
+    pub closest_to_ball_left_area_since: Option<SystemTime>,
 
     pub is_injected_motion_command: bool,
     pub walk_position: Option<Point2<Ground>>,
@@ -135,6 +141,9 @@ impl Behavior {
             static_layout,
             last_sent_game_controller_return_message_time: None,
             last_sent_hsl_message_time: None,
+            last_closest_to_ball: false,
+            closest_to_ball_entered_area_since: None,
+            closest_to_ball_left_area_since: None,
         })
     }
 
@@ -184,6 +193,9 @@ impl Behavior {
             last_motion_command: context.last_motion_command.clone(),
             last_motion_switch_time: self.last_motion_switch_time,
             last_motion_type: self.last_motion_type,
+            last_closest_to_ball: self.last_closest_to_ball,
+            closest_to_ball_entered_area_since: self.closest_to_ball_entered_area_since,
+            closest_to_ball_left_area_since: self.closest_to_ball_left_area_since,
 
             is_injected_motion_command: false,
             walk_position: None,
@@ -197,6 +209,9 @@ impl Behavior {
         self.last_kick_target = blackboard.last_kick_target;
 
         self.last_close_enough_to_kick = blackboard.last_close_enough_to_kick;
+        self.last_closest_to_ball = blackboard.last_closest_to_ball;
+        self.closest_to_ball_entered_area_since = blackboard.closest_to_ball_entered_area_since;
+        self.closest_to_ball_left_area_since = blackboard.closest_to_ball_left_area_since;
         *context.last_motion_command = motion_command.clone();
 
         let motion_type = match motion_command.clone() {

--- a/crates/world_state/src/behavior/tree.rs
+++ b/crates/world_state/src/behavior/tree.rs
@@ -75,7 +75,11 @@ fn playing_subtree() -> Node<Blackboard> {
             negation!(condition!(has_ball_position)),
             subtree!(search_subtree)
         ),
-        sequence!(condition!(is_closest_to_ball), subtree!(striker_subtree)),
+        sequence!(
+            action!(calculate_voronoi_grid),
+            condition!(is_closest_to_ball),
+            subtree!(striker_subtree)
+        ),
         subtree!(supporter_subtree),
     )
 }
@@ -123,10 +127,7 @@ fn striker_subtree() -> Node<Blackboard> {
 fn supporter_subtree() -> Node<Blackboard> {
     sequence!(
         subtree!(look_at_ball_subtree),
-        selection!(
-            sequence!(action!(calculate_voronoi_grid), action!(walk_to_centroid)),
-            action!(stand)
-        ),
+        selection!(action!(walk_to_centroid), action!(stand))
     )
 }
 

--- a/crates/world_state/src/behavior/voronoi.rs
+++ b/crates/world_state/src/behavior/voronoi.rs
@@ -7,6 +7,10 @@ use voronoi::VoronoiGrid;
 use crate::behavior::node::Blackboard;
 
 pub fn calculate_voronoi_grid(blackboard: &mut Blackboard) -> Status {
+    if blackboard.voronoi_map.is_some() {
+        return Status::Success;
+    }
+
     if let Some(ground_to_field) = blackboard.world_state.robot.ground_to_field {
         let field_dimensions = &blackboard.field_dimensions;
         let voronoi_parameters = &blackboard.parameters.voronoi;

--- a/crates/world_state/src/team_ball_filter.rs
+++ b/crates/world_state/src/team_ball_filter.rs
@@ -4,25 +4,22 @@ use std::{
 };
 
 use color_eyre::eyre::Result;
+use ros_z::time::Time;
 use serde::{Deserialize, Serialize};
 
 use context_attribute::context;
 use coordinate_systems::Field;
 use framework::{AdditionalOutput, MainOutput};
 use hsl_network_messages::{GamePhase, HulkMessage, SubState};
-use linear_algebra::{Point2, Vector2};
-use ros_z::time::Time;
 use types::{
     ball_position::BallPosition, cycle_time::CycleTime,
-    filtered_game_controller_state::FilteredGameControllerState,
-    filtered_game_state::FilteredGameState, messages::IncomingMessage, players::Players,
-    world_state::PlayerState,
+    filtered_game_controller_state::FilteredGameControllerState, messages::IncomingMessage,
+    players::Players, world_state::PlayerState,
 };
 
 #[derive(Deserialize, Serialize)]
 pub struct TeamBallReceiver {
     received_balls: Players<Option<BallPosition<Field>>>,
-    rule_team_ball: Option<BallPosition<Field>>,
 }
 
 #[context]
@@ -49,7 +46,6 @@ impl TeamBallReceiver {
     pub fn new(_context: CreationContext) -> Result<Self> {
         Ok(Self {
             received_balls: Players::default(),
-            rule_team_ball: None,
         })
     }
 
@@ -72,15 +68,6 @@ impl TeamBallReceiver {
                 return Ok(MainOutputs {
                     team_ball: None.into(),
                 });
-            }
-
-            // Prevent non-strikers from claiming striker at kickoff
-            if game_controller_state.game_state == FilteredGameState::Set {
-                self.rule_team_ball = Some(BallPosition {
-                    position: Point2::origin(),
-                    velocity: Vector2::zeros(),
-                    last_seen: now,
-                })
             }
         }
 
@@ -108,7 +95,6 @@ impl TeamBallReceiver {
         self.received_balls
             .iter()
             .filter_map(|(_player_number, ball)| *ball)
-            .chain(self.rule_team_ball)
             .max_by_key(|ball| ball.last_seen)
             .filter(|ball| ball.age_at(now).is_some_and(|age| age < trust_duration))
     }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -510,6 +510,14 @@
       "nanos": 0,
       "secs": 50
     },
+    "closest_to_ball_enter_duration": {
+      "nanos": 300000000,
+      "secs": 0
+    },
+    "closest_to_ball_exit_duration": {
+      "nanos": 150000000,
+      "secs": 0
+    },
     "look_action": {
       "angle_threshold": 0.95,
       "distance_threshold": 3.0,


### PR DESCRIPTION
## Why? What?

adds logic for the closest to ball calculation in the behavior
- Fixes #

## How to Test

In playing with at least two Robots: If one robot sees a ball is should only engage with the ball if it is the closest to it and the other should walk to its calculatetd centroid position.