### PR TITLE
feat(ros-z): move parameters behind async actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9361,6 +9361,7 @@ dependencies = [
  "byteorder",
  "color-eyre",
  "event-listener",
+ "flume",
  "itertools 0.14.0",
  "json5",
  "nalgebra",

--- a/crates/nodes/active_vision/src/lib.rs
+++ b/crates/nodes/active_vision/src/lib.rs
@@ -17,7 +17,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("active_vision").build().await?;
 
-    let _parameters = node.bind_parameter_as::<LookActionParameters>("active_vision")?;
+    let _parameters = node
+        .bind_parameter_as::<LookActionParameters>("active_vision")
+        .await?;
     let _field_dimensions_sub = node
         .subscriber::<FieldDimensions>("field_dimensions")?
         .qos(QosProfile {

--- a/crates/nodes/ball_filter/src/lib.rs
+++ b/crates/nodes/ball_filter/src/lib.rs
@@ -39,7 +39,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("ball_filter").build().await?;
 
-    let parameters = node.bind_parameter_as::<BallFilterParameters>("ball_filter")?;
+    let parameters = node
+        .bind_parameter_as::<BallFilterParameters>("ball_filter")
+        .await?;
     let field_dimensions_sub = node
         .create_cache::<FieldDimensions>("field_dimensions", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/behavior_node/src/node.rs
+++ b/crates/nodes/behavior_node/src/node.rs
@@ -72,7 +72,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("behavior_node").build().await?;
 
-    let parameters = node.bind_parameter_as::<BehaviorParameters>("behavior_node")?;
+    let parameters = node
+        .bind_parameter_as::<BehaviorParameters>("behavior_node")
+        .await?;
     let field_dimensions_cache = node
         .create_cache::<FieldDimensions>("field_dimensions", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/camera_matrix_calculator/src/lib.rs
+++ b/crates/nodes/camera_matrix_calculator/src/lib.rs
@@ -18,8 +18,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("camera_matrix_calculator").build().await?;
 
-    let parameters =
-        node.bind_parameter_as::<CameraMatrixParameters>("camera_matrix_calculator")?;
+    let parameters = node
+        .bind_parameter_as::<CameraMatrixParameters>("camera_matrix_calculator")
+        .await?;
     let robot_kinematics_cache = node
         .create_cache::<TimeWrapper<RobotKinematics>>("robot_kinematics", 10)?
         .with_stamp(|w: &TimeWrapper<RobotKinematics>| w.time)

--- a/crates/nodes/detection/src/lib.rs
+++ b/crates/nodes/detection/src/lib.rs
@@ -58,7 +58,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("detection").build().await?;
 
-    let node_parameters = node.bind_parameter_as::<DetectionParameters>("detection")?;
+    let node_parameters = node
+        .bind_parameter_as::<DetectionParameters>("detection")
+        .await?;
 
     let image_sub = node
         .subscriber::<TimeWrapper<Image>>("inputs/left_image")?

--- a/crates/nodes/field_border_detection/src/lib.rs
+++ b/crates/nodes/field_border_detection/src/lib.rs
@@ -26,8 +26,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("field_border_detection").build().await?;
 
-    let parameters =
-        node.bind_parameter_as::<FieldBorderDetectionParameters>("field_border_detection")?;
+    let parameters = node
+        .bind_parameter_as::<FieldBorderDetectionParameters>("field_border_detection")
+        .await?;
     let camera_matrix_cache = node
         .create_cache::<TimeWrapper<CameraMatrix>>("camera_matrix", 10)?
         .with_stamp(|w: &TimeWrapper<CameraMatrix>| w.time)

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -25,7 +25,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("game_controller_filter").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("game_controller_filter")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("game_controller_filter")
+        .await?;
     let network_message_sub = node
         .subscriber::<TimeWrapper<IncomingMessage>>("filtered_message")?
         .build()

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -29,8 +29,9 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
-    let parameters =
-        node.bind_parameter_as::<GameStateFilterParameters>("game_controller_state_filter")?;
+    let parameters = node
+        .bind_parameter_as::<GameStateFilterParameters>("game_controller_state_filter")
+        .await?;
     let field_dimensions_cache = node
         .create_cache::<FieldDimensions>("field_dimensions", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/global_parameter_provider/src/lib.rs
+++ b/crates/nodes/global_parameter_provider/src/lib.rs
@@ -21,7 +21,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("global_parameter_provider").build().await?;
 
-    let node_parameters = node.bind_parameter_as::<Parameters>("global")?;
+    let node_parameters = node.bind_parameter_as::<Parameters>("global").await?;
 
     let player_number_pub = node
         .publisher::<PlayerNumber>("player_number")?

--- a/crates/nodes/head_motion/src/lib.rs
+++ b/crates/nodes/head_motion/src/lib.rs
@@ -22,7 +22,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("head_motion").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("head_motion")?;
+    let _parameters = node.bind_parameter_as::<Parameters>("head_motion").await?;
     let _look_around_target_joints_sub = node
         .subscriber::<HeadJoints<f32>>("look_around_target_joints")?
         .build()

--- a/crates/nodes/image_segmenter/src/lib.rs
+++ b/crates/nodes/image_segmenter/src/lib.rs
@@ -29,7 +29,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("image_segmenter").build().await?;
 
-    let parameters = node.bind_parameter_as::<ImageSegmenterParameters>("image_segmenter")?;
+    let parameters = node
+        .bind_parameter_as::<ImageSegmenterParameters>("image_segmenter")
+        .await?;
     let image_sub = node
         .subscriber::<TimeWrapper<YCbCr422Image>>("inputs/ycbcr422_image")?
         .build()

--- a/crates/nodes/kick/src/lib.rs
+++ b/crates/nodes/kick/src/lib.rs
@@ -14,7 +14,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("kick").build().await?;
 
-    let _parameters = node.bind_parameter_as::<BoosterKickingParameters>("kick")?;
+    let _parameters = node
+        .bind_parameter_as::<BoosterKickingParameters>("kick")
+        .await?;
     let _get_robot_mode_client = node
         .create_service_client::<GetRobotMode>("services/get_robot_mode")?
         .build()

--- a/crates/nodes/line_detection/src/lib.rs
+++ b/crates/nodes/line_detection/src/lib.rs
@@ -37,7 +37,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("line_detection").build().await?;
 
-    let parameters = node.bind_parameter_as::<LineDetectionParameters>("line_detection")?;
+    let parameters = node
+        .bind_parameter_as::<LineDetectionParameters>("line_detection")
+        .await?;
     let camera_matrix_cache = node
         .create_cache::<TimeWrapper<CameraMatrix>>("camera_matrix", 10)?
         .with_stamp(|w: &TimeWrapper<CameraMatrix>| w.time)

--- a/crates/nodes/localization/src/lib.rs
+++ b/crates/nodes/localization/src/lib.rs
@@ -56,7 +56,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("localization").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("localization")?;
+    let _parameters = node.bind_parameter_as::<Parameters>("localization").await?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()

--- a/crates/nodes/look_around/src/lib.rs
+++ b/crates/nodes/look_around/src/lib.rs
@@ -18,7 +18,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("look_around").build().await?;
 
-    let _parameters = node.bind_parameter_as::<LookAroundParameters>("look_around")?;
+    let _parameters = node
+        .bind_parameter_as::<LookAroundParameters>("look_around")
+        .await?;
     let _motion_command_sub = node
         .subscriber::<MotionCommand>("motion_command")?
         .build()

--- a/crates/nodes/look_at/src/lib.rs
+++ b/crates/nodes/look_at/src/lib.rs
@@ -27,7 +27,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("look_at").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("look_at")?;
+    let _parameters = node.bind_parameter_as::<Parameters>("look_at").await?;
     let _camera_matrix_sub = node
         .subscriber::<CameraMatrix>("camera_matrix")?
         .build()

--- a/crates/nodes/low_command_publisher/src/lib.rs
+++ b/crates/nodes/low_command_publisher/src/lib.rs
@@ -24,7 +24,9 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let zenoh_session = ctx.session();
 
-    let parameters = node.bind_parameter_as::<Parameters>("command_sender")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("command_sender")
+        .await?;
     let collected_target_joint_positions_sub = node
         .subscriber::<Joints<f32>>("collected_target_joint_positions")?
         .build()

--- a/crates/nodes/message_handler/src/lib.rs
+++ b/crates/nodes/message_handler/src/lib.rs
@@ -22,7 +22,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("message_handler").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("message_receiver")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("message_receiver")
+        .await?;
     let incoming_message_pub = node
         .publisher::<TimeWrapper<IncomingMessage>>("inputs/message")?
         .build()

--- a/crates/nodes/microphone_recorder/src/lib.rs
+++ b/crates/nodes/microphone_recorder/src/lib.rs
@@ -4,7 +4,7 @@ use std::{boxed::Box, future::Future, pin::Pin};
 use color_eyre::Result;
 
 use microphones::{parameters::Parameters as MicrophonesParameters, reader::Microphones};
-use ros_z::{context::Context, parameter::NodeParametersExt};
+use ros_z::context::Context;
 use types::samples::Samples;
 
 pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
@@ -14,7 +14,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("microphone_recorder").build().await?;
 
-    let parameters = node.bind_parameter_as::<MicrophonesParameters>("microphone_recorder")?;
+    let parameters = node
+        .bind_parameter_as::<MicrophonesParameters>("microphone_recorder")
+        .await?;
 
     let microphones_samples_pub = node
         .publisher::<Samples>("inputs/microphones_samples")?

--- a/crates/nodes/obstacle_filter/src/lib.rs
+++ b/crates/nodes/obstacle_filter/src/lib.rs
@@ -58,7 +58,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("obstacle_filter").build().await?;
 
-    let parameters = node.bind_parameter_as::<ObstacleFilterParameters>("obstacle_filter")?;
+    let parameters = node
+        .bind_parameter_as::<ObstacleFilterParameters>("obstacle_filter")
+        .await?;
     let field_dimensions_cache = node
         .create_cache::<FieldDimensions>("field_dimensions", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/primary_state_filter/src/lib.rs
+++ b/crates/nodes/primary_state_filter/src/lib.rs
@@ -27,7 +27,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("primary_state_filter").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("primary_state_filter")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("primary_state_filter")
+        .await?;
     let player_number_cache = node
         .create_cache::<PlayerNumber>("player_number", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/robot_mode_handler/src/lib.rs
+++ b/crates/nodes/robot_mode_handler/src/lib.rs
@@ -24,7 +24,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("robot_mode_handler").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("robot_mode_handler")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("robot_mode_handler")
+        .await?;
     let primary_state_sub = node
         .subscriber::<PrimaryState>("primary_state")?
         .qos(QosProfile {

--- a/crates/nodes/rotate_head/src/lib.rs
+++ b/crates/nodes/rotate_head/src/lib.rs
@@ -21,7 +21,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("rotate_head").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("rotate_head")?;
+    let _parameters = node.bind_parameter_as::<Parameters>("rotate_head").await?;
     let _get_robot_mode_client = node
         .create_service_client::<GetRobotMode>("services/get_robot_mode")?
         .build()

--- a/crates/nodes/rule_obstacle_composer/src/lib.rs
+++ b/crates/nodes/rule_obstacle_composer/src/lib.rs
@@ -28,7 +28,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("rule_obstacle_composer").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("rule_obstacle_composer")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("rule_obstacle_composer")
+        .await?;
     let field_dimensions_cache = node
         .create_cache::<FieldDimensions>("field_dimensions", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/safe_pose_checker/src/lib.rs
+++ b/crates/nodes/safe_pose_checker/src/lib.rs
@@ -29,7 +29,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("safe_pose_checker").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("safe_pose_checker")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("safe_pose_checker")
+        .await?;
     let imu_state_sub = node
         .subscriber::<ImuState>("inputs/imu_state")?
         .build()

--- a/crates/nodes/search_suggestor/src/lib.rs
+++ b/crates/nodes/search_suggestor/src/lib.rs
@@ -27,7 +27,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("search_suggestor").build().await?;
 
-    let parameters = node.bind_parameter_as::<SearchSuggestorParameters>("search_suggestor")?;
+    let parameters = node
+        .bind_parameter_as::<SearchSuggestorParameters>("search_suggestor")
+        .await?;
     let field_dimensions_sub = node
         .subscriber::<FieldDimensions>("field_dimensions")?
         .qos(QosProfile {

--- a/crates/nodes/support_foot_estimator/src/lib.rs
+++ b/crates/nodes/support_foot_estimator/src/lib.rs
@@ -27,7 +27,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("support_foot_estimator").build().await?;
 
-    let parameters = node.bind_parameter_as::<Parameters>("support_foot_estimator")?;
+    let parameters = node
+        .bind_parameter_as::<Parameters>("support_foot_estimator")
+        .await?;
     let imu_state_sub = node
         .subscriber::<ImuState>("inputs/imu_state")?
         .build()

--- a/crates/nodes/team_ball_receiver/src/lib.rs
+++ b/crates/nodes/team_ball_receiver/src/lib.rs
@@ -24,7 +24,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("team_ball_receiver").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("team_ball_receiver")?;
+    let _parameters = node
+        .bind_parameter_as::<Parameters>("team_ball_receiver")
+        .await?;
     let _filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()

--- a/crates/nodes/trigger/src/lib.rs
+++ b/crates/nodes/trigger/src/lib.rs
@@ -19,7 +19,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("trigger").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("trigger")?;
+    let _parameters = node.bind_parameter_as::<Parameters>("trigger").await?;
 
     pending::<()>().await;
 

--- a/crates/nodes/walking/src/lib.rs
+++ b/crates/nodes/walking/src/lib.rs
@@ -22,7 +22,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("walking").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("walking")?;
+    let _parameters = node.bind_parameter_as::<Parameters>("walking").await?;
 
     let _get_robot_mode_client = node
         .create_service_client::<GetRobotMode>("services/get_robot_mode")?

--- a/crates/nodes/whistle_detection/src/lib.rs
+++ b/crates/nodes/whistle_detection/src/lib.rs
@@ -17,7 +17,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("whistle_detection").build().await?;
 
-    let _parameters = node.bind_parameter_as::<WhistleDetectionParameters>("whistle_detection")?;
+    let _parameters = node
+        .bind_parameter_as::<WhistleDetectionParameters>("whistle_detection")
+        .await?;
     let _samples_sub = node.subscriber::<Samples>("samples")?.build().await?;
     // TODO: restructure type layout here, do not use blank tuples
     // let _audio_spectrums_pub = node

--- a/crates/nodes/whistle_filter/src/lib.rs
+++ b/crates/nodes/whistle_filter/src/lib.rs
@@ -21,7 +21,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("whistle_filter").build().await?;
 
-    let _parameters = node.bind_parameter_as::<Parameters>("whistle_filter")?;
+    let _parameters = node
+        .bind_parameter_as::<Parameters>("whistle_filter")
+        .await?;
     let _detected_whistle_sub = node
         .subscriber::<Whistle>("detected_whistle")?
         .build()

--- a/crates/ros-z-cli/tests/e2e.rs
+++ b/crates/ros-z-cli/tests/e2e.rs
@@ -16,7 +16,7 @@ use ros_z::{
     entity::TypeInfo,
     message::Service,
     node::Node,
-    parameter::{NodeParameters, NodeParametersExt},
+    parameter::NodeParameters,
     pubsub::Publisher,
     service::ServiceServer,
 };
@@ -497,7 +497,9 @@ impl ParameterFixture {
             .with_namespace("/cli_e2e")
             .build()
             .await?;
-        let parameters = node.bind_parameter_as::<VisionParameters>("parameter_fixture")?;
+        let parameters = node
+            .bind_parameter_as::<VisionParameters>("parameter_fixture")
+            .await?;
 
         Ok(Self {
             node_fqn: "/cli_e2e/parameter_fixture".to_string(),

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["lib"]
 arc-swap = { workspace = true }
 byteorder = { workspace = true }
 event-listener = { workspace = true }
+flume = { workspace = true }
 itertools = { workspace = true }
 json5 = { workspace = true }
 nalgebra = { workspace = true, features = ["serde-serialize"], optional = true }

--- a/crates/ros-z/src/parameter/error.rs
+++ b/crates/ros-z/src/parameter/error.rs
@@ -117,7 +117,7 @@ impl From<serde_json::Error> for ParameterError {
 }
 
 impl ParameterError {
-    pub(crate) fn operation(
+    pub fn operation(
         operation: impl Into<String>,
         source: impl std::error::Error + Send + Sync + 'static,
     ) -> Self {

--- a/crates/ros-z/src/parameter/merge.rs
+++ b/crates/ros-z/src/parameter/merge.rs
@@ -5,21 +5,21 @@ use serde_json::{Map, Value};
 use super::{LayerPath, ParameterError, ProvenanceMap, Result};
 
 #[derive(Debug, Clone)]
-pub(crate) struct RecursiveDiffEntry {
+pub struct RecursiveDiffEntry {
     pub path: String,
     pub old_value: Value,
     pub new_value: Value,
 }
 
-pub(crate) type RecursiveDiff = Vec<RecursiveDiffEntry>;
+pub type RecursiveDiff = Vec<RecursiveDiffEntry>;
 
 #[derive(Debug, Clone)]
-pub(crate) struct MergedParameters {
+pub struct MergedParameters {
     pub effective: Value,
     pub provenance: ProvenanceMap,
 }
 
-pub(crate) fn merge_layers(layers: &[(&str, &Value)]) -> Result<MergedParameters> {
+pub fn merge_layers(layers: &[(&str, &Value)]) -> Result<MergedParameters> {
     let mut provenance = ProvenanceMap::new();
     let mut effective = Value::Object(Map::new());
 
@@ -91,7 +91,7 @@ fn merge_value(
     }
 }
 
-pub(crate) fn get_value_at_path(root: &Value, path: &str) -> Result<Option<Value>> {
+pub fn get_value_at_path(root: &Value, path: &str) -> Result<Option<Value>> {
     let segments = parse_path(path)?;
     let mut current = root;
 
@@ -108,7 +108,7 @@ pub(crate) fn get_value_at_path(root: &Value, path: &str) -> Result<Option<Value
     Ok(Some(current.clone()))
 }
 
-pub(crate) fn set_value_at_path(root: &mut Value, path: &str, value: Value) -> Result<()> {
+pub fn set_value_at_path(root: &mut Value, path: &str, value: Value) -> Result<()> {
     let segments = parse_path(path)?;
     if !root.is_object() {
         if segments.len() > 1 {
@@ -150,7 +150,7 @@ pub(crate) fn set_value_at_path(root: &mut Value, path: &str, value: Value) -> R
     Ok(())
 }
 
-pub(crate) fn remove_value_at_path(root: &mut Value, path: &str) -> Result<bool> {
+pub fn remove_value_at_path(root: &mut Value, path: &str) -> Result<bool> {
     let segments = parse_path(path)?;
     let mut current = root;
     for segment in &segments[..segments.len() - 1] {
@@ -172,7 +172,7 @@ pub(crate) fn remove_value_at_path(root: &mut Value, path: &str) -> Result<bool>
         .is_some())
 }
 
-pub(crate) fn recursive_diff(old: &Value, new: &Value) -> RecursiveDiff {
+pub fn recursive_diff(old: &Value, new: &Value) -> RecursiveDiff {
     let mut out = Vec::new();
     diff_value("", old, new, &mut out);
     out
@@ -209,7 +209,7 @@ fn diff_value(path: &str, old: &Value, new: &Value, out: &mut RecursiveDiff) {
     }
 }
 
-pub(crate) fn provenance_for_path(provenance: &ProvenanceMap, path: &str) -> Option<LayerPath> {
+pub fn provenance_for_path(provenance: &ProvenanceMap, path: &str) -> Option<LayerPath> {
     provenance.get(path).cloned()
 }
 

--- a/crates/ros-z/src/parameter/mod.rs
+++ b/crates/ros-z/src/parameter/mod.rs
@@ -6,12 +6,10 @@ mod persistence;
 mod snapshot;
 mod types;
 
-pub mod remote;
+mod remote;
 
 pub use error::{ParameterError, Result};
-pub use node_parameter::{
-    CommitOutcome, NodeParameters, NodeParametersExt, ParameterJsonWrite, ValidateHook,
-};
+pub use node_parameter::{CommitOutcome, NodeParameters, ParameterJsonWrite};
 pub use remote::{RemoteParameterClient, types::*};
 pub use snapshot::{NodeParametersSnapshot, ParameterSubscription, ParameterTimestamp};
 pub use types::{FieldPath, LayerPath, ParameterKey, ProvenanceMap};

--- a/crates/ros-z/src/parameter/node_parameter.rs
+++ b/crates/ros-z/src/parameter/node_parameter.rs
@@ -4,7 +4,10 @@ use arc_swap::ArcSwap;
 use parking_lot::Mutex;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
-use tokio::sync::watch;
+use tokio::{
+    runtime::Handle,
+    sync::{mpsc, watch},
+};
 use tokio_util::task::AbortOnDropHandle;
 
 use crate::{
@@ -48,13 +51,10 @@ struct NodeParametersInner<T>
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    // Field order is shutdown order: stop accepting remote requests, close the
-    // command sender, abort the driver if it is still running, then release the
-    // node-level binding guard.
-    _remote: RemoteParameterServices<T>,
-    commands: flume::Sender<ParameterCommand<T>>,
+    // Field order is shutdown order: drop the local command sender, then abort
+    // the driver if it is still running. Driver drop closes the receiver.
+    commands: mpsc::Sender<ParameterCommand<T>>,
     driver_task: AbortOnDropHandle<()>,
-    _binding_guard: BindingGuard,
     state: Arc<ParameterState<T>>,
 }
 
@@ -71,14 +71,41 @@ impl Drop for BindingGuard {
 pub struct ParameterState<T> {
     node_fqn: String,
     parameter_key: ParameterKey,
-    pub type_name: String,
-    pub schema_hash: SchemaHash,
+    type_name: String,
+    schema_hash: SchemaHash,
     layers: Vec<PathBuf>,
     clock: Clock,
     commit_lock: Mutex<()>,
     hooks: Mutex<Vec<ValidateHook<T>>>,
-    pub current: ArcSwap<NodeParametersSnapshot<T>>,
+    current: ArcSwap<NodeParametersSnapshot<T>>,
     tx: watch::Sender<Arc<NodeParametersSnapshot<T>>>,
+}
+
+impl<T> ParameterState<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    pub fn snapshot(&self) -> Arc<NodeParametersSnapshot<T>> {
+        self.current.load_full()
+    }
+
+    pub fn get_json_from_snapshot(
+        snapshot: &NodeParametersSnapshot<T>,
+        path: &str,
+    ) -> Result<Value> {
+        get_from_value(&snapshot.effective, path)?.ok_or_else(|| ParameterError::PathError {
+            path: path.to_string(),
+            reason: "path not found".to_string(),
+        })
+    }
+
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
+    pub fn schema_hash(&self) -> SchemaHash {
+        self.schema_hash
+    }
 }
 
 impl<T> std::ops::Deref for NodeParametersInner<T>
@@ -120,27 +147,17 @@ where
         hook: ValidateHook<T>,
         reply: ParameterReply<()>,
     },
-    RemoteGetSnapshot {
-        query: zenoh::query::Query,
-    },
-    RemoteGetValue {
-        query: zenoh::query::Query,
-    },
-    RemoteGetTypeInfo {
-        query: zenoh::query::Query,
-    },
-    RemoteSet {
-        query: zenoh::query::Query,
-    },
-    RemoteSetAtomic {
-        query: zenoh::query::Query,
-    },
-    RemoteReset {
-        query: zenoh::query::Query,
-    },
-    RemoteReload {
-        query: zenoh::query::Query,
-    },
+    Remote(RemoteParameterCommand),
+}
+
+pub(crate) enum RemoteParameterCommand {
+    GetSnapshot { query: zenoh::query::Query },
+    GetValue { query: zenoh::query::Query },
+    GetTypeInfo { query: zenoh::query::Query },
+    Set { query: zenoh::query::Query },
+    SetAtomic { query: zenoh::query::Query },
+    Reset { query: zenoh::query::Query },
+    Reload { query: zenoh::query::Query },
 }
 
 pub struct ParameterDriver<T>
@@ -148,8 +165,12 @@ where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     state: Arc<ParameterState<T>>,
-    commands: flume::Receiver<ParameterCommand<T>>,
+    commands: mpsc::Receiver<ParameterCommand<T>>,
     event_publisher: Arc<Publisher<NodeParameterEvent>>,
+    reply_runtime: Handle,
+    // Drop remote service registrations before releasing the node binding.
+    _remote: RemoteParameterServices<T>,
+    _binding_guard: BindingGuard,
 }
 
 fn actor_unavailable_error() -> ParameterError {
@@ -166,10 +187,10 @@ impl Node {
     /// part of the binding, so remote reads and writes are serialized through the
     /// same actor as local writes.
     ///
-    /// A node can only have one active parameter binding. Calling this again on
-    /// the same node while the first [`NodeParameters`] handle is alive returns
-    /// [`ParameterError::AlreadyBound`]. Dropping the handle shuts down the actor
-    /// and releases the binding.
+    /// A node can only have one active parameter actor. Calling this while a
+    /// binding is active returns [`ParameterError::AlreadyBound`]. Dropping the
+    /// last [`NodeParameters`] handle shuts down the actor; the binding is
+    /// released when the actor task exits.
     ///
     /// # Errors
     ///
@@ -273,23 +294,26 @@ where
         current,
         tx,
     });
-    let (command_tx, command_rx) = flume::bounded(PARAMETER_MAILBOX_CAPACITY);
-    let remote = RemoteParameterServices::register(node, state.clone(), command_tx.clone()).await?;
+    let (command_tx, command_rx) = mpsc::channel(PARAMETER_MAILBOX_CAPACITY);
+    let reply_runtime = Handle::current();
+    let remote =
+        RemoteParameterServices::register(node, command_tx.clone(), reply_runtime.clone()).await?;
     let event_publisher = remote.event_publisher();
 
     let driver = ParameterDriver {
         state: state.clone(),
         commands: command_rx,
         event_publisher,
-    };
-    let driver_task = tokio::spawn(driver.run());
-    let inner = Arc::new(NodeParametersInner {
+        reply_runtime,
         _remote: remote,
-        commands: command_tx,
-        driver_task: AbortOnDropHandle::new(driver_task),
         _binding_guard: BindingGuard {
             state: node.parameter_binding_state().clone(),
         },
+    };
+    let driver_task = tokio::spawn(driver.run());
+    let inner = Arc::new(NodeParametersInner {
+        commands: command_tx,
+        driver_task: AbortOnDropHandle::new(driver_task),
         state,
     });
 
@@ -390,16 +414,17 @@ where
         let (reply_tx, reply_rx) = flume::bounded(1);
         let commands = self.command_sender()?;
         commands
-            .send_async(command(reply_tx))
+            .send(command(reply_tx))
             .await
             .map_err(|_| actor_unavailable_error())?;
-        tokio::select! {
-            result = reply_rx.recv_async() => result.map_err(|_| actor_unavailable_error())?,
-            () = self.wait_for_driver_task_to_finish() => Err(actor_unavailable_error()),
-        }
+
+        reply_rx
+            .recv_async()
+            .await
+            .map_err(|_| actor_unavailable_error())?
     }
 
-    fn command_sender(&self) -> Result<flume::Sender<ParameterCommand<T>>> {
+    fn command_sender(&self) -> Result<mpsc::Sender<ParameterCommand<T>>> {
         if self.driver_task_is_unavailable() {
             return Err(actor_unavailable_error());
         }
@@ -407,27 +432,29 @@ where
         Ok(self.inner.commands.clone())
     }
 
-    async fn wait_for_driver_task_to_finish(&self) {
-        while !self.driver_task_is_unavailable() {
-            tokio::task::yield_now().await;
-        }
-    }
-
     fn driver_task_is_unavailable(&self) -> bool {
         self.inner.driver_task.is_finished()
     }
 
     pub fn snapshot(&self) -> Arc<NodeParametersSnapshot<T>> {
-        self.inner.state.current.load_full()
+        self.inner.state.snapshot()
     }
 
     pub fn get_json(&self, path: &str) -> Result<Value> {
-        get_from_value(&self.snapshot().effective, path)?.ok_or_else(|| ParameterError::PathError {
-            path: path.to_string(),
-            reason: "path not found".to_string(),
-        })
+        ParameterState::get_json_from_snapshot(&self.snapshot(), path)
     }
 
+    /// Writes one JSON value through the parameter actor.
+    ///
+    /// The returned future resolves after the actor validates the resulting typed
+    /// parameter set, persists the touched layer, updates the in-memory snapshot,
+    /// and attempts to publish the parameter event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the actor has stopped, the path or target layer is
+    /// invalid, validation fails, persistence fails, or the updated JSON cannot be
+    /// deserialized as the parameter type.
     pub async fn set_json(
         &self,
         path: &str,
@@ -446,6 +473,17 @@ where
         .map(|_| ())
     }
 
+    /// Applies multiple JSON writes as one actor command.
+    ///
+    /// All writes are validated against one candidate snapshot and are committed
+    /// together. If `expected_revision` is `Some`, the actor rejects the command
+    /// unless the current snapshot revision matches it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the actor has stopped, the expected revision does not
+    /// match, any path or target layer is invalid, validation fails, persistence
+    /// fails, or the candidate JSON cannot be deserialized as the parameter type.
     pub async fn set_json_atomically(
         &self,
         changes: Vec<ParameterJsonWrite>,
@@ -460,6 +498,16 @@ where
         .await
     }
 
+    /// Removes one override from a target layer through the parameter actor.
+    ///
+    /// The returned future resolves after the actor validates and commits the
+    /// resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the actor has stopped, the path or target layer is
+    /// invalid, validation fails, persistence fails, or the resulting JSON cannot
+    /// be deserialized as the parameter type.
     pub async fn reset(&self, path: &str, target_layer: impl Into<LayerPath>) -> Result<()> {
         self.request(|reply| ParameterCommand::Reset {
             resets: vec![(path.to_string(), target_layer.into())],
@@ -471,6 +519,15 @@ where
         .map(|_| ())
     }
 
+    /// Reloads all configured parameter layers through the parameter actor.
+    ///
+    /// The returned future resolves after the actor loads, validates, and commits
+    /// the reloaded snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the actor has stopped, layer loading fails, validation
+    /// fails, or the reloaded JSON cannot be deserialized as the parameter type.
     pub async fn reload(&self) -> Result<()> {
         self.request(|reply| ParameterCommand::Reload {
             source: NodeParameterChangeSource::Reload,
@@ -484,6 +541,15 @@ where
         self.inner.state.tx.subscribe()
     }
 
+    /// Registers a validation hook through the parameter actor.
+    ///
+    /// The hook is run against the current snapshot before it is stored. Future
+    /// writes and reloads must pass all registered hooks before they commit.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the actor has stopped or if the new hook rejects the
+    /// current typed parameter value.
     pub async fn add_validation_hook<F>(&self, hook: F) -> Result<()>
     where
         F: Fn(&T) -> std::result::Result<(), String> + Send + Sync + 'static,
@@ -494,24 +560,29 @@ where
     }
 }
 
-impl<T> ParameterCommand<T>
+impl RemoteParameterCommand {
+    pub(crate) fn into_query(self) -> zenoh::query::Query {
+        match self {
+            RemoteParameterCommand::GetSnapshot { query }
+            | RemoteParameterCommand::GetValue { query }
+            | RemoteParameterCommand::GetTypeInfo { query }
+            | RemoteParameterCommand::Set { query }
+            | RemoteParameterCommand::SetAtomic { query }
+            | RemoteParameterCommand::Reset { query }
+            | RemoteParameterCommand::Reload { query } => query,
+        }
+    }
+}
+
+impl<T> Drop for ParameterDriver<T>
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    pub fn into_query(self) -> zenoh::query::Query {
-        match self {
-            ParameterCommand::RemoteGetSnapshot { query }
-            | ParameterCommand::RemoteGetValue { query }
-            | ParameterCommand::RemoteGetTypeInfo { query }
-            | ParameterCommand::RemoteSet { query }
-            | ParameterCommand::RemoteSetAtomic { query }
-            | ParameterCommand::RemoteReset { query }
-            | ParameterCommand::RemoteReload { query } => query,
-            ParameterCommand::SetJson { .. }
-            | ParameterCommand::Reset { .. }
-            | ParameterCommand::Reload { .. }
-            | ParameterCommand::AddValidationHook { .. } => {
-                unreachable!("local parameter commands do not carry remote queries")
+    fn drop(&mut self) {
+        self.commands.close();
+        while let Ok(command) = self.commands.try_recv() {
+            if let ParameterCommand::Remote(command) = command {
+                services::reply_remote_command_unavailable(&self.reply_runtime, command);
             }
         }
     }
@@ -521,8 +592,8 @@ impl<T> ParameterDriver<T>
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    async fn run(self) {
-        while let Ok(command) = self.commands.recv_async().await {
+    async fn run(mut self) {
+        while let Some(command) = self.commands.recv().await {
             match command {
                 ParameterCommand::SetJson {
                     writes,
@@ -550,39 +621,35 @@ where
                     let result = self.add_validation_hook(hook);
                     let _ = reply.send(result);
                 }
-                remote_command => self.handle_remote_command(remote_command).await,
+                ParameterCommand::Remote(remote_command) => {
+                    self.handle_remote_command(remote_command).await;
+                }
             }
         }
     }
 
-    async fn handle_remote_command(&self, command: ParameterCommand<T>) {
+    async fn handle_remote_command(&self, command: RemoteParameterCommand) {
         match command {
-            ParameterCommand::RemoteGetSnapshot { query } => {
-                services::handle_get_snapshot_for_state(&self.state, query);
+            RemoteParameterCommand::GetSnapshot { query } => {
+                services::handle_get_snapshot_for_state(&self.state, &self.reply_runtime, query);
             }
-            ParameterCommand::RemoteGetValue { query } => {
-                services::handle_get_value_for_state(&self.state, query);
+            RemoteParameterCommand::GetValue { query } => {
+                services::handle_get_value_for_state(&self.state, &self.reply_runtime, query);
             }
-            ParameterCommand::RemoteGetTypeInfo { query } => {
-                services::handle_get_type_info_for_state(&self.state, query);
+            RemoteParameterCommand::GetTypeInfo { query } => {
+                services::handle_get_type_info_for_state(&self.state, &self.reply_runtime, query);
             }
-            ParameterCommand::RemoteSet { query } => {
-                services::handle_set_for_driver(self, query).await;
+            RemoteParameterCommand::Set { query } => {
+                services::handle_set_for_driver(self, &self.reply_runtime, query).await;
             }
-            ParameterCommand::RemoteSetAtomic { query } => {
-                services::handle_set_atomic_for_driver(self, query).await;
+            RemoteParameterCommand::SetAtomic { query } => {
+                services::handle_set_atomic_for_driver(self, &self.reply_runtime, query).await;
             }
-            ParameterCommand::RemoteReset { query } => {
-                services::handle_reset_for_driver(self, query).await;
+            RemoteParameterCommand::Reset { query } => {
+                services::handle_reset_for_driver(self, &self.reply_runtime, query).await;
             }
-            ParameterCommand::RemoteReload { query } => {
-                services::handle_reload_for_driver(self, query).await;
-            }
-            ParameterCommand::SetJson { .. }
-            | ParameterCommand::Reset { .. }
-            | ParameterCommand::Reload { .. }
-            | ParameterCommand::AddValidationHook { .. } => {
-                unreachable!("local parameter commands are handled before remote dispatch")
+            RemoteParameterCommand::Reload { query } => {
+                services::handle_reload_for_driver(self, &self.reply_runtime, query).await;
             }
         }
     }
@@ -801,13 +868,17 @@ where
 mod actor_tests {
     use std::{
         fs,
-        sync::atomic::{AtomicUsize, Ordering},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::Duration,
     };
 
     use serde::{Deserialize, Serialize};
 
-    use crate::context::ContextBuilder;
+    use super::*;
+    use crate::{context::ContextBuilder, parameter::remote::RemoteParameterClient};
 
     static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
 
@@ -815,6 +886,229 @@ mod actor_tests {
     #[message(name = "test_parameters::ActorLifecycleParameters")]
     struct ActorLifecycleParameters {
         enabled: bool,
+    }
+
+    type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+    async fn build_actor_lifecycle_node(
+        suffix: &str,
+    ) -> TestResult<(crate::node::Node, std::path::PathBuf)> {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "ros_z_parameter_actor_{suffix}_{}_{}",
+            std::process::id(),
+            id
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let base = root.join("base");
+        fs::create_dir_all(&base)?;
+        fs::write(base.join("actor_lifecycle.json5"), r#"{ enabled: true }"#)?;
+
+        let context = ContextBuilder::default()
+            .with_mode("peer")
+            .disable_multicast_scouting()
+            .with_parameter_layers([base])
+            .build()
+            .await?;
+        let node = context
+            .create_node(format!("actor_lifecycle_{suffix}_{id}"))
+            .build()
+            .await?;
+        Ok((node, root))
+    }
+
+    async fn wait_for_service(node: &crate::node::Node, service: &str) -> TestResult {
+        let start = std::time::Instant::now();
+        let timeout = Duration::from_secs(5);
+        while start.elapsed() < timeout {
+            if !node.graph().view().services_named(service).is_empty() {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        Err(format!("timed out waiting for service {service}").into())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn binding_releases_after_driver_task_exits() -> TestResult {
+        let (node, _root) = build_actor_lifecycle_node("rebind").await?;
+        let parameters = node
+            .bind_parameter_as::<ActorLifecycleParameters>("actor_lifecycle")
+            .await?;
+
+        drop(parameters);
+
+        let err = node
+            .bind_parameter_as::<ActorLifecycleParameters>("actor_lifecycle")
+            .await
+            .expect_err("binding should remain held until the actor task exits");
+        assert!(matches!(
+            err,
+            crate::parameter::ParameterError::AlreadyBound { .. }
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match node
+                    .bind_parameter_as::<ActorLifecycleParameters>("actor_lifecycle")
+                    .await
+                {
+                    Ok(_parameters) => return Ok::<_, Box<dyn std::error::Error + Send + Sync>>(()),
+                    Err(crate::parameter::ParameterError::AlreadyBound { .. }) => {
+                        tokio::task::yield_now().await;
+                    }
+                    Err(err) => return Err(err.into()),
+                }
+            }
+        })
+        .await
+        .map_err(|_| "timed out waiting for parameter binding to release")??;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn binding_resources_release_after_driver_task_aborts() -> TestResult {
+        let (node, _root) = build_actor_lifecycle_node("abort_rebind").await?;
+        let parameters = node
+            .bind_parameter_as::<ActorLifecycleParameters>("actor_lifecycle")
+            .await?;
+
+        parameters.inner.driver_task.abort();
+
+        let _replacement = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match node
+                    .bind_parameter_as::<ActorLifecycleParameters>("actor_lifecycle")
+                    .await
+                {
+                    Ok(parameters) => {
+                        return Ok::<_, Box<dyn std::error::Error + Send + Sync>>(parameters);
+                    }
+                    Err(crate::parameter::ParameterError::AlreadyBound { .. }) => {
+                        tokio::task::yield_now().await;
+                    }
+                    Err(err) => return Err(err.into()),
+                }
+            }
+        })
+        .await
+        .map_err(|_| "timed out waiting for aborted parameter binding to release")??;
+
+        let err = parameters
+            .reload()
+            .await
+            .expect_err("old handle should report unavailable actor");
+        assert!(err.to_string().contains("parameter actor is unavailable"));
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn driver_drop_replies_busy_to_queued_remote_command() -> TestResult {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "ros_z_parameter_actor_remote_drain_{}_{}",
+            std::process::id(),
+            id
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let base = root.join("base");
+        fs::create_dir_all(&base)?;
+        fs::write(base.join("actor_lifecycle.json5"), r#"{ enabled: true }"#)?;
+
+        let context = ContextBuilder::default()
+            .with_mode("peer")
+            .disable_multicast_scouting()
+            .with_parameter_layers([base])
+            .build()
+            .await?;
+        let server_node = context
+            .create_node(format!("remote_drain_server_{id}"))
+            .build()
+            .await?;
+        let client_node = context
+            .create_node(format!("remote_drain_client_{id}"))
+            .build()
+            .await?;
+
+        let parameter_key: ParameterKey = "actor_lifecycle".to_string();
+        let layers = server_node
+            .runtime_parameter_inputs()
+            .parameter_layers
+            .clone();
+        let schema = Arc::new(ActorLifecycleParameters::schema());
+        let type_info = validated_type_info_for_schema::<ActorLifecycleParameters>(&schema);
+        server_node
+            .register_schema_with_service(&type_info.name, schema)
+            .map_err(|source| ParameterError::operation("registering parameter schema", source))?;
+
+        let node_fqn = server_node.node_entity().fully_qualified_name();
+        let snapshot = Arc::new(load_snapshot::<ActorLifecycleParameters>(
+            &node_fqn,
+            &parameter_key,
+            &layers,
+            server_node.clock(),
+            0,
+        )?);
+        let (tx, _rx) = watch::channel(snapshot.clone());
+        let state = Arc::new(ParameterState {
+            node_fqn: node_fqn.clone(),
+            parameter_key,
+            type_name: type_info.name,
+            schema_hash: type_info.hash,
+            layers,
+            clock: server_node.clock().clone(),
+            commit_lock: Mutex::new(()),
+            hooks: Mutex::new(Vec::new()),
+            current: ArcSwap::from(snapshot),
+            tx,
+        });
+        let (command_tx, command_rx) = mpsc::channel(PARAMETER_MAILBOX_CAPACITY);
+        let reply_runtime = Handle::current();
+        let remote =
+            RemoteParameterServices::register(&server_node, command_tx, reply_runtime.clone())
+                .await?;
+        let event_publisher = remote.event_publisher();
+        let driver = ParameterDriver {
+            state,
+            commands: command_rx,
+            event_publisher,
+            reply_runtime,
+            _remote: remote,
+            _binding_guard: BindingGuard {
+                state: server_node.parameter_binding_state().clone(),
+            },
+        };
+
+        let service_name = format!("{node_fqn}/parameter/set");
+        wait_for_service(&client_node, &service_name).await?;
+        let client = RemoteParameterClient::new(Arc::new(client_node), node_fqn)?;
+        let call = tokio::spawn(async move {
+            let value = serde_json::json!(false);
+            client.set_json("enabled", &value, "base", None).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while driver.commands.is_empty() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .map_err(|_| "timed out waiting for remote command to queue")?;
+
+        drop(driver);
+
+        let join_result = tokio::time::timeout(Duration::from_secs(2), call)
+            .await
+            .map_err(|_| "timed out waiting for drained remote reply")?;
+        let response = join_result??;
+        assert!(!response.success);
+        assert_eq!(response.message, "parameter actor is unavailable or busy");
+        assert_eq!(response.committed_revision, 0);
+        assert!(response.changed_paths.is_empty());
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/ros-z/src/parameter/node_parameter.rs
+++ b/crates/ros-z/src/parameter/node_parameter.rs
@@ -1,17 +1,15 @@
-use std::{
-    collections::BTreeSet,
-    path::PathBuf,
-    sync::{Arc, OnceLock},
-};
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
 use arc_swap::ArcSwap;
 use parking_lot::Mutex;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use tokio::sync::watch;
+use tokio_util::task::AbortOnDropHandle;
 
 use crate::{
-    Message, entity::SchemaHash, message::validated_type_info_for_schema, node::Node, time::Clock,
+    Message, entity::SchemaHash, message::validated_type_info_for_schema, node::Node,
+    pubsub::Publisher, time::Clock,
 };
 
 use super::{
@@ -24,12 +22,12 @@ use super::{
     },
     persistence::write_pretty_json_batch,
     remote::{
-        RemoteParameterServices,
+        services::{self, RemoteParameterServices},
         types::{NodeParameterChange, NodeParameterChangeSource, NodeParameterEvent},
     },
 };
 
-pub type ValidateHook<T> = Arc<dyn Fn(&T) -> std::result::Result<(), String> + Send + Sync>;
+type ValidateHook<T> = Arc<dyn Fn(&T) -> std::result::Result<(), String> + Send + Sync>;
 
 #[derive(Debug, Clone)]
 pub struct ParameterJsonWrite {
@@ -39,80 +37,172 @@ pub struct ParameterJsonWrite {
 }
 
 #[derive(Clone)]
-pub struct NodeParameters<T> {
-    pub(crate) inner: Arc<NodeParametersInner<T>>,
+pub struct NodeParameters<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    inner: Arc<NodeParametersInner<T>>,
 }
 
-pub struct NodeParametersInner<T> {
-    pub(crate) node_fqn: String,
-    pub(crate) parameter_key: ParameterKey,
-    pub(crate) type_name: String,
-    pub(crate) schema_hash: SchemaHash,
-    pub(crate) layers: Vec<PathBuf>,
+struct NodeParametersInner<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    // Field order is shutdown order: stop accepting remote requests, close the
+    // command sender, abort the driver if it is still running, then release the
+    // node-level binding guard.
+    _remote: RemoteParameterServices<T>,
+    commands: flume::Sender<ParameterCommand<T>>,
+    driver_task: AbortOnDropHandle<()>,
+    _binding_guard: BindingGuard,
+    state: Arc<ParameterState<T>>,
+}
+
+struct BindingGuard {
+    state: Arc<parking_lot::Mutex<bool>>,
+}
+
+impl Drop for BindingGuard {
+    fn drop(&mut self) {
+        *self.state.lock() = false;
+    }
+}
+
+pub struct ParameterState<T> {
+    node_fqn: String,
+    parameter_key: ParameterKey,
+    pub type_name: String,
+    pub schema_hash: SchemaHash,
+    layers: Vec<PathBuf>,
     clock: Clock,
     commit_lock: Mutex<()>,
     hooks: Mutex<Vec<ValidateHook<T>>>,
-    current: ArcSwap<NodeParametersSnapshot<T>>,
+    pub current: ArcSwap<NodeParametersSnapshot<T>>,
     tx: watch::Sender<Arc<NodeParametersSnapshot<T>>>,
-    binding_state: Arc<parking_lot::Mutex<bool>>,
-    remote: OnceLock<RemoteParameterServices<T>>,
 }
 
-impl<T> Drop for NodeParametersInner<T> {
-    fn drop(&mut self) {
-        *self.binding_state.lock() = false;
-    }
-}
-
-pub trait NodeParametersExt {
-    /// Bind this node to a typed parameter set.
-    ///
-    /// Returns errors for invalid parameter keys, binding state, runtime loading,
-    /// serialization, and dynamic schema registration failures.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `T` builds an invalid static [`Message`] schema or schema hash.
-    fn bind_parameter_as<T>(
-        &self,
-        parameter_key: impl Into<ParameterKey>,
-    ) -> Result<NodeParameters<T>>
-    where
-        T: Serialize + DeserializeOwned + Message + Send + Sync + 'static;
-}
-
-fn block_on_parameter_future<F, T>(future: F) -> Result<T>
+impl<T> std::ops::Deref for NodeParametersInner<T>
 where
-    F: std::future::Future<Output = Result<T>>,
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        match handle.runtime_flavor() {
-            tokio::runtime::RuntimeFlavor::MultiThread => {
-                tokio::task::block_in_place(|| handle.block_on(future))
-            }
-            tokio::runtime::RuntimeFlavor::CurrentThread => Err(ParameterError::RemoteError {
-                message: "blocking parameter APIs cannot run on Tokio current_thread runtimes; use async parameter APIs from async contexts".to_string(),
-            }),
-            _ => Err(ParameterError::RemoteError {
-                message: "blocking parameter APIs require a supported Tokio runtime".to_string(),
-            }),
-        }
-    } else {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|source| {
-                ParameterError::operation(
-                    "creating Tokio runtime for blocking parameter call",
-                    source,
-                )
-            })?
-            .block_on(future)
+    type Target = ParameterState<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
     }
 }
 
-impl NodeParametersExt for Node {
-    fn bind_parameter_as<T>(
+const PARAMETER_MAILBOX_CAPACITY: usize = 64;
+
+type ParameterReply<T> = flume::Sender<Result<T>>;
+
+pub enum ParameterCommand<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    SetJson {
+        writes: Vec<ParameterJsonWrite>,
+        expected_revision: Option<u64>,
+        source: NodeParameterChangeSource,
+        reply: ParameterReply<CommitOutcome>,
+    },
+    Reset {
+        resets: Vec<(FieldPath, LayerPath)>,
+        expected_revision: Option<u64>,
+        source: NodeParameterChangeSource,
+        reply: ParameterReply<CommitOutcome>,
+    },
+    Reload {
+        source: NodeParameterChangeSource,
+        reply: ParameterReply<CommitOutcome>,
+    },
+    AddValidationHook {
+        hook: ValidateHook<T>,
+        reply: ParameterReply<()>,
+    },
+    RemoteGetSnapshot {
+        query: zenoh::query::Query,
+    },
+    RemoteGetValue {
+        query: zenoh::query::Query,
+    },
+    RemoteGetTypeInfo {
+        query: zenoh::query::Query,
+    },
+    RemoteSet {
+        query: zenoh::query::Query,
+    },
+    RemoteSetAtomic {
+        query: zenoh::query::Query,
+    },
+    RemoteReset {
+        query: zenoh::query::Query,
+    },
+    RemoteReload {
+        query: zenoh::query::Query,
+    },
+}
+
+pub struct ParameterDriver<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    state: Arc<ParameterState<T>>,
+    commands: flume::Receiver<ParameterCommand<T>>,
+    event_publisher: Arc<Publisher<NodeParameterEvent>>,
+}
+
+fn actor_unavailable_error() -> ParameterError {
+    ParameterError::RemoteError {
+        message: "parameter actor is unavailable".to_string(),
+    }
+}
+
+impl Node {
+    /// Binds this node to its typed parameter set and starts the parameter actor.
+    ///
+    /// The returned handle reads from the current snapshot immediately and sends
+    /// mutations through the actor. Remote parameter services are registered as
+    /// part of the binding, so remote reads and writes are serialized through the
+    /// same actor as local writes.
+    ///
+    /// A node can only have one active parameter binding. Calling this again on
+    /// the same node while the first [`NodeParameters`] handle is alive returns
+    /// [`ParameterError::AlreadyBound`]. Dropping the handle shuts down the actor
+    /// and releases the binding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key is invalid, no parameter layers are configured,
+    /// the initial JSON5 layers cannot be loaded or deserialized as `T`, schema or
+    /// remote-service registration fails, or the node already has an active
+    /// parameter binding.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use ros_z::{context::ContextBuilder, node::Node, parameter::NodeParameters};
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(Debug, Clone, Serialize, Deserialize, ros_z::Message)]
+    /// #[message(name = "example::DetectorParameters")]
+    /// struct DetectorParameters {
+    ///     enabled: bool,
+    /// }
+    ///
+    /// async fn bind(node: &Node) -> ros_z::parameter::Result<NodeParameters<DetectorParameters>> {
+    ///     node.bind_parameter_as::<DetectorParameters>("detector").await
+    /// }
+    ///
+    /// # async fn build_node() -> ros_z::Result<Node> {
+    /// #     let context = ContextBuilder::default()
+    /// #         .with_parameter_layers([std::path::PathBuf::from("etc/parameters/ros_z/base")])
+    /// #         .build()
+    /// #         .await?;
+    /// #     context.create_node("detector").build().await
+    /// # }
+    /// ```
+    pub async fn bind_parameter_as<T>(
         &self,
         parameter_key: impl Into<ParameterKey>,
     ) -> Result<NodeParameters<T>>
@@ -121,25 +211,34 @@ impl NodeParametersExt for Node {
     {
         let parameter_key = parameter_key.into();
         validate_parameter_key(&parameter_key)?;
-        let mut bound = self.parameter_binding_state().lock();
-        if *bound {
-            return Err(ParameterError::AlreadyBound {
-                node_fqn: self.node_entity().fully_qualified_name(),
-            });
-        }
-        *bound = true;
+        mark_parameter_bound(self)?;
 
-        match block_on_parameter_future(bind_parameter_inner(self, parameter_key)) {
+        match build_parameter_actor(self, parameter_key).await {
             Ok(parameters) => Ok(parameters),
             Err(err) => {
-                *bound = false;
+                clear_parameter_bound(self);
                 Err(err)
             }
         }
     }
 }
 
-async fn bind_parameter_inner<T>(
+fn mark_parameter_bound(node: &Node) -> Result<()> {
+    let mut bound = node.parameter_binding_state().lock();
+    if *bound {
+        return Err(ParameterError::AlreadyBound {
+            node_fqn: node.node_entity().fully_qualified_name(),
+        });
+    }
+    *bound = true;
+    Ok(())
+}
+
+fn clear_parameter_bound(node: &Node) {
+    *node.parameter_binding_state().lock() = false;
+}
+
+async fn build_parameter_actor<T>(
     node: &Node,
     parameter_key: ParameterKey,
 ) -> Result<NodeParameters<T>>
@@ -161,9 +260,8 @@ where
     let snapshot = Arc::new(snapshot);
     let (tx, _rx) = watch::channel(snapshot.clone());
 
-    let binding_state = self_binding_state(node);
     let current = ArcSwap::from(snapshot);
-    let inner = Arc::new(NodeParametersInner {
+    let state = Arc::new(ParameterState {
         node_fqn: node_fqn.clone(),
         parameter_key,
         type_name: type_info.name,
@@ -174,18 +272,28 @@ where
         hooks: Mutex::new(Vec::new()),
         current,
         tx,
-        binding_state,
-        remote: OnceLock::new(),
+    });
+    let (command_tx, command_rx) = flume::bounded(PARAMETER_MAILBOX_CAPACITY);
+    let remote = RemoteParameterServices::register(node, state.clone(), command_tx.clone()).await?;
+    let event_publisher = remote.event_publisher();
+
+    let driver = ParameterDriver {
+        state: state.clone(),
+        commands: command_rx,
+        event_publisher,
+    };
+    let driver_task = tokio::spawn(driver.run());
+    let inner = Arc::new(NodeParametersInner {
+        _remote: remote,
+        commands: command_tx,
+        driver_task: AbortOnDropHandle::new(driver_task),
+        _binding_guard: BindingGuard {
+            state: node.parameter_binding_state().clone(),
+        },
+        state,
     });
 
-    let remote = RemoteParameterServices::register(node, inner.clone()).await?;
-    let _ = inner.remote.set(remote);
-
     Ok(NodeParameters { inner })
-}
-
-fn self_binding_state(node: &Node) -> Arc<parking_lot::Mutex<bool>> {
-    node.parameter_binding_state().clone()
 }
 
 fn validate_parameter_key(parameter_key: &str) -> Result<()> {
@@ -272,8 +380,45 @@ impl<T> NodeParameters<T>
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
+    async fn request<R>(
+        &self,
+        command: impl FnOnce(ParameterReply<R>) -> ParameterCommand<T>,
+    ) -> Result<R>
+    where
+        R: Send + 'static,
+    {
+        let (reply_tx, reply_rx) = flume::bounded(1);
+        let commands = self.command_sender()?;
+        commands
+            .send_async(command(reply_tx))
+            .await
+            .map_err(|_| actor_unavailable_error())?;
+        tokio::select! {
+            result = reply_rx.recv_async() => result.map_err(|_| actor_unavailable_error())?,
+            () = self.wait_for_driver_task_to_finish() => Err(actor_unavailable_error()),
+        }
+    }
+
+    fn command_sender(&self) -> Result<flume::Sender<ParameterCommand<T>>> {
+        if self.driver_task_is_unavailable() {
+            return Err(actor_unavailable_error());
+        }
+
+        Ok(self.inner.commands.clone())
+    }
+
+    async fn wait_for_driver_task_to_finish(&self) {
+        while !self.driver_task_is_unavailable() {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    fn driver_task_is_unavailable(&self) -> bool {
+        self.inner.driver_task.is_finished()
+    }
+
     pub fn snapshot(&self) -> Arc<NodeParametersSnapshot<T>> {
-        self.inner.current.load_full()
+        self.inner.state.current.load_full()
     }
 
     pub fn get_json(&self, path: &str) -> Result<Value> {
@@ -283,74 +428,186 @@ where
         })
     }
 
-    pub fn set_json(
+    pub async fn set_json(
         &self,
         path: &str,
         value: Value,
         target_layer: impl Into<LayerPath>,
     ) -> Result<()> {
-        self.commit(
-            &[ParameterJsonWrite {
+        self.set_json_atomically(
+            vec![ParameterJsonWrite {
                 path: path.to_string(),
                 value,
                 target_layer: target_layer.into(),
             }],
-            &[],
             None,
-            NodeParameterChangeSource::LocalWrite,
         )
+        .await
         .map(|_| ())
     }
 
-    pub fn set_json_atomically(
+    pub async fn set_json_atomically(
         &self,
         changes: Vec<ParameterJsonWrite>,
         expected_revision: Option<u64>,
     ) -> Result<CommitOutcome> {
-        self.commit(
-            &changes,
-            &[],
+        self.request(|reply| ParameterCommand::SetJson {
+            writes: changes,
             expected_revision,
-            NodeParameterChangeSource::LocalWrite,
-        )
+            source: NodeParameterChangeSource::LocalWrite,
+            reply,
+        })
+        .await
     }
 
-    pub fn reset(&self, path: &str, target_layer: impl Into<LayerPath>) -> Result<()> {
-        self.commit(
-            &[],
-            &[(path.to_string(), target_layer.into())],
-            None,
-            NodeParameterChangeSource::LocalWrite,
-        )
+    pub async fn reset(&self, path: &str, target_layer: impl Into<LayerPath>) -> Result<()> {
+        self.request(|reply| ParameterCommand::Reset {
+            resets: vec![(path.to_string(), target_layer.into())],
+            expected_revision: None,
+            source: NodeParameterChangeSource::LocalWrite,
+            reply,
+        })
+        .await
         .map(|_| ())
     }
 
-    pub fn reload(&self) -> Result<()> {
-        self.reload_with_source(NodeParameterChangeSource::Reload)
-            .map(|_| ())
+    pub async fn reload(&self) -> Result<()> {
+        self.request(|reply| ParameterCommand::Reload {
+            source: NodeParameterChangeSource::Reload,
+            reply,
+        })
+        .await
+        .map(|_| ())
     }
 
-    pub(crate) fn reload_with_source(
+    pub fn subscribe(&self) -> ParameterSubscription<T> {
+        self.inner.state.tx.subscribe()
+    }
+
+    pub async fn add_validation_hook<F>(&self, hook: F) -> Result<()>
+    where
+        F: Fn(&T) -> std::result::Result<(), String> + Send + Sync + 'static,
+    {
+        let hook: ValidateHook<T> = Arc::new(hook);
+        self.request(|reply| ParameterCommand::AddValidationHook { hook, reply })
+            .await
+    }
+}
+
+impl<T> ParameterCommand<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    pub fn into_query(self) -> zenoh::query::Query {
+        match self {
+            ParameterCommand::RemoteGetSnapshot { query }
+            | ParameterCommand::RemoteGetValue { query }
+            | ParameterCommand::RemoteGetTypeInfo { query }
+            | ParameterCommand::RemoteSet { query }
+            | ParameterCommand::RemoteSetAtomic { query }
+            | ParameterCommand::RemoteReset { query }
+            | ParameterCommand::RemoteReload { query } => query,
+            ParameterCommand::SetJson { .. }
+            | ParameterCommand::Reset { .. }
+            | ParameterCommand::Reload { .. }
+            | ParameterCommand::AddValidationHook { .. } => {
+                unreachable!("local parameter commands do not carry remote queries")
+            }
+        }
+    }
+}
+
+impl<T> ParameterDriver<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
+    async fn run(self) {
+        while let Ok(command) = self.commands.recv_async().await {
+            match command {
+                ParameterCommand::SetJson {
+                    writes,
+                    expected_revision,
+                    source,
+                    reply,
+                } => {
+                    let result = self.commit(&writes, &[], expected_revision, source).await;
+                    let _ = reply.send(result);
+                }
+                ParameterCommand::Reset {
+                    resets,
+                    expected_revision,
+                    source,
+                    reply,
+                } => {
+                    let result = self.commit(&[], &resets, expected_revision, source).await;
+                    let _ = reply.send(result);
+                }
+                ParameterCommand::Reload { source, reply } => {
+                    let result = self.reload_with_source(source).await;
+                    let _ = reply.send(result);
+                }
+                ParameterCommand::AddValidationHook { hook, reply } => {
+                    let result = self.add_validation_hook(hook);
+                    let _ = reply.send(result);
+                }
+                remote_command => self.handle_remote_command(remote_command).await,
+            }
+        }
+    }
+
+    async fn handle_remote_command(&self, command: ParameterCommand<T>) {
+        match command {
+            ParameterCommand::RemoteGetSnapshot { query } => {
+                services::handle_get_snapshot_for_state(&self.state, query);
+            }
+            ParameterCommand::RemoteGetValue { query } => {
+                services::handle_get_value_for_state(&self.state, query);
+            }
+            ParameterCommand::RemoteGetTypeInfo { query } => {
+                services::handle_get_type_info_for_state(&self.state, query);
+            }
+            ParameterCommand::RemoteSet { query } => {
+                services::handle_set_for_driver(self, query).await;
+            }
+            ParameterCommand::RemoteSetAtomic { query } => {
+                services::handle_set_atomic_for_driver(self, query).await;
+            }
+            ParameterCommand::RemoteReset { query } => {
+                services::handle_reset_for_driver(self, query).await;
+            }
+            ParameterCommand::RemoteReload { query } => {
+                services::handle_reload_for_driver(self, query).await;
+            }
+            ParameterCommand::SetJson { .. }
+            | ParameterCommand::Reset { .. }
+            | ParameterCommand::Reload { .. }
+            | ParameterCommand::AddValidationHook { .. } => {
+                unreachable!("local parameter commands are handled before remote dispatch")
+            }
+        }
+    }
+
+    pub async fn reload_with_source(
         &self,
         source: NodeParameterChangeSource,
     ) -> Result<CommitOutcome> {
         let (outcome, event) = {
-            let _commit_guard = self.inner.commit_lock.lock();
-            let current = self.snapshot();
+            let _commit_guard = self.state.commit_lock.lock();
+            let current = self.state.current.load_full();
 
             let candidate = load_snapshot::<T>(
-                &self.inner.node_fqn,
-                &self.inner.parameter_key,
-                &self.inner.layers,
-                &self.inner.clock,
+                &self.state.node_fqn,
+                &self.state.parameter_key,
+                &self.state.layers,
+                &self.state.clock,
                 current.revision + 1,
             )?;
             self.run_hooks(candidate.typed.as_ref())?;
             let diff = recursive_diff(&current.effective, &candidate.effective);
             let changed_paths = diff.iter().map(|entry| entry.path.clone()).collect();
             let snapshot = Arc::new(candidate);
-            self.inner.current.store(snapshot.clone());
-            let _ = self.inner.tx.send(snapshot.clone());
+            self.state.current.store(snapshot.clone());
+            let _ = self.state.tx.send(snapshot.clone());
             let event = self.build_event(&current, &snapshot, diff, source);
             (
                 CommitOutcome {
@@ -360,29 +617,21 @@ where
                 event,
             )
         };
-        if let Err(err) = self.publish_event(&event) {
+        if let Err(err) = self.publish_event(&event).await {
             tracing::warn!("[PARAM] Failed to publish parameter event: {err}");
         }
         Ok(outcome)
     }
 
-    pub fn subscribe(&self) -> ParameterSubscription<T> {
-        self.inner.tx.subscribe()
-    }
-
-    pub fn add_validation_hook<F>(&self, hook: F) -> Result<()>
-    where
-        F: Fn(&T) -> std::result::Result<(), String> + Send + Sync + 'static,
-    {
-        let hook: ValidateHook<T> = Arc::new(hook);
-        let _commit_guard = self.inner.commit_lock.lock();
-        self.run_hook(self.snapshot().typed.as_ref(), &hook)?;
-        self.inner.hooks.lock().push(hook);
+    fn add_validation_hook(&self, hook: ValidateHook<T>) -> Result<()> {
+        let _commit_guard = self.state.commit_lock.lock();
+        self.run_hook(self.state.current.load_full().typed.as_ref(), &hook)?;
+        self.state.hooks.lock().push(hook);
         Ok(())
     }
 
     fn run_hooks(&self, candidate: &T) -> Result<()> {
-        for hook in self.inner.hooks.lock().iter() {
+        for hook in self.state.hooks.lock().iter() {
             self.run_hook(candidate, hook)?;
         }
         Ok(())
@@ -392,93 +641,101 @@ where
         hook(candidate).map_err(|message| ParameterError::ValidationError { message })
     }
 
-    pub(crate) fn commit(
+    pub async fn commit(
         &self,
         writes: &[ParameterJsonWrite],
         resets: &[(FieldPath, LayerPath)],
         expected_revision: Option<u64>,
         source: NodeParameterChangeSource,
     ) -> Result<CommitOutcome> {
-        let (outcome, event) = {
-            let _commit_guard = self.inner.commit_lock.lock();
-            let current = self.snapshot();
-            if let Some(expected) = expected_revision
-                && expected != current.revision
-            {
-                return Err(ParameterError::RevisionMismatch {
-                    expected,
-                    actual: current.revision,
-                });
-            }
-
-            let mut layer_overlays = current.layer_overlays.clone();
-            let active_layers = &current.layers;
-            let mut touched = BTreeSet::new();
-
-            for write in writes {
-                let index = active_layers
-                    .iter()
-                    .position(|layer| layer == &write.target_layer)
-                    .ok_or_else(|| ParameterError::LayerNotActive {
-                        layer: write.target_layer.clone(),
-                    })?;
-                let overlay = &mut layer_overlays[index];
-                set_value_at_path(overlay, &write.path, write.value.clone())?;
-                touched.insert(index);
-            }
-
-            for (path, target_layer) in resets {
-                let index = active_layers
-                    .iter()
-                    .position(|layer| layer == target_layer)
-                    .ok_or_else(|| ParameterError::LayerNotActive {
-                        layer: target_layer.clone(),
-                    })?;
-                let overlay = &mut layer_overlays[index];
-                if remove_value_at_path(overlay, path)? {
-                    touched.insert(index);
-                }
-            }
-
-            let candidate = snapshot_from_parts::<T>(
-                &self.inner.node_fqn,
-                &self.inner.parameter_key,
-                &self.inner.layers,
-                &self.inner.clock,
-                current.revision + 1,
-                layer_overlays,
-            )?;
-            self.run_hooks(candidate.typed.as_ref())?;
-
-            let persisted_layers = touched
-                .iter()
-                .map(|index| {
-                    let path = self.inner.layers[*index]
-                        .join(format!("{}.json5", self.inner.parameter_key));
-                    let value = candidate.layer_overlays[*index].clone();
-                    (path, value)
-                })
-                .collect::<Vec<_>>();
-            write_pretty_json_batch(&persisted_layers)?;
-
-            let diff = recursive_diff(&current.effective, &candidate.effective);
-            let changed_paths = diff.iter().map(|entry| entry.path.clone()).collect();
-            let snapshot = Arc::new(candidate);
-            self.inner.current.store(snapshot.clone());
-            let _ = self.inner.tx.send(snapshot.clone());
-            let event = self.build_event(&current, &snapshot, diff, source);
-            (
-                CommitOutcome {
-                    committed_revision: snapshot.revision,
-                    changed_paths,
-                },
-                event,
-            )
-        };
-        if let Err(err) = self.publish_event(&event) {
+        let (outcome, event) = self.commit_state(writes, resets, expected_revision, source)?;
+        if let Err(err) = self.publish_event(&event).await {
             tracing::warn!("[PARAM] Failed to publish parameter event: {err}");
         }
         Ok(outcome)
+    }
+
+    fn commit_state(
+        &self,
+        writes: &[ParameterJsonWrite],
+        resets: &[(FieldPath, LayerPath)],
+        expected_revision: Option<u64>,
+        source: NodeParameterChangeSource,
+    ) -> Result<(CommitOutcome, NodeParameterEvent)> {
+        let _commit_guard = self.state.commit_lock.lock();
+        let current = self.state.current.load_full();
+        if let Some(expected) = expected_revision
+            && expected != current.revision
+        {
+            return Err(ParameterError::RevisionMismatch {
+                expected,
+                actual: current.revision,
+            });
+        }
+
+        let mut layer_overlays = current.layer_overlays.clone();
+        let active_layers = &current.layers;
+        let mut touched = BTreeSet::new();
+
+        for write in writes {
+            let index = active_layers
+                .iter()
+                .position(|layer| layer == &write.target_layer)
+                .ok_or_else(|| ParameterError::LayerNotActive {
+                    layer: write.target_layer.clone(),
+                })?;
+            let overlay = &mut layer_overlays[index];
+            set_value_at_path(overlay, &write.path, write.value.clone())?;
+            touched.insert(index);
+        }
+
+        for (path, target_layer) in resets {
+            let index = active_layers
+                .iter()
+                .position(|layer| layer == target_layer)
+                .ok_or_else(|| ParameterError::LayerNotActive {
+                    layer: target_layer.clone(),
+                })?;
+            let overlay = &mut layer_overlays[index];
+            if remove_value_at_path(overlay, path)? {
+                touched.insert(index);
+            }
+        }
+
+        let candidate = snapshot_from_parts::<T>(
+            &self.state.node_fqn,
+            &self.state.parameter_key,
+            &self.state.layers,
+            &self.state.clock,
+            current.revision + 1,
+            layer_overlays,
+        )?;
+        self.run_hooks(candidate.typed.as_ref())?;
+
+        let persisted_layers = touched
+            .iter()
+            .map(|index| {
+                let path =
+                    self.state.layers[*index].join(format!("{}.json5", self.state.parameter_key));
+                let value = candidate.layer_overlays[*index].clone();
+                (path, value)
+            })
+            .collect::<Vec<_>>();
+        write_pretty_json_batch(&persisted_layers)?;
+
+        let diff = recursive_diff(&current.effective, &candidate.effective);
+        let changed_paths = diff.iter().map(|entry| entry.path.clone()).collect();
+        let snapshot = Arc::new(candidate);
+        self.state.current.store(snapshot.clone());
+        let _ = self.state.tx.send(snapshot.clone());
+        let event = self.build_event(&current, &snapshot, diff, source);
+        Ok((
+            CommitOutcome {
+                committed_revision: snapshot.revision,
+                changed_paths,
+            },
+            event,
+        ))
     }
 
     fn build_event(
@@ -502,8 +759,8 @@ where
             .collect::<Vec<_>>();
 
         NodeParameterEvent {
-            node_fqn: self.inner.node_fqn.clone(),
-            parameter_key: self.inner.parameter_key.clone(),
+            node_fqn: self.state.node_fqn.clone(),
+            parameter_key: self.state.parameter_key.clone(),
             previous_revision: previous.revision,
             revision: current.revision,
             source,
@@ -512,10 +769,11 @@ where
         }
     }
 
-    fn publish_event(&self, event: &NodeParameterEvent) -> Result<()> {
-        if let Some(remote) = self.inner.remote.get() {
-            block_on_parameter_future(remote.publish_event(event))?;
-        }
+    async fn publish_event(&self, event: &NodeParameterEvent) -> Result<()> {
+        self.event_publisher
+            .publish(event)
+            .await
+            .map_err(|source| ParameterError::operation("publishing parameter event", source))?;
         Ok(())
     }
 }
@@ -527,11 +785,74 @@ pub struct CommitOutcome {
     pub changed_paths: Vec<String>,
 }
 
-impl<T> std::fmt::Debug for NodeParameters<T> {
+impl<T> std::fmt::Debug for NodeParameters<T>
+where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NodeParameters")
             .field("node_fqn", &self.inner.node_fqn)
             .field("parameter_key", &self.inner.parameter_key)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod actor_tests {
+    use std::{
+        fs,
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
+
+    use serde::{Deserialize, Serialize};
+
+    use crate::context::ContextBuilder;
+
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+    #[derive(Debug, Clone, Serialize, Deserialize, crate::Message)]
+    #[message(name = "test_parameters::ActorLifecycleParameters")]
+    struct ActorLifecycleParameters {
+        enabled: bool,
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn local_mutation_reports_error_after_driver_task_aborts() {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "ros_z_parameter_actor_shutdown_{}_{}",
+            std::process::id(),
+            id
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let base = root.join("base");
+        fs::create_dir_all(&base).expect("create parameter layer");
+        fs::write(base.join("actor_lifecycle.json5"), r#"{ enabled: true }"#)
+            .expect("write parameter file");
+
+        let context = ContextBuilder::default()
+            .with_mode("peer")
+            .disable_multicast_scouting()
+            .with_parameter_layers([base])
+            .build()
+            .await
+            .expect("build context");
+        let node = context
+            .create_node("actor_lifecycle")
+            .build()
+            .await
+            .expect("build node");
+        let parameters = node
+            .bind_parameter_as::<ActorLifecycleParameters>("actor_lifecycle")
+            .await
+            .expect("bind parameters");
+
+        parameters.inner.driver_task.abort();
+        let err = tokio::time::timeout(Duration::from_secs(1), parameters.reload())
+            .await
+            .expect("reload should finish after driver abort")
+            .expect_err("reload should fail after driver abort");
+        assert!(err.to_string().contains("parameter actor is unavailable"));
     }
 }

--- a/crates/ros-z/src/parameter/persistence.rs
+++ b/crates/ros-z/src/parameter/persistence.rs
@@ -17,7 +17,7 @@ fn persistence_error(path: impl Into<PathBuf>, source: std::io::Error) -> Parame
 }
 
 #[cfg(test)]
-pub fn write_pretty_json(path: &Path, value: &Value) -> Result<()> {
+fn write_pretty_json(path: &Path, value: &Value) -> Result<()> {
     let data = serde_json::to_string_pretty(value).map_err(|source| {
         ParameterError::PersistenceSerializationError {
             path: path.to_path_buf(),

--- a/crates/ros-z/src/parameter/remote/client.rs
+++ b/crates/ros-z/src/parameter/remote/client.rs
@@ -60,6 +60,11 @@ impl RemoteParameterClient {
         format!("{}/parameter/events", self.target_node_fqn)
     }
 
+    /// Gets the current parameter snapshot.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn get_snapshot(&self) -> Result<GetNodeParametersSnapshotResponse> {
         self.call_service::<GetNodeParametersSnapshotSrv>(
             &self.service_name("get_snapshot"),
@@ -68,6 +73,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Gets one JSON value by path.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn get_value(
         &self,
         path: impl Into<String>,
@@ -79,6 +89,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Gets type information for the target parameters.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn get_type_info(&self) -> Result<GetNodeParameterTypeInfoResponse> {
         self.call_service::<GetNodeParameterTypeInfoSrv>(
             &self.service_name("get_type_info"),
@@ -87,6 +102,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Sets one JSON value.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn set_json(
         &self,
         path: impl Into<String>,
@@ -106,6 +126,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Applies multiple JSON writes atomically.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn set_json_atomically(
         &self,
         writes: Vec<NodeParameterWriteJson>,
@@ -121,6 +146,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Removes one override from a target layer.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn reset(
         &self,
         path: impl Into<String>,
@@ -138,6 +168,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Reloads all configured parameter layers.
+    ///
+    /// Transport failures are returned as [`Err`]. Service-level failures, including
+    /// a busy or unavailable target parameter actor, are returned as `Ok(response)`
+    /// with `response.success == false` and details in `response.message`.
     pub async fn reload(&self) -> Result<ReloadNodeParametersResponse> {
         self.call_service::<ReloadNodeParametersSrv>(
             &self.service_name("reload"),
@@ -146,6 +181,11 @@ impl RemoteParameterClient {
         .await
     }
 
+    /// Subscribes to committed parameter events published by the target actor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the subscriber cannot be created or registered.
     pub async fn subscribe_events(&self) -> Result<Subscriber<NodeParameterEvent>> {
         let events_topic = self.events_topic();
         let operation = format!("subscribing to remote parameter events '{events_topic}'");

--- a/crates/ros-z/src/parameter/remote/mod.rs
+++ b/crates/ros-z/src/parameter/remote/mod.rs
@@ -1,6 +1,5 @@
-pub mod client;
+mod client;
 pub mod services;
 pub mod types;
 
 pub use client::RemoteParameterClient;
-pub use services::RemoteParameterServices;

--- a/crates/ros-z/src/parameter/remote/services.rs
+++ b/crates/ros-z/src/parameter/remote/services.rs
@@ -8,18 +8,24 @@ use crate::{
     attachment::Attachment,
     message::{Service, WireDecoder, WireEncoder},
     node::Node,
-    parameter::{NodeParameters, ParameterError, Result},
+    parameter::{ParameterError, Result},
     pubsub::Publisher,
     qos::{QosDurability, QosHistory, QosProfile, QosReliability},
     service::ServiceServer,
 };
 
-use crate::parameter::node_parameter::{CommitOutcome, NodeParametersInner, ParameterJsonWrite};
+use crate::parameter::{
+    ParameterTimestamp,
+    merge::get_value_at_path as get_from_value,
+    node_parameter::{
+        CommitOutcome, ParameterCommand, ParameterDriver, ParameterJsonWrite, ParameterState,
+    },
+};
 
 use super::types::*;
 
 pub struct RemoteParameterServices<T> {
-    event_publisher: Publisher<NodeParameterEvent>,
+    event_publisher: Arc<Publisher<NodeParameterEvent>>,
     _get_snapshot: Arc<ServiceServer<GetNodeParametersSnapshotSrv, ()>>,
     _get_value: Arc<ServiceServer<GetNodeParameterValueSrv, ()>>,
     _get_type_info: Arc<ServiceServer<GetNodeParameterTypeInfoSrv, ()>>,
@@ -34,7 +40,11 @@ impl<T> RemoteParameterServices<T>
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    pub async fn register(node: &Node, inner: Arc<NodeParametersInner<T>>) -> Result<Self> {
+    pub async fn register(
+        node: &Node,
+        _state: Arc<ParameterState<T>>,
+        commands: flume::Sender<ParameterCommand<T>>,
+    ) -> Result<Self> {
         let event_publisher = node
             .publisher::<NodeParameterEvent>("~parameter/events")
             .map_err(|err| ParameterError::RemoteError {
@@ -54,52 +64,101 @@ where
 
         let get_snapshot =
             register_server::<GetNodeParametersSnapshotSrv>(node, "~parameter/get_snapshot", {
-                let inner = inner.clone();
-                move |query| handle_get_snapshot::<T>(&inner, query)
+                let commands = commands.clone();
+                move |query| {
+                    enqueue_or_reply_busy(
+                        &commands,
+                        query,
+                        |query| ParameterCommand::RemoteGetSnapshot { query },
+                        busy_snapshot_response(),
+                    );
+                }
             })
             .await?;
 
         let get_value =
             register_server::<GetNodeParameterValueSrv>(node, "~parameter/get_value", {
-                let inner = inner.clone();
-                move |query| handle_get_value::<T>(&inner, query)
+                let commands = commands.clone();
+                move |query| {
+                    enqueue_or_reply_busy(
+                        &commands,
+                        query,
+                        |query| ParameterCommand::RemoteGetValue { query },
+                        busy_value_response(),
+                    );
+                }
             })
             .await?;
 
         let get_type_info =
             register_server::<GetNodeParameterTypeInfoSrv>(node, "~parameter/get_type_info", {
-                let inner = inner.clone();
-                move |query| handle_get_type_info::<T>(&inner, query)
+                let commands = commands.clone();
+                move |query| {
+                    enqueue_or_reply_busy(
+                        &commands,
+                        query,
+                        |query| ParameterCommand::RemoteGetTypeInfo { query },
+                        busy_type_info_response(),
+                    );
+                }
             })
             .await?;
 
         let set = register_server::<SetNodeParameterSrv>(node, "~parameter/set", {
-            let inner = inner.clone();
-            move |query| handle_set::<T>(&inner, query)
+            let commands = commands.clone();
+            move |query| {
+                enqueue_or_reply_busy(
+                    &commands,
+                    query,
+                    |query| ParameterCommand::RemoteSet { query },
+                    busy_write_response::<SetNodeParameterResponse>(),
+                );
+            }
         })
         .await?;
 
         let set_atomic =
             register_server::<SetNodeParametersAtomicallySrv>(node, "~parameter/set_atomic", {
-                let inner = inner.clone();
-                move |query| handle_set_atomic::<T>(&inner, query)
+                let commands = commands.clone();
+                move |query| {
+                    enqueue_or_reply_busy(
+                        &commands,
+                        query,
+                        |query| ParameterCommand::RemoteSetAtomic { query },
+                        busy_write_response::<SetNodeParametersAtomicallyResponse>(),
+                    );
+                }
             })
             .await?;
 
         let reset = register_server::<ResetNodeParameterSrv>(node, "~parameter/reset", {
-            let inner = inner.clone();
-            move |query| handle_reset::<T>(&inner, query)
+            let commands = commands.clone();
+            move |query| {
+                enqueue_or_reply_busy(
+                    &commands,
+                    query,
+                    |query| ParameterCommand::RemoteReset { query },
+                    busy_write_response::<ResetNodeParameterResponse>(),
+                );
+            }
         })
         .await?;
 
         let reload = register_server::<ReloadNodeParametersSrv>(node, "~parameter/reload", {
-            let inner = inner.clone();
-            move |query| handle_reload::<T>(&inner, query)
+            let commands = commands.clone();
+            move |query| {
+                enqueue_or_reply_busy(
+                    &commands,
+                    query,
+                    |query| ParameterCommand::RemoteReload { query },
+                    busy_write_response::<ReloadNodeParametersResponse>(),
+                );
+            }
         })
         .await?;
 
         Ok(Self {
-            event_publisher,
+            event_publisher: Arc::new(event_publisher),
             _get_snapshot: Arc::new(get_snapshot),
             _get_value: Arc::new(get_value),
             _get_type_info: Arc::new(get_type_info),
@@ -111,18 +170,15 @@ where
         })
     }
 
-    pub async fn publish_event(&self, event: &NodeParameterEvent) -> Result<()> {
-        self.event_publisher
-            .publish(event)
-            .await
-            .map_err(|source| ParameterError::operation("publishing parameter event", source))
+    pub fn event_publisher(&self) -> Arc<Publisher<NodeParameterEvent>> {
+        self.event_publisher.clone()
     }
 }
 
 async fn register_server<S>(
     node: &Node,
     name: &str,
-    handler: impl Fn(&Query) + Send + Sync + 'static,
+    handler: impl Fn(Query) + Send + Sync + 'static,
 ) -> Result<ServiceServer<S, ()>>
 where
     S: Service + ServiceTypeInfo,
@@ -132,19 +188,79 @@ where
         .map_err(|err| ParameterError::RemoteError {
             message: err.to_string(),
         })?
-        .build_with_callback(move |query| handler(&query))
+        .build_with_callback(handler)
         .await
         .map_err(|source| ParameterError::operation(operation, source))
 }
 
-fn handle_get_snapshot<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+const PARAMETER_ACTOR_BUSY: &str = "parameter actor is unavailable or busy";
+
+fn busy_snapshot_response() -> GetNodeParametersSnapshotResponse {
+    GetNodeParametersSnapshotResponse {
+        success: false,
+        message: PARAMETER_ACTOR_BUSY.to_string(),
+        node_fqn: String::new(),
+        parameter_key: String::new(),
+        revision: 0,
+        committed_at: ParameterTimestamp::default(),
+        layers: Vec::new(),
+        value_json: "null".to_string(),
+        layer_overlays_json: Vec::new(),
+    }
+}
+
+fn busy_value_response() -> GetNodeParameterValueResponse {
+    GetNodeParameterValueResponse {
+        success: false,
+        message: PARAMETER_ACTOR_BUSY.to_string(),
+        revision: 0,
+        path: String::new(),
+        effective_source_layer: String::new(),
+        value_json: "null".to_string(),
+    }
+}
+
+fn busy_type_info_response() -> GetNodeParameterTypeInfoResponse {
+    GetNodeParameterTypeInfoResponse {
+        success: false,
+        message: PARAMETER_ACTOR_BUSY.to_string(),
+        type_name: String::new(),
+        schema_hash: String::new(),
+    }
+}
+
+fn busy_write_response<T>() -> T
+where
+    T: From<(bool, String, u64, Vec<String>)>,
+{
+    T::from((false, PARAMETER_ACTOR_BUSY.to_string(), 0, Vec::new()))
+}
+
+fn enqueue_or_reply_busy<T, R>(
+    commands: &flume::Sender<ParameterCommand<T>>,
+    query: Query,
+    make_command: impl FnOnce(Query) -> ParameterCommand<T>,
+    busy_response: R,
+) where
+    T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
+    R: Message,
+    for<'a> <R as Message>::Codec: WireEncoder<Input<'a> = &'a R>,
+{
+    match commands.try_send(make_command(query)) {
+        Ok(()) => {}
+        Err(flume::TrySendError::Full(command))
+        | Err(flume::TrySendError::Disconnected(command)) => {
+            let query = command.into_query();
+            reply(&query, &busy_response);
+        }
+    }
+}
+
+pub fn handle_get_snapshot_for_state<T>(state: &Arc<ParameterState<T>>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let parameters = NodeParameters {
-        inner: inner.clone(),
-    };
-    let snapshot = parameters.snapshot();
+    let snapshot = state.current.load_full();
     let response = GetNodeParametersSnapshotResponse {
         success: true,
         message: String::new(),
@@ -156,22 +272,19 @@ where
         value_json: to_json(&snapshot.effective),
         layer_overlays_json: snapshot.layer_overlays.iter().map(to_json).collect(),
     };
-    reply(query, &response);
+    reply(&query, &response);
 }
 
-fn handle_get_value<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+pub fn handle_get_value_for_state<T>(state: &Arc<ParameterState<T>>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let parameters = NodeParameters {
-        inner: inner.clone(),
-    };
-    let request = decode_request::<GetNodeParameterValueRequest>(query);
+    let request = decode_request::<GetNodeParameterValueRequest>(&query);
     let response = match request {
         Ok(request) => {
-            let snapshot = parameters.snapshot();
-            match parameters.get_json(&request.path) {
-                Ok(value) => GetNodeParameterValueResponse {
+            let snapshot = state.current.load_full();
+            match get_from_value(&snapshot.effective, &request.path) {
+                Ok(Some(value)) => GetNodeParameterValueResponse {
                     success: true,
                     message: String::new(),
                     revision: snapshot.revision,
@@ -180,6 +293,18 @@ where
                         .effective_source_layer(&request.path)
                         .unwrap_or_default(),
                     value_json: to_json(&value),
+                },
+                Ok(None) => GetNodeParameterValueResponse {
+                    success: false,
+                    message: ParameterError::PathError {
+                        path: request.path.clone(),
+                        reason: "path not found".to_string(),
+                    }
+                    .to_string(),
+                    revision: snapshot.revision,
+                    path: request.path,
+                    effective_source_layer: String::new(),
+                    value_json: "null".to_string(),
                 },
                 Err(err) => GetNodeParameterValueResponse {
                     success: false,
@@ -200,44 +325,44 @@ where
             value_json: "null".to_string(),
         },
     };
-    reply(query, &response);
+    reply(&query, &response);
 }
 
-fn handle_get_type_info<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+pub fn handle_get_type_info_for_state<T>(state: &Arc<ParameterState<T>>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     reply(
-        query,
+        &query,
         &GetNodeParameterTypeInfoResponse {
             success: true,
             message: String::new(),
-            type_name: inner.type_name.clone(),
-            schema_hash: inner.schema_hash.to_hash_string(),
+            type_name: state.type_name.clone(),
+            schema_hash: state.schema_hash.to_hash_string(),
         },
     );
 }
 
-fn handle_set<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+pub async fn handle_set_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let parameters = NodeParameters {
-        inner: inner.clone(),
-    };
-    let request = decode_request::<SetNodeParameterRequest>(query);
+    let request = decode_request::<SetNodeParameterRequest>(&query);
     let response = match request {
         Ok(request) => match serde_json::from_str::<serde_json::Value>(&request.value_json) {
-            Ok(value) => match parameters.commit(
-                &[ParameterJsonWrite {
-                    path: request.path,
-                    value,
-                    target_layer: request.target_layer,
-                }],
-                &[],
-                request.expected_revision,
-                NodeParameterChangeSource::RemoteWrite,
-            ) {
+            Ok(value) => match driver
+                .commit(
+                    &[ParameterJsonWrite {
+                        path: request.path,
+                        value,
+                        target_layer: request.target_layer,
+                    }],
+                    &[],
+                    request.expected_revision,
+                    NodeParameterChangeSource::RemoteWrite,
+                )
+                .await
+            {
                 Ok(outcome) => write_response(outcome),
                 Err(err) => error_write_response(err),
             },
@@ -250,17 +375,14 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(query, &response);
+    reply(&query, &response);
 }
 
-fn handle_set_atomic<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+pub async fn handle_set_atomic_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let parameters = NodeParameters {
-        inner: inner.clone(),
-    };
-    let request = decode_request::<SetNodeParametersAtomicallyRequest>(query);
+    let request = decode_request::<SetNodeParametersAtomicallyRequest>(&query);
     let response = match request {
         Ok(request) => {
             let mut writes = Vec::with_capacity(request.writes.len());
@@ -282,12 +404,15 @@ where
             if let Some(source) = parse_error {
                 error_write_response(ParameterError::RemotePayloadParseError { source })
             } else {
-                match parameters.commit(
-                    &writes,
-                    &[],
-                    request.expected_revision,
-                    NodeParameterChangeSource::RemoteWrite,
-                ) {
+                match driver
+                    .commit(
+                        &writes,
+                        &[],
+                        request.expected_revision,
+                        NodeParameterChangeSource::RemoteWrite,
+                    )
+                    .await
+                {
                     Ok(outcome) => write_response(outcome),
                     Err(err) => error_write_response(err),
                 }
@@ -300,24 +425,24 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(query, &response);
+    reply(&query, &response);
 }
 
-fn handle_reset<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+pub async fn handle_reset_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let parameters = NodeParameters {
-        inner: inner.clone(),
-    };
-    let request = decode_request::<ResetNodeParameterRequest>(query);
+    let request = decode_request::<ResetNodeParameterRequest>(&query);
     let response = match request {
-        Ok(request) => match parameters.commit(
-            &[],
-            &[(request.path, request.target_layer)],
-            request.expected_revision,
-            NodeParameterChangeSource::RemoteWrite,
-        ) {
+        Ok(request) => match driver
+            .commit(
+                &[],
+                &[(request.path, request.target_layer)],
+                request.expected_revision,
+                NodeParameterChangeSource::RemoteWrite,
+            )
+            .await
+        {
             Ok(outcome) => write_response(outcome),
             Err(err) => error_write_response(err),
         },
@@ -328,17 +453,17 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(query, &response);
+    reply(&query, &response);
 }
 
-fn handle_reload<T>(inner: &Arc<NodeParametersInner<T>>, query: &Query)
+pub async fn handle_reload_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
 where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let parameters = NodeParameters {
-        inner: inner.clone(),
-    };
-    let response = match parameters.reload_with_source(NodeParameterChangeSource::Reload) {
+    let response = match driver
+        .reload_with_source(NodeParameterChangeSource::Reload)
+        .await
+    {
         Ok(outcome) => ReloadNodeParametersResponse {
             success: true,
             message: String::new(),
@@ -352,7 +477,7 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(query, &response);
+    reply(&query, &response);
 }
 
 fn write_response<T>(outcome: CommitOutcome) -> T
@@ -407,6 +532,17 @@ impl From<(bool, String, u64, Vec<String>)> for ResetNodeParameterResponse {
     }
 }
 
+impl From<(bool, String, u64, Vec<String>)> for ReloadNodeParametersResponse {
+    fn from(value: (bool, String, u64, Vec<String>)) -> Self {
+        Self {
+            success: value.0,
+            message: value.1,
+            committed_revision: value.2,
+            changed_paths: value.3,
+        }
+    }
+}
+
 fn decode_request<T>(query: &Query) -> std::result::Result<T, String>
 where
     T: Message,
@@ -444,4 +580,200 @@ where
 
 fn to_json(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
+
+    use serde::{Deserialize, Serialize};
+
+    use crate::{context::ContextBuilder, node::Node};
+
+    use super::*;
+
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+    type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, crate::Message)]
+    #[message(name = "test_parameters::BusyCallbackParameters")]
+    struct BusyCallbackParameters {
+        enabled: bool,
+    }
+
+    #[test]
+    fn busy_write_response_uses_stable_failure_payload() {
+        let response = busy_write_response::<SetNodeParameterResponse>();
+        assert!(!response.success);
+        assert_eq!(response.message, PARAMETER_ACTOR_BUSY);
+        assert_eq!(response.committed_revision, 0);
+        assert!(response.changed_paths.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn callback_replies_busy_when_mailbox_is_full() -> TestResult {
+        let (commands, _receiver) = flume::bounded(0);
+
+        let response = call_set_service_with_commands("full", commands).await?;
+
+        assert_busy_set_response(response);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn callback_replies_busy_when_mailbox_is_disconnected() -> TestResult {
+        let (commands, receiver) = flume::bounded(1);
+        drop(receiver);
+
+        let response = call_set_service_with_commands("disconnected", commands).await?;
+
+        assert_busy_set_response(response);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn callback_replies_busy_for_atomic_when_mailbox_is_full() -> TestResult {
+        let (commands, _receiver) = flume::bounded(0);
+
+        let response = call_atomic_service_with_commands("atomic_full", commands).await?;
+
+        assert_busy_atomic_response(response);
+        Ok(())
+    }
+
+    async fn call_set_service_with_commands(
+        suffix: &str,
+        commands: flume::Sender<ParameterCommand<BusyCallbackParameters>>,
+    ) -> TestResult<SetNodeParameterResponse> {
+        let context = ContextBuilder::default()
+            .with_mode("peer")
+            .disable_multicast_scouting()
+            .build()
+            .await?;
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let server_name = format!("busy_parameter_server_{suffix}_{id}");
+        let server_node = context.create_node(&server_name).build().await?;
+        let service_name = format!("/{server_name}/parameter/set");
+        let _server = register_server::<SetNodeParameterSrv>(&server_node, "~parameter/set", {
+            let commands = commands.clone();
+            move |query| {
+                enqueue_or_reply_busy(
+                    &commands,
+                    query,
+                    |query| ParameterCommand::RemoteSet { query },
+                    busy_write_response::<SetNodeParameterResponse>(),
+                );
+            }
+        })
+        .await?;
+
+        let client_node = context
+            .create_node(format!("busy_parameter_client_{suffix}_{id}"))
+            .build()
+            .await?;
+        wait_for_service(&client_node, &service_name).await?;
+        let client = client_node
+            .create_service_client::<SetNodeParameterSrv>(&service_name)?
+            .build()
+            .await?;
+
+        client
+            .call_with_timeout_async(
+                &SetNodeParameterRequest {
+                    path: "enabled".to_string(),
+                    value_json: "false".to_string(),
+                    target_layer: "base".to_string(),
+                    expected_revision: None,
+                },
+                Duration::from_secs(2),
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn call_atomic_service_with_commands(
+        suffix: &str,
+        commands: flume::Sender<ParameterCommand<BusyCallbackParameters>>,
+    ) -> TestResult<SetNodeParametersAtomicallyResponse> {
+        let context = ContextBuilder::default()
+            .with_mode("peer")
+            .disable_multicast_scouting()
+            .build()
+            .await?;
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let server_name = format!("busy_parameter_server_{suffix}_{id}");
+        let server_node = context.create_node(&server_name).build().await?;
+        let service_name = format!("/{server_name}/parameter/set_atomic");
+        let _server = register_server::<SetNodeParametersAtomicallySrv>(
+            &server_node,
+            "~parameter/set_atomic",
+            {
+                let commands = commands.clone();
+                move |query| {
+                    enqueue_or_reply_busy(
+                        &commands,
+                        query,
+                        |query| ParameterCommand::RemoteSetAtomic { query },
+                        busy_write_response::<SetNodeParametersAtomicallyResponse>(),
+                    );
+                }
+            },
+        )
+        .await?;
+
+        let client_node = context
+            .create_node(format!("busy_parameter_client_{suffix}_{id}"))
+            .build()
+            .await?;
+        wait_for_service(&client_node, &service_name).await?;
+        let client = client_node
+            .create_service_client::<SetNodeParametersAtomicallySrv>(&service_name)?
+            .build()
+            .await?;
+
+        client
+            .call_with_timeout_async(
+                &SetNodeParametersAtomicallyRequest {
+                    writes: vec![NodeParameterWriteJson {
+                        path: "enabled".to_string(),
+                        value_json: "false".to_string(),
+                        target_layer: "base".to_string(),
+                    }],
+                    expected_revision: None,
+                },
+                Duration::from_secs(2),
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn wait_for_service(node: &Node, service: &str) -> TestResult {
+        let start = std::time::Instant::now();
+        let timeout = Duration::from_secs(5);
+        while start.elapsed() < timeout {
+            if !node.graph().view().services_named(service).is_empty() {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        Err(format!("timed out waiting for service {service}").into())
+    }
+
+    fn assert_busy_set_response(response: SetNodeParameterResponse) {
+        assert!(!response.success);
+        assert_eq!(response.message, PARAMETER_ACTOR_BUSY);
+        assert_eq!(response.committed_revision, 0);
+        assert!(response.changed_paths.is_empty());
+    }
+
+    fn assert_busy_atomic_response(response: SetNodeParametersAtomicallyResponse) {
+        assert!(!response.success);
+        assert_eq!(response.message, PARAMETER_ACTOR_BUSY);
+        assert_eq!(response.committed_revision, 0);
+        assert!(response.changed_paths.is_empty());
+    }
 }

--- a/crates/ros-z/src/parameter/remote/services.rs
+++ b/crates/ros-z/src/parameter/remote/services.rs
@@ -1,7 +1,8 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use serde::{Serialize, de::DeserializeOwned};
-use zenoh::{Wait, query::Query};
+use tokio::{runtime::Handle, sync::mpsc};
+use zenoh::query::Query;
 
 use crate::{
     Message, ServiceTypeInfo,
@@ -16,9 +17,9 @@ use crate::{
 
 use crate::parameter::{
     ParameterTimestamp,
-    merge::get_value_at_path as get_from_value,
     node_parameter::{
         CommitOutcome, ParameterCommand, ParameterDriver, ParameterJsonWrite, ParameterState,
+        RemoteParameterCommand,
     },
 };
 
@@ -42,8 +43,8 @@ where
 {
     pub async fn register(
         node: &Node,
-        _state: Arc<ParameterState<T>>,
-        commands: flume::Sender<ParameterCommand<T>>,
+        commands: mpsc::Sender<ParameterCommand<T>>,
+        reply_runtime: Handle,
     ) -> Result<Self> {
         let event_publisher = node
             .publisher::<NodeParameterEvent>("~parameter/events")
@@ -65,12 +66,14 @@ where
         let get_snapshot =
             register_server::<GetNodeParametersSnapshotSrv>(node, "~parameter/get_snapshot", {
                 let commands = commands.clone();
+                let reply_runtime = reply_runtime.clone();
                 move |query| {
                     enqueue_or_reply_busy(
                         &commands,
+                        &reply_runtime,
                         query,
-                        |query| ParameterCommand::RemoteGetSnapshot { query },
-                        busy_snapshot_response(),
+                        |query| RemoteParameterCommand::GetSnapshot { query },
+                        busy_snapshot_response,
                     );
                 }
             })
@@ -79,12 +82,14 @@ where
         let get_value =
             register_server::<GetNodeParameterValueSrv>(node, "~parameter/get_value", {
                 let commands = commands.clone();
+                let reply_runtime = reply_runtime.clone();
                 move |query| {
                     enqueue_or_reply_busy(
                         &commands,
+                        &reply_runtime,
                         query,
-                        |query| ParameterCommand::RemoteGetValue { query },
-                        busy_value_response(),
+                        |query| RemoteParameterCommand::GetValue { query },
+                        busy_value_response,
                     );
                 }
             })
@@ -93,12 +98,14 @@ where
         let get_type_info =
             register_server::<GetNodeParameterTypeInfoSrv>(node, "~parameter/get_type_info", {
                 let commands = commands.clone();
+                let reply_runtime = reply_runtime.clone();
                 move |query| {
                     enqueue_or_reply_busy(
                         &commands,
+                        &reply_runtime,
                         query,
-                        |query| ParameterCommand::RemoteGetTypeInfo { query },
-                        busy_type_info_response(),
+                        |query| RemoteParameterCommand::GetTypeInfo { query },
+                        busy_type_info_response,
                     );
                 }
             })
@@ -106,12 +113,14 @@ where
 
         let set = register_server::<SetNodeParameterSrv>(node, "~parameter/set", {
             let commands = commands.clone();
+            let reply_runtime = reply_runtime.clone();
             move |query| {
                 enqueue_or_reply_busy(
                     &commands,
+                    &reply_runtime,
                     query,
-                    |query| ParameterCommand::RemoteSet { query },
-                    busy_write_response::<SetNodeParameterResponse>(),
+                    |query| RemoteParameterCommand::Set { query },
+                    busy_write_response::<SetNodeParameterResponse>,
                 );
             }
         })
@@ -120,12 +129,14 @@ where
         let set_atomic =
             register_server::<SetNodeParametersAtomicallySrv>(node, "~parameter/set_atomic", {
                 let commands = commands.clone();
+                let reply_runtime = reply_runtime.clone();
                 move |query| {
                     enqueue_or_reply_busy(
                         &commands,
+                        &reply_runtime,
                         query,
-                        |query| ParameterCommand::RemoteSetAtomic { query },
-                        busy_write_response::<SetNodeParametersAtomicallyResponse>(),
+                        |query| RemoteParameterCommand::SetAtomic { query },
+                        busy_write_response::<SetNodeParametersAtomicallyResponse>,
                     );
                 }
             })
@@ -133,12 +144,14 @@ where
 
         let reset = register_server::<ResetNodeParameterSrv>(node, "~parameter/reset", {
             let commands = commands.clone();
+            let reply_runtime = reply_runtime.clone();
             move |query| {
                 enqueue_or_reply_busy(
                     &commands,
+                    &reply_runtime,
                     query,
-                    |query| ParameterCommand::RemoteReset { query },
-                    busy_write_response::<ResetNodeParameterResponse>(),
+                    |query| RemoteParameterCommand::Reset { query },
+                    busy_write_response::<ResetNodeParameterResponse>,
                 );
             }
         })
@@ -146,12 +159,14 @@ where
 
         let reload = register_server::<ReloadNodeParametersSrv>(node, "~parameter/reload", {
             let commands = commands.clone();
+            let reply_runtime = reply_runtime.clone();
             move |query| {
                 enqueue_or_reply_busy(
                     &commands,
+                    &reply_runtime,
                     query,
-                    |query| ParameterCommand::RemoteReload { query },
-                    busy_write_response::<ReloadNodeParametersResponse>(),
+                    |query| RemoteParameterCommand::Reload { query },
+                    busy_write_response::<ReloadNodeParametersResponse>,
                 );
             }
         })
@@ -237,30 +252,38 @@ where
 }
 
 fn enqueue_or_reply_busy<T, R>(
-    commands: &flume::Sender<ParameterCommand<T>>,
+    commands: &mpsc::Sender<ParameterCommand<T>>,
+    reply_runtime: &Handle,
     query: Query,
-    make_command: impl FnOnce(Query) -> ParameterCommand<T>,
-    busy_response: R,
+    make_command: impl FnOnce(Query) -> RemoteParameterCommand,
+    make_busy_response: impl FnOnce() -> R,
 ) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
-    R: Message,
+    R: Message + Send + 'static,
     for<'a> <R as Message>::Codec: WireEncoder<Input<'a> = &'a R>,
 {
-    match commands.try_send(make_command(query)) {
+    match commands.try_send(ParameterCommand::Remote(make_command(query))) {
         Ok(()) => {}
-        Err(flume::TrySendError::Full(command))
-        | Err(flume::TrySendError::Disconnected(command)) => {
+        Err(mpsc::error::TrySendError::Full(ParameterCommand::Remote(command)))
+        | Err(mpsc::error::TrySendError::Closed(ParameterCommand::Remote(command))) => {
             let query = command.into_query();
-            reply(&query, &busy_response);
+            let busy_response = make_busy_response();
+            spawn_reply(reply_runtime, query, busy_response);
+        }
+        Err(mpsc::error::TrySendError::Full(_)) | Err(mpsc::error::TrySendError::Closed(_)) => {
+            tracing::warn!("[PARAM] Unexpected local command returned from remote enqueue");
         }
     }
 }
 
-pub fn handle_get_snapshot_for_state<T>(state: &Arc<ParameterState<T>>, query: Query)
-where
+pub fn handle_get_snapshot_for_state<T>(
+    state: &Arc<ParameterState<T>>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    let snapshot = state.current.load_full();
+    let snapshot = state.snapshot();
     let response = GetNodeParametersSnapshotResponse {
         success: true,
         message: String::new(),
@@ -272,19 +295,22 @@ where
         value_json: to_json(&snapshot.effective),
         layer_overlays_json: snapshot.layer_overlays.iter().map(to_json).collect(),
     };
-    reply(&query, &response);
+    spawn_reply(reply_runtime, query, response);
 }
 
-pub fn handle_get_value_for_state<T>(state: &Arc<ParameterState<T>>, query: Query)
-where
+pub fn handle_get_value_for_state<T>(
+    state: &Arc<ParameterState<T>>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     let request = decode_request::<GetNodeParameterValueRequest>(&query);
     let response = match request {
         Ok(request) => {
-            let snapshot = state.current.load_full();
-            match get_from_value(&snapshot.effective, &request.path) {
-                Ok(Some(value)) => GetNodeParameterValueResponse {
+            let snapshot = state.snapshot();
+            match ParameterState::get_json_from_snapshot(&snapshot, &request.path) {
+                Ok(value) => GetNodeParameterValueResponse {
                     success: true,
                     message: String::new(),
                     revision: snapshot.revision,
@@ -293,18 +319,6 @@ where
                         .effective_source_layer(&request.path)
                         .unwrap_or_default(),
                     value_json: to_json(&value),
-                },
-                Ok(None) => GetNodeParameterValueResponse {
-                    success: false,
-                    message: ParameterError::PathError {
-                        path: request.path.clone(),
-                        reason: "path not found".to_string(),
-                    }
-                    .to_string(),
-                    revision: snapshot.revision,
-                    path: request.path,
-                    effective_source_layer: String::new(),
-                    value_json: "null".to_string(),
                 },
                 Err(err) => GetNodeParameterValueResponse {
                     success: false,
@@ -325,26 +339,30 @@ where
             value_json: "null".to_string(),
         },
     };
-    reply(&query, &response);
+    spawn_reply(reply_runtime, query, response);
 }
 
-pub fn handle_get_type_info_for_state<T>(state: &Arc<ParameterState<T>>, query: Query)
-where
+pub fn handle_get_type_info_for_state<T>(
+    state: &Arc<ParameterState<T>>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
-    reply(
-        &query,
-        &GetNodeParameterTypeInfoResponse {
-            success: true,
-            message: String::new(),
-            type_name: state.type_name.clone(),
-            schema_hash: state.schema_hash.to_hash_string(),
-        },
-    );
+    let response = GetNodeParameterTypeInfoResponse {
+        success: true,
+        message: String::new(),
+        type_name: state.type_name().to_string(),
+        schema_hash: state.schema_hash().to_hash_string(),
+    };
+    spawn_reply(reply_runtime, query, response);
 }
 
-pub async fn handle_set_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
-where
+pub async fn handle_set_for_driver<T>(
+    driver: &ParameterDriver<T>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     let request = decode_request::<SetNodeParameterRequest>(&query);
@@ -375,11 +393,14 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(&query, &response);
+    spawn_reply(reply_runtime, query, response);
 }
 
-pub async fn handle_set_atomic_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
-where
+pub async fn handle_set_atomic_for_driver<T>(
+    driver: &ParameterDriver<T>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     let request = decode_request::<SetNodeParametersAtomicallyRequest>(&query);
@@ -425,11 +446,14 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(&query, &response);
+    spawn_reply(reply_runtime, query, response);
 }
 
-pub async fn handle_reset_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
-where
+pub async fn handle_reset_for_driver<T>(
+    driver: &ParameterDriver<T>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     let request = decode_request::<ResetNodeParameterRequest>(&query);
@@ -453,11 +477,14 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(&query, &response);
+    spawn_reply(reply_runtime, query, response);
 }
 
-pub async fn handle_reload_for_driver<T>(driver: &ParameterDriver<T>, query: Query)
-where
+pub async fn handle_reload_for_driver<T>(
+    driver: &ParameterDriver<T>,
+    reply_runtime: &Handle,
+    query: Query,
+) where
     T: Serialize + DeserializeOwned + Message + Send + Sync + 'static,
 {
     let response = match driver
@@ -477,7 +504,7 @@ where
             changed_paths: Vec::new(),
         },
     };
-    reply(&query, &response);
+    spawn_reply(reply_runtime, query, response);
 }
 
 fn write_response<T>(outcome: CommitOutcome) -> T
@@ -555,27 +582,79 @@ where
         .map_err(|err| format!("{err}"))
 }
 
-fn reply<T>(query: &Query, response: &T)
+pub(crate) fn reply_remote_command_unavailable(
+    reply_runtime: &Handle,
+    command: RemoteParameterCommand,
+) {
+    match command {
+        RemoteParameterCommand::GetSnapshot { query } => {
+            spawn_reply(reply_runtime, query, busy_snapshot_response());
+        }
+        RemoteParameterCommand::GetValue { query } => {
+            spawn_reply(reply_runtime, query, busy_value_response());
+        }
+        RemoteParameterCommand::GetTypeInfo { query } => {
+            spawn_reply(reply_runtime, query, busy_type_info_response());
+        }
+        RemoteParameterCommand::Set { query } => {
+            spawn_reply(
+                reply_runtime,
+                query,
+                busy_write_response::<SetNodeParameterResponse>(),
+            );
+        }
+        RemoteParameterCommand::SetAtomic { query } => {
+            spawn_reply(
+                reply_runtime,
+                query,
+                busy_write_response::<SetNodeParametersAtomicallyResponse>(),
+            );
+        }
+        RemoteParameterCommand::Reset { query } => {
+            spawn_reply(
+                reply_runtime,
+                query,
+                busy_write_response::<ResetNodeParameterResponse>(),
+            );
+        }
+        RemoteParameterCommand::Reload { query } => {
+            spawn_reply(
+                reply_runtime,
+                query,
+                busy_write_response::<ReloadNodeParametersResponse>(),
+            );
+        }
+    }
+}
+
+fn spawn_reply<T>(reply_runtime: &Handle, query: Query, response: T)
+where
+    T: Message + Send + 'static,
+    for<'a> <T as Message>::Codec: WireEncoder<Input<'a> = &'a T>,
+{
+    reply_runtime.spawn(async move {
+        if let Err(err) = reply_async(query, response).await {
+            tracing::warn!("[PARAM] Failed to send parameter reply: {err}");
+        }
+    });
+}
+
+async fn reply_async<T>(query: Query, response: T) -> std::result::Result<(), String>
 where
     T: Message,
     for<'a> <T as Message>::Codec: WireEncoder<Input<'a> = &'a T>,
 {
-    let bytes = match <<T as Message>::Codec as WireEncoder>::serialize(response) {
-        Ok(bytes) => bytes,
-        Err(error) => {
-            tracing::warn!(error = ?error, "[PARAM] Failed to serialize parameter reply");
-            return;
-        }
-    };
+    let bytes = <<T as Message>::Codec as WireEncoder>::serialize(&response)
+        .map_err(|error| format!("failed to serialize parameter reply: {error}"))?;
     let mut reply = query.reply(query.key_expr().clone(), bytes);
     if let Some(att_bytes) = query.attachment()
         && let Ok(att) = Attachment::try_from(att_bytes)
     {
         reply = reply.attachment(att);
     }
-    if let Err(err) = reply.wait() {
-        tracing::warn!("[PARAM] Failed to send parameter reply: {err}");
-    }
+    reply
+        .await
+        .map_err(|err| format!("failed to send parameter reply: {err}"))
 }
 
 fn to_json(value: &serde_json::Value) -> String {
@@ -616,7 +695,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn callback_replies_busy_when_mailbox_is_full() -> TestResult {
-        let (commands, _receiver) = flume::bounded(0);
+        let (commands, _receiver) = mpsc::channel(1);
+        let _permit = commands.clone().reserve_owned().await?;
 
         let response = call_set_service_with_commands("full", commands).await?;
 
@@ -626,7 +706,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn callback_replies_busy_when_mailbox_is_disconnected() -> TestResult {
-        let (commands, receiver) = flume::bounded(1);
+        let (commands, receiver) = mpsc::channel(1);
         drop(receiver);
 
         let response = call_set_service_with_commands("disconnected", commands).await?;
@@ -637,7 +717,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn callback_replies_busy_for_atomic_when_mailbox_is_full() -> TestResult {
-        let (commands, _receiver) = flume::bounded(0);
+        let (commands, _receiver) = mpsc::channel(1);
+        let _permit = commands.clone().reserve_owned().await?;
 
         let response = call_atomic_service_with_commands("atomic_full", commands).await?;
 
@@ -647,7 +728,7 @@ mod tests {
 
     async fn call_set_service_with_commands(
         suffix: &str,
-        commands: flume::Sender<ParameterCommand<BusyCallbackParameters>>,
+        commands: mpsc::Sender<ParameterCommand<BusyCallbackParameters>>,
     ) -> TestResult<SetNodeParameterResponse> {
         let context = ContextBuilder::default()
             .with_mode("peer")
@@ -658,14 +739,17 @@ mod tests {
         let server_name = format!("busy_parameter_server_{suffix}_{id}");
         let server_node = context.create_node(&server_name).build().await?;
         let service_name = format!("/{server_name}/parameter/set");
+        let reply_runtime = Handle::current();
         let _server = register_server::<SetNodeParameterSrv>(&server_node, "~parameter/set", {
             let commands = commands.clone();
+            let reply_runtime = reply_runtime.clone();
             move |query| {
                 enqueue_or_reply_busy(
                     &commands,
+                    &reply_runtime,
                     query,
-                    |query| ParameterCommand::RemoteSet { query },
-                    busy_write_response::<SetNodeParameterResponse>(),
+                    |query| RemoteParameterCommand::Set { query },
+                    busy_write_response::<SetNodeParameterResponse>,
                 );
             }
         })
@@ -697,7 +781,7 @@ mod tests {
 
     async fn call_atomic_service_with_commands(
         suffix: &str,
-        commands: flume::Sender<ParameterCommand<BusyCallbackParameters>>,
+        commands: mpsc::Sender<ParameterCommand<BusyCallbackParameters>>,
     ) -> TestResult<SetNodeParametersAtomicallyResponse> {
         let context = ContextBuilder::default()
             .with_mode("peer")
@@ -708,17 +792,20 @@ mod tests {
         let server_name = format!("busy_parameter_server_{suffix}_{id}");
         let server_node = context.create_node(&server_name).build().await?;
         let service_name = format!("/{server_name}/parameter/set_atomic");
+        let reply_runtime = Handle::current();
         let _server = register_server::<SetNodeParametersAtomicallySrv>(
             &server_node,
             "~parameter/set_atomic",
             {
                 let commands = commands.clone();
+                let reply_runtime = reply_runtime.clone();
                 move |query| {
                     enqueue_or_reply_busy(
                         &commands,
+                        &reply_runtime,
                         query,
-                        |query| ParameterCommand::RemoteSetAtomic { query },
-                        busy_write_response::<SetNodeParametersAtomicallyResponse>(),
+                        |query| RemoteParameterCommand::SetAtomic { query },
+                        busy_write_response::<SetNodeParametersAtomicallyResponse>,
                     );
                 }
             },

--- a/crates/ros-z/src/prelude.rs
+++ b/crates/ros-z/src/prelude.rs
@@ -22,9 +22,6 @@
 pub use crate::context::{Context, ContextBuilder};
 pub use crate::node::Node;
 
-/// Parameter extension methods on [`Node`].
-pub use crate::parameter::NodeParametersExt;
-
 /// Core pub/sub handles and builders.
 pub use crate::pubsub::{Publisher, PublisherBuilder, Subscriber, SubscriberBuilder};
 

--- a/crates/ros-z/tests/message_api.rs
+++ b/crates/ros-z/tests/message_api.rs
@@ -144,6 +144,19 @@ fn handwritten_message_constructs_static_pubsub_builders_without_legacy_type_inf
 }
 
 #[test]
+fn parameter_api_exports_remote_client_and_wire_types_at_top_level() {
+    let _client_type = std::any::type_name::<ros_z::parameter::RemoteParameterClient>();
+    let _snapshot_request = ros_z::parameter::GetNodeParametersSnapshotRequest::default();
+    let write = ros_z::parameter::NodeParameterWriteJson::default();
+
+    assert!(write.path.is_empty());
+    assert_eq!(
+        <ros_z::parameter::SetNodeParameterSrv as ros_z::ServiceTypeInfo>::service_type_info().name,
+        "ros_z_parameter::SetNodeParameter"
+    );
+}
+
+#[test]
 fn wire_message_uses_codec_vocabulary() {
     let original = ApiSmokeMessage { value: 7 };
     let encoded = SerdeCdrCodec::<ApiSmokeMessage>::serialize_to_zbuf(&original).unwrap();

--- a/crates/ros-z/tests/parameter_integration.rs
+++ b/crates/ros-z/tests/parameter_integration.rs
@@ -10,8 +10,9 @@ use ros_z::{
     context::ContextBuilder,
     parameter::{
         GetNodeParameterTypeInfoSrv, GetNodeParameterValueRequest, GetNodeParameterValueSrv,
-        GetNodeParametersSnapshotSrv, NodeParameterEvent, NodeParametersExt, ParameterError,
-        ParameterJsonWrite, RemoteParameterClient, SetNodeParameterRequest, SetNodeParameterSrv,
+        GetNodeParametersSnapshotSrv, NodeParameterChangeSource, NodeParameterEvent,
+        NodeParameterWriteJson, ParameterError, ParameterJsonWrite, RemoteParameterClient,
+        SetNodeParameterRequest, SetNodeParameterSrv,
     },
 };
 use ros_z_schema::{FieldDef, SchemaBundle, TypeDef, TypeDefinition};
@@ -145,17 +146,21 @@ async fn local_atomic_write_returns_commit_outcome() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let revision = parameters.snapshot().revision;
 
-    let outcome = parameters.set_json_atomically(
-        vec![ParameterJsonWrite {
-            path: "threshold".into(),
-            value: serde_json::json!(0.9),
-            target_layer: layer_string(&layers.robot),
-        }],
-        Some(revision),
-    )?;
+    let outcome = parameters
+        .set_json_atomically(
+            vec![ParameterJsonWrite {
+                path: "threshold".into(),
+                value: serde_json::json!(0.9),
+                target_layer: layer_string(&layers.robot),
+            }],
+            Some(revision),
+        )
+        .await?;
 
     assert_eq!(outcome.committed_revision, revision + 1);
     assert_eq!(outcome.changed_paths, vec!["threshold".to_string()]);
@@ -179,7 +184,9 @@ async fn local_atomic_write_does_not_partially_persist_layers_on_error() -> Test
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let revision = parameters.snapshot().revision;
     let base_file = layers.base.join("ball_detector.json5");
     let location_file = layers.location.join("ball_detector.json5");
@@ -188,21 +195,23 @@ async fn local_atomic_write_does_not_partially_persist_layers_on_error() -> Test
     fs::remove_file(&location_file)?;
     fs::create_dir(&location_file)?;
 
-    let result = parameters.set_json_atomically(
-        vec![
-            ParameterJsonWrite {
-                path: "enabled".into(),
-                value: serde_json::json!(false),
-                target_layer: layer_string(&layers.base),
-            },
-            ParameterJsonWrite {
-                path: "threshold".into(),
-                value: serde_json::json!(0.9),
-                target_layer: layer_string(&layers.location),
-            },
-        ],
-        Some(revision),
-    );
+    let result = parameters
+        .set_json_atomically(
+            vec![
+                ParameterJsonWrite {
+                    path: "enabled".into(),
+                    value: serde_json::json!(false),
+                    target_layer: layer_string(&layers.base),
+                },
+                ParameterJsonWrite {
+                    path: "threshold".into(),
+                    value: serde_json::json!(0.9),
+                    target_layer: layer_string(&layers.location),
+                },
+            ],
+            Some(revision),
+        )
+        .await;
 
     assert!(result.is_err());
     assert_eq!(parameters.snapshot().revision, revision);
@@ -232,17 +241,21 @@ async fn bind_merge_set_and_subscribe_work() -> TestResult {
         .build()
         .await?;
 
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let snapshot = parameters.snapshot();
     assert!(snapshot.typed().enabled);
     assert_eq!(snapshot.typed().threshold, 0.8);
 
     let mut rx = parameters.subscribe();
-    parameters.set_json(
-        "nested.count",
-        serde_json::json!(7),
-        layer_string(&layers.robot),
-    )?;
+    parameters
+        .set_json(
+            "nested.count",
+            serde_json::json!(7),
+            layer_string(&layers.robot),
+        )
+        .await?;
     rx.changed().await.expect("watch update");
     let updated = rx.borrow().clone();
     assert_eq!(updated.typed().nested.count, 7);
@@ -271,11 +284,52 @@ async fn second_bind_fails() -> TestResult {
         .build()
         .await?;
 
-    let _parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let _parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let err = node
         .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await
         .expect_err("second bind must fail");
     assert!(err.to_string().contains("already bound"));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn dropping_all_parameter_handles_allows_rebind() -> TestResult {
+    let root = temp_parameter_root();
+    let layers = test_layers(&root, "rebind-after-drop");
+    write_layer_file(
+        &layers.base,
+        "ball_detector",
+        r#"{ enabled: true, threshold: 0.5, nested: { count: 1 } }"#,
+    );
+
+    let context = build_ctx(&layers).await?;
+    let node = context
+        .create_node("ball_detector")
+        .with_namespace("vision")
+        .build()
+        .await?;
+
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
+    let clone = parameters.clone();
+    drop(parameters);
+
+    let err = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await
+        .expect_err("clone should keep the binding active");
+    assert!(matches!(err, ParameterError::AlreadyBound { .. }));
+
+    drop(clone);
+
+    let rebound = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
+    assert_eq!(rebound.snapshot().typed().threshold, 0.5);
     Ok(())
 }
 
@@ -290,8 +344,37 @@ async fn bind_rejects_empty_layer_list() -> TestResult {
 
     let err = node
         .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await
         .expect_err("bind must reject empty parameter layer list");
     assert!(matches!(err, ParameterError::EmptyLayerList));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn async_binding_reports_deserialization_errors() -> TestResult {
+    #[derive(Debug, Clone, Serialize, Deserialize, ros_z::Message)]
+    #[message(name = "test_parameters::RequiredOnlyParameters")]
+    struct RequiredOnlyParameters {
+        required: f64,
+    }
+
+    let root = temp_parameter_root();
+    let layers = test_layers(&root, "async-bind-error");
+    write_layer_file(&layers.base, "ball_detector", r#"{ threshold: 0.5 }"#);
+
+    let context = build_ctx(&layers).await?;
+    let node = context
+        .create_node("ball_detector")
+        .with_namespace("vision")
+        .build()
+        .await?;
+
+    let err = node
+        .bind_parameter_as::<RequiredOnlyParameters>("ball_detector")
+        .await
+        .expect_err("binding should return typed parameter errors");
+
+    assert!(matches!(err, ParameterError::DeserializationError { .. }));
     Ok(())
 }
 
@@ -314,11 +397,13 @@ async fn bind_rejects_invalid_parameter_key() -> TestResult {
 
     let err = node
         .bind_parameter_as::<VisionParameters>("ball detector")
+        .await
         .expect_err("bind must reject spaces in parameter key");
     assert!(matches!(err, ParameterError::InvalidParameterKey { .. }));
 
     let err = node
         .bind_parameter_as::<VisionParameters>("vision/ball_detector")
+        .await
         .expect_err("bind must reject path separators in parameter key");
     assert!(matches!(err, ParameterError::InvalidParameterKey { .. }));
     Ok(())
@@ -341,7 +426,9 @@ async fn late_validation_hook_validates_current_snapshot() -> TestResult {
         .build()
         .await?;
 
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let err = parameters
         .add_validation_hook(|cfg: &VisionParameters| {
             if cfg.threshold > 1.0 {
@@ -350,6 +437,7 @@ async fn late_validation_hook_validates_current_snapshot() -> TestResult {
                 Ok(())
             }
         })
+        .await
         .expect_err("late hook must validate current snapshot");
     assert!(err.to_string().contains("threshold too high"));
     Ok(())
@@ -371,7 +459,9 @@ async fn remote_v1_services_work() -> TestResult {
         .with_namespace("motion")
         .build()
         .await?;
-    let _parameters = server_node.bind_parameter_as::<VisionParameters>("walk_publisher")?;
+    let _parameters = server_node
+        .bind_parameter_as::<VisionParameters>("walk_publisher")
+        .await?;
 
     let client_node = context
         .create_node("tester")
@@ -437,7 +527,9 @@ async fn bound_parameters_expose_type_info_and_schema_lookup() -> TestResult {
         .with_namespace("motion")
         .build()
         .await?;
-    let _parameters = server_node.bind_parameter_as::<VisionParameters>("walk_publisher")?;
+    let _parameters = server_node
+        .bind_parameter_as::<VisionParameters>("walk_publisher")
+        .await?;
 
     let client_node = context
         .create_node("tester")
@@ -507,7 +599,9 @@ async fn remote_client_round_trips_and_receives_events() -> TestResult {
         .with_namespace("motion")
         .build()
         .await?;
-    let _parameters = server_node.bind_parameter_as::<VisionParameters>("walk_publisher")?;
+    let _parameters = server_node
+        .bind_parameter_as::<VisionParameters>("walk_publisher")
+        .await?;
 
     let client_node = std::sync::Arc::new(
         context
@@ -545,7 +639,85 @@ async fn remote_client_round_trips_and_receives_events() -> TestResult {
     let event: NodeParameterEvent = events.recv().await?;
     assert_eq!(event.node_fqn, "/motion/walk_publisher");
     assert_eq!(event.parameter_key, "walk_publisher");
+    assert_eq!(event.source, NodeParameterChangeSource::RemoteWrite);
     assert!(event.changed_paths.contains(&"threshold".to_string()));
+
+    let atomic = client
+        .set_json_atomically(
+            vec![
+                NodeParameterWriteJson {
+                    path: "threshold".into(),
+                    value_json: "0.95".into(),
+                    target_layer: layer_string(&layers.robot),
+                },
+                NodeParameterWriteJson {
+                    path: "nested.count".into(),
+                    value_json: "7".into(),
+                    target_layer: layer_string(&layers.robot),
+                },
+            ],
+            Some(set.committed_revision),
+        )
+        .await?;
+    assert!(atomic.success);
+    assert_eq!(atomic.committed_revision, set.committed_revision + 1);
+    assert!(atomic.changed_paths.contains(&"threshold".to_string()));
+    assert!(atomic.changed_paths.contains(&"nested.count".to_string()));
+
+    let event: NodeParameterEvent = events.recv().await?;
+    assert_eq!(event.node_fqn, "/motion/walk_publisher");
+    assert_eq!(event.parameter_key, "walk_publisher");
+    assert_eq!(event.source, NodeParameterChangeSource::RemoteWrite);
+    assert!(event.changed_paths.contains(&"threshold".to_string()));
+    assert!(event.changed_paths.contains(&"nested.count".to_string()));
+
+    let value = client.get_value("nested.count").await?;
+    assert!(value.success);
+    assert_eq!(value.value_json, "7");
+
+    let reset = client
+        .reset(
+            "threshold",
+            layer_string(&layers.robot),
+            Some(atomic.committed_revision),
+        )
+        .await?;
+    assert!(reset.success);
+    assert_eq!(reset.committed_revision, atomic.committed_revision + 1);
+    assert_eq!(reset.changed_paths, vec!["threshold".to_string()]);
+
+    let event: NodeParameterEvent = events.recv().await?;
+    assert_eq!(event.node_fqn, "/motion/walk_publisher");
+    assert_eq!(event.parameter_key, "walk_publisher");
+    assert_eq!(event.source, NodeParameterChangeSource::RemoteWrite);
+    assert_eq!(event.changed_paths, vec!["threshold".to_string()]);
+
+    let value = client.get_value("threshold").await?;
+    assert!(value.success);
+    assert_eq!(value.value_json, "0.5");
+
+    fs::write(
+        layers.base.join("walk_publisher.json5"),
+        r#"{ enabled: false, threshold: 0.8, nested: { count: 1 } }"#,
+    )?;
+
+    let reload = client.reload().await?;
+    assert!(reload.success);
+    assert_eq!(reload.committed_revision, reset.committed_revision + 1);
+    assert!(reload.changed_paths.contains(&"enabled".to_string()));
+    assert!(reload.changed_paths.contains(&"threshold".to_string()));
+
+    let event: NodeParameterEvent = events.recv().await?;
+    assert_eq!(event.node_fqn, "/motion/walk_publisher");
+    assert_eq!(event.parameter_key, "walk_publisher");
+    assert_eq!(event.source, NodeParameterChangeSource::Reload);
+    assert!(event.changed_paths.contains(&"enabled".to_string()));
+    assert!(event.changed_paths.contains(&"threshold".to_string()));
+
+    let snapshot = client.get_snapshot().await?;
+    assert!(snapshot.success);
+    assert!(snapshot.value_json.contains(r#""enabled":false"#));
+    assert!(snapshot.value_json.contains(r#""threshold":0.8"#));
 
     Ok(())
 }
@@ -567,13 +739,19 @@ async fn reset_exposes_lower_scope_and_noop_succeeds() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     assert_eq!(parameters.snapshot().typed().threshold, 0.9);
 
-    parameters.reset("threshold", layer_string(&layers.robot))?;
+    parameters
+        .reset("threshold", layer_string(&layers.robot))
+        .await?;
     assert_eq!(parameters.snapshot().typed().threshold, 0.5);
 
-    parameters.reset("threshold", layer_string(&layers.robot))?;
+    parameters
+        .reset("threshold", layer_string(&layers.robot))
+        .await?;
     assert_eq!(parameters.snapshot().typed().threshold, 0.5);
     Ok(())
 }
@@ -594,11 +772,14 @@ async fn writes_reject_inactive_target_layer() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
 
     let inactive_layer = "/not/an/active/layer".to_string();
     let err = parameters
         .set_json("threshold", serde_json::json!(0.9), inactive_layer.clone())
+        .await
         .expect_err("set_json must reject inactive layer");
     assert!(matches!(
         err,
@@ -607,6 +788,7 @@ async fn writes_reject_inactive_target_layer() -> TestResult {
 
     let err = parameters
         .reset("threshold", inactive_layer.clone())
+        .await
         .expect_err("reset must reject inactive layer");
     assert!(matches!(
         err,
@@ -634,10 +816,13 @@ async fn reset_rejects_invalid_config() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<RequiredOnlyParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<RequiredOnlyParameters>("ball_detector")
+        .await?;
 
     let err = parameters
         .reset("threshold", layer_string(&layers.robot))
+        .await
         .expect_err("reset should fail when it removes required parameters");
     assert!(
         err.to_string().contains("deserialization") || err.to_string().contains("missing field")
@@ -663,19 +848,22 @@ async fn reload_updates_snapshot_and_preserves_last_good_on_failure() -> TestRes
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
 
     fs::write(
         &path,
         r#"{ enabled: true, threshold: 0.8, nested: { count: 3 } }"#,
     )?;
-    parameters.reload()?;
+    parameters.reload().await?;
     assert_eq!(parameters.snapshot().typed().threshold, 0.8);
     assert_eq!(parameters.snapshot().typed().nested.count, 3);
 
     fs::write(&path, r#"{ threshold: "bad" }"#)?;
     let err = parameters
         .reload()
+        .await
         .expect_err("reload must reject invalid parameters");
     assert!(err.to_string().contains("deserialization"));
     assert_eq!(parameters.snapshot().typed().threshold, 0.8);
@@ -698,7 +886,9 @@ async fn revision_mismatch_rejects_local_atomic_write() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
 
     let err = parameters
         .set_json_atomically(
@@ -709,6 +899,7 @@ async fn revision_mismatch_rejects_local_atomic_write() -> TestResult {
             }],
             Some(999),
         )
+        .await
         .expect_err("revision mismatch must fail");
     assert!(err.to_string().contains("revision mismatch"));
     assert_eq!(parameters.snapshot().typed().threshold, 0.5);
@@ -731,24 +922,28 @@ async fn local_atomic_write_updates_multiple_paths() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let revision = parameters.snapshot().revision;
 
-    parameters.set_json_atomically(
-        vec![
-            ParameterJsonWrite {
-                path: "threshold".into(),
-                value: serde_json::json!(0.9),
-                target_layer: layer_string(&layers.robot),
-            },
-            ParameterJsonWrite {
-                path: "nested.count".into(),
-                value: serde_json::json!(42),
-                target_layer: layer_string(&layers.robot),
-            },
-        ],
-        Some(revision),
-    )?;
+    parameters
+        .set_json_atomically(
+            vec![
+                ParameterJsonWrite {
+                    path: "threshold".into(),
+                    value: serde_json::json!(0.9),
+                    target_layer: layer_string(&layers.robot),
+                },
+                ParameterJsonWrite {
+                    path: "nested.count".into(),
+                    value: serde_json::json!(42),
+                    target_layer: layer_string(&layers.robot),
+                },
+            ],
+            Some(revision),
+        )
+        .await?;
 
     let snapshot = parameters.snapshot();
     assert_eq!(snapshot.typed().threshold, 0.9);
@@ -772,7 +967,9 @@ async fn concurrent_readers_and_writers_do_not_lose_updates() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let robot_layer = layer_string(&layers.robot);
 
     let writer_a = {
@@ -780,11 +977,13 @@ async fn concurrent_readers_and_writers_do_not_lose_updates() -> TestResult {
         let robot_layer = robot_layer.clone();
         tokio::spawn(async move {
             for value in 1..=10u32 {
-                parameters.set_json(
-                    "nested.count",
-                    serde_json::json!(value),
-                    robot_layer.clone(),
-                )?;
+                parameters
+                    .set_json(
+                        "nested.count",
+                        serde_json::json!(value),
+                        robot_layer.clone(),
+                    )
+                    .await?;
             }
             Ok::<_, ros_z::parameter::ParameterError>(())
         })
@@ -795,11 +994,13 @@ async fn concurrent_readers_and_writers_do_not_lose_updates() -> TestResult {
         let robot_layer = robot_layer.clone();
         tokio::spawn(async move {
             for value in 1..=10u32 {
-                parameters.set_json(
-                    "threshold",
-                    serde_json::json!(0.5 + (value as f64 / 10.0)),
-                    robot_layer.clone(),
-                )?;
+                parameters
+                    .set_json(
+                        "threshold",
+                        serde_json::json!(0.5 + (value as f64 / 10.0)),
+                        robot_layer.clone(),
+                    )
+                    .await?;
             }
             Ok::<_, ros_z::parameter::ParameterError>(())
         })
@@ -843,13 +1044,17 @@ async fn persistence_round_trip_pretty_json_is_valid_json5() -> TestResult {
         .with_namespace("vision")
         .build()
         .await?;
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
 
-    parameters.set_json(
-        "threshold",
-        serde_json::json!(0.75),
-        layer_string(&layers.robot),
-    )?;
+    parameters
+        .set_json(
+            "threshold",
+            serde_json::json!(0.75),
+            layer_string(&layers.robot),
+        )
+        .await?;
     let written = fs::read_to_string(layers.robot.join("ball_detector.json5"))?;
     let reparsed: serde_json::Value = json5::from_str(&written)?;
     assert_eq!(reparsed["threshold"], 0.75);

--- a/crates/ros-z/tests/parameter_integration.rs
+++ b/crates/ros-z/tests/parameter_integration.rs
@@ -326,9 +326,24 @@ async fn dropping_all_parameter_handles_allows_rebind() -> TestResult {
 
     drop(clone);
 
-    let rebound = node
-        .bind_parameter_as::<VisionParameters>("ball_detector")
-        .await?;
+    let rebound = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            match node
+                .bind_parameter_as::<VisionParameters>("ball_detector")
+                .await
+            {
+                Ok(parameters) => {
+                    return Ok::<_, Box<dyn std::error::Error + Send + Sync>>(parameters);
+                }
+                Err(ParameterError::AlreadyBound { .. }) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+    })
+    .await
+    .map_err(|_| "timed out waiting for parameter binding to release")??;
     assert_eq!(rebound.snapshot().typed().threshold, 0.5);
     Ok(())
 }

--- a/crates/ros-z/tests/parameter_smoke.rs
+++ b/crates/ros-z/tests/parameter_smoke.rs
@@ -57,17 +57,21 @@ async fn bind_merge_set_and_subscribe_work() -> TestResult {
         .build()
         .await?;
 
-    let parameters = node.bind_parameter_as::<VisionParameters>("ball_detector")?;
+    let parameters = node
+        .bind_parameter_as::<VisionParameters>("ball_detector")
+        .await?;
     let snapshot = parameters.snapshot();
     assert!(snapshot.typed().enabled);
     assert_eq!(snapshot.typed().threshold, 0.8);
 
     let mut updates = parameters.subscribe();
-    parameters.set_json(
-        "threshold",
-        serde_json::json!(0.9),
-        robot.to_string_lossy().into_owned(),
-    )?;
+    parameters
+        .set_json(
+            "threshold",
+            serde_json::json!(0.9),
+            robot.to_string_lossy().into_owned(),
+        )
+        .await?;
     updates.changed().await?;
     assert_eq!(updates.borrow().typed().threshold, 0.9);
 

--- a/etc/parameters/ros_z/base/behavior_node.json5
+++ b/etc/parameters/ros_z/base/behavior_node.json5
@@ -26,8 +26,6 @@
   },
   path_planning: {
     robot_radius: 0.4,
-    robot_radius_at_hip_height: 0.3,
-    robot_radius_at_foot_height: 0.4,
     minimum_robot_radius_at_foot_height: 0.11,
     ball_obstacle_radius: 0.05,
     field_border_weight: 0.15,
@@ -51,9 +49,6 @@
     kicking: 0.5,
     search: 0.5,
     blocking: 0.5,
-    support: 0.75,
-    walk_to_kickoff: 0.5,
-    walk_to_penalty_kick: 0.5,
   },
   role_positions: {
     defender_aggressive_ring_radius: 2.0,

--- a/etc/parameters/ros_z/base/behavior_node.json5
+++ b/etc/parameters/ros_z/base/behavior_node.json5
@@ -30,7 +30,6 @@
     robot_radius_at_foot_height: 0.4,
     minimum_robot_radius_at_foot_height: 0.11,
     ball_obstacle_radius: 0.05,
-    ball_obstacle_radius_factor: 1.0,
     field_border_weight: 0.15,
     line_walking_speed: 0.25,
     arc_walking_speed: 0.2,
@@ -49,10 +48,7 @@
     supporter_hysteresis: [0.5, 0.5],
   },
   walk_speed: {
-    defend: 0.75,
     kicking: 0.5,
-    intercept_ball: 1.0,
-    lost_ball: 0.8,
     search: 0.5,
     blocking: 0.5,
     support: 0.75,


### PR DESCRIPTION
## Summary
- moves bound ROS-Z parameters behind an async actor with a bounded mailbox
- changes parameter binding to `node.bind_parameter_as::<T>(key).await?` and updates node call sites
- routes remote parameter callbacks through actor commands with busy responses on mailbox backpressure or disconnect
- simplifies parameter actor lifecycle ownership by storing initialized resources directly instead of impossible `None` states
- narrows parameter actor internals so only `Node::bind_parameter_as`, `NodeParameters`, `RemoteParameterClient`, snapshots/errors, and the wire service/message types remain public API
- documents async binding semantics, failure modes, and one-binding-per-node behavior
- includes stale `behavior_node` parameter cleanup in `etc/parameters/ros_z/base/behavior_node.json5` for parameters no longer consumed after the node migration

## Related
- Fixes #2510 by replacing the callback-time parameter mutation path with serialized async actor commands and explicit error propagation
- Builds on shared node FQN normalization and CLI FQN reuse from #2562, now merged into `main`

## Test Plan
- `cargo fmt --all -- --check`
- `./pepsi fmt --check`
- `cargo clippy -p ros-z-protocol -p ros-z-cli -p ros-z --all-targets -- -D warnings`
- `./pepsi clippy --locked . -- --deny warnings`
- `cargo nextest run -p ros-z-protocol -p ros-z-cli -p ros-z -E "test(fully_qualified_name_prefixes_bare_namespace) or test(fully_qualified_node_name_prefixes_bare_namespace) or test(remote_client_round_trips_and_receives_events) or test(local_mutation_reports_error_after_driver_task_aborts)"`
