### PR TITLE
add rosz doctor pubsub diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9411,6 +9411,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "color-eyre",
+ "humantime",
  "ros-z",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,7 @@ home = "=0.5.9"
 hsl_network = { path = "crates/hsl_network" }
 hsl_network_messages = { path = "crates/hsl_network_messages" }
 hula_types = { path = "crates/hula_types" }
+humantime = "2.3.0"
 hulk_manifest = { path = "crates/hulk_manifest" }
 hulk_widgets = { path = "crates/hulk_widgets" }
 hungarian_algorithm = { path = "crates/hungarian_algorithm" }

--- a/crates/ros-z-cli/Cargo.toml
+++ b/crates/ros-z-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { workspace = true }
 color-eyre = { workspace = true }
+humantime = { workspace = true }
 ros-z = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/ros-z-cli/src/app/context.rs
+++ b/crates/ros-z-cli/src/app/context.rs
@@ -12,9 +12,8 @@ use ros_z::{
     parameter::RemoteParameterClient,
 };
 
-use crate::support::graph::SnapshotFingerprint;
-
 const GRAPH_POLL_INTERVAL: Duration = Duration::from_millis(200);
+const GRAPH_SETTLE_QUIET_WINDOW: Duration = Duration::from_millis(500);
 const GRAPH_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub struct AppContext {
@@ -54,18 +53,26 @@ impl AppContext {
     }
 
     pub async fn wait_for_graph_settle(&self) {
-        let deadline = Instant::now() + GRAPH_SETTLE_TIMEOUT;
-        let mut previous = SnapshotFingerprint::from(&self.snapshot());
+        self.wait_for_graph_settle_with_timeout(GRAPH_SETTLE_TIMEOUT)
+            .await;
+    }
 
-        while Instant::now() < deadline {
-            tokio::time::sleep(GRAPH_POLL_INTERVAL).await;
+    pub async fn wait_for_graph_settle_with_timeout(&self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        let mut changes = self.graph().subscribe_changes();
+        changes.mark_seen();
 
-            let current_snapshot = self.snapshot();
-            let current = SnapshotFingerprint::from(&current_snapshot);
-            if current == previous {
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
                 return;
             }
-            previous = current;
+
+            let wait = GRAPH_SETTLE_QUIET_WINDOW.min(remaining);
+            match tokio::time::timeout(wait, changes.changed()).await {
+                Ok(Some(_revision)) => {}
+                Ok(None) | Err(_) => return,
+            }
         }
     }
 

--- a/crates/ros-z-cli/src/cli.rs
+++ b/crates/ros-z-cli/src/cli.rs
@@ -24,7 +24,6 @@ fn parse_positive_duration(value: &str) -> Result<Duration, String> {
     }
     Ok(duration)
 }
-
 /// Graph entity kind accepted by `rosz list`.
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum ListTarget {
@@ -122,6 +121,12 @@ pub enum OnlineCommand {
     Watch,
     /// Show the full graph snapshot
     Graph,
+    /// Diagnose pub/sub graph issues and exit non-zero on errors
+    Doctor {
+        /// Maximum time to wait for graph changes to settle
+        #[arg(long, default_value = "2s", value_parser = humantime::parse_duration)]
+        settle_timeout: Duration,
+    },
     /// Dynamically inspect a topic's messages
     Echo {
         topic: String,
@@ -345,6 +350,51 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_doctor_command_with_default_settle_timeout() {
+        let cli = Cli::parse_from(["rosz", "doctor"]);
+
+        match cli.command {
+            Command::Online(OnlineCommand::Doctor { settle_timeout }) => {
+                assert_eq!(settle_timeout, Duration::from_secs(2));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_doctor_command_with_custom_settle_timeout() {
+        let cli = Cli::parse_from(["rosz", "doctor", "--settle-timeout", "500ms"]);
+
+        match cli.command {
+            Command::Online(OnlineCommand::Doctor { settle_timeout }) => {
+                assert_eq!(settle_timeout, Duration::from_millis(500));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn doctor_help_describes_exit_status_and_settle_timeout() {
+        let error = Cli::try_parse_from(["rosz", "doctor", "--help"])
+            .expect_err("doctor help should exit before parsing a command");
+
+        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+
+        let help = error.to_string();
+        assert!(help.contains("Diagnose pub/sub graph issues and exit non-zero on errors"));
+        assert!(help.contains("Maximum time to wait for graph changes to settle"));
+        assert!(!help.contains("in seconds"));
+    }
+
+    #[test]
+    fn doctor_rejects_unitless_settle_timeout() {
+        let error = Cli::try_parse_from(["rosz", "doctor", "--settle-timeout", "0.5"])
+            .expect_err("unitless settle timeout should be rejected");
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/ros-z-cli/src/commands/doctor.rs
+++ b/crates/ros-z-cli/src/commands/doctor.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use color_eyre::eyre::Result;
+
+use crate::{
+    app::AppContext,
+    model::doctor::DoctorReport,
+    render::{OutputMode, json, text},
+};
+
+pub async fn run(
+    app: &AppContext,
+    output_mode: OutputMode,
+    settle_timeout: Duration,
+) -> Result<bool> {
+    app.wait_for_graph_settle_with_timeout(settle_timeout).await;
+    let report = DoctorReport::from_graph(app.graph());
+    let has_errors = report.has_errors();
+
+    match output_mode {
+        OutputMode::Json => json::print_pretty(&report)?,
+        OutputMode::Text => text::print_doctor_report(&report),
+    }
+
+    Ok(has_errors)
+}

--- a/crates/ros-z-cli/src/commands/mod.rs
+++ b/crates/ros-z-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod doctor;
 pub mod echo;
 pub mod graph;
 pub mod hz;

--- a/crates/ros-z-cli/src/lib.rs
+++ b/crates/ros-z-cli/src/lib.rs
@@ -8,6 +8,8 @@ mod model;
 mod render;
 mod support;
 
+use std::process::ExitCode;
+
 use clap::CommandFactory;
 use color_eyre::eyre::Result;
 
@@ -18,7 +20,7 @@ use crate::{
 };
 
 /// Run the CLI with parsed command-line arguments.
-pub async fn run(cli: Cli) -> Result<()> {
+pub async fn run(cli: Cli) -> Result<ExitCode> {
     let Cli {
         router,
         json,
@@ -29,7 +31,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Completions { shell } => {
             let mut command = Cli::command();
             clap_complete::generate(shell, &mut command, "rosz", &mut std::io::stdout());
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
         Command::Online(command) => {
             let output_mode = OutputMode::from_json_flag(json);
@@ -42,13 +44,25 @@ async fn run_online_command(
     router: String,
     output_mode: OutputMode,
     command: OnlineCommand,
-) -> Result<()> {
+) -> Result<ExitCode> {
     let app = AppContext::new(&router).await?;
+    let mut exit_code = ExitCode::SUCCESS;
 
     let result = match command {
         OnlineCommand::List { target } => commands::list::run(&app, output_mode, target).await,
         OnlineCommand::Watch => commands::watch::run(&app, output_mode).await,
         OnlineCommand::Graph => commands::graph::run(&app, output_mode).await,
+        OnlineCommand::Doctor { settle_timeout } => {
+            match commands::doctor::run(&app, output_mode, settle_timeout).await {
+                Ok(has_errors) => {
+                    if has_errors {
+                        exit_code = ExitCode::from(1);
+                    }
+                    Ok(())
+                }
+                Err(error) => Err(error),
+            }
+        }
         OnlineCommand::Schema {
             type_name,
             node,
@@ -72,7 +86,7 @@ async fn run_online_command(
     let shutdown_result = app.shutdown();
 
     match (result, shutdown_result) {
-        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Ok(())) => Ok(exit_code),
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
     }

--- a/crates/ros-z-cli/src/main.rs
+++ b/crates/ros-z-cli/src/main.rs
@@ -1,9 +1,10 @@
 use clap::Parser;
 use color_eyre::eyre::{Result, WrapErr};
 use ros_z_cli::{cli::Cli, run};
+use std::process::ExitCode;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<ExitCode> {
     color_eyre::install().wrap_err("failed to install color-eyre")?;
     run(Cli::parse()).await
 }

--- a/crates/ros-z-cli/src/model/doctor.rs
+++ b/crates/ros-z-cli/src/model/doctor.rs
@@ -1,0 +1,507 @@
+use std::collections::BTreeMap;
+
+use ros_z::{
+    entity::{EndpointEntity, EndpointKind},
+    graph::{Graph, GraphRevision, GraphView},
+    qos::{QosCompatibility, QosProfile},
+};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorFindingKind {
+    DanglingPublisher,
+    DanglingSubscriber,
+    TypeMismatch,
+    QosIncompatibility,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoctorQosCompatibility {
+    IncompatibleReliability,
+    IncompatibleDurability,
+}
+
+impl TryFrom<QosCompatibility> for DoctorQosCompatibility {
+    type Error = ();
+
+    fn try_from(compatibility: QosCompatibility) -> Result<Self, Self::Error> {
+        match compatibility {
+            QosCompatibility::IncompatibleReliability => Ok(Self::IncompatibleReliability),
+            QosCompatibility::IncompatibleDurability => Ok(Self::IncompatibleDurability),
+            QosCompatibility::Compatible => Err(()),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorEndpoint {
+    pub node: String,
+    pub kind: String,
+    pub topic: String,
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub schema_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DoctorFinding {
+    pub severity: DoctorSeverity,
+    pub kind: DoctorFindingKind,
+    pub topic: String,
+    pub endpoints: Vec<DoctorEndpoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qos_compatibility: Option<DoctorQosCompatibility>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorReport {
+    pub revision: GraphRevision,
+    pub warning_count: usize,
+    pub error_count: usize,
+    pub findings: Vec<DoctorFinding>,
+}
+
+impl DoctorReport {
+    pub fn new(revision: GraphRevision, mut findings: Vec<DoctorFinding>) -> Self {
+        for finding in &mut findings {
+            sort_doctor_endpoints(&mut finding.endpoints);
+        }
+        findings.sort_by_key(finding_sort_key);
+        let warning_count = findings
+            .iter()
+            .filter(|finding| finding.severity == DoctorSeverity::Warning)
+            .count();
+        let error_count = findings
+            .iter()
+            .filter(|finding| finding.severity == DoctorSeverity::Error)
+            .count();
+
+        Self {
+            revision,
+            warning_count,
+            error_count,
+            findings,
+        }
+    }
+
+    pub fn from_graph(graph: &Graph) -> Self {
+        let (revision, endpoints) = {
+            let view = graph.view();
+            doctor_endpoint_snapshot(&view)
+        };
+
+        Self::from_endpoints(revision, endpoints)
+    }
+
+    fn from_endpoints(revision: GraphRevision, endpoints: Vec<EndpointEntity>) -> Self {
+        let mut by_topic: BTreeMap<String, TopicEndpoints> = BTreeMap::new();
+        for endpoint in endpoints {
+            let entry = by_topic.entry(endpoint.topic.clone()).or_default();
+            match endpoint.kind {
+                EndpointKind::Publisher => entry.publishers.push(endpoint),
+                EndpointKind::Subscription => entry.subscribers.push(endpoint),
+                EndpointKind::Service | EndpointKind::Client => {}
+            }
+        }
+
+        let mut findings = Vec::new();
+        for (topic, endpoints) in &by_topic {
+            collect_dangling_topic_findings(&mut findings, topic, endpoints);
+            collect_type_mismatch_findings(&mut findings, topic, endpoints);
+            collect_qos_incompatibility_findings(&mut findings, topic, endpoints);
+        }
+
+        Self::new(revision, findings)
+    }
+
+    pub fn has_errors(&self) -> bool {
+        self.error_count > 0
+    }
+}
+
+#[derive(Default)]
+struct TopicEndpoints {
+    publishers: Vec<EndpointEntity>,
+    subscribers: Vec<EndpointEntity>,
+}
+
+fn doctor_endpoint_snapshot(view: &GraphView<'_>) -> (GraphRevision, Vec<EndpointEntity>) {
+    let revision = view.revision();
+    let endpoints = view
+        .endpoints()
+        .filter(|endpoint| {
+            matches!(
+                endpoint.kind,
+                EndpointKind::Publisher | EndpointKind::Subscription
+            )
+        })
+        .cloned()
+        .collect();
+
+    (revision, endpoints)
+}
+
+fn collect_dangling_topic_findings(
+    findings: &mut Vec<DoctorFinding>,
+    topic: &str,
+    endpoints: &TopicEndpoints,
+) {
+    if endpoints.subscribers.is_empty() && !endpoints.publishers.is_empty() {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            kind: DoctorFindingKind::DanglingPublisher,
+            topic: topic.to_string(),
+            endpoints: endpoints
+                .publishers
+                .iter()
+                .map(DoctorEndpoint::from)
+                .collect(),
+            qos_compatibility: None,
+        });
+    }
+
+    if endpoints.publishers.is_empty() && !endpoints.subscribers.is_empty() {
+        findings.push(DoctorFinding {
+            severity: DoctorSeverity::Warning,
+            kind: DoctorFindingKind::DanglingSubscriber,
+            topic: topic.to_string(),
+            endpoints: endpoints
+                .subscribers
+                .iter()
+                .map(DoctorEndpoint::from)
+                .collect(),
+            qos_compatibility: None,
+        });
+    }
+}
+
+fn collect_type_mismatch_findings(
+    findings: &mut Vec<DoctorFinding>,
+    topic: &str,
+    endpoints: &TopicEndpoints,
+) {
+    for publisher in &endpoints.publishers {
+        for subscriber in &endpoints.subscribers {
+            if publisher.type_info != subscriber.type_info {
+                findings.push(DoctorFinding {
+                    severity: DoctorSeverity::Error,
+                    kind: DoctorFindingKind::TypeMismatch,
+                    topic: topic.to_string(),
+                    endpoints: vec![
+                        DoctorEndpoint::from(publisher),
+                        DoctorEndpoint::from(subscriber),
+                    ],
+                    qos_compatibility: None,
+                });
+            }
+        }
+    }
+}
+
+fn collect_qos_incompatibility_findings(
+    findings: &mut Vec<DoctorFinding>,
+    topic: &str,
+    endpoints: &TopicEndpoints,
+) {
+    for publisher in &endpoints.publishers {
+        let Ok(offered) = QosProfile::try_from(publisher.qos) else {
+            continue;
+        };
+
+        for subscriber in &endpoints.subscribers {
+            let Ok(requested) = QosProfile::try_from(subscriber.qos) else {
+                continue;
+            };
+            let compatibility = requested.compatibility_with_offered(&offered);
+            let Ok(qos_compatibility) = DoctorQosCompatibility::try_from(compatibility) else {
+                continue;
+            };
+
+            findings.push(DoctorFinding {
+                severity: DoctorSeverity::Error,
+                kind: DoctorFindingKind::QosIncompatibility,
+                topic: topic.to_string(),
+                endpoints: vec![
+                    DoctorEndpoint::from(publisher),
+                    DoctorEndpoint::from(subscriber),
+                ],
+                qos_compatibility: Some(qos_compatibility),
+            });
+        }
+    }
+}
+
+impl From<&EndpointEntity> for DoctorEndpoint {
+    fn from(endpoint: &EndpointEntity) -> Self {
+        Self {
+            node: endpoint.node.fully_qualified_name(),
+            kind: endpoint_kind_name(endpoint.kind).to_string(),
+            topic: endpoint.topic.clone(),
+            type_name: endpoint.type_info.name.clone(),
+            schema_hash: endpoint.type_info.hash.to_hash_string(),
+        }
+    }
+}
+
+fn endpoint_kind_name(kind: EndpointKind) -> &'static str {
+    match kind {
+        EndpointKind::Publisher => "publisher",
+        EndpointKind::Subscription => "subscriber",
+        EndpointKind::Service => "service",
+        EndpointKind::Client => "client",
+    }
+}
+
+fn sort_doctor_endpoints(endpoints: &mut [DoctorEndpoint]) {
+    endpoints.sort_by(|left, right| endpoint_sort_key(left).cmp(&endpoint_sort_key(right)));
+}
+
+type EndpointSortKey<'a> = (&'a str, &'a str, &'a str, &'a str, &'a str);
+type OwnedEndpointSortKey = (String, String, String, String, String);
+type FindingSortKey = (
+    DoctorSeverity,
+    DoctorFindingKind,
+    String,
+    Vec<OwnedEndpointSortKey>,
+    Option<DoctorQosCompatibility>,
+);
+
+fn endpoint_sort_key(endpoint: &DoctorEndpoint) -> EndpointSortKey<'_> {
+    (
+        endpoint.node.as_str(),
+        endpoint.type_name.as_str(),
+        endpoint.schema_hash.as_str(),
+        endpoint.kind.as_str(),
+        endpoint.topic.as_str(),
+    )
+}
+
+fn finding_sort_key(finding: &DoctorFinding) -> FindingSortKey {
+    (
+        finding.severity,
+        finding.kind,
+        finding.topic.clone(),
+        finding
+            .endpoints
+            .iter()
+            .map(|endpoint| {
+                (
+                    endpoint.node.clone(),
+                    endpoint.type_name.clone(),
+                    endpoint.schema_hash.clone(),
+                    endpoint.kind.clone(),
+                    endpoint.topic.clone(),
+                )
+            })
+            .collect(),
+        finding.qos_compatibility,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use ros_z::entity::{EndpointEntity, EndpointKind, NodeEntity, SchemaHash, TypeInfo};
+    use ros_z::qos::{QosCompatibility, QosHistory, QosProfile, QosReliability};
+    use serde_json::json;
+
+    use super::{DoctorFindingKind, DoctorReport, DoctorSeverity};
+
+    fn endpoint_with_hash(
+        id: usize,
+        kind: EndpointKind,
+        topic: &str,
+        type_name: &str,
+        schema_hash: SchemaHash,
+    ) -> EndpointEntity {
+        EndpointEntity {
+            id,
+            node: NodeEntity {
+                z_id: Default::default(),
+                id,
+                name: format!("node_{id}"),
+                namespace: "/doctor_test".to_string(),
+            },
+            kind,
+            topic: topic.to_string(),
+            type_info: TypeInfo::new(type_name, schema_hash),
+            qos: Default::default(),
+        }
+    }
+
+    fn endpoint(id: usize, kind: EndpointKind, topic: &str, type_name: &str) -> EndpointEntity {
+        endpoint_with_hash(id, kind, topic, type_name, SchemaHash::zero())
+    }
+
+    #[test]
+    fn warning_only_report_has_no_errors() {
+        let report = DoctorReport::from_endpoints(
+            ros_z::graph::GraphRevision::INITIAL,
+            vec![endpoint(
+                1,
+                EndpointKind::Publisher,
+                "/topic",
+                "test_msgs::A",
+            )],
+        );
+
+        assert_eq!(report.warning_count, 1);
+        assert_eq!(report.error_count, 0);
+        assert!(!report.has_errors());
+    }
+
+    #[test]
+    fn dangling_subscriber_report_is_warning_only() {
+        let report = DoctorReport::from_endpoints(
+            ros_z::graph::GraphRevision::INITIAL,
+            vec![endpoint(
+                1,
+                EndpointKind::Subscription,
+                "/topic",
+                "test_msgs::A",
+            )],
+        );
+
+        assert_eq!(report.warning_count, 1);
+        assert_eq!(report.error_count, 0);
+        assert!(!report.has_errors());
+        assert_eq!(report.findings[0].severity, DoctorSeverity::Warning);
+        assert_eq!(
+            report.findings[0].kind,
+            DoctorFindingKind::DanglingSubscriber
+        );
+    }
+
+    #[test]
+    fn from_endpoints_reports_type_mismatches() {
+        let report = DoctorReport::from_endpoints(
+            ros_z::graph::GraphRevision::INITIAL,
+            vec![
+                endpoint(1, EndpointKind::Publisher, "/topic", "test_msgs::A"),
+                endpoint(2, EndpointKind::Subscription, "/topic", "test_msgs::B"),
+            ],
+        );
+
+        assert_eq!(report.warning_count, 0);
+        assert_eq!(report.error_count, 1);
+        assert!(report.has_errors());
+        assert_eq!(report.findings[0].severity, DoctorSeverity::Error);
+        assert_eq!(report.findings[0].kind, DoctorFindingKind::TypeMismatch);
+        assert_eq!(report.findings[0].topic, "/topic");
+        assert_eq!(report.findings[0].endpoints.len(), 2);
+    }
+
+    #[test]
+    fn from_endpoints_reports_qos_incompatibilities() {
+        let mut publisher = endpoint(1, EndpointKind::Publisher, "/topic", "test_msgs::A");
+        publisher.qos = QosProfile {
+            reliability: QosReliability::BestEffort,
+            history: QosHistory::KeepLast(std::num::NonZeroUsize::new(10).unwrap()),
+            ..Default::default()
+        }
+        .to_protocol_qos();
+
+        let mut subscriber = endpoint(2, EndpointKind::Subscription, "/topic", "test_msgs::A");
+        subscriber.qos = QosProfile {
+            reliability: QosReliability::Reliable,
+            history: QosHistory::KeepLast(std::num::NonZeroUsize::new(10).unwrap()),
+            ..Default::default()
+        }
+        .to_protocol_qos();
+
+        let report = DoctorReport::from_endpoints(
+            ros_z::graph::GraphRevision::INITIAL,
+            vec![publisher, subscriber],
+        );
+
+        assert_eq!(report.warning_count, 0);
+        assert_eq!(report.error_count, 1);
+        assert!(report.has_errors());
+        assert_eq!(report.findings[0].severity, DoctorSeverity::Error);
+        assert_eq!(
+            report.findings[0].kind,
+            DoctorFindingKind::QosIncompatibility
+        );
+        assert_eq!(
+            report.findings[0].qos_compatibility,
+            Some(super::DoctorQosCompatibility::IncompatibleReliability)
+        );
+    }
+
+    #[test]
+    fn qos_compatibility_serializes_as_snake_case() {
+        let finding = super::DoctorFinding {
+            severity: DoctorSeverity::Error,
+            kind: DoctorFindingKind::QosIncompatibility,
+            topic: "/topic".to_string(),
+            endpoints: Vec::new(),
+            qos_compatibility: Some(
+                super::DoctorQosCompatibility::try_from(QosCompatibility::IncompatibleReliability)
+                    .expect("incompatible reliability should be representable"),
+            ),
+        };
+
+        let value = serde_json::to_value(&finding).expect("doctor finding should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "severity": "error",
+                "kind": "qos_incompatibility",
+                "topic": "/topic",
+                "endpoints": [],
+                "qos_compatibility": "incompatible_reliability"
+            })
+        );
+    }
+
+    #[test]
+    fn finding_order_is_deterministic() {
+        let report = DoctorReport::from_endpoints(
+            ros_z::graph::GraphRevision::INITIAL,
+            vec![
+                endpoint(2, EndpointKind::Publisher, "/z_topic", "test_msgs::A"),
+                endpoint(1, EndpointKind::Publisher, "/a_topic", "test_msgs::A"),
+            ],
+        );
+
+        assert_eq!(report.findings.len(), 2);
+        assert_eq!(report.findings[0].topic, "/a_topic");
+        assert_eq!(report.findings[1].topic, "/z_topic");
+    }
+
+    #[test]
+    fn dangling_finding_endpoint_order_is_deterministic() {
+        let report = DoctorReport::from_endpoints(
+            ros_z::graph::GraphRevision::INITIAL,
+            vec![
+                endpoint(3, EndpointKind::Publisher, "/topic", "test_msgs::C"),
+                endpoint(1, EndpointKind::Publisher, "/topic", "test_msgs::A"),
+                endpoint(2, EndpointKind::Publisher, "/topic", "test_msgs::B"),
+            ],
+        );
+
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(
+            report.findings[0]
+                .endpoints
+                .iter()
+                .map(|endpoint| (endpoint.node.as_str(), endpoint.type_name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("/doctor_test/node_1", "test_msgs::A"),
+                ("/doctor_test/node_2", "test_msgs::B"),
+                ("/doctor_test/node_3", "test_msgs::C"),
+            ]
+        );
+    }
+}

--- a/crates/ros-z-cli/src/model/mod.rs
+++ b/crates/ros-z-cli/src/model/mod.rs
@@ -1,3 +1,4 @@
+pub mod doctor;
 pub mod echo;
 pub mod graph;
 pub mod hz;

--- a/crates/ros-z-cli/src/render/text.rs
+++ b/crates/ros-z-cli/src/render/text.rs
@@ -4,6 +4,10 @@ use ros_z::graph::GraphSnapshot;
 
 use crate::{
     model::{
+        doctor::{
+            DoctorEndpoint, DoctorFinding, DoctorFindingKind, DoctorQosCompatibility, DoctorReport,
+            DoctorSeverity,
+        },
         echo::EchoHeader,
         graph::{NodeSummary, ServiceSummary, TopicSummary},
         hz::{HzReport, HzStats},
@@ -253,6 +257,80 @@ fn format_hz(rate_hz: f64) -> String {
 
 fn format_seconds(seconds: f64) -> String {
     format!("{seconds:.3}s")
+}
+
+pub fn print_doctor_report(report: &DoctorReport) {
+    if report.findings.is_empty() {
+        println!(
+            "rosz doctor found no pub/sub graph issues at graph revision {}",
+            format_graph_revision(report.revision)
+        );
+        return;
+    }
+
+    println!(
+        "rosz doctor found {} warning(s), {} error(s) at graph revision {}",
+        report.warning_count,
+        report.error_count,
+        format_graph_revision(report.revision)
+    );
+    println!();
+
+    for (index, finding) in report.findings.iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        print_doctor_finding(finding);
+    }
+}
+
+fn print_doctor_finding(finding: &DoctorFinding) {
+    let severity = doctor_severity_name(finding.severity);
+    let kind = doctor_finding_kind_name(finding.kind);
+    println!("{severity} {kind} topic {}", finding.topic);
+    if let Some(compatibility) = finding.qos_compatibility {
+        println!(
+            "  compatibility: {}",
+            doctor_qos_compatibility_name(compatibility)
+        );
+    }
+    for endpoint in &finding.endpoints {
+        print_doctor_endpoint(endpoint);
+    }
+}
+
+fn print_doctor_endpoint(endpoint: &DoctorEndpoint) {
+    println!(
+        "  {}: {} type={} schema_hash={}",
+        endpoint.kind, endpoint.node, endpoint.type_name, endpoint.schema_hash
+    );
+}
+
+fn doctor_severity_name(severity: DoctorSeverity) -> &'static str {
+    match severity {
+        DoctorSeverity::Warning => "warning",
+        DoctorSeverity::Error => "error",
+    }
+}
+
+fn doctor_finding_kind_name(kind: DoctorFindingKind) -> &'static str {
+    match kind {
+        DoctorFindingKind::DanglingPublisher => "dangling publisher",
+        DoctorFindingKind::DanglingSubscriber => "dangling subscriber",
+        DoctorFindingKind::TypeMismatch => "type mismatch",
+        DoctorFindingKind::QosIncompatibility => "qos incompatibility",
+    }
+}
+
+fn doctor_qos_compatibility_name(compatibility: DoctorQosCompatibility) -> &'static str {
+    match compatibility {
+        DoctorQosCompatibility::IncompatibleReliability => "incompatible reliability",
+        DoctorQosCompatibility::IncompatibleDurability => "incompatible durability",
+    }
+}
+
+fn format_graph_revision(revision: ros_z::graph::GraphRevision) -> String {
+    serde_json::to_string(&revision).unwrap_or_else(|_| format!("{revision:?}"))
 }
 
 pub fn print_schema(view: &SchemaView) {

--- a/crates/ros-z-cli/src/support/graph.rs
+++ b/crates/ros-z-cli/src/support/graph.rs
@@ -4,51 +4,6 @@ use ros_z::graph::GraphSnapshot;
 
 use crate::model::watch::WatchEvent;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SnapshotFingerprint {
-    topics: Vec<(String, String, usize, usize)>,
-    nodes: Vec<(String, String)>,
-    services: Vec<(String, String)>,
-}
-
-impl From<&GraphSnapshot> for SnapshotFingerprint {
-    fn from(snapshot: &GraphSnapshot) -> Self {
-        let mut topics: Vec<_> = snapshot
-            .topics
-            .iter()
-            .map(|topic| {
-                (
-                    topic.name.clone(),
-                    topic.type_name.clone(),
-                    topic.publishers,
-                    topic.subscribers,
-                )
-            })
-            .collect();
-        topics.sort();
-
-        let mut nodes: Vec<_> = snapshot
-            .nodes
-            .iter()
-            .map(|node| (node.namespace.clone(), node.name.clone()))
-            .collect();
-        nodes.sort();
-
-        let mut services: Vec<_> = snapshot
-            .services
-            .iter()
-            .map(|service| (service.name.clone(), service.type_name.clone()))
-            .collect();
-        services.sort();
-
-        Self {
-            topics,
-            nodes,
-            services,
-        }
-    }
-}
-
 pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<WatchEvent> {
     let mut events = Vec::new();
     let revision = current.revision;

--- a/crates/ros-z-cli/tests/e2e.rs
+++ b/crates/ros-z-cli/tests/e2e.rs
@@ -42,6 +42,12 @@ struct Telemetry {
 }
 
 #[derive(Debug, Clone, SerdeEnc, SerdeDec, PartialEq, ros_z::Message)]
+#[message(name = "test_cli::Command")]
+struct CommandMessage {
+    enabled: bool,
+}
+
+#[derive(Debug, Clone, SerdeEnc, SerdeDec, PartialEq, ros_z::Message)]
 #[message(name = "test_cli::VisionParameters")]
 #[serde(deny_unknown_fields)]
 struct VisionParameters {
@@ -211,6 +217,95 @@ where
     }
 }
 
+fn eventually_doctor_json<F>(env: &TestEnv, expected_code: i32, mut predicate: F) -> Value
+where
+    F: FnMut(&Value) -> bool,
+{
+    let started = Instant::now();
+
+    loop {
+        let output = env
+            .rosz()
+            .json_command(["doctor", "--settle-timeout", "500ms"])
+            .run();
+        let value: Value = serde_json::from_str(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "failed to parse rosz doctor JSON: {error}\nargs: {:?}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+                output.args, output.status, output.stdout, output.stderr
+            )
+        });
+        let status_matches = output.status.code() == Some(expected_code);
+        if status_matches && predicate(&value) {
+            return value;
+        }
+
+        if started.elapsed() >= EVENTUALLY_TIMEOUT {
+            let graph = env.rosz().json_command(["graph"]).run_json();
+            panic!(
+                "condition was not met for rosz doctor\nexpected status: {expected_code}\nlast status: {}\nlast stdout:\n{}\nlast stderr:\n{}\nlast output:\n{}\nlast graph:\n{}",
+                output.status,
+                output.stdout,
+                output.stderr,
+                serde_json::to_string_pretty(&value).expect("last doctor json"),
+                serde_json::to_string_pretty(&graph).expect("graph json")
+            );
+        }
+
+        std::thread::sleep(EVENTUALLY_POLL);
+    }
+}
+
+fn doctor_finding<'a>(
+    value: &'a Value,
+    severity: &str,
+    kind: &str,
+    topic: &str,
+) -> Option<&'a Value> {
+    value["findings"].as_array()?.iter().find(|finding| {
+        finding["severity"] == severity && finding["kind"] == kind && finding["topic"] == topic
+    })
+}
+
+fn doctor_has_finding(value: &Value, severity: &str, kind: &str, topic: &str) -> bool {
+    doctor_finding(value, severity, kind, topic).is_some()
+}
+
+fn assert_doctor_endpoint_count(finding: &Value, expected_count: usize) {
+    let endpoints = finding["endpoints"]
+        .as_array()
+        .expect("doctor finding endpoints must be an array");
+    assert_eq!(
+        endpoints.len(),
+        expected_count,
+        "doctor finding had unexpected endpoint count:\n{}",
+        serde_json::to_string_pretty(finding).expect("doctor finding json")
+    );
+}
+
+fn assert_doctor_endpoint(
+    finding: &Value,
+    node: &str,
+    kind: &str,
+    topic: &str,
+    type_name: &str,
+    schema_hash: &str,
+) {
+    let endpoints = finding["endpoints"]
+        .as_array()
+        .expect("doctor finding endpoints must be an array");
+    assert!(
+        endpoints.iter().any(|endpoint| {
+            endpoint["node"] == node
+                && endpoint["kind"] == kind
+                && endpoint["topic"] == topic
+                && endpoint["type"] == type_name
+                && endpoint["schema_hash"] == schema_hash
+        }),
+        "doctor finding missing endpoint node={node} kind={kind} topic={topic} type={type_name} schema_hash={schema_hash}:\n{}",
+        serde_json::to_string_pretty(finding).expect("doctor finding json")
+    );
+}
+
 fn json_array_contains_field(value: &Value, field: &str, expected: &str) -> bool {
     value.as_array().is_some_and(|items| {
         items
@@ -307,6 +402,22 @@ impl RoszCommand {
         })
     }
 
+    fn run_status(self, expected_code: i32) -> CommandOutput {
+        let output = self.run();
+        output.assert_code(expected_code);
+        output
+    }
+
+    fn run_json_status(self, expected_code: i32) -> Value {
+        let output = self.run_status(expected_code);
+        serde_json::from_str(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "failed to parse rosz JSON: {error}\nargs: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.args, output.stdout, output.stderr
+            )
+        })
+    }
+
     fn run_json_lines(self) -> Vec<Value> {
         let output = self.run_success();
         output
@@ -343,6 +454,18 @@ impl CommandOutput {
         assert!(
             self.status.success(),
             "rosz failed\nargs: {:?}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            self.args,
+            self.status,
+            self.stdout,
+            self.stderr
+        );
+    }
+
+    fn assert_code(&self, expected_code: i32) {
+        assert_eq!(
+            self.status.code(),
+            Some(expected_code),
+            "rosz returned unexpected status\nargs: {:?}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
             self.args,
             self.status,
             self.stdout,
@@ -604,6 +727,202 @@ async fn graph_list_and_info_report_fixture_entities() -> TestResult {
         serde_json::to_string_pretty(&node_info).expect("node info json")
     );
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn doctor_reports_no_errors_for_matching_pubsub() -> TestResult {
+    let env = TestEnv::new();
+    let context = env.create_context().await?;
+    let node = context
+        .create_node("doctor_matching")
+        .with_namespace("/cli_e2e")
+        .build()
+        .await?;
+    let topic = "/cli_e2e/doctor_matching";
+    let _publisher = node.publisher::<Telemetry>(topic).build().await?;
+    let _subscriber = node.subscriber::<Telemetry>(topic).build().await?;
+
+    eventually_json(&env, &["graph"], |graph| {
+        graph["topics"].as_array().is_some_and(|topics| {
+            topics.iter().any(|candidate| {
+                candidate["name"] == topic
+                    && candidate["publishers"].as_u64() == Some(1)
+                    && candidate["subscribers"].as_u64() == Some(1)
+            })
+        })
+    });
+
+    let report = env
+        .rosz()
+        .json_command(["doctor", "--settle-timeout", "500ms"])
+        .run_json_status(0);
+    assert!(report["revision"].as_u64().is_some());
+    assert_eq!(report["warning_count"].as_u64(), Some(0));
+    assert_eq!(report["error_count"].as_u64(), Some(0));
+    assert!(
+        report["findings"]
+            .as_array()
+            .is_some_and(|findings| findings.is_empty()),
+        "doctor report had unexpected findings:\n{}",
+        serde_json::to_string_pretty(&report).expect("doctor report json")
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn doctor_reports_dangling_publisher_as_warning_and_exits_zero() -> TestResult {
+    let env = TestEnv::new();
+    let context = env.create_context().await?;
+    let node = context
+        .create_node("doctor_dangling_pub")
+        .with_namespace("/cli_e2e")
+        .build()
+        .await?;
+    let topic = "/cli_e2e/doctor_dangling_pub";
+    let _publisher = node.publisher::<Telemetry>(topic).build().await?;
+
+    let report = eventually_doctor_json(&env, 0, |report| {
+        doctor_has_finding(report, "warning", "dangling_publisher", topic)
+    });
+
+    assert_eq!(report["warning_count"].as_u64(), Some(1));
+    assert_eq!(report["error_count"].as_u64(), Some(0));
+    let finding = doctor_finding(&report, "warning", "dangling_publisher", topic)
+        .expect("doctor dangling publisher finding");
+    assert_doctor_endpoint_count(finding, 1);
+    let telemetry_type = Telemetry::type_name();
+    let telemetry_hash = Telemetry::schema_hash().to_hash_string();
+    assert_doctor_endpoint(
+        finding,
+        "/cli_e2e/doctor_dangling_pub",
+        "publisher",
+        topic,
+        telemetry_type.as_str(),
+        telemetry_hash.as_str(),
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn doctor_reports_type_mismatch_as_error_and_exits_one() -> TestResult {
+    let env = TestEnv::new();
+    let context = env.create_context().await?;
+    let pub_node = context
+        .create_node("doctor_type_pub")
+        .with_namespace("/cli_e2e")
+        .build()
+        .await?;
+    let sub_node = context
+        .create_node("doctor_type_sub")
+        .with_namespace("/cli_e2e")
+        .build()
+        .await?;
+    let topic = "/cli_e2e/doctor_type_mismatch";
+    let _publisher = pub_node.publisher::<Telemetry>(topic).build().await?;
+    let _subscriber = sub_node.subscriber::<CommandMessage>(topic).build().await?;
+
+    let report = eventually_doctor_json(&env, 1, |report| {
+        doctor_has_finding(report, "error", "type_mismatch", topic)
+    });
+
+    assert_eq!(report["warning_count"].as_u64(), Some(0));
+    assert_eq!(report["error_count"].as_u64(), Some(1));
+    let finding = doctor_finding(&report, "error", "type_mismatch", topic)
+        .expect("doctor type mismatch finding");
+    assert_doctor_endpoint_count(finding, 2);
+    let telemetry_type = Telemetry::type_name();
+    let telemetry_hash = Telemetry::schema_hash().to_hash_string();
+    assert_doctor_endpoint(
+        finding,
+        "/cli_e2e/doctor_type_pub",
+        "publisher",
+        topic,
+        telemetry_type.as_str(),
+        telemetry_hash.as_str(),
+    );
+    let command_type = CommandMessage::type_name();
+    let command_hash = CommandMessage::schema_hash().to_hash_string();
+    assert_doctor_endpoint(
+        finding,
+        "/cli_e2e/doctor_type_sub",
+        "subscriber",
+        topic,
+        command_type.as_str(),
+        command_hash.as_str(),
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn doctor_reports_qos_incompatibility_as_error_and_exits_one() -> TestResult {
+    use std::num::NonZeroUsize;
+
+    use ros_z::qos::{QosHistory, QosProfile, QosReliability};
+
+    let env = TestEnv::new();
+    let context = env.create_context().await?;
+    let pub_node = context
+        .create_node("doctor_qos_pub")
+        .with_namespace("/cli_e2e")
+        .build()
+        .await?;
+    let sub_node = context
+        .create_node("doctor_qos_sub")
+        .with_namespace("/cli_e2e")
+        .build()
+        .await?;
+    let topic = "/cli_e2e/doctor_qos";
+    let _publisher = pub_node
+        .publisher::<Telemetry>(topic)
+        .qos(QosProfile {
+            reliability: QosReliability::BestEffort,
+            history: QosHistory::KeepLast(NonZeroUsize::new(10).unwrap()),
+            ..Default::default()
+        })
+        .build()
+        .await?;
+    let _subscriber = sub_node
+        .subscriber::<Telemetry>(topic)
+        .qos(QosProfile {
+            reliability: QosReliability::Reliable,
+            history: QosHistory::KeepLast(NonZeroUsize::new(10).unwrap()),
+            ..Default::default()
+        })
+        .build()
+        .await?;
+
+    let report = eventually_doctor_json(&env, 1, |report| {
+        doctor_has_finding(report, "error", "qos_incompatibility", topic)
+    });
+
+    assert_eq!(report["warning_count"].as_u64(), Some(0));
+    assert_eq!(report["error_count"].as_u64(), Some(1));
+    let finding = doctor_finding(&report, "error", "qos_incompatibility", topic)
+        .expect("doctor QoS incompatibility finding");
+    assert_eq!(
+        finding["qos_compatibility"].as_str(),
+        Some("incompatible_reliability")
+    );
+    assert_doctor_endpoint_count(finding, 2);
+    let telemetry_type = Telemetry::type_name();
+    let telemetry_hash = Telemetry::schema_hash().to_hash_string();
+    assert_doctor_endpoint(
+        finding,
+        "/cli_e2e/doctor_qos_pub",
+        "publisher",
+        topic,
+        telemetry_type.as_str(),
+        telemetry_hash.as_str(),
+    );
+    assert_doctor_endpoint(
+        finding,
+        "/cli_e2e/doctor_qos_sub",
+        "subscriber",
+        topic,
+        telemetry_type.as_str(),
+        telemetry_hash.as_str(),
+    );
     Ok(())
 }
 

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -4,7 +4,7 @@ mod snapshot;
 mod state;
 
 use discovery::install_liveliness;
-pub use query::{GraphChangeSubscription, GraphView, QosIncompatibility};
+pub use query::{GraphChangeSubscription, GraphView, QosIncompatibility, TypeMismatch};
 pub use snapshot::{GraphSnapshot, NodeSnapshot, ServiceSnapshot, TopicSnapshot};
 use state::GraphStore;
 

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -15,6 +15,18 @@ pub struct QosIncompatibility {
     pub compatibility: QosCompatibility,
 }
 
+/// A publisher/subscriber type mismatch for one topic.
+///
+/// Each value represents one publisher/subscriber pair on the same topic whose
+/// full [`TypeInfo`](crate::entity::TypeInfo) values differ. Services and
+/// clients are not considered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeMismatch {
+    pub topic: String,
+    pub publisher: EndpointEntity,
+    pub subscription: EndpointEntity,
+}
+
 /// A snapshot view of graph entities while the graph lock is held.
 ///
 /// Do not hold a `GraphView` across `.await` points or while calling other `Graph` methods.
@@ -192,6 +204,89 @@ impl GraphView<'_> {
             .collect()
     }
 
+    fn collect_pub_sub_pair_diagnostics<T>(
+        &self,
+        topic: &str,
+        mut diagnostic_for_pair: impl FnMut(&str, &EndpointEntity, &EndpointEntity) -> Option<T>,
+    ) -> Vec<T> {
+        let publishers = self.publishers_on(topic);
+        let subscriptions = self.subscriptions_on(topic);
+
+        let mut diagnostics = Vec::new();
+        for publisher in &publishers {
+            for subscription in &subscriptions {
+                if let Some(diagnostic) = diagnostic_for_pair(topic, publisher, subscription) {
+                    diagnostics.push(diagnostic);
+                }
+            }
+        }
+
+        diagnostics
+    }
+
+    /// Return pairwise QoS incompatibilities for publishers and subscribers on `topic`.
+    ///
+    /// The query runs against this locked graph view, so all returned diagnostics
+    /// come from the same local graph revision. Compatible pairs are omitted.
+    /// Endpoints whose QoS cannot be converted into [`QosProfile`] are ignored.
+    /// Services and clients are not considered.
+    pub fn qos_incompatibilities_for_topic(
+        &self,
+        topic: impl AsRef<str>,
+    ) -> Vec<QosIncompatibility> {
+        let topic = topic.as_ref();
+
+        self.collect_pub_sub_pair_diagnostics(topic, |topic, publisher, subscription| {
+            let Ok(offered) = QosProfile::try_from(publisher.qos) else {
+                return None;
+            };
+            let Ok(requested) = QosProfile::try_from(subscription.qos) else {
+                return None;
+            };
+
+            let compatibility = requested.compatibility_with_offered(&offered);
+            if compatibility == QosCompatibility::Compatible {
+                return None;
+            }
+
+            tracing::warn!(
+                topic = %topic,
+                publisher_qos = ?publisher.qos,
+                subscription_qos = ?subscription.qos,
+                compatibility = ?compatibility,
+                "QoS incompatibility detected"
+            );
+            Some(QosIncompatibility {
+                topic: topic.to_string(),
+                publisher: publisher.clone(),
+                subscription: subscription.clone(),
+                compatibility,
+            })
+        })
+    }
+
+    /// Return pairwise publisher/subscriber type mismatches for `topic`.
+    ///
+    /// The query runs against this locked graph view, so all returned diagnostics
+    /// come from the same local graph revision. The comparison uses the full
+    /// [`TypeInfo`](crate::entity::TypeInfo), including the schema hash. Services
+    /// and clients are not considered.
+    pub fn pub_sub_type_mismatches_for_topic(&self, topic: impl AsRef<str>) -> Vec<TypeMismatch> {
+        let topic = topic.as_ref();
+
+        self.collect_pub_sub_pair_diagnostics(topic, |topic, publisher, subscription| {
+            if publisher.type_info == subscription.type_info {
+                return None;
+            }
+
+            Some(TypeMismatch {
+                topic: topic.to_string(),
+                publisher: publisher.clone(),
+                subscription: subscription.clone(),
+            })
+        })
+    }
+
     fn endpoints_named(&self, kind: EndpointKind, name: impl AsRef<str>) -> Vec<EndpointEntity> {
         let name = name.as_ref();
         self.endpoints()
@@ -231,47 +326,6 @@ impl GraphView<'_> {
 }
 
 impl Graph {
-    pub fn qos_incompatibilities_for_topic(
-        &self,
-        topic: impl AsRef<str>,
-    ) -> Vec<QosIncompatibility> {
-        let topic = topic.as_ref();
-        let view = self.view();
-        let publishers = view.publishers_on(topic);
-        let subscriptions = view.subscriptions_on(topic);
-        drop(view);
-
-        let mut diagnostics = Vec::new();
-        for publisher in publishers {
-            let Ok(offered) = QosProfile::try_from(publisher.qos) else {
-                continue;
-            };
-
-            for subscription in &subscriptions {
-                let Ok(requested) = QosProfile::try_from(subscription.qos) else {
-                    continue;
-                };
-                let compatibility = requested.compatibility_with_offered(&offered);
-                if compatibility != QosCompatibility::Compatible {
-                    tracing::warn!(
-                        topic = %topic,
-                        publisher_qos = ?publisher.qos,
-                        subscription_qos = ?subscription.qos,
-                        compatibility = ?compatibility,
-                        "QoS incompatibility detected"
-                    );
-                    diagnostics.push(QosIncompatibility {
-                        topic: topic.to_string(),
-                        publisher: publisher.clone(),
-                        subscription: subscription.clone(),
-                        compatibility,
-                    });
-                }
-            }
-        }
-
-        diagnostics
-    }
     pub(crate) fn type_incompatible_endpoints_for(
         &self,
         endpoint: &EndpointEntity,
@@ -401,6 +455,87 @@ mod tests {
         assert!(service_incompatible_endpoints.contains(&incompatible_publisher));
         assert!(service_incompatible_endpoints.contains(&incompatible_client));
 
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn graph_view_pub_sub_type_mismatches_for_topic_returns_pub_sub_pairs_only() -> Result<()>
+    {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Graph::new(&session).await?;
+        let pub_node = NodeEntity::new(
+            session.zid(),
+            71,
+            "type_mismatch_pub".to_string(),
+            String::new(),
+        );
+        let sub_node = NodeEntity::new(
+            session.zid(),
+            72,
+            "type_mismatch_sub".to_string(),
+            String::new(),
+        );
+        let publisher = endpoint(
+            pub_node.clone(),
+            73,
+            EndpointKind::Publisher,
+            "/doctor_type_mismatch",
+            "std_msgs::String",
+        );
+        let incompatible_subscription = endpoint(
+            sub_node.clone(),
+            74,
+            EndpointKind::Subscription,
+            "/doctor_type_mismatch",
+            "std_msgs::Int32",
+        );
+        let compatible_subscription = endpoint(
+            sub_node,
+            75,
+            EndpointKind::Subscription,
+            "/doctor_type_mismatch",
+            "std_msgs::String",
+        );
+        let incompatible_publisher = endpoint(
+            pub_node,
+            76,
+            EndpointKind::Publisher,
+            "/doctor_type_mismatch",
+            "std_msgs::Bool",
+        );
+
+        graph.add_local_entity(Entity::Endpoint(publisher.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(incompatible_subscription.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(compatible_subscription.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(incompatible_publisher.clone()))?;
+
+        let view = graph.view();
+        let mismatches = view.pub_sub_type_mismatches_for_topic("/doctor_type_mismatch");
+
+        assert_eq!(mismatches.len(), 3);
+        assert!(mismatches.contains(&TypeMismatch {
+            topic: "/doctor_type_mismatch".to_string(),
+            publisher: publisher.clone(),
+            subscription: incompatible_subscription.clone(),
+        }));
+        assert!(mismatches.contains(&TypeMismatch {
+            topic: "/doctor_type_mismatch".to_string(),
+            publisher: incompatible_publisher.clone(),
+            subscription: incompatible_subscription,
+        }));
+        assert!(mismatches.contains(&TypeMismatch {
+            topic: "/doctor_type_mismatch".to_string(),
+            publisher: incompatible_publisher,
+            subscription: compatible_subscription,
+        }));
+
+        drop(view);
         session
             .close()
             .await

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -704,7 +704,8 @@ mod tests {
         assert!(wait_for_publishers(&pub_node, &topic, 1, 2_000).await?);
         assert!(wait_for_subscribers(&pub_node, &topic, 1, 2_000).await?);
 
-        let diagnostics = pub_node.graph().qos_incompatibilities_for_topic(&topic);
+        let view = pub_node.graph().view();
+        let diagnostics = view.qos_incompatibilities_for_topic(&topic);
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
@@ -751,7 +752,8 @@ mod tests {
         assert!(wait_for_publishers(&pub_node, &topic, 1, 2_000).await?);
         assert!(wait_for_subscribers(&pub_node, &topic, 1, 2_000).await?);
 
-        let diagnostics = pub_node.graph().qos_incompatibilities_for_topic(&topic);
+        let view = pub_node.graph().view();
+        let diagnostics = view.qos_incompatibilities_for_topic(&topic);
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(


### PR DESCRIPTION
## Summary
- add `rosz doctor [--settle-timeout SECONDS]` as a bounded whole-graph pub/sub snapshot linter
- support text output and the existing global `--json` output mode
- report dangling publishers/subscribers as warnings
- report type/schema mismatches and QoS incompatibilities as errors
- return exit code `1` only when error-level findings exist
- use graph revision changes for CLI-owned graph settling before collecting diagnostics

## Review response
- keep the intentional `Graph` to `GraphView` diagnostics API break and document the new public graph APIs
- build doctor reports from a cloned endpoint snapshot so report analysis and sorting happen outside the graph lock
- compute doctor type and QoS findings from grouped endpoint data in `ros-z-cli`
- serialize QoS compatibility as stable `snake_case` JSON instead of Rust debug text
- keep shared graph-change quiet-window settling for existing CLI commands

## How to Test
- `cargo fmt --check`
- `cargo nextest run -p ros-z-cli`
- `cargo nextest run -p ros-z`
- `cargo test --doc -p ros-z`