### PR TITLE
warn on endpoint type mismatch

### DIFF
--- a/crates/ros-z/src/dynamic/schema_service.rs
+++ b/crates/ros-z/src/dynamic/schema_service.rs
@@ -14,6 +14,7 @@ use crate::ServiceTypeInfo;
 use crate::attachment::Attachment;
 use crate::context::GlobalCounter;
 use crate::entity::{EndpointEntity, EndpointKind, NodeEntity, SchemaHash, TypeInfo};
+use crate::graph::Graph;
 use crate::message::{SerdeCdrCodec, Service, WireDecoder, WireEncoder};
 use crate::schema::{MessageSchema, SchemaBuilder};
 use crate::service::{ServiceServer, ServiceServerBuilder};
@@ -272,6 +273,7 @@ fn schema_service_server_builder(
     node: SchemaServiceNodeIdentity<'_>,
     counter: &GlobalCounter,
     clock: &Clock,
+    graph: Arc<Graph>,
 ) -> ServiceServerBuilder<GetSchema> {
     let service_name = "~get_schema";
 
@@ -295,6 +297,7 @@ fn schema_service_server_builder(
         entity,
         session,
         clock: clock.clone(),
+        graph,
         _phantom_data: Default::default(),
     }
 }
@@ -305,9 +308,10 @@ impl SchemaService {
         node: SchemaServiceNodeIdentity<'_>,
         counter: &GlobalCounter,
         clock: &Clock,
+        graph: Arc<Graph>,
     ) -> ZResult<Self> {
         let schemas: Arc<RwLock<SchemaRegistry>> = Arc::new(RwLock::new(HashMap::new()));
-        let server_builder = schema_service_server_builder(session, node, counter, clock);
+        let server_builder = schema_service_server_builder(session, node, counter, clock, graph);
 
         let schemas_clone = Arc::clone(&schemas);
         let server = server_builder

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -178,4 +178,139 @@ impl Graph {
 
         diagnostics
     }
+    pub(crate) fn type_incompatible_endpoints_for(
+        &self,
+        endpoint: &EndpointEntity,
+    ) -> Vec<EndpointEntity> {
+        self.view()
+            .endpoints()
+            .filter(|candidate| {
+                candidate.topic == endpoint.topic && candidate.type_info != endpoint.type_info
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Error, Result,
+        entity::{Entity, NodeEntity, SchemaHash, TypeInfo},
+    };
+
+    use super::*;
+
+    fn endpoint(
+        node: NodeEntity,
+        id: usize,
+        kind: EndpointKind,
+        topic: &str,
+        type_name: &str,
+    ) -> EndpointEntity {
+        EndpointEntity {
+            id,
+            node,
+            kind,
+            topic: topic.to_string(),
+            type_info: TypeInfo::new(type_name, SchemaHash::zero()),
+            qos: Default::default(),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn type_incompatible_endpoints_for_returns_visible_type_mismatches_for_all_endpoint_kinds()
+    -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Graph::new(&session).await?;
+        let node = NodeEntity::new(
+            session.zid(),
+            61,
+            "type_mismatch_node".to_string(),
+            String::new(),
+        );
+        let publisher = endpoint(
+            node.clone(),
+            62,
+            EndpointKind::Publisher,
+            "/type_mismatch_topic",
+            "std_msgs::String",
+        );
+        let incompatible_subscription = endpoint(
+            node.clone(),
+            63,
+            EndpointKind::Subscription,
+            "/type_mismatch_topic",
+            "std_msgs::Int32",
+        );
+        let compatible_subscription = endpoint(
+            node.clone(),
+            64,
+            EndpointKind::Subscription,
+            "/type_mismatch_topic",
+            "std_msgs::String",
+        );
+        let different_topic_subscription = endpoint(
+            node,
+            65,
+            EndpointKind::Subscription,
+            "/other_type_mismatch_topic",
+            "std_msgs::Float32",
+        );
+        let incompatible_publisher = endpoint(
+            publisher.node.clone(),
+            66,
+            EndpointKind::Publisher,
+            "/type_mismatch_topic",
+            "std_msgs::Bool",
+        );
+        let incompatible_service = endpoint(
+            publisher.node.clone(),
+            67,
+            EndpointKind::Service,
+            "/type_mismatch_topic",
+            "test_msgs::Service",
+        );
+        let incompatible_client = endpoint(
+            publisher.node.clone(),
+            68,
+            EndpointKind::Client,
+            "/type_mismatch_topic",
+            "test_msgs::Client",
+        );
+
+        graph.add_local_entity(Entity::Endpoint(publisher.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(incompatible_subscription.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(compatible_subscription.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(different_topic_subscription))?;
+        graph.add_local_entity(Entity::Endpoint(incompatible_publisher.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(incompatible_service.clone()))?;
+        graph.add_local_entity(Entity::Endpoint(incompatible_client.clone()))?;
+
+        let incompatible_endpoints = graph.type_incompatible_endpoints_for(&publisher);
+
+        assert_eq!(incompatible_endpoints.len(), 4);
+        assert!(incompatible_endpoints.contains(&incompatible_subscription));
+        assert!(incompatible_endpoints.contains(&incompatible_publisher));
+        assert!(incompatible_endpoints.contains(&incompatible_service));
+        assert!(incompatible_endpoints.contains(&incompatible_client));
+
+        let service_incompatible_endpoints =
+            graph.type_incompatible_endpoints_for(&incompatible_service);
+
+        assert_eq!(service_incompatible_endpoints.len(), 5);
+        assert!(service_incompatible_endpoints.contains(&publisher));
+        assert!(service_incompatible_endpoints.contains(&incompatible_subscription));
+        assert!(service_incompatible_endpoints.contains(&compatible_subscription));
+        assert!(service_incompatible_endpoints.contains(&incompatible_publisher));
+        assert!(service_incompatible_endpoints.contains(&incompatible_client));
+
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
 }

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -191,6 +191,7 @@ impl NodeBuilder {
                 },
                 &self.counter,
                 &self.clock,
+                self.graph.clone(),
             )
             .await
             .map_err(|source| Error::zenoh("create schema service", source))?;
@@ -442,6 +443,7 @@ impl Node {
             entity,
             session: self.session.clone(),
             clock: self.clock.clone(),
+            graph: self.graph.clone(),
             _phantom_data: Default::default(),
         }
     }
@@ -490,6 +492,7 @@ impl Node {
             entity,
             session: self.session.clone(),
             clock: self.clock.clone(),
+            graph: self.graph.clone(),
             _phantom_data: Default::default(),
         }
     }

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -298,6 +298,22 @@ where
         ))
     }
 
+    fn warn_about_incompatible_endpoints(&self) {
+        for endpoint in self.graph.type_incompatible_endpoints_for(&self.entity) {
+            warn!(
+                topic = %self.entity.topic,
+                publisher_node = %self.entity.node.fully_qualified_name(),
+                publisher_type = %self.entity.type_info.name,
+                publisher_schema_hash = %self.entity.type_info.hash,
+                endpoint_kind = ?endpoint.kind,
+                endpoint_node = %endpoint.node.fully_qualified_name(),
+                endpoint_type = %endpoint.type_info.name,
+                endpoint_schema_hash = %endpoint.type_info.hash,
+                "[PUB] endpoint type metadata does not match publisher"
+            );
+        }
+    }
+
     async fn build_inner_async(mut self) -> Result<Publisher<T, C>> {
         let (key_expr, topic_key_expr, transient_local_cache, endpoint_global_id) =
             self.prepare_build()?;
@@ -344,6 +360,7 @@ where
             .map_err(|source| crate::Error::zenoh("declare publisher liveliness token", source))?;
         let encoding = Arc::new(Encoding::cdr().to_zenoh_encoding());
         debug!("[PUB] Using encoding: {}", encoding);
+        self.warn_about_incompatible_endpoints();
 
         Ok(Publisher {
             entity: self.entity,

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -168,7 +168,25 @@ where
             )
             .await?;
 
+        self.warn_about_incompatible_endpoints("RAW_SUB");
+
         Ok(raw::RawSubscriber::new(queue, resources))
+    }
+
+    fn warn_about_incompatible_endpoints(&self, log_prefix: &str) {
+        for endpoint in self.graph.type_incompatible_endpoints_for(&self.entity) {
+            warn!(
+                topic = %self.entity.topic,
+                subscriber_node = %self.entity.node.fully_qualified_name(),
+                subscriber_type = %self.entity.type_info.name,
+                subscriber_schema_hash = %self.entity.type_info.hash,
+                endpoint_kind = ?endpoint.kind,
+                endpoint_node = %endpoint.node.fully_qualified_name(),
+                endpoint_type = %endpoint.type_info.name,
+                endpoint_schema_hash = %endpoint.type_info.hash,
+                "[{log_prefix}] endpoint type metadata does not match subscriber"
+            );
+        }
     }
 
     async fn build_subscriber_resources<F>(
@@ -323,6 +341,8 @@ where
                 "SUB",
             )
             .await?;
+
+        builder.warn_about_incompatible_endpoints("SUB");
 
         let entity = builder.entity;
 

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -17,6 +17,7 @@ use crate::{Error, Result, error::WireError, topic_name};
 use crate::{
     attachment::{Attachment, EndpointGlobalId},
     entity::EndpointEntity,
+    graph::Graph,
     message::{Message, Service, WireDecoder, WireEncoder},
     qos::QosProfile,
     queue::BoundedQueue,
@@ -28,6 +29,7 @@ pub struct ServiceClientBuilder<T> {
     pub(crate) entity: EndpointEntity,
     pub(crate) session: Session,
     pub(crate) clock: Clock,
+    pub(crate) graph: Arc<Graph>,
     pub(crate) _phantom_data: PhantomData<T>,
 }
 
@@ -109,6 +111,7 @@ where
             .map_err(|source| {
                 crate::Error::zenoh("declare service client liveliness token", source)
             })?;
+        self.warn_about_incompatible_endpoints();
         debug!("[CLN] Client ready: service={}", self.entity.topic);
 
         Ok(ServiceClient {
@@ -120,6 +123,25 @@ where
             clock: self.clock,
             _phantom_data: Default::default(),
         })
+    }
+
+    fn warn_about_incompatible_endpoints(&self) -> usize {
+        let endpoints = self.graph.type_incompatible_endpoints_for(&self.entity);
+        let count = endpoints.len();
+        for endpoint in endpoints {
+            warn!(
+                service = %self.entity.topic,
+                client_node = %self.entity.node.fully_qualified_name(),
+                client_type = %self.entity.type_info.name,
+                client_schema_hash = %self.entity.type_info.hash,
+                endpoint_kind = ?endpoint.kind,
+                endpoint_node = %endpoint.node.fully_qualified_name(),
+                endpoint_type = %endpoint.type_info.name,
+                endpoint_schema_hash = %endpoint.type_info.hash,
+                "[CLN] endpoint type metadata does not match service client"
+            );
+        }
+        count
     }
 }
 
@@ -341,6 +363,7 @@ pub struct ServiceServerBuilder<T> {
     pub(crate) entity: EndpointEntity,
     pub(crate) session: Session,
     pub(crate) clock: Clock,
+    pub(crate) graph: Arc<Graph>,
     pub(crate) _phantom_data: PhantomData<T>,
 }
 
@@ -491,6 +514,7 @@ where
             .map_err(|source| {
                 crate::Error::zenoh("declare service server liveliness token", source)
             })?;
+        self.warn_about_incompatible_endpoints();
 
         Ok(ServiceServer {
             key_expr,
@@ -518,6 +542,25 @@ where
         let queue = Arc::new(BoundedQueue::new(queue_size));
         self.build_internal(ServiceQueryHandler::Queue(queue.clone()), Some(queue))
             .await
+    }
+
+    fn warn_about_incompatible_endpoints(&self) -> usize {
+        let endpoints = self.graph.type_incompatible_endpoints_for(&self.entity);
+        let count = endpoints.len();
+        for endpoint in endpoints {
+            warn!(
+                service = %self.entity.topic,
+                server_node = %self.entity.node.fully_qualified_name(),
+                server_type = %self.entity.type_info.name,
+                server_schema_hash = %self.entity.type_info.hash,
+                endpoint_kind = ?endpoint.kind,
+                endpoint_node = %endpoint.node.fully_qualified_name(),
+                endpoint_type = %endpoint.type_info.name,
+                endpoint_schema_hash = %endpoint.type_info.hash,
+                "[SRV] endpoint type metadata does not match service server"
+            );
+        }
+        count
     }
 }
 
@@ -769,7 +812,7 @@ mod tests {
     use crate::{
         Message, SerdeCdrCodec, ServiceTypeInfo,
         context::ContextBuilder,
-        entity::TypeInfo,
+        entity::{Entity, TypeInfo},
         message::{Service, WireEncoder},
     };
     use ros_z_schema::ServiceDef;
@@ -808,6 +851,62 @@ mod tests {
                 .expect("test service hash should be static and valid");
             TypeInfo::new(descriptor.type_name.as_str(), hash)
         }
+    }
+
+    struct MultiplyTwoInts;
+
+    impl Service for MultiplyTwoInts {
+        type Request = AddTwoIntsRequest;
+        type Response = AddTwoIntsResponse;
+    }
+
+    impl ServiceTypeInfo for MultiplyTwoInts {
+        fn service_type_info() -> TypeInfo {
+            let descriptor = ServiceDef::new(
+                "test_msgs::MultiplyTwoInts",
+                AddTwoIntsRequest::type_name(),
+                AddTwoIntsResponse::type_name(),
+            )
+            .expect("test service descriptor should be static and valid");
+            let hash = ros_z_schema::compute_hash(&descriptor)
+                .expect("test service hash should be static and valid");
+            TypeInfo::new(descriptor.type_name.as_str(), hash)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn service_builder_warning_helpers_report_same_name_type_mismatches() {
+        let context = ContextBuilder::default()
+            .disable_multicast_scouting()
+            .with_json("connect/endpoints", json!([]))
+            .build()
+            .await
+            .expect("Failed to create context");
+        let node = context
+            .create_node("service_warning_helpers")
+            .without_schema_service()
+            .build()
+            .await
+            .expect("Failed to create node");
+
+        let server_builder = node
+            .create_service_server::<AddTwoInts>("/service_warning_helpers")
+            .expect("service server factory should succeed");
+        let client_builder = node
+            .create_service_client::<MultiplyTwoInts>("/service_warning_helpers")
+            .expect("service client factory should succeed");
+
+        server_builder
+            .graph
+            .add_local_entity(Entity::Endpoint(client_builder.entity.clone()))
+            .expect("client endpoint should be inserted");
+        client_builder
+            .graph
+            .add_local_entity(Entity::Endpoint(server_builder.entity.clone()))
+            .expect("server endpoint should be inserted");
+
+        assert_eq!(server_builder.warn_about_incompatible_endpoints(), 1);
+        assert_eq!(client_builder.warn_about_incompatible_endpoints(), 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
- add a generalized graph helper for endpoint type metadata mismatches
- compare all visible endpoints on the same graph name, including publishers, subscribers, services, and clients
- warn when a publisher, subscriber, service server, or service client starts and any visible endpoint on that name advertises a different type name or schema hash
- keep the warnings non-fatal

## How to Test
- Start a ros-z publisher, subscriber, service server, or service client for a graph name with one advertised type.
- Start another visible endpoint on the same graph name with a different advertised type.
- Confirm the endpoint still starts, but logs a warning that includes the local endpoint metadata and mismatching endpoint metadata.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p ros-z`
- `cargo test -p ros-z --doc`