### PR TITLE
test(ros-z-protocol): cover public node fqn helper

### DIFF
--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -251,7 +251,7 @@ pub enum EntityConversionError {
 
 #[cfg(test)]
 mod tests {
-    use super::NodeEntity;
+    use super::{NodeEntity, fully_qualified_node_name};
 
     fn node(namespace: &str) -> NodeEntity {
         NodeEntity::new(
@@ -275,6 +275,11 @@ mod tests {
     #[test]
     fn fully_qualified_name_inserts_separator_after_non_root_namespace() {
         assert_eq!(node("/robot").fully_qualified_name(), "/robot/node");
+    }
+
+    #[test]
+    fn public_helper_prefixes_bare_namespace() {
+        assert_eq!(fully_qualified_node_name("robot", "node"), "/robot/node");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add direct regression coverage for the public `ros_z_protocol::entity::fully_qualified_node_name` helper.
- Lock in bare-namespace formatting through the public helper API.

## Stack
- Depends on #2586.
- Base branch: `ros-z-debug-topic-validation-prereq`.
- Review only the commit(s) after #2586, mainly `crates/ros-z-protocol/src/entity.rs`.
- Next PR: #2506.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run -p ros-z-protocol fully_qualified`
- [x] `cargo nextest run -p ros-z-protocol public_helper_prefixes_bare_namespace`
- [x] `cargo nextest run -p ros-z-protocol -p ros-z -p ros-z-cli -p ros-z-debug`
- [x] `cargo clippy -p ros-z-protocol -p ros-z -p ros-z-cli -p ros-z-debug --all-targets --locked -- -D warnings`
- [x] `cargo test --doc -p ros-z-protocol -p ros-z -p ros-z-debug`