### PR TITLE
fix(ros-z): validate topic and namespace components

### DIFF
--- a/crates/ros-z/src/topic_name.rs
+++ b/crates/ros-z/src/topic_name.rs
@@ -37,6 +37,26 @@ fn is_valid_topic_component(component: &str) -> bool {
         .all(|&b| b.is_ascii_alphanumeric() || b == b'_')
 }
 
+fn validate_topic_components(topic: &str, context: &str) -> Result<(), TopicNameError> {
+    for (index, part) in topic.split('/').enumerate() {
+        if part.is_empty() {
+            if index == 0 && topic.starts_with('/') {
+                continue;
+            }
+            return Err(TopicNameError::InvalidCharacters(format!(
+                "empty component{context}"
+            )));
+        }
+
+        if !is_valid_topic_component(part) {
+            return Err(TopicNameError::InvalidCharacters(format!(
+                "invalid component '{part}'{context}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Validate a namespace string
 /// Namespaces can be empty, "/", or a series of valid components separated by "/"
 fn validate_namespace(namespace: &str) -> Result<(), TopicNameError> {
@@ -146,6 +166,7 @@ pub fn qualify_topic_name(
                 "topic cannot be just '/'".to_string(),
             ));
         }
+        validate_topic_components(topic, "")?;
         topic.to_string()
     } else if topic.starts_with('~') {
         // Private topic - expand with namespace and node name
@@ -154,14 +175,7 @@ pub fn qualify_topic_name(
 
         // Validate the topic suffix
         if !topic_suffix.is_empty() {
-            for part in topic_suffix.split('/') {
-                if !part.is_empty() && !is_valid_topic_component(part) {
-                    return Err(TopicNameError::InvalidCharacters(format!(
-                        "invalid component '{}' in private topic",
-                        part
-                    )));
-                }
-            }
+            validate_topic_components(topic_suffix, " in private topic")?;
         }
 
         if namespace.is_empty() || namespace == "/" {
@@ -179,15 +193,7 @@ pub fn qualify_topic_name(
         // Relative topic - expand with namespace only
         let topic = topic.strip_suffix('/').unwrap_or(topic);
 
-        // Validate topic components
-        for part in topic.split('/') {
-            if !part.is_empty() && !is_valid_topic_component(part) {
-                return Err(TopicNameError::InvalidCharacters(format!(
-                    "invalid component '{}'",
-                    part
-                )));
-            }
-        }
+        validate_topic_components(topic, "")?;
 
         if namespace.is_empty() || namespace == "/" {
             format!("/{}", topic)
@@ -256,6 +262,18 @@ mod tests {
             qualify_topic_name("/chatter/", "/ns", "node").unwrap(),
             "/chatter"
         );
+    }
+
+    #[test]
+    fn test_absolute_topics_validate_components() {
+        assert!(matches!(
+            qualify_topic_name("/123invalid", "/ns", "node"),
+            Err(TopicNameError::InvalidCharacters(_))
+        ));
+        assert!(matches!(
+            qualify_topic_name("/valid/foo-bar", "/ns", "node"),
+            Err(TopicNameError::InvalidCharacters(_))
+        ));
     }
 
     #[test]

--- a/crates/ros-z/src/topic_name.rs
+++ b/crates/ros-z/src/topic_name.rs
@@ -70,9 +70,14 @@ fn validate_namespace(namespace: &str) -> Result<(), TopicNameError> {
         ));
     }
 
-    for part in namespace.split('/') {
+    for (index, part) in namespace.split('/').enumerate() {
         if part.is_empty() {
-            continue; // Leading slash creates empty first component
+            if index == 0 && namespace.starts_with('/') {
+                continue;
+            }
+            return Err(TopicNameError::InvalidNamespace(
+                "empty component".to_string(),
+            ));
         }
         if !is_valid_topic_component(part) {
             return Err(TopicNameError::InvalidNamespace(format!(
@@ -341,6 +346,18 @@ mod tests {
     fn test_invalid_namespace() {
         assert!(matches!(
             qualify_topic_name("chatter", "/ns/", "node"),
+            Err(TopicNameError::InvalidNamespace(_))
+        ));
+    }
+
+    #[test]
+    fn test_invalid_namespace_rejects_empty_components() {
+        assert!(matches!(
+            qualify_topic_name("chatter", "/ns//nested", "node"),
+            Err(TopicNameError::InvalidNamespace(_))
+        ));
+        assert!(matches!(
+            qualify_topic_name("chatter", "ns//nested", "node"),
             Err(TopicNameError::InvalidNamespace(_))
         ));
     }


### PR DESCRIPTION
## Summary
- Validate components of absolute topic names instead of accepting any absolute string.
- Reject namespaces with interior empty components such as `/ns//nested`.
- Preserve relative, private, and service topic qualification behavior.
- Add focused topic-name regression coverage for invalid absolute components and invalid namespace components.

## Stack
- Depends on #2585.
- Base branch: `ros-z-debug-dynamic-json-prereq`.
- Review only the commit(s) after #2585, mainly `crates/ros-z/src/topic_name.rs`.
- Next PR: #2587.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run -p ros-z topic_name`
- [x] `cargo nextest run -p ros-z-protocol -p ros-z -p ros-z-cli -p ros-z-debug`
- [x] `cargo clippy -p ros-z-protocol -p ros-z -p ros-z-cli -p ros-z-debug --all-targets --locked -- -D warnings`
- [x] `cargo test --doc -p ros-z-protocol -p ros-z -p ros-z-debug`