### PR TITLE
fix(ros-z): use Zenoh-native graph name validation

### DIFF
--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -109,25 +109,20 @@ fn derive_namespace(robot: &str) -> String {
 }
 
 fn sanitize_namespace_component(component: &str) -> String {
-    let mut sanitized = String::new();
-
-    for character in component.chars() {
-        if character.is_ascii_alphanumeric() || character == '_' {
-            sanitized.push(character);
-        } else {
-            sanitized.push('_');
-        }
-    }
-
-    if sanitized
+    component
         .chars()
-        .next()
-        .is_some_and(|character| character.is_ascii_digit())
-    {
-        sanitized.insert(0, '_');
-    }
+        .map(|character| {
+            if is_valid_namespace_component_character(character) {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
 
-    sanitized
+fn is_valid_namespace_component_character(character: char) -> bool {
+    !matches!(character, '/' | '%' | '#' | '$' | '?' | '*')
 }
 
 async fn spawn_all(ctx: Arc<Context>) -> Result<RunningStack> {
@@ -206,8 +201,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn derive_namespace_replaces_invalid_characters() {
-        assert_eq!(derive_namespace("robot-01"), "/robot_01");
+    fn derive_namespace_keeps_ros_z_valid_components() {
+        assert_eq!(derive_namespace("42"), "/42");
+        assert_eq!(derive_namespace("robot-01"), "/robot-01");
+        assert_eq!(derive_namespace("robot/42"), "/robot/42");
+    }
+
+    #[test]
+    fn derive_namespace_replaces_rejected_characters() {
+        assert_eq!(derive_namespace("robot%01"), "/robot_01");
+        assert_eq!(derive_namespace("robot#01"), "/robot_01");
+        assert_eq!(derive_namespace("robot$01"), "/robot_01");
+        assert_eq!(derive_namespace("robot?01"), "/robot_01");
+        assert_eq!(derive_namespace("robot*01"), "/robot_01");
     }
 
     #[test]

--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -10,7 +10,10 @@ const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Parser)]
 struct Args {
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "Robot graph namespace. Bare values like '42' become '/42'; invalid ros-z names are rejected."
+    )]
     robot: String,
     #[arg(long)]
     location: String,
@@ -95,34 +98,11 @@ fn derive_parameter_layers(
 }
 
 fn derive_namespace(robot: &str) -> String {
-    let components = robot
-        .split('/')
-        .filter(|component| !component.is_empty())
-        .map(sanitize_namespace_component)
-        .collect::<Vec<_>>();
-
-    if components.is_empty() {
-        "/".to_string()
+    if robot.starts_with('/') {
+        robot.to_string()
     } else {
-        format!("/{}", components.join("/"))
+        format!("/{robot}")
     }
-}
-
-fn sanitize_namespace_component(component: &str) -> String {
-    component
-        .chars()
-        .map(|character| {
-            if is_valid_namespace_component_character(character) {
-                character
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
-fn is_valid_namespace_component_character(character: char) -> bool {
-    !matches!(character, '/' | '%' | '#' | '$' | '?' | '*')
 }
 
 async fn spawn_all(ctx: Arc<Context>) -> Result<RunningStack> {
@@ -201,19 +181,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn derive_namespace_keeps_ros_z_valid_components() {
+    fn derive_namespace_prefixes_bare_robot_without_sanitizing() {
         assert_eq!(derive_namespace("42"), "/42");
         assert_eq!(derive_namespace("robot-01"), "/robot-01");
-        assert_eq!(derive_namespace("robot/42"), "/robot/42");
-    }
-
-    #[test]
-    fn derive_namespace_replaces_rejected_characters() {
-        assert_eq!(derive_namespace("robot%01"), "/robot_01");
-        assert_eq!(derive_namespace("robot#01"), "/robot_01");
-        assert_eq!(derive_namespace("robot$01"), "/robot_01");
-        assert_eq!(derive_namespace("robot?01"), "/robot_01");
-        assert_eq!(derive_namespace("robot*01"), "/robot_01");
+        assert_eq!(derive_namespace("robot//42"), "/robot//42");
+        assert_eq!(derive_namespace("/robot/42"), "/robot/42");
+        assert_eq!(derive_namespace("robot%01"), "/robot%01");
     }
 
     #[test]

--- a/crates/ros-z-protocol/tests/key_expr.rs
+++ b/crates/ros-z-protocol/tests/key_expr.rs
@@ -175,8 +175,8 @@ fn test_node_liveliness_roundtrip() {
     let node = NodeEntity {
         z_id,
         id: 5,
-        name: "my_node".to_string(),
-        namespace: "/my_ns".to_string(),
+        name: "123node".to_string(),
+        namespace: "/42/robot-01".to_string(),
     };
 
     let ke = format::node_liveliness_key_expr(&node).unwrap();
@@ -185,61 +185,11 @@ fn test_node_liveliness_roundtrip() {
     if let Entity::Node(n) = parsed {
         assert_eq!(n.z_id, z_id);
         assert_eq!(n.id, 5);
-        assert_eq!(n.name, "my_node");
-        assert_eq!(n.namespace, "/my_ns");
+        assert_eq!(n.name, "123node");
+        assert_eq!(n.namespace, "/42/robot-01");
     } else {
         panic!("expected Node entity");
     }
-}
-
-#[test]
-fn node_liveliness_roundtrip_preserves_digit_leading_identity() {
-    let z_id = ZenohId::default();
-    let node = NodeEntity {
-        z_id,
-        id: 7,
-        name: "123node".to_string(),
-        namespace: "/42".to_string(),
-    };
-
-    let ke = format::node_liveliness_key_expr(&node).unwrap();
-    let parsed = format::parse_liveliness(&ke).unwrap();
-
-    let Entity::Node(parsed_node) = parsed else {
-        panic!("expected Node entity");
-    };
-    assert_eq!(parsed_node.z_id, z_id);
-    assert_eq!(parsed_node.id, 7);
-    assert_eq!(parsed_node.name, "123node");
-    assert_eq!(parsed_node.namespace, "/42");
-}
-
-#[test]
-fn endpoint_liveliness_roundtrip_preserves_digit_leading_identity_and_topic() {
-    let z_id = ZenohId::default();
-    let entity = EndpointEntity {
-        id: 8,
-        node: NodeEntity {
-            z_id,
-            id: 7,
-            name: "123node".to_string(),
-            namespace: "/42".to_string(),
-        },
-        kind: EndpointKind::Publisher,
-        topic: "/42/status".to_string(),
-        type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
-        qos: QosProfile::default(),
-    };
-
-    let ke = format::liveliness_key_expr(&entity, &z_id).unwrap();
-    let parsed = format::parse_liveliness(&ke).unwrap();
-
-    let Entity::Endpoint(parsed_endpoint) = parsed else {
-        panic!("expected Endpoint entity");
-    };
-    assert_eq!(parsed_endpoint.node.name, "123node");
-    assert_eq!(parsed_endpoint.node.namespace, "/42");
-    assert_eq!(parsed_endpoint.topic, "/42/status");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ros-z-protocol/tests/key_expr.rs
+++ b/crates/ros-z-protocol/tests/key_expr.rs
@@ -192,6 +192,56 @@ fn test_node_liveliness_roundtrip() {
     }
 }
 
+#[test]
+fn node_liveliness_roundtrip_preserves_digit_leading_identity() {
+    let z_id = ZenohId::default();
+    let node = NodeEntity {
+        z_id,
+        id: 7,
+        name: "123node".to_string(),
+        namespace: "/42".to_string(),
+    };
+
+    let ke = format::node_liveliness_key_expr(&node).unwrap();
+    let parsed = format::parse_liveliness(&ke).unwrap();
+
+    let Entity::Node(parsed_node) = parsed else {
+        panic!("expected Node entity");
+    };
+    assert_eq!(parsed_node.z_id, z_id);
+    assert_eq!(parsed_node.id, 7);
+    assert_eq!(parsed_node.name, "123node");
+    assert_eq!(parsed_node.namespace, "/42");
+}
+
+#[test]
+fn endpoint_liveliness_roundtrip_preserves_digit_leading_identity_and_topic() {
+    let z_id = ZenohId::default();
+    let entity = EndpointEntity {
+        id: 8,
+        node: NodeEntity {
+            z_id,
+            id: 7,
+            name: "123node".to_string(),
+            namespace: "/42".to_string(),
+        },
+        kind: EndpointKind::Publisher,
+        topic: "/42/status".to_string(),
+        type_info: TypeInfo::new("std_msgs::String", SchemaHash::zero()),
+        qos: QosProfile::default(),
+    };
+
+    let ke = format::liveliness_key_expr(&entity, &z_id).unwrap();
+    let parsed = format::parse_liveliness(&ke).unwrap();
+
+    let Entity::Endpoint(parsed_endpoint) = parsed else {
+        panic!("expected Endpoint entity");
+    };
+    assert_eq!(parsed_endpoint.node.name, "123node");
+    assert_eq!(parsed_endpoint.node.namespace, "/42");
+    assert_eq!(parsed_endpoint.topic, "/42/status");
+}
+
 // ---------------------------------------------------------------------------
 // Topic names with namespaces
 // ---------------------------------------------------------------------------

--- a/crates/ros-z/README.md
+++ b/crates/ros-z/README.md
@@ -40,6 +40,16 @@ Builders that create runtime resources are async. Build contexts, nodes,
 publishers, subscribers, services, and caches inside a Tokio-compatible runtime.
 Endpoint factory methods validate schema/type metadata immediately and return `Result<Builder>`; `.build().await` only creates runtime Zenoh resources.
 
+## Name Rules
+
+`ros-z` uses Zenoh-native concrete graph names. Namespace, node, topic, and
+service components may start with digits, so a namespace such as `/42` is valid.
+
+Names must still qualify to concrete Zenoh keys. Components cannot be empty and
+cannot contain `/`, `%`, `#`, `$`, `?`, or `*`. Slash separates components, `%`
+is reserved by the current ros-z liveliness identity encoding, and `*` is a
+selector wildcard rather than a concrete endpoint character.
+
 ## Examples
 
 Run examples from the workspace root:

--- a/crates/ros-z/README.md
+++ b/crates/ros-z/README.md
@@ -50,6 +50,11 @@ cannot contain `/`, `%`, `#`, `$`, `?`, or `*`. Slash separates components, `%`
 is reserved by the current ros-z liveliness identity encoding, and `*` is a
 selector wildcard rather than a concrete endpoint character.
 
+Applications should pass graph names through unchanged except for adding a
+leading slash where they accept a bare namespace. For example,
+`hulk_ros_z --robot 42` uses namespace `/42`; invalid names such as `robot%01`
+are rejected instead of rewritten.
+
 ## Examples
 
 Run examples from the workspace root:

--- a/crates/ros-z/src/error.rs
+++ b/crates/ros-z/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
         source: zenoh::Error,
     },
 
-    /// ROS name qualification failed.
+    /// Graph name qualification failed.
     #[error("failed to qualify {kind} name '{name}'")]
     Name {
         kind: NameKind,
@@ -92,7 +92,7 @@ impl From<crate::parameter::ParameterError> for Error {
     }
 }
 
-/// Kind of ROS name being qualified.
+/// Kind of graph name being qualified.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NameKind {
     /// Topic name.

--- a/crates/ros-z/src/error.rs
+++ b/crates/ros-z/src/error.rs
@@ -308,6 +308,22 @@ impl Error {
         }
     }
 
+    pub(crate) fn namespace(name: impl Into<String>, source: TopicNameError) -> Self {
+        Self::Name {
+            kind: NameKind::Namespace,
+            name: name.into(),
+            source,
+        }
+    }
+
+    pub(crate) fn node_name(name: impl Into<String>, source: TopicNameError) -> Self {
+        Self::Name {
+            kind: NameKind::Node,
+            name: name.into(),
+            source,
+        }
+    }
+
     pub(crate) fn encode<E>(type_name: impl Into<String>, source: E) -> Self
     where
         E: StdError + Send + Sync + 'static,

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -17,6 +17,7 @@ use crate::{
     service::{ServiceClientBuilder, ServiceServerBuilder},
     shm::ShmConfig,
     time::{Clock, Timer},
+    topic_name::{validate_namespace, validate_node_name},
 };
 use tracing::{debug, info};
 use zenoh::{Session, liveliness::LivelinessToken};
@@ -149,6 +150,11 @@ impl NodeBuilder {
         id = tracing::field::Empty
     ))]
     pub async fn build(self) -> Result<Node> {
+        validate_namespace(&self.namespace)
+            .map_err(|source| Error::namespace(self.namespace.clone(), source))?;
+        validate_node_name(&self.name)
+            .map_err(|source| Error::node_name(self.name.clone(), source))?;
+
         let id = self.counter.increment();
         tracing::Span::current().record("id", id);
 

--- a/crates/ros-z/src/topic_name.rs
+++ b/crates/ros-z/src/topic_name.rs
@@ -22,24 +22,53 @@ pub enum TopicNameError {
     InvalidNodeName(String),
 }
 
-/// Validate that a topic name component (between slashes) is valid
-/// Components must start with a letter or underscore, followed by alphanumeric or underscores
-fn is_valid_topic_component(component: &str) -> bool {
-    if component.is_empty() {
-        return false;
-    }
-    let bytes = component.as_bytes();
-    if !bytes[0].is_ascii_alphabetic() && bytes[0] != b'_' {
-        return false;
-    }
-    bytes[1..]
-        .iter()
-        .all(|&b| b.is_ascii_alphanumeric() || b == b'_')
+/// Validate one concrete ros-z graph-name component.
+///
+/// Components follow Zenoh key-expression chunk rules, with extra exclusions
+/// for ros-z concrete endpoints and current liveliness identity escaping.
+#[cfg(test)]
+fn is_valid_graph_component(component: &str) -> bool {
+    invalid_graph_component_reason(component).is_none()
 }
 
-/// Validate a namespace string
-/// Namespaces can be empty, "/", or a series of valid components separated by "/"
-fn validate_namespace(namespace: &str) -> Result<(), TopicNameError> {
+fn invalid_graph_component_reason(component: &str) -> Option<&'static str> {
+    if component.is_empty() {
+        return Some("component is empty");
+    }
+
+    for character in component.chars() {
+        match character {
+            '/' => return Some("component contains '/'"),
+            '%' => return Some("component contains '%'"),
+            '#' => return Some("component contains '#'"),
+            '$' => return Some("component contains '$'"),
+            '?' => return Some("component contains '?'"),
+            '*' => return Some("component contains '*'"),
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn validate_graph_component(component: &str) -> Result<(), String> {
+    match invalid_graph_component_reason(component) {
+        Some(reason) => Err(format!("invalid component '{component}': {reason}")),
+        None => Ok(()),
+    }
+}
+
+fn validate_graph_path(path: &str) -> Result<(), String> {
+    for component in path.split('/') {
+        validate_graph_component(component)?;
+    }
+
+    Ok(())
+}
+
+/// Validate a namespace string.
+/// Namespaces can be empty, "/", or concrete components separated by "/".
+pub(crate) fn validate_namespace(namespace: &str) -> Result<(), TopicNameError> {
     if namespace.is_empty() || namespace == "/" {
         return Ok(());
     }
@@ -50,34 +79,13 @@ fn validate_namespace(namespace: &str) -> Result<(), TopicNameError> {
         ));
     }
 
-    for part in namespace.split('/') {
-        if part.is_empty() {
-            continue; // Leading slash creates empty first component
-        }
-        if !is_valid_topic_component(part) {
-            return Err(TopicNameError::InvalidNamespace(format!(
-                "invalid component '{}'",
-                part
-            )));
-        }
-    }
-    Ok(())
+    let namespace_path = namespace.strip_prefix('/').unwrap_or(namespace);
+    validate_graph_path(namespace_path).map_err(TopicNameError::InvalidNamespace)
 }
 
-/// Validate a node name
-fn validate_node_name(node_name: &str) -> Result<(), TopicNameError> {
-    if node_name.is_empty() {
-        return Err(TopicNameError::InvalidNodeName(
-            "node name is empty".to_string(),
-        ));
-    }
-    if !is_valid_topic_component(node_name) {
-        return Err(TopicNameError::InvalidNodeName(format!(
-            "invalid node name '{}'",
-            node_name
-        )));
-    }
-    Ok(())
+/// Validate a node name.
+pub(crate) fn validate_node_name(node_name: &str) -> Result<(), TopicNameError> {
+    validate_graph_component(node_name).map_err(TopicNameError::InvalidNodeName)
 }
 
 /// Qualify a topic name according to ros-z naming rules.
@@ -139,29 +147,27 @@ pub fn qualify_topic_name(
 
     // Handle different topic name types
     let qualified = if topic.starts_with('/') {
-        // Absolute topic - use as-is, but remove trailing slash if present
+        // Absolute topic - use as-is, but remove trailing slash if present.
         let topic = topic.strip_suffix('/').unwrap_or(topic);
-        if topic.is_empty() || topic == "/" {
+        let topic_path = topic.strip_prefix('/').unwrap_or(topic);
+        if topic_path.is_empty() {
             return Err(TopicNameError::InvalidCharacters(
                 "topic cannot be just '/'".to_string(),
             ));
         }
+        validate_graph_path(topic_path).map_err(TopicNameError::InvalidCharacters)?;
         topic.to_string()
     } else if topic.starts_with('~') {
         // Private topic - expand with namespace and node name
         let topic_suffix = topic.strip_prefix('~').unwrap();
         let topic_suffix = topic_suffix.strip_prefix('/').unwrap_or(topic_suffix);
 
-        // Validate the topic suffix
+        let topic_suffix = topic_suffix.strip_suffix('/').unwrap_or(topic_suffix);
+
         if !topic_suffix.is_empty() {
-            for part in topic_suffix.split('/') {
-                if !part.is_empty() && !is_valid_topic_component(part) {
-                    return Err(TopicNameError::InvalidCharacters(format!(
-                        "invalid component '{}' in private topic",
-                        part
-                    )));
-                }
-            }
+            validate_graph_path(topic_suffix).map_err(|source| {
+                TopicNameError::InvalidCharacters(format!("invalid private topic suffix: {source}"))
+            })?;
         }
 
         if namespace.is_empty() || namespace == "/" {
@@ -179,15 +185,7 @@ pub fn qualify_topic_name(
         // Relative topic - expand with namespace only
         let topic = topic.strip_suffix('/').unwrap_or(topic);
 
-        // Validate topic components
-        for part in topic.split('/') {
-            if !part.is_empty() && !is_valid_topic_component(part) {
-                return Err(TopicNameError::InvalidCharacters(format!(
-                    "invalid component '{}'",
-                    part
-                )));
-            }
-        }
+        validate_graph_path(topic).map_err(TopicNameError::InvalidCharacters)?;
 
         if namespace.is_empty() || namespace == "/" {
             format!("/{}", topic)
@@ -312,6 +310,60 @@ mod tests {
     }
 
     #[test]
+    fn accepts_zenoh_native_digit_and_hyphen_components() {
+        assert_eq!(
+            qualify_topic_name("chatter", "/42", "node").unwrap(),
+            "/42/chatter"
+        );
+        assert_eq!(
+            qualify_topic_name("~status", "/robot", "123node").unwrap(),
+            "/robot/123node/status"
+        );
+        assert_eq!(
+            qualify_topic_name("42/status", "/robot", "node").unwrap(),
+            "/robot/42/status"
+        );
+        assert_eq!(
+            qualify_topic_name("camera-left/image_raw", "/robot-01", "node").unwrap(),
+            "/robot-01/camera-left/image_raw"
+        );
+        assert_eq!(
+            qualify_service_name("42/service", "/7", "123node").unwrap(),
+            "/7/42/service"
+        );
+    }
+
+    #[test]
+    fn rejects_non_concrete_or_protocol_reserved_components() {
+        for topic in [
+            "foo//bar",
+            "/foo//bar",
+            "/foo%bar",
+            "/foo#bar",
+            "/foo$bar",
+            "/foo?bar",
+            "/foo*bar",
+        ] {
+            assert!(
+                matches!(
+                    qualify_topic_name(topic, "/", "node"),
+                    Err(TopicNameError::InvalidCharacters(_))
+                ),
+                "topic {topic:?} should be rejected"
+            );
+        }
+
+        assert!(matches!(
+            qualify_topic_name("status", "/robot//ns", "node"),
+            Err(TopicNameError::InvalidNamespace(_))
+        ));
+        assert!(matches!(
+            qualify_topic_name("~status", "/robot", "node%name"),
+            Err(TopicNameError::InvalidNodeName(_))
+        ));
+    }
+
+    #[test]
     fn test_empty_topic() {
         assert!(matches!(
             qualify_topic_name("", "/", "node"),
@@ -334,23 +386,28 @@ mod tests {
             Err(TopicNameError::InvalidNodeName(_))
         ));
         assert!(matches!(
-            qualify_topic_name("chatter", "/ns", "123node"),
+            qualify_topic_name("chatter", "/ns", "node%name"),
             Err(TopicNameError::InvalidNodeName(_))
         ));
     }
 
     #[test]
-    fn test_valid_topic_components() {
-        assert!(is_valid_topic_component("foo"));
-        assert!(is_valid_topic_component("_foo"));
-        assert!(is_valid_topic_component("foo123"));
-        assert!(is_valid_topic_component("foo_bar"));
-        assert!(is_valid_topic_component("FooBar"));
+    fn test_valid_graph_components() {
+        assert!(is_valid_graph_component("foo"));
+        assert!(is_valid_graph_component("_foo"));
+        assert!(is_valid_graph_component("123"));
+        assert!(is_valid_graph_component("foo123"));
+        assert!(is_valid_graph_component("foo_bar"));
+        assert!(is_valid_graph_component("foo-bar"));
+        assert!(is_valid_graph_component("FooBar"));
 
-        assert!(!is_valid_topic_component(""));
-        assert!(!is_valid_topic_component("123"));
-        assert!(!is_valid_topic_component("foo-bar"));
-        assert!(!is_valid_topic_component("foo bar"));
+        assert!(!is_valid_graph_component(""));
+        assert!(!is_valid_graph_component("foo/bar"));
+        assert!(!is_valid_graph_component("foo%bar"));
+        assert!(!is_valid_graph_component("foo#bar"));
+        assert!(!is_valid_graph_component("foo$bar"));
+        assert!(!is_valid_graph_component("foo?bar"));
+        assert!(!is_valid_graph_component("foo*bar"));
     }
 
     #[test]

--- a/crates/ros-z/src/topic_name.rs
+++ b/crates/ros-z/src/topic_name.rs
@@ -22,48 +22,24 @@ pub enum TopicNameError {
     InvalidNodeName(String),
 }
 
-/// Validate one concrete ros-z graph-name component.
-///
-/// Components follow Zenoh key-expression chunk rules, with extra exclusions
-/// for ros-z concrete endpoints and current liveliness identity escaping.
-#[cfg(test)]
-fn is_valid_graph_component(component: &str) -> bool {
-    invalid_graph_component_reason(component).is_none()
-}
-
-fn invalid_graph_component_reason(component: &str) -> Option<&'static str> {
+fn validate_graph_component(component: &str) -> Result<(), String> {
     if component.is_empty() {
-        return Some("component is empty");
+        return Err("invalid component: component is empty".to_string());
     }
 
     for character in component.chars() {
-        match character {
-            '/' => return Some("component contains '/'"),
-            '%' => return Some("component contains '%'"),
-            '#' => return Some("component contains '#'"),
-            '$' => return Some("component contains '$'"),
-            '?' => return Some("component contains '?'"),
-            '*' => return Some("component contains '*'"),
-            _ => {}
+        if matches!(character, '/' | '%' | '#' | '$' | '?' | '*') {
+            return Err(format!(
+                "invalid component '{component}': contains '{character}'"
+            ));
         }
     }
 
-    None
-}
-
-fn validate_graph_component(component: &str) -> Result<(), String> {
-    match invalid_graph_component_reason(component) {
-        Some(reason) => Err(format!("invalid component '{component}': {reason}")),
-        None => Ok(()),
-    }
+    Ok(())
 }
 
 fn validate_graph_path(path: &str) -> Result<(), String> {
-    for component in path.split('/') {
-        validate_graph_component(component)?;
-    }
-
-    Ok(())
+    path.split('/').try_for_each(validate_graph_component)
 }
 
 /// Validate a namespace string.
@@ -97,6 +73,8 @@ pub(crate) fn validate_node_name(node_name: &str) -> Result<(), TopicNameError> 
 /// - Private topics (starting with '~') are expanded to `/<namespace>/<node_name>/<topic>`
 /// - Relative topics are expanded to `/<namespace>/<topic>`
 /// - Empty namespace is treated as "/"
+/// - Components may start with digits and may contain hyphens
+/// - Components must be non-empty and cannot contain `/`, `%`, `#`, `$`, `?`, or `*`
 ///
 /// # Arguments
 /// * `topic` - The input topic name (can be absolute, relative, or private)
@@ -199,7 +177,7 @@ pub fn qualify_topic_name(
 
 /// Qualify a service name according to ros-z naming rules.
 ///
-/// Service names follow the same rules as topic names
+/// Service names follow the same graph-name component rules as topic names.
 pub fn qualify_service_name(
     service: &str,
     namespace: &str,
@@ -312,46 +290,25 @@ mod tests {
     #[test]
     fn accepts_zenoh_native_digit_and_hyphen_components() {
         assert_eq!(
-            qualify_topic_name("chatter", "/42", "node").unwrap(),
-            "/42/chatter"
-        );
-        assert_eq!(
-            qualify_topic_name("~status", "/robot", "123node").unwrap(),
-            "/robot/123node/status"
-        );
-        assert_eq!(
-            qualify_topic_name("42/status", "/robot", "node").unwrap(),
-            "/robot/42/status"
-        );
-        assert_eq!(
-            qualify_topic_name("camera-left/image_raw", "/robot-01", "node").unwrap(),
-            "/robot-01/camera-left/image_raw"
-        );
-        assert_eq!(
-            qualify_service_name("42/service", "/7", "123node").unwrap(),
-            "/7/42/service"
+            qualify_topic_name("~camera-left/42", "/7/robot-01", "123node").unwrap(),
+            "/7/robot-01/123node/camera-left/42"
         );
     }
 
     #[test]
-    fn rejects_non_concrete_or_protocol_reserved_components() {
-        for topic in [
-            "foo//bar",
-            "/foo//bar",
-            "/foo%bar",
-            "/foo#bar",
-            "/foo$bar",
-            "/foo?bar",
-            "/foo*bar",
-        ] {
-            assert!(
-                matches!(
-                    qualify_topic_name(topic, "/", "node"),
-                    Err(TopicNameError::InvalidCharacters(_))
-                ),
-                "topic {topic:?} should be rejected"
-            );
-        }
+    fn rejects_empty_or_reserved_components() {
+        assert!(matches!(
+            qualify_topic_name("foo//bar", "/", "node"),
+            Err(TopicNameError::InvalidCharacters(_))
+        ));
+        assert!(matches!(
+            qualify_topic_name("/foo%bar", "/", "node"),
+            Err(TopicNameError::InvalidCharacters(_))
+        ));
+        assert!(matches!(
+            qualify_topic_name("/foo*bar", "/", "node"),
+            Err(TopicNameError::InvalidCharacters(_))
+        ));
 
         assert!(matches!(
             qualify_topic_name("status", "/robot//ns", "node"),
@@ -385,29 +342,6 @@ mod tests {
             qualify_topic_name("chatter", "/ns", ""),
             Err(TopicNameError::InvalidNodeName(_))
         ));
-        assert!(matches!(
-            qualify_topic_name("chatter", "/ns", "node%name"),
-            Err(TopicNameError::InvalidNodeName(_))
-        ));
-    }
-
-    #[test]
-    fn test_valid_graph_components() {
-        assert!(is_valid_graph_component("foo"));
-        assert!(is_valid_graph_component("_foo"));
-        assert!(is_valid_graph_component("123"));
-        assert!(is_valid_graph_component("foo123"));
-        assert!(is_valid_graph_component("foo_bar"));
-        assert!(is_valid_graph_component("foo-bar"));
-        assert!(is_valid_graph_component("FooBar"));
-
-        assert!(!is_valid_graph_component(""));
-        assert!(!is_valid_graph_component("foo/bar"));
-        assert!(!is_valid_graph_component("foo%bar"));
-        assert!(!is_valid_graph_component("foo#bar"));
-        assert!(!is_valid_graph_component("foo$bar"));
-        assert!(!is_valid_graph_component("foo?bar"));
-        assert!(!is_valid_graph_component("foo*bar"));
     }
 
     #[test]

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -96,72 +96,37 @@ async fn node_builder_accepts_zenoh_native_identity() -> ros_z::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn node_builder_rejects_invalid_node_names_before_protocol_formatting() -> ros_z::Result<()> {
+async fn node_builder_rejects_protocol_reserved_identity_before_formatting() -> ros_z::Result<()> {
     let context = test_context().await?;
 
-    for invalid_name in [
-        "",
-        "node/name",
-        "node%name",
-        "node#name",
-        "node$name",
-        "node?name",
-        "node*name",
-    ] {
-        let error = context
-            .create_node(invalid_name)
-            .build()
-            .await
-            .expect_err("invalid node name should fail during node build");
+    let node_error = context
+        .create_node("node%name")
+        .build()
+        .await
+        .expect_err("invalid node name should fail during node build");
+    assert!(matches!(
+        node_error,
+        ros_z::Error::Name {
+            kind: ros_z::error::NameKind::Node,
+            source: ros_z::topic_name::TopicNameError::InvalidNodeName(_),
+            ..
+        }
+    ));
 
-        assert!(
-            matches!(
-                error,
-                ros_z::Error::Name {
-                    kind: ros_z::error::NameKind::Node,
-                    source: ros_z::topic_name::TopicNameError::InvalidNodeName(_),
-                    ..
-                }
-            ),
-            "unexpected error for node name {invalid_name:?}: {error:?}"
-        );
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn node_builder_rejects_invalid_namespaces_before_protocol_formatting() -> ros_z::Result<()> {
-    let context = test_context().await?;
-
-    for invalid_namespace in [
-        "/robot/",
-        "/robot//ns",
-        "/robot%ns",
-        "/robot#ns",
-        "/robot$ns",
-        "/robot?ns",
-        "/robot*ns",
-    ] {
-        let error = context
-            .create_node("node")
-            .with_namespace(invalid_namespace)
-            .build()
-            .await
-            .expect_err("invalid namespace should fail during node build");
-
-        assert!(
-            matches!(
-                error,
-                ros_z::Error::Name {
-                    kind: ros_z::error::NameKind::Namespace,
-                    source: ros_z::topic_name::TopicNameError::InvalidNamespace(_),
-                    ..
-                }
-            ),
-            "unexpected error for namespace {invalid_namespace:?}: {error:?}"
-        );
-    }
+    let namespace_error = context
+        .create_node("node")
+        .with_namespace("/robot%ns")
+        .build()
+        .await
+        .expect_err("invalid namespace should fail during node build");
+    assert!(matches!(
+        namespace_error,
+        ros_z::Error::Name {
+            kind: ros_z::error::NameKind::Namespace,
+            source: ros_z::topic_name::TopicNameError::InvalidNamespace(_),
+            ..
+        }
+    ));
 
     Ok(())
 }

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -81,6 +81,91 @@ async fn node_builder_can_disable_schema_service_explicitly() -> ros_z::Result<(
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn node_builder_accepts_zenoh_native_identity() -> ros_z::Result<()> {
+    let context = test_context().await?;
+    let node = context
+        .create_node("123node")
+        .with_namespace("/42/robot-01")
+        .build()
+        .await?;
+
+    assert_eq!(node.name(), "123node");
+    assert_eq!(node.namespace(), "/42/robot-01");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn node_builder_rejects_invalid_node_names_before_protocol_formatting() -> ros_z::Result<()> {
+    let context = test_context().await?;
+
+    for invalid_name in [
+        "",
+        "node/name",
+        "node%name",
+        "node#name",
+        "node$name",
+        "node?name",
+        "node*name",
+    ] {
+        let error = context
+            .create_node(invalid_name)
+            .build()
+            .await
+            .expect_err("invalid node name should fail during node build");
+
+        assert!(
+            matches!(
+                error,
+                ros_z::Error::Name {
+                    kind: ros_z::error::NameKind::Node,
+                    source: ros_z::topic_name::TopicNameError::InvalidNodeName(_),
+                    ..
+                }
+            ),
+            "unexpected error for node name {invalid_name:?}: {error:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn node_builder_rejects_invalid_namespaces_before_protocol_formatting() -> ros_z::Result<()> {
+    let context = test_context().await?;
+
+    for invalid_namespace in [
+        "/robot/",
+        "/robot//ns",
+        "/robot%ns",
+        "/robot#ns",
+        "/robot$ns",
+        "/robot?ns",
+        "/robot*ns",
+    ] {
+        let error = context
+            .create_node("node")
+            .with_namespace(invalid_namespace)
+            .build()
+            .await
+            .expect_err("invalid namespace should fail during node build");
+
+        assert!(
+            matches!(
+                error,
+                ros_z::Error::Name {
+                    kind: ros_z::error::NameKind::Namespace,
+                    source: ros_z::topic_name::TopicNameError::InvalidNamespace(_),
+                    ..
+                }
+            ),
+            "unexpected error for namespace {invalid_namespace:?}: {error:?}"
+        );
+    }
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn raw_subscriber_receives_sample_payload() -> zenoh::Result<()> {
     let context = ContextBuilder::default().build().await?;


### PR DESCRIPTION
## Summary
- Relax ros-z graph-name validation to accept Zenoh-native concrete components, including digit-leading and hyphenated names.
- Validate node identities before liveliness formatting so reserved characters like `%` cannot corrupt discovery round-trips.
- Preserve `hulk_ros_z --robot` values except for adding a leading slash, so invalid names are rejected by ros-z instead of rewritten.
- Simplify graph-name validation helpers and keep behavior-focused coverage/docs for the new rules.