### PR TITLE
refactor(ros-z): move endpoint global id to protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9372,7 +9372,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9438,6 +9437,8 @@ name = "ros-z-protocol"
 version = "0.1.0"
 dependencies = [
  "ros-z-schema",
+ "serde",
+ "sha2",
  "thiserror 2.0.18",
  "zenoh",
 ]

--- a/crates/ros-z-debug/src/history.rs
+++ b/crates/ros-z-debug/src/history.rs
@@ -135,7 +135,7 @@ mod tests {
             transport_time: None,
             source_time: Time::zero(),
             sequence_number: 1,
-            source_global_id: [7; 16],
+            source_global_id: ros_z::EndpointGlobalId::from([7; 16]),
         }
         .publication_id()
     }

--- a/crates/ros-z-debug/src/subscription.rs
+++ b/crates/ros-z-debug/src/subscription.rs
@@ -270,7 +270,7 @@ mod tests {
             transport_time: None,
             source_time: Time::zero(),
             sequence_number: 1,
-            source_global_id: [7; 16],
+            source_global_id: ros_z::EndpointGlobalId::from([7; 16]),
         }
         .publication_id()
     }

--- a/crates/ros-z-protocol/Cargo.toml
+++ b/crates/ros-z-protocol/Cargo.toml
@@ -7,6 +7,8 @@ homepage.workspace = true
 
 [dependencies]
 ros-z-schema = { workspace = true }
+serde = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 zenoh = { workspace = true }
 

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -2,6 +2,7 @@
 
 use core::{fmt::Display, ops::Deref};
 pub use ros_z_schema::SchemaHash;
+use serde::{Deserialize, Serialize};
 use std::string::String;
 use zenoh::{key_expr::KeyExpr, session::ZenohId};
 
@@ -47,6 +48,50 @@ impl Deref for TopicKE {
 impl Display for TopicKE {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// Number of bytes in an endpoint global identifier.
+pub const ENDPOINT_GLOBAL_ID_SIZE: usize = 16;
+
+/// Stable protocol-visible identifier for a ros-z endpoint.
+///
+/// Use `EndpointGlobalId::from(&endpoint)` to derive the identifier from an
+/// [`EndpointEntity`]. Use [`EndpointGlobalId::as_bytes`] or
+/// [`EndpointGlobalId::into_bytes`] when raw wire-layout bytes are needed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EndpointGlobalId([u8; ENDPOINT_GLOBAL_ID_SIZE]);
+
+impl EndpointGlobalId {
+    /// All-zero endpoint identifier.
+    pub const ZERO: Self = Self([0; ENDPOINT_GLOBAL_ID_SIZE]);
+
+    /// Create an endpoint global identifier from its raw bytes.
+    pub fn new(bytes: [u8; ENDPOINT_GLOBAL_ID_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the raw endpoint identifier bytes.
+    pub fn as_bytes(&self) -> &[u8; ENDPOINT_GLOBAL_ID_SIZE] {
+        &self.0
+    }
+
+    /// Return the raw endpoint identifier bytes.
+    pub fn into_bytes(self) -> [u8; ENDPOINT_GLOBAL_ID_SIZE] {
+        self.0
+    }
+}
+
+impl From<[u8; ENDPOINT_GLOBAL_ID_SIZE]> for EndpointGlobalId {
+    fn from(bytes: [u8; ENDPOINT_GLOBAL_ID_SIZE]) -> Self {
+        Self::new(bytes)
+    }
+}
+
+impl From<EndpointGlobalId> for [u8; ENDPOINT_GLOBAL_ID_SIZE] {
+    fn from(value: EndpointGlobalId) -> Self {
+        value.into_bytes()
     }
 }
 
@@ -252,6 +297,20 @@ impl EndpointEntity {
     }
 }
 
+impl From<&EndpointEntity> for EndpointGlobalId {
+    fn from(endpoint: &EndpointEntity) -> Self {
+        use sha2::Digest;
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(endpoint.node.z_id.to_le_bytes());
+        hasher.update((endpoint.id as u64).to_le_bytes());
+        let hash = hasher.finalize();
+        let mut bytes = [0u8; ENDPOINT_GLOBAL_ID_SIZE];
+        bytes.copy_from_slice(&hash[..ENDPOINT_GLOBAL_ID_SIZE]);
+        Self::new(bytes)
+    }
+}
+
 /// Generic ros-z entity (node or endpoint).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Entity {
@@ -319,8 +378,8 @@ pub enum EntityConversionError {
 #[cfg(test)]
 mod tests {
     use super::{
-        EndpointEntity, EndpointKind, Entity, EntityKind, NodeEntity, SchemaHash, TypeInfo,
-        normalize_node_namespace,
+        ENDPOINT_GLOBAL_ID_SIZE, EndpointEntity, EndpointGlobalId, EndpointKind, Entity,
+        EntityKind, NodeEntity, SchemaHash, TypeInfo, normalize_node_namespace,
     };
     use crate::qos::QosProfile;
 
@@ -338,6 +397,17 @@ mod tests {
             id: 2,
             node: node("/robot"),
             kind,
+            topic: "/topic".to_string(),
+            type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
+            qos: QosProfile::default(),
+        }
+    }
+
+    fn endpoint_with_id(id: usize) -> EndpointEntity {
+        EndpointEntity {
+            id,
+            node: node("/robot"),
+            kind: EndpointKind::Publisher,
             topic: "/topic".to_string(),
             type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
             qos: QosProfile::default(),
@@ -432,5 +502,62 @@ mod tests {
         let entity = Entity::Endpoint(endpoint);
 
         assert_eq!(entity.liveliness_key_expr().unwrap(), expected);
+    }
+
+    #[test]
+    fn endpoint_global_id_roundtrips_bytes() {
+        let bytes = [7u8; ENDPOINT_GLOBAL_ID_SIZE];
+
+        let id = EndpointGlobalId::new(bytes);
+
+        assert_eq!(id.as_bytes(), &bytes);
+        assert_eq!(id.into_bytes(), bytes);
+        assert_eq!(EndpointGlobalId::from(bytes).as_bytes(), &bytes);
+        let roundtrip: [u8; ENDPOINT_GLOBAL_ID_SIZE] = EndpointGlobalId::from(bytes).into();
+        assert_eq!(roundtrip, bytes);
+    }
+
+    #[test]
+    fn endpoint_global_id_zero_is_all_zero_bytes() {
+        assert_eq!(
+            EndpointGlobalId::ZERO.as_bytes(),
+            &[0u8; ENDPOINT_GLOBAL_ID_SIZE]
+        );
+    }
+
+    #[test]
+    fn endpoint_global_id_is_stable_for_same_node_zenoh_id_and_endpoint_local_id() {
+        let node = node("/");
+        let endpoint = EndpointEntity {
+            node: node.clone(),
+            ..endpoint_with_id(7)
+        };
+        let matching_endpoint = EndpointEntity {
+            node,
+            ..endpoint_with_id(7)
+        };
+
+        assert_eq!(
+            EndpointGlobalId::from(&endpoint),
+            EndpointGlobalId::from(&matching_endpoint)
+        );
+    }
+
+    #[test]
+    fn endpoint_global_id_changes_when_endpoint_local_id_changes() {
+        let node = node("/");
+        let endpoint = EndpointEntity {
+            node: node.clone(),
+            ..endpoint_with_id(7)
+        };
+        let different_endpoint = EndpointEntity {
+            node,
+            ..endpoint_with_id(8)
+        };
+
+        assert_ne!(
+            EndpointGlobalId::from(&endpoint),
+            EndpointGlobalId::from(&different_endpoint)
+        );
     }
 }

--- a/crates/ros-z-protocol/src/lib.rs
+++ b/crates/ros-z-protocol/src/lib.rs
@@ -34,6 +34,7 @@ pub mod format;
 pub mod qos;
 
 pub use entity::{
-    EndpointEntity, EndpointKind, Entity, EntityKind, NodeEntity, SchemaHash, TypeInfo,
+    ENDPOINT_GLOBAL_ID_SIZE, EndpointEntity, EndpointGlobalId, EndpointKind, Entity, EntityKind,
+    NodeEntity, SchemaHash, TypeInfo,
 };
 pub use error::{ProtocolError, Result};

--- a/crates/ros-z/Cargo.toml
+++ b/crates/ros-z/Cargo.toml
@@ -22,7 +22,6 @@ ros-z-protocol = { workspace = true }
 ros-z-schema = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }

--- a/crates/ros-z/src/attachment.rs
+++ b/crates/ros-z/src/attachment.rs
@@ -3,9 +3,7 @@ use zenoh_ext::{z_deserialize, z_serialize};
 
 use crate::time::{Clock, Time};
 
-const RMW_GID_STORAGE_SIZE: usize = 16;
-
-pub type EndpointGlobalId = [u8; RMW_GID_STORAGE_SIZE];
+pub use ros_z_protocol::entity::{ENDPOINT_GLOBAL_ID_SIZE, EndpointGlobalId};
 
 #[derive(Clone, Hash)]
 pub struct Attachment {
@@ -52,11 +50,11 @@ impl TryFrom<&ZBytes> for Attachment {
     type Error = zenoh::Error;
     fn try_from(value: &ZBytes) -> Result<Self, Self::Error> {
         let (sequence_number, source_timestamp, source_global_id) =
-            z_deserialize::<(i64, i64, EndpointGlobalId)>(value)?;
+            z_deserialize::<(i64, i64, [u8; ENDPOINT_GLOBAL_ID_SIZE])>(value)?;
         Ok(Attachment {
             sequence_number,
             source_timestamp,
-            source_global_id,
+            source_global_id: EndpointGlobalId::from(source_global_id),
         })
     }
 }
@@ -66,7 +64,28 @@ impl From<Attachment> for ZBytes {
         z_serialize(&(
             value.sequence_number,
             value.source_timestamp,
-            value.source_global_id,
+            value.source_global_id.into_bytes(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attachment_roundtrip_preserves_endpoint_global_id_bytes() {
+        let bytes = [0xAB; ENDPOINT_GLOBAL_ID_SIZE];
+        let endpoint_global_id = EndpointGlobalId::from(bytes);
+        let attachment =
+            Attachment::with_source_time(42, endpoint_global_id, Time::from_nanos(123_456));
+
+        let encoded = ZBytes::from(attachment.clone());
+        let decoded = Attachment::try_from(&encoded).unwrap();
+
+        assert_eq!(decoded.sequence_number, 42);
+        assert_eq!(decoded.source_timestamp, 123_456);
+        assert_eq!(decoded.source_global_id, endpoint_global_id);
+        assert_eq!(decoded.source_global_id.as_bytes(), &bytes);
     }
 }

--- a/crates/ros-z/src/entity.rs
+++ b/crates/ros-z/src/entity.rs
@@ -6,73 +6,12 @@
 // Re-export all entity types from ros-z-protocol
 pub use ros_z_protocol::entity::*;
 
-use crate::attachment::EndpointGlobalId;
-
 // Constants for ros-z-specific functionality
 pub const ADMIN_SPACE: &str = ros_z_protocol::format::ADMIN_SPACE;
 
 pub type Topic = String;
 
-// Extension functions for EndpointEntity
-
 /// Get the global identifier for this endpoint.
 pub fn endpoint_global_id(entity: &EndpointEntity) -> EndpointGlobalId {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(entity.node.z_id.to_le_bytes());
-    hasher.update(entity.id.to_le_bytes());
-    let hash = hasher.finalize();
-    let mut endpoint_global_id = [0u8; 16];
-    endpoint_global_id.copy_from_slice(&hash[..16]);
-    endpoint_global_id
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use zenoh::session::ZenohId;
-
-    fn node_entity() -> NodeEntity {
-        NodeEntity {
-            z_id: ZenohId::default(),
-            id: 1,
-            name: "node".to_string(),
-            namespace: "/".to_string(),
-        }
-    }
-
-    fn endpoint_entity(node: NodeEntity, id: usize) -> EndpointEntity {
-        EndpointEntity {
-            id,
-            node,
-            kind: EndpointKind::Publisher,
-            topic: "/topic".to_string(),
-            type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
-            qos: Default::default(),
-        }
-    }
-
-    #[test]
-    fn endpoint_global_id_is_stable_for_same_node_zenoh_id_and_endpoint_local_id() {
-        let node = node_entity();
-        let endpoint = endpoint_entity(node.clone(), 7);
-        let matching_endpoint = endpoint_entity(node, 7);
-
-        assert_eq!(
-            endpoint_global_id(&endpoint),
-            endpoint_global_id(&matching_endpoint)
-        );
-    }
-
-    #[test]
-    fn endpoint_global_id_changes_when_endpoint_local_id_changes() {
-        let node = node_entity();
-        let endpoint = endpoint_entity(node.clone(), 7);
-        let different_endpoint = endpoint_entity(node, 8);
-
-        assert_ne!(
-            endpoint_global_id(&endpoint),
-            endpoint_global_id(&different_endpoint)
-        );
-    }
+    EndpointGlobalId::from(entity)
 }

--- a/crates/ros-z/src/lib.rs
+++ b/crates/ros-z/src/lib.rs
@@ -87,7 +87,7 @@ pub mod zbuf;
 #[macro_use]
 pub mod utils;
 
-pub use attachment::EndpointGlobalId;
+pub use attachment::{ENDPOINT_GLOBAL_ID_SIZE, EndpointGlobalId};
 pub use entity::{SchemaHash, TypeInfo};
 pub use error::{Error, Result};
 pub use message::{Message, SerdeCdrCodec, Service};
@@ -101,5 +101,4 @@ pub use zbuf::ZBuf;
 #[doc(hidden)]
 pub mod __private {
     pub use ros_z_schema;
-    pub use sha2;
 }

--- a/crates/ros-z/src/message.rs
+++ b/crates/ros-z/src/message.rs
@@ -15,6 +15,7 @@ use std::time::{Duration, SystemTime};
 use zenoh::shm::{PosixShmProviderBackend, ShmProvider};
 use zenoh_buffers::ZBuf;
 
+use crate::attachment::{ENDPOINT_GLOBAL_ID_SIZE, EndpointGlobalId};
 use crate::entity::TypeInfo;
 use crate::schema::{MessageSchema, SchemaBuilder};
 use crate::shm::ShmWriter;
@@ -552,6 +553,12 @@ where
             element: Box::new(T::build_schema(builder)?),
             length: SequenceLengthDef::Dynamic,
         })
+    }
+}
+
+impl MessageSchema for EndpointGlobalId {
+    fn build_schema(builder: &mut SchemaBuilder) -> Result<TypeDef, SchemaError> {
+        <[u8; ENDPOINT_GLOBAL_ID_SIZE]>::build_schema(builder)
     }
 }
 

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -118,7 +118,7 @@ mod tests {
             transport_time: None,
             source_time: crate::time::Time::from_nanos(0),
             sequence_number: 1,
-            source_global_id: [0; 16],
+            source_global_id: crate::EndpointGlobalId::ZERO,
         };
 
         assert_eq!(received.len(), 3);

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -13,7 +13,7 @@ use crate::Result;
 use crate::attachment::{Attachment, EndpointGlobalId};
 use crate::dynamic::{DynamicCdrCodec, DynamicPayload, Schema};
 use crate::encoding::Encoding;
-use crate::entity::{EndpointEntity, endpoint_global_id};
+use crate::entity::EndpointEntity;
 use crate::graph::Graph;
 use crate::message::WireEncoder;
 use crate::pubsub::metadata::PublicationId;
@@ -288,7 +288,7 @@ where
 
         let transient_local_cache = replay::transient_local_cache_capacity(&self.entity.qos)
             .map(|capacity| Arc::new(TransientLocalCache::new(capacity)));
-        let endpoint_global_id = endpoint_global_id(&self.entity);
+        let endpoint_global_id = EndpointGlobalId::from(&self.entity);
 
         Ok((
             data_key_expr,
@@ -452,7 +452,7 @@ where
         trace!(
             "[PUB] Creating attachment: sequence_number={}, endpoint_global_id={:02x?}",
             publication_id.sequence_number(),
-            &publication_id.endpoint_global_id()[..4]
+            &publication_id.endpoint_global_id().as_bytes()[..4]
         );
         Attachment::with_clock(
             publication_id.sequence_number(),
@@ -499,7 +499,7 @@ where
     ) -> Result<(zenoh::bytes::ZBytes, Attachment)> {
         tracing::Span::current().record(
             "endpoint_global_id",
-            format_args!("{:02x?}", publication_id.endpoint_global_id()),
+            format_args!("{:02x?}", publication_id.endpoint_global_id().as_bytes()),
         );
         use zenoh_buffers::buffer::Buffer;
 

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -10,7 +10,7 @@ use zenoh::{Session, sample::Sample};
 use super::metadata::{self, PublicationId};
 use crate::Result;
 use crate::attachment::{Attachment, EndpointGlobalId};
-use crate::entity::{EndpointEntity, endpoint_global_id};
+use crate::entity::EndpointEntity;
 use crate::graph::Graph;
 use ros_z_protocol::qos::{QosDurability, QosHistory};
 
@@ -449,6 +449,7 @@ impl TransientLocalCache {
 
 fn format_endpoint_global_id_hex(endpoint_global_id: EndpointGlobalId) -> String {
     endpoint_global_id
+        .as_bytes()
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect()
@@ -588,7 +589,7 @@ fn replay_capable_publisher(endpoint: &EndpointEntity) -> Option<(EndpointGlobal
     let QosHistory::KeepLast(depth) = endpoint.qos.history else {
         return None;
     };
-    Some((endpoint_global_id(endpoint), depth))
+    Some((EndpointGlobalId::from(endpoint), depth))
 }
 
 pub(super) fn replay_capable_publishers(
@@ -683,7 +684,7 @@ mod tests {
     #[test]
     fn replay_window_drops_duplicate_publication_ids() {
         let mut delivered = std::collections::HashSet::new();
-        let id = PublicationId::new([1; 16], 7);
+        let id = PublicationId::new(EndpointGlobalId::from([1; 16]), 7);
 
         assert!(should_deliver_replay_id(&mut delivered, Some(id)));
         assert!(!should_deliver_replay_id(&mut delivered, Some(id)));
@@ -746,8 +747,8 @@ mod tests {
 
     #[test]
     fn initial_replay_plan_seeds_seen_with_only_queried_publishers() {
-        let first_publisher_global_id = [1_u8; 16];
-        let second_publisher_global_id = [2_u8; 16];
+        let first_publisher_global_id = EndpointGlobalId::from([1_u8; 16]);
+        let second_publisher_global_id = EndpointGlobalId::from([2_u8; 16]);
 
         let (publishers, seen) = initial_replay_plan([
             (first_publisher_global_id, 1),
@@ -792,7 +793,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(3, handler));
-        let publisher_global_id = [3_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([3_u8; 16]);
 
         coordinator.finish_initial_replay();
         coordinator.begin_late_publisher(publisher_global_id, 2);
@@ -857,7 +858,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(3, handler));
-        let publication_id = PublicationId::new([3_u8; 16], 7);
+        let publication_id = PublicationId::new(EndpointGlobalId::from([3_u8; 16]), 7);
 
         coordinator.handle_replay(sample_with_publication_id("replay", publication_id), 0);
         coordinator.handle_replay(
@@ -877,7 +878,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(3, handler));
-        let publisher_global_id = [4_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([4_u8; 16]);
 
         coordinator.finish_initial_replay();
         coordinator.begin_late_publisher(publisher_global_id, 3);
@@ -896,7 +897,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = TransientLocalReplayCoordinator::new_for_test(1, handler);
-        let publisher_global_id = [9_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([9_u8; 16]);
         let mut seen = HashSet::from([publisher_global_id]);
 
         let discovered =
@@ -914,7 +915,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(1, handler));
-        let publisher_global_id = [8_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([8_u8; 16]);
 
         coordinator.handle_replay(sample_with_payload("same"), 0);
         coordinator.finish_initial_replay();
@@ -933,7 +934,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(3, handler));
-        let publisher_global_id = [9_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([9_u8; 16]);
 
         coordinator.finish_initial_replay();
         coordinator.begin_late_publisher(publisher_global_id, 3);
@@ -955,7 +956,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(2, handler));
-        let publisher_global_id = [10_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([10_u8; 16]);
 
         coordinator.finish_initial_replay();
         coordinator.begin_late_publisher(publisher_global_id, 2);
@@ -987,7 +988,7 @@ mod tests {
     fn replay_coordinator_keeps_late_window_active_while_draining() {
         let received = Arc::new(ParkingMutex::new(Vec::new()));
         let coordinator_slot = Arc::new(ParkingMutex::new(None));
-        let publisher_global_id = [5_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([5_u8; 16]);
 
         let handler_received = received.clone();
         let handler_coordinator = coordinator_slot.clone();
@@ -1047,7 +1048,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(3, handler));
-        let publisher_global_id = [6_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([6_u8; 16]);
         let publication_id = PublicationId::new(publisher_global_id, 7);
 
         coordinator.finish_initial_replay();
@@ -1081,7 +1082,7 @@ mod tests {
             handler,
             cancelled.clone(),
         ));
-        let publisher_global_id = [7_u8; 16];
+        let publisher_global_id = EndpointGlobalId::from([7_u8; 16]);
 
         coordinator.finish_initial_replay();
         coordinator.begin_late_publisher(publisher_global_id, 3);
@@ -1119,8 +1120,8 @@ mod tests {
         let handler = Arc::new(|_sample: Sample| {});
         let coordinator = TransientLocalReplayCoordinator::new_for_test(3, handler);
         let mut seen = HashSet::new();
-        let first_publisher_global_id = [8_u8; 16];
-        let second_publisher_global_id = [9_u8; 16];
+        let first_publisher_global_id = EndpointGlobalId::from([8_u8; 16]);
+        let second_publisher_global_id = EndpointGlobalId::from([9_u8; 16]);
 
         let discovered = begin_unseen_late_publishers(
             &mut seen,
@@ -1158,7 +1159,7 @@ mod tests {
             handler_received.lock().push(sample_payload(&sample));
         });
         let coordinator = Arc::new(TransientLocalReplayCoordinator::new_for_test(3, handler));
-        let publication_id = PublicationId::new([2_u8; 16], 7);
+        let publication_id = PublicationId::new(EndpointGlobalId::from([2_u8; 16]), 7);
 
         coordinator.handle_replay(sample_with_publication_id("replay", publication_id), 0);
         coordinator.finish_initial_replay();

--- a/crates/ros-z/src/service.rs
+++ b/crates/ros-z/src/service.rs
@@ -16,7 +16,7 @@ use crate::{Error, Result, error::WireError, topic_name};
 
 use crate::{
     attachment::{Attachment, EndpointGlobalId},
-    entity::{EndpointEntity, endpoint_global_id},
+    entity::EndpointEntity,
     message::{Message, Service, WireDecoder, WireEncoder},
     qos::QosProfile,
     queue::BoundedQueue,
@@ -115,7 +115,7 @@ where
             sequence_number: AtomicUsize::new(1), // Start at 1; zero is reserved for missing sequence values.
             inner,
             _lv_token: lv_token,
-            endpoint_global_id: endpoint_global_id(&self.entity),
+            endpoint_global_id: EndpointGlobalId::from(&self.entity),
             topic: self.entity.topic,
             clock: self.clock,
             _phantom_data: Default::default(),

--- a/crates/ros-z/tests/communication_pubsub_alignment.rs
+++ b/crates/ros-z/tests/communication_pubsub_alignment.rs
@@ -105,7 +105,7 @@ async fn publisher_direct_publish_attaches_publication_id() {
 
     assert_eq!(received.message(), &message);
     assert!(
-        received.publication_id().endpoint_global_id() != [0; 16],
+        received.publication_id().endpoint_global_id() != ros_z::EndpointGlobalId::ZERO,
         "direct publish should still carry a publication id"
     );
 }

--- a/crates/ros-z/tests/message_api.rs
+++ b/crates/ros-z/tests/message_api.rs
@@ -1,7 +1,9 @@
-use ros_z::Message;
 use ros_z::message::{SerdeCdrCodec, WireDecoder, WireEncoder};
 use ros_z::schema::{MessageSchema, SchemaBuilder};
-use ros_z_schema::{SchemaError, TypeDef, TypeDefinition, TypeName};
+use ros_z::{ENDPOINT_GLOBAL_ID_SIZE, EndpointGlobalId, Message};
+use ros_z_schema::{
+    PrimitiveTypeDef, SchemaError, SequenceLengthDef, TypeDef, TypeDefinition, TypeName,
+};
 use serde::{Deserialize, Serialize};
 use zenoh_buffers::buffer::SplitBuffer;
 
@@ -180,6 +182,24 @@ fn fixed_arrays_are_fixed_sequences() {
         panic!("expected sequence schema");
     };
     assert_eq!(length, ros_z_schema::SequenceLengthDef::Fixed(16));
+}
+
+#[test]
+fn endpoint_global_id_schema_is_fixed_u8_sequence() {
+    // The public ros_z re-export should expose the semantic ID API and schema.
+    assert_eq!(
+        EndpointGlobalId::ZERO.as_bytes(),
+        &[0u8; ENDPOINT_GLOBAL_ID_SIZE]
+    );
+
+    let mut builder = SchemaBuilder::new();
+    let schema = EndpointGlobalId::build_schema(&mut builder).unwrap();
+
+    let TypeDef::Sequence { element, length } = schema else {
+        panic!("expected sequence schema");
+    };
+    assert_eq!(element.as_ref(), &TypeDef::Primitive(PrimitiveTypeDef::U8));
+    assert_eq!(length, SequenceLengthDef::Fixed(ENDPOINT_GLOBAL_ID_SIZE));
 }
 
 #[test]

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -426,7 +426,7 @@ async fn recv_with_metadata_includes_transport_and_source_timestamps() {
     assert_eq!(received.message, message);
     assert!(received.transport_time.is_some());
     assert_eq!(received.sequence_number, 0);
-    assert_ne!(received.source_global_id, [0; 16]);
+    assert_ne!(received.source_global_id, ros_z::EndpointGlobalId::ZERO);
     assert_eq!(
         received.publication_id().sequence_number(),
         received.sequence_number


### PR DESCRIPTION
Summary:
- Move `EndpointGlobalId` into `ros-z-protocol` as a semantic newtype derived from `EndpointEntity`.
- Keep attachment serialization on the existing `(sequence_number, source_timestamp, [u8; 16])` wire layout.
- Re-export `ros_z::EndpointGlobalId` and add `MessageSchema` support for fields without implementing `ros_z::Message` for the ID itself.

Test Plan:
- `cargo fmt --check`
- `cargo check -p ros-z-protocol`
- `cargo check -p ros-z`
- `cargo check -p ros-z-streams`
- `cargo nextest run -p ros-z-protocol entity::tests`
- `cargo nextest run -p ros-z pubsub`
- `cargo nextest run -p ros-z --test communication_pubsub_alignment`
- `git diff --check`