### PR TITLE
refactor(ros-z): move entity helpers to protocol

### DIFF
--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -50,6 +50,21 @@ impl Display for TopicKE {
     }
 }
 
+/// Namespace/name key used to index graph entities by node.
+pub type NodeKey = (String, String);
+
+/// Normalize a node namespace for internal graph indexing.
+///
+/// The root namespace (`"/"`) is stored as an empty string so local and remote
+/// entities use the same key representation.
+pub fn normalize_node_namespace(namespace: &str) -> String {
+    if namespace == "/" {
+        String::new()
+    } else {
+        namespace.to_owned()
+    }
+}
+
 /// ros-z node entity.
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub struct NodeEntity {
@@ -71,6 +86,24 @@ impl NodeEntity {
 
     pub fn fully_qualified_name(&self) -> String {
         fully_qualified_node_name(&self.namespace, &self.name)
+    }
+
+    /// Return this node's namespace in the graph-index representation.
+    pub fn normalized_namespace(&self) -> String {
+        normalize_node_namespace(&self.namespace)
+    }
+
+    /// Return the graph index key for this node.
+    pub fn key(&self) -> NodeKey {
+        (self.normalized_namespace(), self.name.clone())
+    }
+
+    /// Convert this node into its native ros-z liveliness key expression.
+    ///
+    /// This remains fallible because Zenoh validates key-expression syntax and
+    /// `NodeEntity` can contain arbitrary names/namespaces.
+    pub fn liveliness_key_expr(&self) -> crate::Result<LivelinessKE> {
+        crate::format::node_liveliness_key_expr(self)
     }
 }
 
@@ -209,6 +242,14 @@ impl EndpointEntity {
     pub fn entity_kind(&self) -> EntityKind {
         self.kind.into()
     }
+
+    /// Convert this endpoint into its native ros-z liveliness key expression.
+    ///
+    /// This remains fallible because Zenoh validates key-expression syntax and
+    /// endpoint names, topics, and type names are represented as strings.
+    pub fn liveliness_key_expr(&self) -> crate::Result<LivelinessKE> {
+        crate::format::liveliness_key_expr(self, &self.node.z_id)
+    }
 }
 
 /// Generic ros-z entity (node or endpoint).
@@ -216,6 +257,32 @@ impl EndpointEntity {
 pub enum Entity {
     Node(NodeEntity),
     Endpoint(EndpointEntity),
+}
+
+impl Entity {
+    /// Return the semantic kind of this entity.
+    pub fn kind(&self) -> EntityKind {
+        match self {
+            Entity::Node(_) => EntityKind::Node,
+            Entity::Endpoint(endpoint) => endpoint.entity_kind(),
+        }
+    }
+
+    /// Return the endpoint payload when this entity is an endpoint.
+    pub fn as_endpoint(&self) -> Option<&EndpointEntity> {
+        match self {
+            Entity::Node(_) => None,
+            Entity::Endpoint(endpoint) => Some(endpoint),
+        }
+    }
+
+    /// Convert this entity into its native ros-z liveliness key expression.
+    pub fn liveliness_key_expr(&self) -> crate::Result<LivelinessKE> {
+        match self {
+            Entity::Node(node) => node.liveliness_key_expr(),
+            Entity::Endpoint(endpoint) => endpoint.liveliness_key_expr(),
+        }
+    }
 }
 
 /// Errors during entity conversion.
@@ -251,7 +318,11 @@ pub enum EntityConversionError {
 
 #[cfg(test)]
 mod tests {
-    use super::NodeEntity;
+    use super::{
+        EndpointEntity, EndpointKind, Entity, EntityKind, NodeEntity, SchemaHash, TypeInfo,
+        normalize_node_namespace,
+    };
+    use crate::qos::QosProfile;
 
     fn node(namespace: &str) -> NodeEntity {
         NodeEntity::new(
@@ -260,6 +331,17 @@ mod tests {
             "node".to_string(),
             namespace.to_string(),
         )
+    }
+
+    fn endpoint(kind: EndpointKind) -> EndpointEntity {
+        EndpointEntity {
+            id: 2,
+            node: node("/robot"),
+            kind,
+            topic: "/topic".to_string(),
+            type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
+            qos: QosProfile::default(),
+        }
     }
 
     #[test]
@@ -280,5 +362,72 @@ mod tests {
     #[test]
     fn fully_qualified_name_prefixes_bare_namespace() {
         assert_eq!(node("robot").fully_qualified_name(), "/robot/node");
+    }
+
+    #[test]
+    fn normalize_node_namespace_formats_root_as_empty() {
+        assert_eq!(normalize_node_namespace("/"), "");
+    }
+
+    #[test]
+    fn normalize_node_namespace_keeps_non_root_namespace() {
+        assert_eq!(normalize_node_namespace("/robot"), "/robot");
+    }
+
+    #[test]
+    fn node_key_uses_normalized_namespace_and_name() {
+        assert_eq!(node("/").key(), ("".to_string(), "node".to_string()));
+        assert_eq!(
+            node("/robot").key(),
+            ("/robot".to_string(), "node".to_string())
+        );
+    }
+
+    #[test]
+    fn entity_kind_returns_node_for_node_entity() {
+        assert_eq!(Entity::Node(node("/")).kind(), EntityKind::Node);
+    }
+
+    #[test]
+    fn entity_kind_returns_endpoint_kind_for_endpoint_entity() {
+        assert_eq!(
+            Entity::Endpoint(endpoint(EndpointKind::Publisher)).kind(),
+            EntityKind::Publisher
+        );
+        assert_eq!(
+            Entity::Endpoint(endpoint(EndpointKind::Subscription)).kind(),
+            EntityKind::Subscription
+        );
+    }
+
+    #[test]
+    fn entity_as_endpoint_projects_endpoint_variant() {
+        let endpoint = endpoint(EndpointKind::Publisher);
+        let entity = Entity::Endpoint(endpoint.clone());
+
+        assert_eq!(entity.as_endpoint(), Some(&endpoint));
+    }
+
+    #[test]
+    fn entity_as_endpoint_returns_none_for_node_variant() {
+        assert!(Entity::Node(node("/")).as_endpoint().is_none());
+    }
+
+    #[test]
+    fn node_liveliness_key_expr_uses_existing_native_format() {
+        let node = node("/robot");
+
+        let key_expr = node.liveliness_key_expr().unwrap().to_string();
+
+        assert_eq!(key_expr, format!("@ros_z/{}/1/1/NN/%robot/node", node.z_id));
+    }
+
+    #[test]
+    fn entity_liveliness_key_expr_delegates_to_variant() {
+        let endpoint = endpoint(EndpointKind::Publisher);
+        let expected = endpoint.liveliness_key_expr().unwrap();
+        let entity = Entity::Endpoint(endpoint);
+
+        assert_eq!(entity.liveliness_key_expr().unwrap(), expected);
     }
 }

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -390,14 +390,17 @@ mod tests {
 
     #[test]
     fn entity_kind_returns_endpoint_kind_for_endpoint_entity() {
-        assert_eq!(
-            Entity::Endpoint(endpoint(EndpointKind::Publisher)).kind(),
-            EntityKind::Publisher
-        );
-        assert_eq!(
-            Entity::Endpoint(endpoint(EndpointKind::Subscription)).kind(),
-            EntityKind::Subscription
-        );
+        for (endpoint_kind, entity_kind) in [
+            (EndpointKind::Publisher, EntityKind::Publisher),
+            (EndpointKind::Subscription, EntityKind::Subscription),
+            (EndpointKind::Service, EntityKind::Service),
+            (EndpointKind::Client, EntityKind::Client),
+        ] {
+            assert_eq!(
+                Entity::Endpoint(endpoint(endpoint_kind)).kind(),
+                entity_kind
+            );
+        }
     }
 
     #[test]

--- a/crates/ros-z/src/entity.rs
+++ b/crates/ros-z/src/entity.rs
@@ -6,47 +6,12 @@
 // Re-export all entity types from ros-z-protocol
 pub use ros_z_protocol::entity::*;
 
-use crate::Result;
 use crate::attachment::EndpointGlobalId;
-
-use zenoh::key_expr::KeyExpr;
 
 // Constants for ros-z-specific functionality
 pub const ADMIN_SPACE: &str = ros_z_protocol::format::ADMIN_SPACE;
 
-// Type aliases
-type NodeName = String;
-type NodeNamespace = String;
-pub type NodeKey = (NodeNamespace, NodeName);
 pub type Topic = String;
-
-// Extension functions for NodeEntity (can't use impl due to orphan rules)
-
-/// Normalize a node namespace for internal storage.
-///
-/// The root namespace (`"/"`) is stored as an empty string so local and remote
-/// entities use the same key representation.
-pub fn normalize_node_namespace(namespace: &str) -> String {
-    if namespace == "/" {
-        String::new()
-    } else {
-        namespace.to_owned()
-    }
-}
-
-/// Get the key for this node (namespace, name)
-pub fn node_key(entity: &NodeEntity) -> NodeKey {
-    (
-        normalize_node_namespace(&entity.namespace),
-        entity.name.clone(),
-    )
-}
-
-/// Get the liveliness token key expression for a node
-pub fn node_lv_token_key_expr(entity: &NodeEntity) -> Result<KeyExpr<'static>> {
-    let key_expr = node_to_liveliness_key_expr(entity)?;
-    Ok(key_expr.0)
-}
 
 // Extension functions for EndpointEntity
 
@@ -60,46 +25,6 @@ pub fn endpoint_global_id(entity: &EndpointEntity) -> EndpointGlobalId {
     let mut endpoint_global_id = [0u8; 16];
     endpoint_global_id.copy_from_slice(&hash[..16]);
     endpoint_global_id
-}
-
-// Helper functions for converting entities to LivelinessKE
-// Note: Can't implement TryFrom due to orphan rules (both types are from ros-z-protocol)
-
-/// Convert a NodeEntity to a LivelinessKE using the default format
-pub fn node_to_liveliness_key_expr(entity: &NodeEntity) -> Result<LivelinessKE> {
-    Ok(ros_z_protocol::format::node_liveliness_key_expr(entity)?)
-}
-
-/// Convert an EndpointEntity to a LivelinessKE using the default format
-pub fn endpoint_to_liveliness_key_expr(entity: &EndpointEntity) -> Result<LivelinessKE> {
-    Ok(ros_z_protocol::format::liveliness_key_expr(
-        entity,
-        &entity.node.z_id,
-    )?)
-}
-
-/// Convert an Entity to a LivelinessKE using the default format
-pub fn entity_to_liveliness_key_expr(entity: &Entity) -> Result<LivelinessKE> {
-    match entity {
-        Entity::Node(n) => node_to_liveliness_key_expr(n),
-        Entity::Endpoint(e) => endpoint_to_liveliness_key_expr(e),
-    }
-}
-
-/// Get the kind of entity
-pub fn entity_kind(entity: &Entity) -> EntityKind {
-    match entity {
-        Entity::Node(_) => EntityKind::Node,
-        Entity::Endpoint(e) => e.entity_kind(),
-    }
-}
-
-/// Get the endpoint entity if this is an endpoint
-pub fn entity_get_endpoint(entity: &Entity) -> Option<&EndpointEntity> {
-    match entity {
-        Entity::Node(_) => None,
-        Entity::Endpoint(e) => Some(e),
-    }
 }
 
 #[cfg(test)]

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -13,7 +13,7 @@ pub use snapshot::{GraphSnapshot, NodeSnapshot, ServiceSnapshot, TopicSnapshot};
 use state::GraphData;
 
 use crate::Result;
-use crate::entity::{ADMIN_SPACE, Entity, entity_to_liveliness_key_expr};
+use crate::entity::{ADMIN_SPACE, Entity};
 use zenoh::{Session, pubsub::Subscriber, session::ZenohId};
 
 #[derive(Debug, Clone)]
@@ -89,7 +89,7 @@ impl Graph {
     /// This is used to make local publishers/subscriptions/services/clients
     /// immediately visible in graph queries without waiting for Zenoh liveliness propagation
     pub fn add_local_entity(&self, entity: Entity) -> Result<()> {
-        let key_expr = entity_to_liveliness_key_expr(&entity)?;
+        let key_expr = entity.liveliness_key_expr()?;
         self.data.lock().insert(key_expr, entity);
         self.change_notify.notify_waiters();
         Ok(())
@@ -97,7 +97,7 @@ impl Graph {
 
     /// Remove a local entity from the graph
     pub fn remove_local_entity(&self, entity: &Entity) -> Result<()> {
-        let key_expr = entity_to_liveliness_key_expr(entity)?;
+        let key_expr = entity.liveliness_key_expr()?;
         if self.data.lock().remove(&key_expr) {
             self.change_notify.notify_waiters();
         }

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use parking_lot::MutexGuard;
 
-use crate::entity::{EndpointEntity, EndpointKind, Entity, NodeEntity, NodeKey, node_key};
+use crate::entity::{EndpointEntity, EndpointKind, Entity, NodeEntity, NodeKey};
 use crate::qos::{QosCompatibility, QosProfile};
 
 use super::{Graph, state::GraphData};
@@ -71,15 +71,15 @@ impl GraphView<'_> {
 
     pub fn endpoints_for_node(&self, node: NodeKey) -> Vec<EndpointEntity> {
         self.endpoints()
-            .filter(|endpoint| node_key(&endpoint.node) == node)
+            .filter(|endpoint| endpoint.node.key() == node)
             .cloned()
             .collect()
     }
 
     pub fn node_exists(&self, node: &NodeKey) -> bool {
         self.entities().any(|entity| match entity {
-            Entity::Node(node_entity) => node_key(node_entity) == *node,
-            Entity::Endpoint(endpoint) => node_key(&endpoint.node) == *node,
+            Entity::Node(node_entity) => node_entity.key() == *node,
+            Entity::Endpoint(endpoint) => endpoint.node.key() == *node,
         })
     }
 

--- a/crates/ros-z/src/graph/state.rs
+++ b/crates/ros-z/src/graph/state.rs
@@ -29,10 +29,7 @@ impl GraphData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::entity::{
-        EndpointEntity, EndpointKind, NodeEntity, SchemaHash, TypeInfo,
-        entity_to_liveliness_key_expr,
-    };
+    use crate::entity::{EndpointEntity, EndpointKind, NodeEntity, SchemaHash, TypeInfo};
     use zenoh::session::ZenohId;
 
     fn node(name: &str) -> NodeEntity {
@@ -51,7 +48,9 @@ mod tests {
     }
 
     fn key_for(entity: &Entity) -> LivelinessKE {
-        entity_to_liveliness_key_expr(entity).expect("test entity should format as liveliness key")
+        entity
+            .liveliness_key_expr()
+            .expect("test entity should format as liveliness key")
     }
 
     #[test]

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -169,7 +169,7 @@ impl NodeBuilder {
             self.name.clone(),
             self.namespace.clone(),
         );
-        let liveliness_token_key_expr = node_lv_token_key_expr(&node)?;
+        let liveliness_token_key_expr = node.liveliness_key_expr()?.0;
         debug!("[NOD] Liveliness token KE: {}", liveliness_token_key_expr);
 
         let lv_token = self

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -335,12 +335,11 @@ where
             .map_err(|source| crate::Error::zenoh("declare publisher", source))?;
         debug!("[PUB] Publisher ready: topic={}", self.entity.topic);
 
-        let liveliness_key_expr =
-            ros_z_protocol::format::liveliness_key_expr(&self.entity, &self.session.zid())?;
+        let liveliness_key_expr = self.entity.liveliness_key_expr()?.0;
         let lv_token = self
             .session
             .liveliness()
-            .declare_token((*liveliness_key_expr).clone())
+            .declare_token(liveliness_key_expr)
             .await
             .map_err(|source| crate::Error::zenoh("declare publisher liveliness token", source))?;
         let encoding = Arc::new(Encoding::cdr().to_zenoh_encoding());

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -96,10 +96,10 @@ fn record_queue_push<T>(
 }
 
 async fn declare_liveliness(session: &Session, entity: &EndpointEntity) -> Result<LivelinessToken> {
-    let liveliness_key_expr = ros_z_protocol::format::liveliness_key_expr(entity, &session.zid())?;
+    let liveliness_key_expr = entity.liveliness_key_expr()?.0;
     session
         .liveliness()
-        .declare_token((*liveliness_key_expr).clone())
+        .declare_token(liveliness_key_expr)
         .await
         .map_err(|source| crate::Error::zenoh("declare subscriber liveliness token", source))
 }

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -100,12 +100,11 @@ where
             .consolidation(zenoh::query::ConsolidationMode::None)
             .await
             .map_err(|source| crate::Error::zenoh("declare service querier", source))?;
-        let liveliness_key_expr =
-            ros_z_protocol::format::liveliness_key_expr(&self.entity, &self.session.zid())?;
+        let liveliness_key_expr = self.entity.liveliness_key_expr()?.0;
         let lv_token = self
             .session
             .liveliness()
-            .declare_token((*liveliness_key_expr).clone())
+            .declare_token(liveliness_key_expr)
             .await
             .map_err(|source| {
                 crate::Error::zenoh("declare service client liveliness token", source)
@@ -483,12 +482,11 @@ where
             .await
             .map_err(|source| crate::Error::zenoh("declare service queryable", source))?;
 
-        let liveliness_key_expr =
-            ros_z_protocol::format::liveliness_key_expr(&self.entity, &self.session.zid())?;
+        let liveliness_key_expr = self.entity.liveliness_key_expr()?.0;
         let lv_token = self
             .session
             .liveliness()
-            .declare_token((*liveliness_key_expr).clone())
+            .declare_token(liveliness_key_expr)
             .await
             .map_err(|source| {
                 crate::Error::zenoh("declare service server liveliness token", source)

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -283,12 +283,9 @@ mod tests {
             vec![service_endpoint.clone()]
         );
         assert_eq!(view.clients_named(&service), vec![client_endpoint]);
-        assert_eq!(
-            view.endpoints_for_node(ros_z::entity::node_key(&node))
-                .len(),
-            4
-        );
-        assert!(view.node_exists(&ros_z::entity::node_key(&node)));
+        let node_key = node.key();
+        assert_eq!(view.endpoints_for_node(node_key.clone()).len(), 4);
+        assert!(view.node_exists(&node_key));
         assert!(
             view.topic_names_and_types()
                 .contains(&(topic, "std_msgs::String".to_string()))
@@ -459,7 +456,7 @@ mod tests {
             unique_node_name("endpoint_only_node"),
             String::new(),
         );
-        let node_key = ros_z::entity::node_key(&node);
+        let node_key = node.key();
 
         graph.add_local_entity(Entity::Endpoint(EndpointEntity {
             id: 3,

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -431,7 +431,7 @@ mod tests {
         let session = zenoh::open(zenoh::Config::default()).await?;
         let graph = ros_z::graph::Graph::new(&session).await?;
         let node = NodeEntity::new(session.zid(), 1, "removed_node".to_string(), String::new());
-        let node_key = ros_z::entity::node_key(&node);
+        let node_key = node.key();
         let entity = Entity::Node(node);
 
         graph.add_local_entity(entity.clone())?;

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -430,7 +430,12 @@ mod tests {
     async fn node_exists_returns_false_after_only_node_removed() -> Result<()> {
         let session = zenoh::open(zenoh::Config::default()).await?;
         let graph = ros_z::graph::Graph::new(&session).await?;
-        let node = NodeEntity::new(session.zid(), 1, "removed_node".to_string(), String::new());
+        let node = NodeEntity::new(
+            session.zid(),
+            1,
+            "removed_node".to_string(),
+            "/".to_string(),
+        );
         let node_key = node.key();
         let entity = Entity::Node(node);
 


### PR DESCRIPTION
## Summary
- Move protocol-owned entity helpers onto `ros-z-protocol` entity types.
- Replace `ros-z` graph/node/pubsub/service free-function call sites with entity methods.
- Keep `EndpointGlobalId` in `ros-z` for a separate follow-up cleanup.

## How to Test
- `cargo fmt --check`
- `cargo check -p ros-z-protocol`
- `cargo check -p ros-z`
- `cargo nextest run -p ros-z-protocol key_expr`
- `cargo nextest run -p ros-z-protocol entity::tests`
- `cargo nextest run -p ros-z graph`
