### PR TITLE
Transient local primary state

### DIFF
--- a/crates/nodes/ball_state_composer/src/lib.rs
+++ b/crates/nodes/ball_state_composer/src/lib.rs
@@ -38,6 +38,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node

--- a/crates/nodes/led_handler/src/lib.rs
+++ b/crates/nodes/led_handler/src/lib.rs
@@ -4,13 +4,17 @@ use booster_sdk::client::light_control::SetLedLightColorParameter;
 use booster_sdk_interface::LedCommand;
 use color_eyre::Result;
 
-use ros_z::prelude::*;
+use ros_z::{prelude::*, qos::QosDurability};
 use types::primary_state::PrimaryState;
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("led_handler").build().await?;
     let primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
 

--- a/crates/nodes/localization/src/lib.rs
+++ b/crates/nodes/localization/src/lib.rs
@@ -58,6 +58,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
     let _odometer_sub = node

--- a/crates/nodes/obstacle_filter/src/lib.rs
+++ b/crates/nodes/obstacle_filter/src/lib.rs
@@ -43,6 +43,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
     let _current_ground_to_field_sub = node

--- a/crates/nodes/primary_state_filter/src/lib.rs
+++ b/crates/nodes/primary_state_filter/src/lib.rs
@@ -48,6 +48,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let primary_state_pub = node
         .publisher::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
 

--- a/crates/nodes/robot_mode_handler/src/lib.rs
+++ b/crates/nodes/robot_mode_handler/src/lib.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use serde::{Deserialize, Serialize};
 
 use booster_sdk_interface::{GetRobotMode, GetRobotModeRequest, HighLevelCommand, RobotMode};
-use ros_z::prelude::*;
+use ros_z::{prelude::*, qos::QosDurability};
 use types::{
     buttons::{ButtonPressType, Buttons},
     primary_state::PrimaryState,
@@ -22,6 +22,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let parameters = node.bind_parameter_as::<Parameters>("robot_mode_handler")?;
     let primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
     let buttons_sub = node

--- a/crates/nodes/search_suggestor/src/lib.rs
+++ b/crates/nodes/search_suggestor/src/lib.rs
@@ -40,6 +40,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node

--- a/crates/nodes/world_state_composer/src/lib.rs
+++ b/crates/nodes/world_state_composer/src/lib.rs
@@ -54,6 +54,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
         .build()
         .await?;
     let _rule_ball_sub = node


### PR DESCRIPTION
## Why? What?

Change the Qos of the Primary State publisher and subsribers to transient local, since it is an event triggered output and this allow nodes to always have an initial value to go off from.
