### PR TITLE
feat(ros-z): warn on subscriber queue loss

### DIFF
--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -42,6 +42,58 @@ pub(super) struct SubscriberResources {
     _replay_guard: Option<replay::TransientLocalReplayGuard>,
     _subscriber: zenoh::pubsub::Subscriber<()>,
     _liveliness_token: LivelinessToken,
+}
+
+#[derive(Debug, Clone)]
+struct QueueDropContext {
+    log_prefix: &'static str,
+    topic: String,
+    node_namespace: String,
+    node_name: String,
+    type_name: String,
+    queue_capacity: usize,
+}
+
+impl QueueDropContext {
+    fn from_entity(
+        log_prefix: &'static str,
+        entity: &EndpointEntity,
+        queue_capacity: usize,
+    ) -> Result<Self> {
+        let topic = qualify_topic_name(&entity.topic, &entity.node.namespace, &entity.node.name)
+            .map_err(|source| crate::Error::topic_name(entity.topic.clone(), source))?;
+
+        Ok(Self {
+            log_prefix,
+            topic,
+            node_namespace: entity.node.namespace.clone(),
+            node_name: entity.node.name.clone(),
+            type_name: entity.type_info.name.clone(),
+            queue_capacity,
+        })
+    }
+}
+
+fn record_queue_push<T>(
+    queue: &BoundedQueue<T>,
+    dropped_samples: &AtomicU64,
+    context: &QueueDropContext,
+    sample: T,
+) {
+    if queue.push(sample) {
+        let total_dropped_samples = dropped_samples.fetch_add(1, Ordering::Relaxed) + 1;
+        warn!(
+            subscriber = context.log_prefix,
+            topic = %context.topic,
+            node_namespace = %context.node_namespace,
+            node_name = %context.node_name,
+            type_name = %context.type_name,
+            queue_capacity = context.queue_capacity,
+            drop_policy = "oldest",
+            total_dropped_samples,
+            "subscriber queue full; dropped oldest sample"
+        );
+    }
 }
 
 async fn declare_liveliness(session: &Session, entity: &EndpointEntity) -> Result<LivelinessToken> {
@@ -105,12 +157,13 @@ where
         let queue_size = subscriber_queue_capacity(&self.entity.qos);
         let queue = Arc::new(BoundedQueue::new(queue_size));
         let raw_queue = queue.clone();
+        let dropped_samples = Arc::new(AtomicU64::new(0));
+        let raw_dropped_samples = dropped_samples.clone();
+        let drop_context = QueueDropContext::from_entity("RAW_SUB", &self.entity, queue_size)?;
         let resources = self
             .build_subscriber_resources(
                 move |sample| {
-                    if raw_queue.push(sample) {
-                        tracing::debug!("Queue full, dropped oldest message");
-                    }
+                    record_queue_push(&raw_queue, &raw_dropped_samples, &drop_context, sample);
                 },
                 "RAW_SUB",
             )
@@ -255,12 +308,18 @@ where
         let queue_size = subscriber_queue_capacity(&builder.entity.qos);
         let queue = Arc::new(BoundedQueue::new(queue_size));
         let subscriber_queue = queue.clone();
+        let dropped_samples = Arc::new(AtomicU64::new(0));
+        let subscriber_dropped_samples = dropped_samples.clone();
+        let drop_context = QueueDropContext::from_entity("SUB", &builder.entity, queue_size)?;
         let resources = builder
             .build_subscriber_resources(
                 move |sample| {
-                    if subscriber_queue.push(sample) {
-                        tracing::debug!("Queue full, dropped oldest message");
-                    }
+                    record_queue_push(
+                        &subscriber_queue,
+                        &subscriber_dropped_samples,
+                        &drop_context,
+                        sample,
+                    );
                 },
                 "SUB",
             )


### PR DESCRIPTION
## Summary
- Emit a structured warning when a bounded subscriber queue drops the oldest sample.
- Include subscriber kind, topic, node namespace/name, message type, queue capacity, drop policy, and total dropped samples in the warning fields.
- Keep queue loss as logging-only UX for now instead of exposing a public stats API.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run -p ros-z queue`
- [x] `cargo nextest run -p ros-z pubsub`
- [x] `cargo clippy -p ros-z --all-targets --locked -- -D warnings`
- [x] `cargo test --doc -p ros-z`