### PR TITLE
Set `Restart=no`

### DIFF
--- a/tools/k1-setup/hulk.service
+++ b/tools/k1-setup/hulk.service
@@ -11,7 +11,7 @@ ExecStop=/usr/local/bin/podman exec hulk pkill -SIGTERM hulk
 KillMode=control-group
 KillSignal=SIGTERM
 TimeoutStopSec=10
-Restart=on-failure
+Restart=no
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Why? What?

Someone :eyes: configures `hulk` to always restart when stopped. 
I disabled this so we have the same behavior as with the NAOs before: No restart after a crash.

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
