### PR TITLE
Activate mkdocs ci job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -165,17 +165,17 @@ jobs:
       - name: Build
         run: ./pepsi build --locked --release ${{ matrix.tool }}
 
-  # build_mkdocs:
-  #   name: Build mkdocs
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         lfs: true
-  #     - name: Install mkdocs
-  #       run: pip install mkdocs-material
-  #     - name: Build docs
-  #       run: mkdocs build --strict
+  build_mkdocs:
+    name: Build mkdocs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Install mkdocs
+        run: pip install mkdocs-material
+      - name: Build docs
+        run: mkdocs build --strict
 
   # check-mujoco:
   #   name: Check Mujoco


### PR DESCRIPTION
## Why? What?

What the title says. We had failed doc publishing docs, because our PR ci does not check docs anymore. This PR enables the CI again.

