### PR TITLE
warn on recv without visible publishers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8948,6 +8948,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "trybuild",
  "zenoh",
  "zenoh-buffers",

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -34,6 +34,7 @@ zenoh-ext = { workspace = true }
 [dev-dependencies]
 color-eyre = { workspace = true }
 serial_test = { workspace = true }
+tracing-subscriber = { workspace = true }
 trybuild = { workspace = true }
 
 [features]

--- a/crates/ros-z/src/cache.rs
+++ b/crates/ros-z/src/cache.rs
@@ -39,6 +39,7 @@ use parking_lot::RwLock;
 use std::collections::{BTreeMap, VecDeque};
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, warn};
 
 use crate::Result;
@@ -361,6 +362,27 @@ pub struct CacheBuilder<T, S = SerdeCdrCodec<T>, Stamp = ZenohStamp> {
     pub(crate) sub_builder: SubscriberBuilder<T, S>,
     capacity: usize,
     stamp: Stamp,
+}
+
+impl<T, S, Stamp> CacheBuilder<T, S, Stamp>
+where
+    T: Send + Sync + 'static,
+{
+    /// Configure how long cache receive waits before warning that no publishers are visible.
+    ///
+    /// The warning is informational only: cache receive continues waiting for samples after the
+    /// timeout fires. Use [`without_publisher_warning`](Self::without_publisher_warning) to disable
+    /// the warning.
+    pub fn publisher_warning_timeout(mut self, timeout: Duration) -> Self {
+        self.sub_builder = self.sub_builder.publisher_warning_timeout(timeout);
+        self
+    }
+
+    /// Disable warnings when cache receive waits without any visible publishers.
+    pub fn without_publisher_warning(mut self) -> Self {
+        self.sub_builder = self.sub_builder.without_publisher_warning();
+        self
+    }
 }
 
 impl<T, S> SubscriberBuilder<T, S>

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -557,6 +557,21 @@ impl DynamicSubscriberDiscoveryBuilder {
         self
     }
 
+    /// Configure how long receive waits before warning that no publishers are visible.
+    ///
+    /// The warning is emitted only when no sample arrives before `timeout` and the graph has no
+    /// visible publishers for the subscriber topic. Receiving continues waiting after the warning.
+    pub fn publisher_warning_timeout(mut self, timeout: Duration) -> Self {
+        self.options = self.options.publisher_warning_timeout(timeout);
+        self
+    }
+
+    /// Disable warnings when receive waits without any visible publishers.
+    pub fn without_publisher_warning(mut self) -> Self {
+        self.options = self.options.without_publisher_warning();
+        self
+    }
+
     /// Switch this discovery builder to raw sample delivery.
     ///
     /// Publisher type discovery still runs at build time so the subscriber
@@ -611,7 +626,22 @@ impl DynamicRawSubscriberDiscoveryBuilder {
         self
     }
 
-    /// Discover topic type metadata and build a raw dynamic subscriber.
+    /// Configure how long receive waits before warning that no publishers are visible.
+    ///
+    /// The warning is emitted only when no sample arrives before `timeout` and the graph has no
+    /// visible publishers for the subscriber topic. Receiving continues waiting after the warning.
+    pub fn publisher_warning_timeout(mut self, timeout: Duration) -> Self {
+        self.options = self.options.publisher_warning_timeout(timeout);
+        self
+    }
+
+    /// Disable warnings when receive waits without any visible publishers.
+    pub fn without_publisher_warning(mut self) -> Self {
+        self.options = self.options.without_publisher_warning();
+        self
+    }
+
+    /// Discover the topic schema and build a raw dynamic subscriber.
     pub async fn build(self) -> crate::Result<RawSubscriber> {
         let Self {
             context,

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -10,7 +10,7 @@ pub use metadata::{PublicationId, Received};
 pub use publisher::{PreparedPublication, Publisher, PublisherBuilder};
 pub use raw::{RawPayload, RawPayloadCodec, RawSubscriber, RawSubscriberBuilder};
 pub(crate) use subscriber::SubscriberOptions;
-pub use subscriber::{Subscriber, SubscriberBuilder};
+pub use subscriber::{DEFAULT_PUBLISHER_WARNING_TIMEOUT, Subscriber, SubscriberBuilder};
 
 pub(crate) const DEFAULT_TRANSIENT_LOCAL_REPLAY_TIMEOUT: Duration = Duration::from_secs(1);
 

--- a/crates/ros-z/src/pubsub/raw.rs
+++ b/crates/ros-z/src/pubsub/raw.rs
@@ -5,8 +5,12 @@ use std::time::Duration;
 use zenoh::sample::Sample;
 
 use crate::Result;
+use crate::entity::EndpointEntity;
+use crate::graph::Graph;
 use crate::message::WireDecoder;
-use crate::pubsub::subscriber::{SubscriberBuilder, SubscriberResources};
+use crate::pubsub::subscriber::{
+    SubscriberBuilder, SubscriberResources, recv_sample_with_publisher_warning,
+};
 use crate::qos::QosProfile;
 use crate::queue::BoundedQueue;
 
@@ -37,13 +41,25 @@ impl WireDecoder for RawPayloadCodec {
 /// Received samples are delivered as [`Sample`] values without deserialization.
 pub struct RawSubscriber {
     queue: Arc<BoundedQueue<Sample>>,
+    graph: Arc<Graph>,
+    entity: EndpointEntity,
+    publisher_warning_timeout: Option<Duration>,
     _resources: SubscriberResources,
 }
 
 impl RawSubscriber {
-    pub(super) fn new(queue: Arc<BoundedQueue<Sample>>, resources: SubscriberResources) -> Self {
+    pub(super) fn new(
+        queue: Arc<BoundedQueue<Sample>>,
+        resources: SubscriberResources,
+        graph: Arc<Graph>,
+        entity: EndpointEntity,
+        publisher_warning_timeout: Option<Duration>,
+    ) -> Self {
         Self {
             queue,
+            graph,
+            entity,
+            publisher_warning_timeout,
             _resources: resources,
         }
     }
@@ -54,8 +70,20 @@ impl RawSubscriber {
     /// Zenoh and does not deserialize it into a message type. The receive is
     /// cancel-safe: cancelling this future before it completes does not remove a
     /// sample from the queue.
+    ///
+    /// By default, this logs a warning after
+    /// [`DEFAULT_PUBLISHER_WARNING_TIMEOUT`](crate::pubsub::DEFAULT_PUBLISHER_WARNING_TIMEOUT) if
+    /// no sample arrives and no publishers are visible for the topic. The warning does not end the
+    /// receive; this method continues waiting for the next sample.
     pub async fn recv(&mut self) -> Result<Sample> {
-        Ok(self.queue.recv_async().await)
+        let sample = recv_sample_with_publisher_warning(
+            &self.queue,
+            &self.graph,
+            &self.entity,
+            self.publisher_warning_timeout,
+        )
+        .await;
+        Ok(sample)
     }
 }
 
@@ -88,6 +116,23 @@ where
     pub fn transient_local_replay_timeout(self, timeout: Duration) -> Self {
         Self {
             inner: self.inner.transient_local_replay_timeout(timeout),
+        }
+    }
+
+    /// Configure how long receive waits before warning that no publishers are visible.
+    ///
+    /// The warning is emitted only when no sample arrives before `timeout` and the graph has no
+    /// visible publishers for the subscriber topic. Receiving continues waiting after the warning.
+    pub fn publisher_warning_timeout(self, timeout: Duration) -> Self {
+        Self {
+            inner: self.inner.publisher_warning_timeout(timeout),
+        }
+    }
+
+    /// Disable warnings when receive waits without any visible publishers.
+    pub fn without_publisher_warning(self) -> Self {
+        Self {
+            inner: self.inner.without_publisher_warning(),
         }
     }
 

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -28,11 +28,18 @@ pub(super) fn subscriber_queue_capacity(qos: &ros_z_protocol::qos::QosProfile) -
     }
 }
 
+/// Default time a subscriber receive waits before warning that no publishers are visible.
+///
+/// The warning is informational only: receiving continues waiting for a sample after the
+/// timeout fires.
+pub const DEFAULT_PUBLISHER_WARNING_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Debug, Clone)]
 pub(crate) struct SubscriberOptions {
     pub(crate) qos: ros_z_protocol::qos::QosProfile,
     pub(crate) locality: Option<zenoh::sample::Locality>,
     pub(crate) transient_local_replay_timeout: Duration,
+    pub(crate) publisher_warning_timeout: Option<Duration>,
 }
 
 impl Default for SubscriberOptions {
@@ -41,6 +48,7 @@ impl Default for SubscriberOptions {
             qos: crate::endpoint_builder::default_protocol_qos(),
             locality: None,
             transient_local_replay_timeout: crate::pubsub::DEFAULT_TRANSIENT_LOCAL_REPLAY_TIMEOUT,
+            publisher_warning_timeout: Some(DEFAULT_PUBLISHER_WARNING_TIMEOUT),
         }
     }
 }
@@ -58,6 +66,16 @@ impl SubscriberOptions {
 
     pub(crate) fn transient_local_replay_timeout(mut self, timeout: Duration) -> Self {
         self.transient_local_replay_timeout = timeout;
+        self
+    }
+
+    pub(crate) fn publisher_warning_timeout(mut self, timeout: Duration) -> Self {
+        self.publisher_warning_timeout = Some(timeout);
+        self
+    }
+
+    pub(crate) fn without_publisher_warning(mut self) -> Self {
+        self.publisher_warning_timeout = None;
         self
     }
 }
@@ -195,6 +213,21 @@ impl<T, C> SubscriberBuilder<T, C> {
         self
     }
 
+    /// Configure how long receive waits before warning that no publishers are visible.
+    ///
+    /// The warning is emitted only when no sample arrives before `timeout` and the graph has no
+    /// visible publishers for the subscriber topic. Receiving continues waiting after the warning.
+    pub fn publisher_warning_timeout(mut self, timeout: Duration) -> Self {
+        self.options = self.options.publisher_warning_timeout(timeout);
+        self
+    }
+
+    /// Disable warnings when receive waits without any visible publishers.
+    pub fn without_publisher_warning(mut self) -> Self {
+        self.options = self.options.without_publisher_warning();
+        self
+    }
+
     /// Switch this builder to raw sample delivery.
     ///
     /// Only settings that affect raw sample delivery continue to apply.
@@ -251,7 +284,13 @@ impl<T, C> SubscriberBuilder<T, C> {
 
         prepared.warn_about_incompatible_endpoints("RAW_SUB");
 
-        Ok(raw::RawSubscriber::new(queue, resources))
+        Ok(raw::RawSubscriber::new(
+            queue,
+            resources,
+            Arc::clone(&prepared.context.graph),
+            prepared.entity.clone(),
+            prepared.options.publisher_warning_timeout,
+        ))
     }
 }
 
@@ -442,7 +481,7 @@ where
             context,
             dyn_schema,
             entity,
-            ..
+            options,
         } = prepared;
 
         Ok(Subscriber {
@@ -451,8 +490,37 @@ where
             queue,
             graph: context.graph,
             dyn_schema,
+            publisher_warning_timeout: options.publisher_warning_timeout,
             _phantom_data: Default::default(),
         })
+    }
+}
+
+pub(super) async fn recv_sample_with_publisher_warning(
+    queue: &BoundedQueue<Sample>,
+    graph: &Graph,
+    entity: &EndpointEntity,
+    publisher_warning_timeout: Option<Duration>,
+) -> Sample {
+    let Some(timeout) = publisher_warning_timeout else {
+        return queue.recv_async().await;
+    };
+
+    match tokio::time::timeout(timeout, queue.recv_async()).await {
+        Ok(sample) => sample,
+        Err(_) => {
+            if graph.lock().publishers_on(&entity.topic).next().is_none() {
+                warn!(
+                    topic = %entity.topic,
+                    subscriber_node = %entity.node.fully_qualified_name(),
+                    subscriber_type = %entity.type_info.name,
+                    subscriber_schema_hash = %entity.type_info.hash,
+                    timeout_seconds = timeout.as_secs_f64(),
+                    "[SUB] no message received and no publishers are visible for subscriber topic"
+                );
+            }
+            queue.recv_async().await
+        }
     }
 }
 
@@ -464,6 +532,7 @@ pub struct Subscriber<T, C: WireDecoder = <T as crate::Message>::Codec> {
     /// Schema for dynamic message deserialization.
     /// Required for runtime-typed dynamic subscribers using `DynamicPayload`.
     dyn_schema: Option<Schema>,
+    publisher_warning_timeout: Option<Duration>,
     _phantom_data: PhantomData<(T, C)>,
 }
 
@@ -534,13 +603,26 @@ where
         self.publisher_count() > 0
     }
 
+    /// Receive and deserialize the next message.
+    ///
+    /// By default, this logs a warning after [`DEFAULT_PUBLISHER_WARNING_TIMEOUT`] if no sample
+    /// arrives and no publishers are visible for the topic. The warning does not end the receive;
+    /// this method continues waiting for the next message.
     pub async fn recv(&self) -> Result<C::Output> {
         self.recv_with_metadata().await.map(Received::into_message)
     }
 
     /// Receive and deserialize the next message together with metadata.
+    ///
+    /// The publisher warning behavior is the same as [`recv`](Self::recv).
     pub async fn recv_with_metadata(&self) -> Result<Received<C::Output>> {
-        let sample = self.queue.recv_async().await;
+        let sample = recv_sample_with_publisher_warning(
+            &self.queue,
+            &self.graph,
+            &self.entity,
+            self.publisher_warning_timeout,
+        )
+        .await;
         let payload = sample.payload().to_bytes();
         let message = C::deserialize(&payload)
             .map_err(|source| crate::Error::decode(std::any::type_name::<C::Output>(), source))?;
@@ -554,6 +636,10 @@ impl Subscriber<DynamicPayload, DynamicCdrCodec> {
     ///
     /// This method requires that the subscriber was built through a dynamic
     /// subscriber factory.
+    ///
+    /// By default, this logs a warning after [`DEFAULT_PUBLISHER_WARNING_TIMEOUT`] if no sample
+    /// arrives and no publishers are visible for the topic. The warning does not end the receive;
+    /// this method continues waiting for the next message.
     ///
     /// # Errors
     ///
@@ -569,6 +655,9 @@ impl Subscriber<DynamicPayload, DynamicCdrCodec> {
         self.recv_with_metadata().await.map(Received::into_message)
     }
 
+    /// Receive and deserialize the next dynamic message together with metadata.
+    ///
+    /// The publisher warning behavior is the same as [`recv`](Self::recv).
     pub async fn recv_with_metadata(&self) -> Result<Received<DynamicPayload>> {
         let schema = self.dyn_schema.as_ref().ok_or_else(|| {
             crate::error::WireError::MissingDynamicSchema {
@@ -576,7 +665,13 @@ impl Subscriber<DynamicPayload, DynamicCdrCodec> {
             }
         })?;
 
-        let sample = self.queue.recv_async().await;
+        let sample = recv_sample_with_publisher_warning(
+            &self.queue,
+            &self.graph,
+            &self.entity,
+            self.publisher_warning_timeout,
+        )
+        .await;
         let payload = sample.payload().to_bytes();
 
         let message = DynamicCdrCodec::deserialize((&payload, schema))

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -1,4 +1,9 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::{
+    io,
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use ros_z::{
     Message,
@@ -13,10 +18,52 @@ use ros_z::{
 use ros_z_schema::{SchemaBundle, StructDef, TypeDef, TypeDefinition, TypeDefinitions, TypeName};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use tracing_subscriber::fmt::MakeWriter;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Message)]
 struct TestMessage {
     data: Vec<u8>,
     counter: u64,
+}
+
+#[derive(Clone, Default)]
+struct CapturedLogs {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CapturedLogs {
+    fn contents(&self) -> String {
+        let buffer = self.buffer.lock().expect("captured log buffer poisoned");
+        String::from_utf8_lossy(&buffer).into_owned()
+    }
+}
+
+struct CapturedLogWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl io::Write for CapturedLogWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.buffer
+            .lock()
+            .expect("captured log buffer poisoned")
+            .extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'writer> MakeWriter<'writer> for CapturedLogs {
+    type Writer = CapturedLogWriter;
+
+    fn make_writer(&'writer self) -> Self::Writer {
+        CapturedLogWriter {
+            buffer: Arc::clone(&self.buffer),
+        }
+    }
 }
 
 fn topic_key_expr_for<T: Message>(node: &ros_z::node::Node, topic: &str) -> String {
@@ -163,6 +210,116 @@ async fn raw_subscriber_receives_sample_payload() -> zenoh::Result<()> {
 
     let sample = tokio::time::timeout(Duration::from_secs(1), subscriber.recv()).await??;
     assert!(!sample.payload().to_bytes().is_empty());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn raw_recv_warning_timeout_still_waits_for_eventual_sample() -> ros_z::Result<()> {
+    let context = ContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_json("connect/endpoints", json!([]))
+        .build()
+        .await?;
+    let node = context
+        .create_node("recv_warning_timeout_raw")
+        .build()
+        .await?;
+    let topic = "/recv_warning_timeout_raw";
+    let mut subscriber = node
+        .subscriber::<TestMessage>(topic)
+        .raw()
+        .publisher_warning_timeout(Duration::from_millis(25))
+        .build()
+        .await?;
+
+    let receive_task = tokio::spawn(async move { subscriber.recv().await });
+    tokio::time::sleep(Duration::from_millis(75)).await;
+
+    let publisher = node.publisher::<TestMessage>(topic).build().await?;
+    assert!(
+        publisher
+            .wait_for_subscribers(1, Duration::from_secs(1))
+            .await
+    );
+
+    publisher
+        .publish(&TestMessage {
+            data: vec![2, 1],
+            counter: 21,
+        })
+        .await?;
+
+    let sample = tokio::time::timeout(Duration::from_secs(1), receive_task)
+        .await
+        .expect("raw receive task should complete")
+        .expect("raw receive task should not panic")?;
+    assert!(!sample.payload().to_bytes().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn recv_warning_timeout_logs_when_no_publishers_are_visible() -> ros_z::Result<()> {
+    let captured_logs = CapturedLogs::default();
+    let log_subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .without_time()
+        .with_writer(captured_logs.clone())
+        .finish();
+    let _log_guard = tracing::subscriber::set_default(log_subscriber);
+
+    let context = ContextBuilder::default()
+        .disable_multicast_scouting()
+        .with_json("connect/endpoints", json!([]))
+        .build()
+        .await?;
+    let node = context
+        .create_node("recv_warning_timeout_logs")
+        .build()
+        .await?;
+    let topic = "/recv_warning_timeout_logs";
+    let subscriber = node
+        .subscriber::<TestMessage>(topic)
+        .publisher_warning_timeout(Duration::from_millis(25))
+        .build()
+        .await?;
+    let message = TestMessage {
+        data: vec![3, 4, 5],
+        counter: 345,
+    };
+    let expected_message = message.clone();
+
+    let publish_later = async {
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        let publisher = node.publisher::<TestMessage>(topic).build().await?;
+        assert!(
+            publisher
+                .wait_for_subscribers(1, Duration::from_secs(1))
+                .await
+        );
+        publisher.publish(&message).await
+    };
+    let receive = async {
+        tokio::time::timeout(Duration::from_secs(1), subscriber.recv())
+            .await
+            .expect("receive should complete")
+    };
+
+    let (publish_result, received) = tokio::join!(publish_later, receive);
+    publish_result?;
+    assert_eq!(received?, expected_message);
+
+    let logs = captured_logs.contents();
+    assert!(
+        logs.contains(topic),
+        "warning should include topic; captured logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("no message received and no publishers are visible"),
+        "warning should describe missing publishers; captured logs:\n{logs}"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add a default 5s receive warning timeout for typed, dynamic, raw, and cache subscribers
- add builder controls to configure or disable the warning, including cache builders for both default and custom stamp modes
- keep recv semantics unchanged: after the timeout, check visible publishers through `GraphView`, warn only if none are visible, then keep waiting
- document the warning behavior and public controls

## Testing
- keep behavioral coverage focused on typed/raw `recv()` continuing after the warning timeout path
- omit structural/private-field builder tests for warning option plumbing

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo check -p ros-z`
- [x] `cargo nextest run -p ros-z recv_warning_timeout_still_waits_for_eventual_typed_message raw_recv_warning_timeout_still_waits_for_eventual_sample --no-fail-fast`
- [x] `cargo test -p ros-z --doc`
- [x] `cargo nextest run -p ros-z --no-fail-fast`