### PR TITLE
fix(hulk_ros_z): surface startup failures

### DIFF
--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -1,10 +1,12 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{future::Future, path::PathBuf, sync::Arc, time::Duration};
 
 use clap::Parser;
 use color_eyre::{Result, eyre::Context as _};
 use ros_z::prelude::*;
 use tokio::task::JoinSet;
 use tracing_subscriber::EnvFilter;
+
+const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -22,13 +24,29 @@ struct RunningStack {
     join_set: JoinSet<Result<()>>,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     color_eyre::install()?;
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 
+    run_with_shutdown_timeout(run(), RUNTIME_SHUTDOWN_TIMEOUT)?
+}
+
+fn run_with_shutdown_timeout<F>(future: F, shutdown_timeout: Duration) -> Result<F::Output>
+where
+    F: Future,
+{
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .wrap_err("failed to build Tokio runtime")?;
+    let output = runtime.block_on(future);
+    runtime.shutdown_timeout(shutdown_timeout);
+    Ok(output)
+}
+
+async fn run() -> Result<()> {
     let args = Args::parse();
     let namespace = derive_namespace(&args.robot);
     let parameter_layers =
@@ -58,7 +76,9 @@ async fn main() -> Result<()> {
     };
 
     running.join_set.abort_all();
-    ctx.shutdown()?;
+    if result.is_ok() {
+        ctx.shutdown()?;
+    }
     result
 }
 
@@ -188,5 +208,27 @@ mod tests {
     #[test]
     fn derive_namespace_replaces_invalid_characters() {
         assert_eq!(derive_namespace("robot-01"), "/robot_01");
+    }
+
+    #[test]
+    fn runtime_shutdown_timeout_does_not_wait_forever_for_blocking_tasks() {
+        let (started_sender, started_receiver) = std::sync::mpsc::channel();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel::<()>();
+        let started_at = std::time::Instant::now();
+
+        let result = run_with_shutdown_timeout(
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    started_sender.send(()).expect("started signal should send");
+                    let _ = release_receiver.recv();
+                });
+                started_receiver.recv().expect("blocking task should start");
+            },
+            std::time::Duration::from_millis(10),
+        );
+
+        drop(release_sender);
+        result.expect("runtime should build and run");
+        assert!(started_at.elapsed() < std::time::Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
## Summary
- surface monitor task errors and panics from hulk_ros_z startup
- skip graceful ROS-Z context shutdown on failed startup/runtime paths
- bound Tokio runtime shutdown so blocking tasks cannot hang process exit

## Test Plan
- cargo fmt --all -- --check
- cargo nextest run -p hulk_ros_z
- cargo build -p hulk_ros_z
- timeout -v --kill-after=2s 8s target/debug/hulk_ros_z --robot alpha --location lab --parameter-root etc/parameters/ros_z/ --router tcp/10.4.24.15:7448