### PR TITLE
refactor(ros-z): share dynamic JSON rendering

### DIFF
--- a/crates/ros-z-cli/src/commands/echo.rs
+++ b/crates/ros-z-cli/src/commands/echo.rs
@@ -2,10 +2,10 @@ use std::time::Duration;
 
 use color_eyre::eyre::{Result, WrapErr, bail, eyre};
 use ros_z::dynamic::{
-    DynamicNamedValue, DynamicPayload, DynamicStruct, DynamicSubscriber, DynamicValue,
-    EnumPayloadValue, EnumValue,
+    ByteRenderPolicy, DynamicJsonRenderPolicy, DynamicNamedValue, DynamicPayload, DynamicStruct,
+    DynamicSubscriber, DynamicValue, EnumPayloadValue, EnumValue, NonFiniteFloatRenderPolicy,
+    dynamic_payload_to_json,
 };
-use serde_json::{Map, Value};
 
 use crate::{
     app::AppContext,
@@ -14,6 +14,11 @@ use crate::{
 };
 
 const TYPE_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+const JSON_RENDER_POLICY: DynamicJsonRenderPolicy = DynamicJsonRenderPolicy {
+    bytes: ByteRenderPolicy::FullArray,
+    non_finite_float: NonFiniteFloatRenderPolicy::Null,
+};
 
 pub async fn run(
     app: &AppContext,
@@ -61,7 +66,7 @@ pub async fn run(
                     header.topic.clone(),
                     subscriber.entity().type_info.name.clone(),
                     header.schema_hash.clone(),
-                    dynamic_payload_to_json(&message),
+                    dynamic_payload_to_json(&message, JSON_RENDER_POLICY),
                 );
                 json::print_line(&view)?;
             }
@@ -87,93 +92,6 @@ async fn receive_message(
         None => receive
             .await
             .wrap_err_with(|| format!("subscriber receive failed for {topic}")),
-    }
-}
-
-fn dynamic_payload_to_json(payload: &DynamicPayload) -> Value {
-    dynamic_value_to_json(&payload.value)
-}
-
-fn dynamic_message_to_json(message: &DynamicStruct) -> Value {
-    let mut fields = Map::new();
-    for (name, value) in message.iter() {
-        fields.insert(name.to_string(), dynamic_value_to_json(value));
-    }
-    Value::Object(fields)
-}
-
-fn dynamic_value_to_json(value: &DynamicValue) -> Value {
-    match value {
-        DynamicValue::Bool(value) => Value::Bool(*value),
-        DynamicValue::Int8(value) => Value::Number((*value).into()),
-        DynamicValue::Int16(value) => Value::Number((*value).into()),
-        DynamicValue::Int32(value) => Value::Number((*value).into()),
-        DynamicValue::Int64(value) => Value::Number((*value).into()),
-        DynamicValue::Uint8(value) => Value::Number((*value).into()),
-        DynamicValue::Uint16(value) => Value::Number((*value).into()),
-        DynamicValue::Uint32(value) => Value::Number((*value).into()),
-        DynamicValue::Uint64(value) => Value::Number((*value).into()),
-        DynamicValue::Float32(value) => serde_json::Number::from_f64(*value as f64)
-            .map(Value::Number)
-            .unwrap_or(Value::Null),
-        DynamicValue::Float64(value) => serde_json::Number::from_f64(*value)
-            .map(Value::Number)
-            .unwrap_or(Value::Null),
-        DynamicValue::String(value) => Value::String(value.clone()),
-        DynamicValue::Bytes(value) => Value::Array(
-            value
-                .iter()
-                .map(|byte| Value::Number((*byte).into()))
-                .collect(),
-        ),
-        DynamicValue::Struct(value) => dynamic_message_to_json(value),
-        DynamicValue::Optional(None) => Value::Null,
-        DynamicValue::Optional(Some(value)) => dynamic_value_to_json(value),
-        DynamicValue::Enum(value) => enum_value_to_json(value),
-        DynamicValue::Sequence(values) => {
-            Value::Array(values.iter().map(dynamic_value_to_json).collect())
-        }
-        DynamicValue::Map(entries) => Value::Array(
-            entries
-                .iter()
-                .map(|(key, value)| {
-                    let mut entry = Map::new();
-                    entry.insert("key".to_string(), dynamic_value_to_json(key));
-                    entry.insert("value".to_string(), dynamic_value_to_json(value));
-                    Value::Object(entry)
-                })
-                .collect(),
-        ),
-    }
-}
-
-fn enum_value_to_json(value: &EnumValue) -> Value {
-    let mut fields = Map::new();
-    fields.insert(
-        "variant_index".to_string(),
-        Value::Number(value.variant_index.into()),
-    );
-    fields.insert(
-        "variant_name".to_string(),
-        Value::String(value.variant_name.clone()),
-    );
-    fields.insert("payload".to_string(), enum_payload_to_json(&value.payload));
-    Value::Object(fields)
-}
-
-fn enum_payload_to_json(payload: &EnumPayloadValue) -> Value {
-    match payload {
-        EnumPayloadValue::Unit => Value::Null,
-        EnumPayloadValue::Newtype(value) => dynamic_value_to_json(value),
-        EnumPayloadValue::Tuple(values) => {
-            Value::Array(values.iter().map(dynamic_value_to_json).collect())
-        }
-        EnumPayloadValue::Struct(fields) => Value::Object(
-            fields
-                .iter()
-                .map(|field| (field.name.clone(), dynamic_value_to_json(&field.value)))
-                .collect(),
-        ),
     }
 }
 

--- a/crates/ros-z/src/dynamic/json.rs
+++ b/crates/ros-z/src/dynamic/json.rs
@@ -1,0 +1,203 @@
+use serde_json::{Map, Number, Value};
+
+use super::{DynamicPayload, DynamicStruct, DynamicValue, EnumPayloadValue, EnumValue};
+
+/// Rendering options for dynamic payload JSON values.
+///
+/// Primitive values render as their matching JSON scalar. Structs render as JSON
+/// objects, sequences as arrays, maps as arrays of `{ "key", "value" }` entries,
+/// optional `None` as `null`, and enums as objects with `variant_index`,
+/// `variant_name`, and `payload` fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DynamicJsonRenderPolicy {
+    /// Rendering policy for `DynamicValue::Bytes`.
+    pub bytes: ByteRenderPolicy,
+    /// Rendering policy for `NaN` and infinite floating point values.
+    pub non_finite_float: NonFiniteFloatRenderPolicy,
+}
+
+impl Default for DynamicJsonRenderPolicy {
+    fn default() -> Self {
+        Self {
+            bytes: ByteRenderPolicy::Compact { preview_len: 32 },
+            non_finite_float: NonFiniteFloatRenderPolicy::Object,
+        }
+    }
+}
+
+/// JSON representation for dynamic byte arrays.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ByteRenderPolicy {
+    /// Render bytes as `{ "$type": "bytes", "len", "preview", "truncated" }`.
+    Compact { preview_len: usize },
+    /// Render bytes as a JSON array of byte values.
+    FullArray,
+}
+
+/// JSON representation for non-finite floating point values.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NonFiniteFloatRenderPolicy {
+    /// Render non-finite floats as JSON `null`.
+    Null,
+    /// Render non-finite floats as `{ "$type": "non_finite_float", "value" }`.
+    Object,
+}
+
+/// Render a dynamic payload value as JSON according to `policy`.
+pub fn dynamic_payload_to_json(payload: &DynamicPayload, policy: DynamicJsonRenderPolicy) -> Value {
+    dynamic_value_to_json(&payload.value, policy)
+}
+
+/// Render a dynamic value as JSON according to `policy`.
+pub fn dynamic_value_to_json(value: &DynamicValue, policy: DynamicJsonRenderPolicy) -> Value {
+    match value {
+        DynamicValue::Bool(value) => Value::Bool(*value),
+        DynamicValue::Int8(value) => Value::Number((*value).into()),
+        DynamicValue::Int16(value) => Value::Number((*value).into()),
+        DynamicValue::Int32(value) => Value::Number((*value).into()),
+        DynamicValue::Int64(value) => Value::Number((*value).into()),
+        DynamicValue::Uint8(value) => Value::Number((*value).into()),
+        DynamicValue::Uint16(value) => Value::Number((*value).into()),
+        DynamicValue::Uint32(value) => Value::Number((*value).into()),
+        DynamicValue::Uint64(value) => Value::Number((*value).into()),
+        DynamicValue::Float32(value) => float_to_json(f64::from(*value), policy),
+        DynamicValue::Float64(value) => float_to_json(*value, policy),
+        DynamicValue::String(value) => Value::String(value.clone()),
+        DynamicValue::Bytes(bytes) => bytes_to_json(bytes, policy.bytes),
+        DynamicValue::Struct(value) => struct_to_json(value, policy),
+        DynamicValue::Optional(None) => Value::Null,
+        DynamicValue::Optional(Some(value)) => dynamic_value_to_json(value, policy),
+        DynamicValue::Enum(value) => enum_to_json(value, policy),
+        DynamicValue::Sequence(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| dynamic_value_to_json(value, policy))
+                .collect(),
+        ),
+        DynamicValue::Map(entries) => Value::Array(
+            entries
+                .iter()
+                .map(|(key, value)| {
+                    let mut entry = Map::new();
+                    entry.insert("key".to_string(), dynamic_value_to_json(key, policy));
+                    entry.insert("value".to_string(), dynamic_value_to_json(value, policy));
+                    Value::Object(entry)
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn float_to_json(value: f64, policy: DynamicJsonRenderPolicy) -> Value {
+    Number::from_f64(value)
+        .map(Value::Number)
+        .unwrap_or_else(|| non_finite_float_to_json(value, policy.non_finite_float))
+}
+
+fn non_finite_float_to_json(value: f64, policy: NonFiniteFloatRenderPolicy) -> Value {
+    match policy {
+        NonFiniteFloatRenderPolicy::Null => Value::Null,
+        NonFiniteFloatRenderPolicy::Object => {
+            let mut fields = Map::new();
+            fields.insert(
+                "$type".to_string(),
+                Value::String("non_finite_float".to_string()),
+            );
+            fields.insert(
+                "value".to_string(),
+                Value::String(non_finite_float_label(value).to_string()),
+            );
+            Value::Object(fields)
+        }
+    }
+}
+
+fn non_finite_float_label(value: f64) -> &'static str {
+    if value.is_nan() {
+        "NaN"
+    } else if value.is_sign_negative() {
+        "-Infinity"
+    } else {
+        "Infinity"
+    }
+}
+
+fn bytes_to_json(bytes: &[u8], policy: ByteRenderPolicy) -> Value {
+    match policy {
+        ByteRenderPolicy::Compact { preview_len } => {
+            let mut fields = Map::new();
+            fields.insert("$type".to_string(), Value::String("bytes".to_string()));
+            fields.insert("len".to_string(), Value::from(bytes.len()));
+            fields.insert(
+                "preview".to_string(),
+                Value::Array(
+                    bytes
+                        .iter()
+                        .take(preview_len)
+                        .map(|byte| Value::from(*byte))
+                        .collect(),
+                ),
+            );
+            fields.insert(
+                "truncated".to_string(),
+                Value::Bool(bytes.len() > preview_len),
+            );
+            Value::Object(fields)
+        }
+        ByteRenderPolicy::FullArray => {
+            Value::Array(bytes.iter().map(|byte| Value::from(*byte)).collect())
+        }
+    }
+}
+
+fn struct_to_json(value: &DynamicStruct, policy: DynamicJsonRenderPolicy) -> Value {
+    Value::Object(
+        value
+            .iter()
+            .map(|(name, value)| (name.to_string(), dynamic_value_to_json(value, policy)))
+            .collect(),
+    )
+}
+
+fn enum_to_json(value: &EnumValue, policy: DynamicJsonRenderPolicy) -> Value {
+    let mut fields = Map::new();
+    fields.insert(
+        "variant_index".to_string(),
+        Value::Number(value.variant_index.into()),
+    );
+    fields.insert(
+        "variant_name".to_string(),
+        Value::String(value.variant_name.clone()),
+    );
+    fields.insert(
+        "payload".to_string(),
+        enum_payload_to_json(&value.payload, policy),
+    );
+    Value::Object(fields)
+}
+
+fn enum_payload_to_json(payload: &EnumPayloadValue, policy: DynamicJsonRenderPolicy) -> Value {
+    match payload {
+        EnumPayloadValue::Unit => Value::Null,
+        EnumPayloadValue::Newtype(value) => dynamic_value_to_json(value, policy),
+        EnumPayloadValue::Tuple(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| dynamic_value_to_json(value, policy))
+                .collect(),
+        ),
+        EnumPayloadValue::Struct(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|field| {
+                    (
+                        field.name.clone(),
+                        dynamic_value_to_json(&field.value, policy),
+                    )
+                })
+                .collect(),
+        ),
+    }
+}

--- a/crates/ros-z/src/dynamic/mod.rs
+++ b/crates/ros-z/src/dynamic/mod.rs
@@ -67,6 +67,7 @@
 pub mod codec;
 pub(crate) mod discovery;
 pub mod error;
+pub mod json;
 pub mod message;
 pub mod registry;
 pub mod schema;
@@ -82,6 +83,10 @@ mod tests;
 pub use codec::{DynamicCdrCodec, DynamicPayload};
 pub use discovery::DiscoveredTopicSchema;
 pub use error::DynamicError;
+pub use json::{
+    ByteRenderPolicy, DynamicJsonRenderPolicy, NonFiniteFloatRenderPolicy, dynamic_payload_to_json,
+    dynamic_value_to_json,
+};
 pub use message::{DynamicStruct, DynamicStructBuilder};
 pub use registry::{SchemaRegistry, get_root_schema_with_hash, has_schema, register_root_schema};
 pub use schema::{

--- a/crates/ros-z/src/dynamic/tests/mod.rs
+++ b/crates/ros-z/src/dynamic/tests/mod.rs
@@ -1,1 +1,41 @@
 //! Tests for the dynamic message module.
+
+use crate::dynamic::{
+    ByteRenderPolicy, DynamicJsonRenderPolicy, DynamicValue, NonFiniteFloatRenderPolicy,
+    dynamic_value_to_json,
+};
+
+#[test]
+fn dynamic_json_default_distinguishes_non_finite_floats_from_absent_optionals() {
+    let value = dynamic_value_to_json(
+        &DynamicValue::Sequence(vec![
+            DynamicValue::Float32(f32::NAN),
+            DynamicValue::Optional(None),
+        ]),
+        DynamicJsonRenderPolicy::default(),
+    );
+
+    assert_eq!(
+        value,
+        serde_json::json!([
+            { "$type": "non_finite_float", "value": "NaN" },
+            null
+        ])
+    );
+}
+
+#[test]
+fn dynamic_json_policy_can_preserve_cli_byte_and_float_shape() {
+    let value = dynamic_value_to_json(
+        &DynamicValue::Sequence(vec![
+            DynamicValue::Bytes(vec![1, 2, 3]),
+            DynamicValue::Float64(f64::INFINITY),
+        ]),
+        DynamicJsonRenderPolicy {
+            bytes: ByteRenderPolicy::FullArray,
+            non_finite_float: NonFiniteFloatRenderPolicy::Null,
+        },
+    );
+
+    assert_eq!(value, serde_json::json!([[1, 2, 3], null]));
+}

--- a/crates/ros-z/tests/nalgebra_field_type_info.rs
+++ b/crates/ros-z/tests/nalgebra_field_type_info.rs
@@ -9,14 +9,16 @@ use nalgebra::{
 use ros_z::{
     Message,
     context::ContextBuilder,
-    dynamic::{DynamicStruct, DynamicValue, EnumPayloadValue, EnumValue},
+    dynamic::{
+        ByteRenderPolicy, DynamicJsonRenderPolicy, DynamicValue, NonFiniteFloatRenderPolicy,
+    },
     entity::EntityKind,
 };
 use ros_z_schema::{
     FieldDef, PrimitiveTypeDef, SchemaBundle, SequenceLengthDef, TypeDef, TypeDefinition,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use zenoh::{Wait, config::WhatAmI};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ros_z::Message)]
@@ -143,86 +145,14 @@ fn example_math_command() -> MathCommand {
     }
 }
 
-fn dynamic_message_to_json(message: &DynamicStruct) -> Value {
-    let mut fields = Map::new();
-    for (name, value) in message.iter() {
-        fields.insert(name.to_string(), dynamic_value_to_json(value));
-    }
-    Value::Object(fields)
-}
-
 fn dynamic_value_to_json(value: &DynamicValue) -> Value {
-    match value {
-        DynamicValue::Bool(value) => Value::Bool(*value),
-        DynamicValue::Int8(value) => Value::Number((*value).into()),
-        DynamicValue::Int16(value) => Value::Number((*value).into()),
-        DynamicValue::Int32(value) => Value::Number((*value).into()),
-        DynamicValue::Int64(value) => Value::Number((*value).into()),
-        DynamicValue::Uint8(value) => Value::Number((*value).into()),
-        DynamicValue::Uint16(value) => Value::Number((*value).into()),
-        DynamicValue::Uint32(value) => Value::Number((*value).into()),
-        DynamicValue::Uint64(value) => Value::Number((*value).into()),
-        DynamicValue::Float32(value) => serde_json::Number::from_f64(*value as f64)
-            .map(Value::Number)
-            .unwrap_or(Value::Null),
-        DynamicValue::Float64(value) => serde_json::Number::from_f64(*value)
-            .map(Value::Number)
-            .unwrap_or(Value::Null),
-        DynamicValue::String(value) => Value::String(value.clone()),
-        DynamicValue::Bytes(value) => Value::Array(
-            value
-                .iter()
-                .map(|byte| Value::Number((*byte).into()))
-                .collect(),
-        ),
-        DynamicValue::Struct(value) => dynamic_message_to_json(value),
-        DynamicValue::Optional(None) => Value::Null,
-        DynamicValue::Optional(Some(value)) => dynamic_value_to_json(value),
-        DynamicValue::Enum(value) => enum_value_to_json(value),
-        DynamicValue::Sequence(values) => {
-            Value::Array(values.iter().map(dynamic_value_to_json).collect())
-        }
-        DynamicValue::Map(entries) => Value::Array(
-            entries
-                .iter()
-                .map(|(key, value)| {
-                    let mut entry = Map::new();
-                    entry.insert("key".to_string(), dynamic_value_to_json(key));
-                    entry.insert("value".to_string(), dynamic_value_to_json(value));
-                    Value::Object(entry)
-                })
-                .collect(),
-        ),
-    }
+    ros_z::dynamic::dynamic_value_to_json(value, test_json_policy())
 }
 
-fn enum_value_to_json(value: &EnumValue) -> Value {
-    let mut fields = Map::new();
-    fields.insert(
-        "variant_index".to_string(),
-        Value::Number(value.variant_index.into()),
-    );
-    fields.insert(
-        "variant_name".to_string(),
-        Value::String(value.variant_name.clone()),
-    );
-    fields.insert("payload".to_string(), enum_payload_to_json(&value.payload));
-    Value::Object(fields)
-}
-
-fn enum_payload_to_json(payload: &EnumPayloadValue) -> Value {
-    match payload {
-        EnumPayloadValue::Unit => Value::Null,
-        EnumPayloadValue::Newtype(value) => dynamic_value_to_json(value),
-        EnumPayloadValue::Tuple(values) => {
-            Value::Array(values.iter().map(dynamic_value_to_json).collect())
-        }
-        EnumPayloadValue::Struct(fields) => Value::Object(
-            fields
-                .iter()
-                .map(|field| (field.name.clone(), dynamic_value_to_json(&field.value)))
-                .collect(),
-        ),
+fn test_json_policy() -> DynamicJsonRenderPolicy {
+    DynamicJsonRenderPolicy {
+        bytes: ByteRenderPolicy::FullArray,
+        non_finite_float: NonFiniteFloatRenderPolicy::Null,
     }
 }
 
@@ -284,7 +214,7 @@ fn fixed_sequence(shape: &TypeDef) -> Option<(PrimitiveTypeDef, usize)> {
 }
 
 fn dynamic_payload_to_json(message: &ros_z::dynamic::DynamicPayload) -> Value {
-    dynamic_value_to_json(&message.value)
+    ros_z::dynamic::dynamic_payload_to_json(message, test_json_policy())
 }
 
 fn dynamic_payload_field(


### PR DESCRIPTION
## Summary
- Move dynamic JSON rendering into reusable `ros-z` APIs with explicit byte and non-finite float policies.
- Keep `ros-z-cli echo --json` output compatible by selecting the legacy full-byte-array/null-float policy.
- Cover shared renderer behavior, including nalgebra dynamic JSON and non-finite floats.