### PR TITLE
Cache entry extractor

### DIFF
--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -3,9 +3,9 @@
 //! [`Cache`](crate::cache::Cache) retains a sliding window of received messages
 //! and lets callers query them by time.
 //!
-//! # Stamp strategies
+//! # Cache population strategies
 //!
-//! Two indexing strategies are available, selected at build time:
+//! Three cache population strategies are available, selected at build time:
 //!
 //! - **[`ZenohStamp`](crate::cache::ZenohStamp)** (default) — indexes by the
 //!   Zenoh transport timestamp (`uhlc::Timestamp` → [`crate::time::Time`]). Zero-config;
@@ -14,6 +14,10 @@
 //! - **[`ExtractorStamp`](crate::cache::ExtractorStamp)** — indexes by a
 //!   user-supplied closure that extracts a [`crate::time::Time`] from each deserialized
 //!   message. Required for `header.stamp` / sensor capture time alignment.
+//! - **[`ExtractorEntry`](crate::cache::ExtractorEntry)** — consumes each source
+//!   message and expands it into zero or more `(timestamp, value)` entries. The
+//!   resulting cache stores the extracted value type, and capacity counts expanded
+//!   entries.
 //!
 //! # Example
 //!
@@ -48,7 +52,7 @@ use crate::qos::QosProfile;
 use crate::time::Time;
 
 // ---------------------------------------------------------------------------
-// Stamp strategy markers
+// Cache population strategy markers
 // ---------------------------------------------------------------------------
 
 /// Index by the Zenoh transport timestamp (`uhlc::Timestamp` → [`crate::time::Time`]).
@@ -68,8 +72,11 @@ where
     F: Fn(&T) -> O,
     O: Into<Time>;
 
-/// Expand one source message into zero or more independently timestamped cache entries.
-pub struct StampedEntries<T, F, I, O, U>(pub(crate) F, pub(crate) PhantomData<(T, I, O, U)>)
+/// Extract zero or more independently timestamped cache entries from one source message.
+///
+/// The resulting builder creates a [`Cache`] of `U` values, and capacity
+/// applies to the extracted entries rather than the source messages.
+pub struct ExtractorEntry<T, F, I, O, U>(pub(crate) F, pub(crate) PhantomData<(T, I, O, U)>)
 where
     F: Fn(T) -> I,
     I: IntoIterator<Item = (O, U)>,
@@ -364,11 +371,13 @@ impl<T> Cache<T> {
 ///
 /// Created by [`Node::create_cache`](crate::node::Node::create_cache).
 /// Use [`with_stamp`](CacheBuilder::with_stamp) to switch from the default
-/// Zenoh transport timestamp to an application-level extractor.
-pub struct CacheBuilder<T, S = SerdeCdrCodec<T>, Stamp = ZenohStamp> {
+/// Zenoh transport timestamp to an application-level extractor. Use
+/// [`with_entry_extractor`](CacheBuilder::with_entry_extractor) to expand one
+/// source message into zero or more timestamped cache values.
+pub struct CacheBuilder<T, S = SerdeCdrCodec<T>, Strategy = ZenohStamp> {
     pub(crate) sub_builder: SubscriberBuilder<T, S>,
     capacity: usize,
-    stamp: Stamp,
+    strategy: Strategy,
 }
 
 impl<T, S> CacheBuilder<T, S, ZenohStamp> {
@@ -376,7 +385,7 @@ impl<T, S> CacheBuilder<T, S, ZenohStamp> {
         Self {
             sub_builder,
             capacity,
-            stamp: ZenohStamp,
+            strategy: ZenohStamp,
         }
     }
 
@@ -393,18 +402,20 @@ impl<T, S> CacheBuilder<T, S, ZenohStamp> {
         CacheBuilder {
             sub_builder: self.sub_builder,
             capacity: self.capacity,
-            stamp: ExtractorStamp(extractor, PhantomData),
+            strategy: ExtractorStamp(extractor, PhantomData),
         }
     }
 
-    /// Switch to stamped-entry extraction.
+    /// Switch to entry-extractor population.
     ///
     /// The extractor consumes each deserialized source message and returns
     /// zero or more `(timestamp, value)` entries to store in the resulting cache.
-    pub fn with_stamped_entries<F, I, O, U>(
+    /// The resulting [`Cache`] stores `U` values, and capacity counts expanded
+    /// entries.
+    pub fn with_entry_extractor<F, I, O, U>(
         self,
         extractor: F,
-    ) -> CacheBuilder<T, S, StampedEntries<T, F, I, O, U>>
+    ) -> CacheBuilder<T, S, ExtractorEntry<T, F, I, O, U>>
     where
         F: Fn(T) -> I + Send + Sync + 'static,
         I: IntoIterator<Item = (O, U)> + 'static,
@@ -414,7 +425,7 @@ impl<T, S> CacheBuilder<T, S, ZenohStamp> {
         CacheBuilder {
             sub_builder: self.sub_builder,
             capacity: self.capacity,
-            stamp: StampedEntries(extractor, PhantomData),
+            strategy: ExtractorEntry(extractor, PhantomData),
         }
     }
 
@@ -535,7 +546,7 @@ where
         let CacheBuilder {
             sub_builder,
             capacity,
-            stamp: ExtractorStamp(extractor, _),
+            strategy: ExtractorStamp(extractor, _),
         } = self;
         let inner = Arc::new(RwLock::new(CacheInner::<T>::new(capacity)));
         let inner_cb = inner.clone();
@@ -570,7 +581,7 @@ where
     }
 }
 
-impl<T, S, F, I, O, U> CacheBuilder<T, S, StampedEntries<T, F, I, O, U>>
+impl<T, S, F, I, O, U> CacheBuilder<T, S, ExtractorEntry<T, F, I, O, U>>
 where
     F: Fn(T) -> I + Send + Sync + 'static,
     I: IntoIterator<Item = (O, U)> + 'static,
@@ -594,7 +605,7 @@ where
     }
 }
 
-impl<T, S, F, I, O, U> CacheBuilder<T, S, StampedEntries<T, F, I, O, U>>
+impl<T, S, F, I, O, U> CacheBuilder<T, S, ExtractorEntry<T, F, I, O, U>>
 where
     T: Send + Sync + 'static,
     S: for<'a> WireDecoder<Input<'a> = &'a [u8], Output = T> + 'static,
@@ -607,7 +618,7 @@ where
         let CacheBuilder {
             sub_builder,
             capacity,
-            stamp: StampedEntries(extractor, _),
+            strategy: ExtractorEntry(extractor, _),
         } = self;
         let inner = Arc::new(RwLock::new(CacheInner::<U>::new(capacity)));
         let inner_cb = inner.clone();
@@ -640,7 +651,7 @@ where
             }
         });
 
-        debug!("[CACHE] StampedEntries cache ready");
+        debug!("[CACHE] ExtractorEntry cache ready");
         Ok(Cache {
             inner,
             _raw_subscriber_task: task,

--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -68,6 +68,13 @@ where
     F: Fn(&T) -> O,
     O: Into<Time>;
 
+/// Expand one source message into zero or more independently timestamped cache entries.
+pub struct StampedEntries<T, F, I, O, U>(pub(crate) F, pub(crate) PhantomData<(T, I, O, U)>)
+where
+    F: Fn(T) -> I,
+    I: IntoIterator<Item = (O, U)>,
+    O: Into<Time>;
+
 // ---------------------------------------------------------------------------
 // CacheInner — shared mutable state
 // ---------------------------------------------------------------------------
@@ -390,6 +397,27 @@ impl<T, S> CacheBuilder<T, S, ZenohStamp> {
         }
     }
 
+    /// Switch to stamped-entry extraction.
+    ///
+    /// The extractor consumes each deserialized source message and returns
+    /// zero or more `(timestamp, value)` entries to store in the resulting cache.
+    pub fn with_stamped_entries<F, I, O, U>(
+        self,
+        extractor: F,
+    ) -> CacheBuilder<T, S, StampedEntries<T, F, I, O, U>>
+    where
+        F: Fn(T) -> I + Send + Sync + 'static,
+        I: IntoIterator<Item = (O, U)> + 'static,
+        O: Into<Time> + 'static,
+        U: Send + Sync + 'static,
+    {
+        CacheBuilder {
+            sub_builder: self.sub_builder,
+            capacity: self.capacity,
+            stamp: StampedEntries(extractor, PhantomData),
+        }
+    }
+
     /// Maximum number of messages to retain. Oldest are evicted when full.
     /// A capacity of `0` disables retention and stores no messages.
     pub fn with_capacity(mut self, capacity: usize) -> Self {
@@ -535,6 +563,81 @@ where
         });
 
         debug!("[CACHE] ExtractorStamp cache ready");
+        Ok(Cache {
+            inner,
+            _raw_subscriber_task: task,
+        })
+    }
+}
+
+impl<T, S, F, I, O, U> CacheBuilder<T, S, StampedEntries<T, F, I, O, U>>
+where
+    F: Fn(T) -> I + Send + Sync + 'static,
+    I: IntoIterator<Item = (O, U)> + 'static,
+    O: Into<Time> + 'static,
+    U: Send + Sync + 'static,
+{
+    /// Maximum number of messages to retain. Oldest are evicted when full.
+    /// A capacity of `0` disables retention and stores no messages.
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = capacity;
+        self
+    }
+
+    /// Apply a QoS profile to the underlying subscriber.
+    pub fn with_qos(mut self, qos: QosProfile) -> Self
+    where
+        T: Send + Sync + 'static,
+    {
+        self.sub_builder = self.sub_builder.qos(qos);
+        self
+    }
+}
+
+impl<T, S, F, I, O, U> CacheBuilder<T, S, StampedEntries<T, F, I, O, U>>
+where
+    T: Send + Sync + 'static,
+    S: for<'a> WireDecoder<Input<'a> = &'a [u8], Output = T> + 'static,
+    F: Fn(T) -> I + Send + Sync + 'static,
+    I: IntoIterator<Item = (O, U)> + 'static,
+    O: Into<Time> + 'static,
+    U: Send + Sync + 'static,
+{
+    pub async fn build(self) -> Result<Cache<U>> {
+        let CacheBuilder {
+            sub_builder,
+            capacity,
+            stamp: StampedEntries(extractor, _),
+        } = self;
+        let inner = Arc::new(RwLock::new(CacheInner::<U>::new(capacity)));
+        let inner_cb = inner.clone();
+
+        let raw_subscriber = sub_builder.raw().build().await?;
+        let mut raw_subscriber_task = raw_subscriber;
+        let task = tokio::spawn(async move {
+            loop {
+                let sample = match raw_subscriber_task.recv().await {
+                    Ok(sample) => sample,
+                    Err(error) => {
+                        tracing::error!("[CACHE] Failed to receive raw sample: {}", error);
+                        break;
+                    }
+                };
+                let payload = sample.payload().to_bytes();
+                match S::deserialize(&payload) {
+                    Ok(message) => {
+                        let entries = extractor(message);
+                        let mut guard = inner_cb.write();
+                        for (stamp, value) in entries {
+                            guard.insert(stamp.into(), value);
+                        }
+                    }
+                    Err(e) => tracing::error!("[CACHE] Failed to deserialize message: {}", e),
+                }
+            }
+        });
+
+        debug!("[CACHE] StampedEntries cache ready");
         Ok(Cache {
             inner,
             _raw_subscriber_task: task,

--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -626,10 +626,13 @@ where
                 let payload = sample.payload().to_bytes();
                 match S::deserialize(&payload) {
                     Ok(message) => {
-                        let entries = extractor(message);
+                        let entries: Vec<_> = extractor(message)
+                            .into_iter()
+                            .map(|(stamp, value)| (stamp.into(), value))
+                            .collect();
                         let mut guard = inner_cb.write();
                         for (stamp, value) in entries {
-                            guard.insert(stamp.into(), value);
+                            guard.insert(stamp, value);
                         }
                     }
                     Err(e) => tracing::error!("[CACHE] Failed to deserialize message: {}", e),

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -336,7 +336,10 @@ impl Node {
     /// (zero-config, works for any message type). Call
     /// [`.with_stamp(|message| ...)`](CacheBuilder::with_stamp) on the returned
     /// builder to switch to application-level timestamp extraction (e.g.
-    /// `header.stamp`).
+    /// `header.stamp`), or
+    /// [`.with_entry_extractor(|message| ...)`](CacheBuilder::with_entry_extractor)
+    /// to expand one source message into zero or more timestamped cache values.
+    /// In entry-extractor mode, capacity counts the expanded entries.
     ///
     /// # Example
     ///

--- a/crates/ros-z/tests/cache_entry_extractor.rs
+++ b/crates/ros-z/tests/cache_entry_extractor.rs
@@ -1,7 +1,16 @@
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
 
-use ros_z::{context::ContextBuilder, prelude::*, time::Time};
+use ros_z::{context::ContextBuilder, entity::EntityKind, prelude::*, time::Time};
 use serde::{Deserialize, Serialize};
+
+const EVENTUALLY_TIMEOUT: Duration = Duration::from_secs(2);
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -16,16 +25,42 @@ struct Entry {
     value: String,
 }
 
+async fn eventually(description: &str, mut condition: impl FnMut() -> bool) {
+    let start = Instant::now();
+    loop {
+        if condition() {
+            return;
+        }
+
+        assert!(
+            start.elapsed() < EVENTUALLY_TIMEOUT,
+            "{description} did not happen within {EVENTUALLY_TIMEOUT:?}"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn wait_for_subscriber(node: &ros_z::node::Node, topic: &str) {
+    eventually("cache subscriber discovery", || {
+        node.graph().count(EntityKind::Subscription, topic) >= 1
+    })
+    .await;
+}
+
+async fn wait_for_cache_len<T>(cache: &ros_z::cache::Cache<T>, expected_len: usize) {
+    eventually("cache length update", || cache.len() == expected_len).await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn stamped_entries_cache_expands_one_message_into_many_entries() -> Result {
+async fn entry_extractor_cache_expands_one_message_into_many_entries() -> Result {
     let context = ContextBuilder::default().build().await?;
-    let publisher_node = context.create_node("stamped_entries_pub").build().await?;
-    let cache_node = context.create_node("stamped_entries_cache").build().await?;
-    let topic = "/cache_stamped_entries_many";
+    let publisher_node = context.create_node("entry_extractor_pub").build().await?;
+    let cache_node = context.create_node("entry_extractor_cache").build().await?;
+    let topic = "/cache_entry_extractor_many";
 
     let cache = cache_node
         .create_cache::<Batch>(topic, 10)?
-        .with_stamped_entries(|batch| {
+        .with_entry_extractor(|batch| {
             batch
                 .entries
                 .into_iter()
@@ -35,7 +70,7 @@ async fn stamped_entries_cache_expands_one_message_into_many_entries() -> Result
         .await?;
 
     let publisher = publisher_node.publisher::<Batch>(topic)?.build().await?;
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    wait_for_subscriber(&publisher_node, topic).await;
 
     publisher
         .publish(&Batch {
@@ -52,7 +87,7 @@ async fn stamped_entries_cache_expands_one_message_into_many_entries() -> Result
         })
         .await?;
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    wait_for_cache_len(&cache, 2).await;
 
     let ten = cache.get_nearest(Time::from_nanos(10)).unwrap();
     let twenty = cache.get_nearest(Time::from_nanos(20)).unwrap();
@@ -65,21 +100,24 @@ async fn stamped_entries_cache_expands_one_message_into_many_entries() -> Result
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn stamped_entries_cache_accepts_empty_iterators_and_respects_capacity() -> Result {
+async fn entry_extractor_cache_accepts_empty_iterators_and_respects_capacity() -> Result {
     let context = ContextBuilder::default().build().await?;
     let publisher_node = context
-        .create_node("stamped_entries_capacity_pub")
+        .create_node("entry_extractor_capacity_pub")
         .build()
         .await?;
     let cache_node = context
-        .create_node("stamped_entries_capacity_cache")
+        .create_node("entry_extractor_capacity_cache")
         .build()
         .await?;
-    let topic = "/cache_stamped_entries_capacity";
+    let topic = "/cache_entry_extractor_capacity";
+    let extracted_batches = Arc::new(AtomicUsize::new(0));
+    let extracted_batches_cb = Arc::clone(&extracted_batches);
 
     let cache = cache_node
         .create_cache::<Batch>(topic, 2)?
-        .with_stamped_entries(|batch| {
+        .with_entry_extractor(move |batch| {
+            extracted_batches_cb.fetch_add(1, Ordering::SeqCst);
             batch
                 .entries
                 .into_iter()
@@ -89,9 +127,14 @@ async fn stamped_entries_cache_accepts_empty_iterators_and_respects_capacity() -
         .await?;
 
     let publisher = publisher_node.publisher::<Batch>(topic)?.build().await?;
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    wait_for_subscriber(&publisher_node, topic).await;
 
     publisher.publish(&Batch { entries: vec![] }).await?;
+    eventually("empty batch extraction", || {
+        extracted_batches.load(Ordering::SeqCst) >= 1
+    })
+    .await;
+
     publisher
         .publish(&Batch {
             entries: vec![
@@ -111,7 +154,11 @@ async fn stamped_entries_cache_accepts_empty_iterators_and_respects_capacity() -
         })
         .await?;
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    wait_for_cache_len(&cache, 2).await;
+    eventually("all batches extracted", || {
+        extracted_batches.load(Ordering::SeqCst) >= 2
+    })
+    .await;
 
     assert_eq!(cache.len(), 2);
     assert_eq!(

--- a/crates/ros-z/tests/cache_stamped_entries.rs
+++ b/crates/ros-z/tests/cache_stamped_entries.rs
@@ -1,0 +1,128 @@
+use std::time::Duration;
+
+use ros_z::{context::ContextBuilder, prelude::*, time::Time};
+use serde::{Deserialize, Serialize};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+#[derive(Clone, Debug, Deserialize, Serialize, Message)]
+struct Batch {
+    entries: Vec<Entry>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Message)]
+struct Entry {
+    time: Time,
+    value: String,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stamped_entries_cache_expands_one_message_into_many_entries() -> Result {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("stamped_entries_pub").build().await?;
+    let cache_node = context.create_node("stamped_entries_cache").build().await?;
+    let topic = "/cache_stamped_entries_many";
+
+    let cache = cache_node
+        .create_cache::<Batch>(topic, 10)?
+        .with_stamped_entries(|batch| {
+            batch
+                .entries
+                .into_iter()
+                .map(|entry| (entry.time, entry.value))
+        })
+        .build()
+        .await?;
+
+    let publisher = publisher_node.publisher::<Batch>(topic)?.build().await?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    publisher
+        .publish(&Batch {
+            entries: vec![
+                Entry {
+                    time: Time::from_nanos(10),
+                    value: "ten".to_string(),
+                },
+                Entry {
+                    time: Time::from_nanos(20),
+                    value: "twenty".to_string(),
+                },
+            ],
+        })
+        .await?;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let ten = cache.get_nearest(Time::from_nanos(10)).unwrap();
+    let twenty = cache.get_nearest(Time::from_nanos(20)).unwrap();
+
+    assert_eq!(ten.as_ref(), "ten");
+    assert_eq!(twenty.as_ref(), "twenty");
+    assert_eq!(cache.len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stamped_entries_cache_accepts_empty_iterators_and_respects_capacity() -> Result {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context
+        .create_node("stamped_entries_capacity_pub")
+        .build()
+        .await?;
+    let cache_node = context
+        .create_node("stamped_entries_capacity_cache")
+        .build()
+        .await?;
+    let topic = "/cache_stamped_entries_capacity";
+
+    let cache = cache_node
+        .create_cache::<Batch>(topic, 2)?
+        .with_stamped_entries(|batch| {
+            batch
+                .entries
+                .into_iter()
+                .map(|entry| (entry.time, entry.value))
+        })
+        .build()
+        .await?;
+
+    let publisher = publisher_node.publisher::<Batch>(topic)?.build().await?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    publisher.publish(&Batch { entries: vec![] }).await?;
+    publisher
+        .publish(&Batch {
+            entries: vec![
+                Entry {
+                    time: Time::from_nanos(10),
+                    value: "dropped".to_string(),
+                },
+                Entry {
+                    time: Time::from_nanos(20),
+                    value: "kept-a".to_string(),
+                },
+                Entry {
+                    time: Time::from_nanos(30),
+                    value: "kept-b".to_string(),
+                },
+            ],
+        })
+        .await?;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert_eq!(cache.len(), 2);
+    assert_eq!(
+        cache.get_nearest(Time::from_nanos(20)).unwrap().as_ref(),
+        "kept-a"
+    );
+    assert_eq!(
+        cache.get_nearest(Time::from_nanos(30)).unwrap().as_ref(),
+        "kept-b"
+    );
+    assert_eq!(cache.earliest_stamp(), Some(Time::from_nanos(20)));
+
+    Ok(())
+}


### PR DESCRIPTION
## Why? What?

During development of #2554, it came up, that being able to flatten or map structured subscribed types to one or many different time stamped entries in the cache would be nice. This PR implements a `.with_stamped_entries(|value| impl IntoIterator<(Time, Vec<EntryType>)>)` on the cache builder. 

## How to Test

- `pepsi nextest --remote -p ros-z`