### PR TITLE
Add Boosterize Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8024,7 +8024,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.26.0"
+version = "7.27.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.26.0"
+version = "7.27.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/boosterize.rs
+++ b/tools/pepsi/src/boosterize.rs
@@ -1,0 +1,66 @@
+use clap::Args;
+use color_eyre::Result;
+
+use argument_parsers::RobotAddress;
+use robot::Robot;
+
+use crate::{gammaray::CommandExt, progress_indicator::ProgressIndicator};
+
+#[derive(Args, Debug)]
+pub struct Arguments {
+    /// Robots to boosterize
+    #[arg(required = true)]
+    pub robots: Vec<RobotAddress>,
+}
+
+pub async fn boosterize(arguments: Arguments) -> Result<()> {
+    let progress = ProgressIndicator::new();
+
+    progress
+        .map_tasks(
+            arguments.robots,
+            "Boosterizing robot".to_string(),
+            |robot, progress_bar| async move {
+                let robot = Robot::try_new_with_ping(robot.ip).await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg("sudo systemctl disable --now")
+                    .arg("hulk-runtime")
+                    .ssh_with_log("disabling hulk-runtime", &progress_bar)
+                    .await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg("sudo systemctl disable --now")
+                    .arg("hulk")
+                    .ssh_with_log("disabling hulk", &progress_bar)
+                    .await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg("sudo systemctl enable --now")
+                    .arg("booster-daemon-perception")
+                    .ssh_with_log("enabling booster-daemon-perception", &progress_bar)
+                    .await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg("sudo systemctl enable --now")
+                    .arg("booster-agent-manager")
+                    .ssh_with_log("enabling booster-agent-manager", &progress_bar)
+                    .await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg("sudo systemctl enable --now")
+                    .arg("booster-lui")
+                    .ssh_with_log("enabling booster-lui", &progress_bar)
+                    .await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg("sudo systemctl enable --now")
+                    .arg("booster-rtc-speech")
+                    .ssh_with_log("enabling booster-rtc-speech", &progress_bar)
+                    .await
+            },
+        )
+        .await;
+
+    Ok(())
+}

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -10,6 +10,7 @@ use repository::{Repository, inspect_version::check_for_update};
 
 use aliveness::aliveness;
 use analyze::analyze;
+use boosterize::boosterize;
 use cargo::{build, cargo, check, clippy, install, nextest, run, test};
 use communication::communication;
 use completions::completions;
@@ -34,6 +35,7 @@ use wifi::wifi;
 
 mod aliveness;
 mod analyze;
+mod boosterize;
 mod cargo;
 mod communication;
 mod completions;
@@ -77,6 +79,9 @@ enum Command {
     #[clap(subcommand)]
     #[command(visible_alias = "analysier")]
     Analyze(analyze::Arguments),
+    /// Boosterize Robots (enable booster services)
+    #[command(visible_alias = "boost")]
+    Boosterize(boosterize::Arguments),
     /// Get aliveness information from Robots
     #[command(visible_alias = "lebt")]
     Aliveness(aliveness::Arguments),
@@ -216,6 +221,9 @@ async fn main() -> Result<()> {
         Command::Aliveness(arguments) => aliveness(arguments, repository)
             .await
             .wrap_err("failed to execute aliveness command")?,
+        Command::Boosterize(arguments) => boosterize(arguments)
+            .await
+            .wrap_err("failed to execute boosterize command")?,
         Command::Build(arguments) => cargo(arguments, &repository?, &[] as &[&str])
             .await
             .wrap_err("failed to execute build command")?,


### PR DESCRIPTION
## Why? What?

Some services need to be enabled and disabled to use the booster demo mode.
Adds `boosterize` or `boost`

## ToDo / Known Issues

- [x] test

## How to Test

- boost robot
- try remote control and let it walk / dance / round-house-kick
- revert by running gammaray
