### PR TITLE
fix(ros-z): normalize node FQN formatting

### DIFF
--- a/crates/ros-z-cli/src/support/nodes.rs
+++ b/crates/ros-z-cli/src/support/nodes.rs
@@ -79,11 +79,7 @@ pub fn graph_node_key(target: &NodeTarget) -> (String, String) {
 }
 
 pub fn fully_qualified_node_name(namespace: &str, name: &str) -> String {
-    if namespace == "/" {
-        format!("/{name}")
-    } else {
-        format!("{namespace}/{name}")
-    }
+    ros_z::entity::fully_qualified_node_name(namespace, name)
 }
 
 fn node_candidates(graph: &ros_z::graph::Graph) -> Vec<NodeTarget> {
@@ -99,5 +95,15 @@ fn normalize_node_namespace(namespace: &str) -> String {
         String::new()
     } else {
         namespace.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fully_qualified_node_name;
+
+    #[test]
+    fn fully_qualified_node_name_prefixes_bare_namespace() {
+        assert_eq!(fully_qualified_node_name("robot", "node"), "/robot/node");
     }
 }

--- a/crates/ros-z-cli/src/support/parameter.rs
+++ b/crates/ros-z-cli/src/support/parameter.rs
@@ -4,6 +4,8 @@ use color_eyre::eyre::{Result, WrapErr, bail};
 use ros_z::graph::Graph;
 use serde_json::Value;
 
+use crate::support::nodes::fully_qualified_node_name;
+
 pub fn resolve_parameter_node_fqn(graph: &Graph, selector: &str) -> Result<String> {
     let candidates = sorted_node_fqns(graph);
     resolve_parameter_node_fqn_from_candidates(&candidates, selector)
@@ -90,21 +92,13 @@ fn service_names(graph: &Graph) -> BTreeSet<String> {
         .collect()
 }
 
-fn fully_qualified_node_name(namespace: &str, name: &str) -> String {
-    if namespace.is_empty() || namespace == "/" {
-        format!("/{name}")
-    } else {
-        format!("{namespace}/{name}")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
 
     use super::{
-        parameter_service_name, parse_parameter_json, resolve_parameter_node_fqn_from_candidates,
-        verify_parameter_capability_from_services,
+        fully_qualified_node_name, parameter_service_name, parse_parameter_json,
+        resolve_parameter_node_fqn_from_candidates, verify_parameter_capability_from_services,
     };
 
     #[test]
@@ -161,5 +155,10 @@ mod tests {
         )]);
         verify_parameter_capability_from_services(&services, "/motion/walk_publisher")
             .expect("must accept parameter capability");
+    }
+
+    #[test]
+    fn fully_qualified_node_name_prefixes_bare_namespace() {
+        assert_eq!(fully_qualified_node_name("robot", "node"), "/robot/node");
     }
 }

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -70,11 +70,15 @@ impl NodeEntity {
     }
 
     pub fn fully_qualified_name(&self) -> String {
-        if self.namespace == "/" {
-            format!("/{}", self.name)
-        } else {
-            format!("{}/{}", self.namespace, self.name)
-        }
+        fully_qualified_node_name(&self.namespace, &self.name)
+    }
+}
+
+pub fn fully_qualified_node_name(namespace: &str, name: &str) -> String {
+    if namespace.is_empty() || namespace == "/" {
+        format!("/{name}")
+    } else {
+        format!("/{}/{}", namespace.trim_start_matches('/'), name)
     }
 }
 
@@ -271,5 +275,10 @@ mod tests {
     #[test]
     fn fully_qualified_name_inserts_separator_after_non_root_namespace() {
         assert_eq!(node("/robot").fully_qualified_name(), "/robot/node");
+    }
+
+    #[test]
+    fn fully_qualified_name_prefixes_bare_namespace() {
+        assert_eq!(node("robot").fully_qualified_name(), "/robot/node");
     }
 }

--- a/crates/ros-z/src/parameter/node_parameter.rs
+++ b/crates/ros-z/src/parameter/node_parameter.rs
@@ -124,7 +124,7 @@ impl NodeParametersExt for Node {
         let mut bound = self.parameter_binding_state().lock();
         if *bound {
             return Err(ParameterError::AlreadyBound {
-                node_fqn: node_fqn(self),
+                node_fqn: self.node_entity().fully_qualified_name(),
             });
         }
         *bound = true;
@@ -156,7 +156,7 @@ where
     node.register_schema_with_service(&type_info.name, schema)
         .map_err(|source| ParameterError::operation("registering parameter schema", source))?;
 
-    let node_fqn = node_fqn(node);
+    let node_fqn = node.node_entity().fully_qualified_name();
     let snapshot = load_snapshot::<T>(&node_fqn, &parameter_key, &layers, node.clock(), 0)?;
     let snapshot = Arc::new(snapshot);
     let (tx, _rx) = watch::channel(snapshot.clone());
@@ -186,18 +186,6 @@ where
 
 fn self_binding_state(node: &Node) -> Arc<parking_lot::Mutex<bool>> {
     node.parameter_binding_state().clone()
-}
-
-fn node_fqn(node: &Node) -> String {
-    if node.namespace().is_empty() || node.namespace() == "/" {
-        format!("/{}", node.name())
-    } else {
-        format!(
-            "/{}/{}",
-            node.namespace().trim_start_matches('/'),
-            node.name()
-        )
-    }
 }
 
 fn validate_parameter_key(parameter_key: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
- adds a shared `fully_qualified_node_name(namespace, name)` formatter next to `NodeEntity::fully_qualified_name()`
- normalizes bare namespaces like `robot` to `/robot/node` instead of `robot/node`
- routes CLI graph/schema/parameter FQN formatting and node-parameter binding metadata through the shared formatter

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy -p ros-z-protocol -p ros-z-cli -p ros-z --all-targets -- -D warnings`
- `cargo nextest run -p ros-z-protocol -p ros-z-cli -p ros-z -E 'test(fully_qualified_name_prefixes_bare_namespace) or test(fully_qualified_node_name_prefixes_bare_namespace) or test(remote_client_round_trips_and_receives_events)'`
