### PR TITLE
keep unlimited history in future map subscribers

### DIFF
--- a/crates/ros-z-streams/src/future_queue.rs
+++ b/crates/ros-z-streams/src/future_queue.rs
@@ -7,6 +7,7 @@ use ros_z::{
     Message, Result,
     node::Node,
     pubsub::{Received, Subscriber},
+    qos::{QosHistory, QosProfile},
     time::Time,
 };
 use tokio::select;
@@ -147,9 +148,20 @@ impl CreateFutureQueue for Node {
         topic: &str,
         transit_lag: Duration,
     ) -> Result<FutureQueueSubscriber<T>> {
-        let data_subscriber = self.subscriber(topic)?.build().await?;
+        let data_subscriber = self
+            .subscriber(topic)?
+            .qos(QosProfile {
+                history: QosHistory::KeepAll,
+                ..Default::default()
+            })
+            .build()
+            .await?;
         let announcement_subscriber = self
             .subscriber(&format!("{}/announce", topic))?
+            .qos(QosProfile {
+                history: QosHistory::KeepAll,
+                ..Default::default()
+            })
             .build()
             .await?;
 


### PR DESCRIPTION
## Why? What?

Fixes future maps breaking with slow subscribers and/or large differences in publisher frequency. Not the prettiest fix, a proper one needs some more thought to work.

## ToDo / Known Issues



## Ideas for Next Iterations (Not This PR)

- work without unbounded buffers

## How to Test

Not sure where this bug occurred before, I have a test case which is fixed by these changes.