### PR TITLE
Remove game controller TimeWrappers

### DIFF
--- a/crates/nodes/active_vision/src/lib.rs
+++ b/crates/nodes/active_vision/src/lib.rs
@@ -40,7 +40,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let _position_of_interest_pub = node

--- a/crates/nodes/active_vision/src/lib.rs
+++ b/crates/nodes/active_vision/src/lib.rs
@@ -40,7 +40,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _position_of_interest_pub = node

--- a/crates/nodes/ball_state_composer/src/lib.rs
+++ b/crates/nodes/ball_state_composer/src/lib.rs
@@ -50,7 +50,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _additional_last_ball_state_pub = node

--- a/crates/nodes/game_controller_filter/src/lib.rs
+++ b/crates/nodes/game_controller_filter/src/lib.rs
@@ -35,7 +35,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let game_controller_state_pub = node
-        .publisher::<TimeWrapper<Option<GameControllerState>>>("game_controller_state")?
+        .publisher::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
     let game_controller_address_pub = node
@@ -76,12 +76,9 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             .max_by_key(|(_address, time)| *time)
             .map(|(address, _time)| *address);
 
-        let time_wrapper = TimeWrapper {
-            time,
-            inner: game_controller_filter.game_controller_state.clone(),
-        };
-
-        game_controller_state_pub.publish(&time_wrapper).await?;
+        game_controller_state_pub
+            .publish(&game_controller_filter.game_controller_state)
+            .await?;
         game_controller_address_pub.publish(&last_address).await?;
     }
 }

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -12,7 +12,7 @@ use types::{
     field_dimensions::FieldDimensions, filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState, filtered_whistle::FilteredWhistle,
     game_controller_state::GameControllerState, parameters::GameStateFilterParameters,
-    players::Players, time_wrapper::TimeWrapper, world_state::BallState,
+    players::Players, world_state::BallState,
 };
 
 use crate::state::State;
@@ -49,7 +49,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
 
     let game_controller_state_sub = node
-        .subscriber::<TimeWrapper<Option<GameControllerState>>>("game_controller_state")?
+        .subscriber::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
     let filtered_whistle_cache = node
@@ -66,7 +66,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let filtered_game_controller_state_pub = node
-        .publisher::<TimeWrapper<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .publisher::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
 
@@ -77,13 +77,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         let parameters_snapshot = parameters.snapshot();
         let parameters = parameters_snapshot.typed();
 
-        let game_controller_state_wrapper = game_controller_state_sub.recv().await?;
-
-        let TimeWrapper {
-            time,
-            inner: Some(game_controller_state),
-        } = game_controller_state_wrapper
-        else {
+        let Some(game_controller_state) = game_controller_state_sub.recv().await? else {
             continue;
         };
 
@@ -102,9 +96,8 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             latest_known_ball_state = Some((ball_state, time))
         };
 
-        let filtered_game_controller_state = TimeWrapper {
-            time,
-            inner: game_controller_state_filter.compute_filtered_game_controller_state(
+        let filtered_game_controller_state = Some(
+            game_controller_state_filter.compute_filtered_game_controller_state(
                 node.clock().now(),
                 parameters,
                 &field_dimensions,
@@ -114,7 +107,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
                 &filtered_whistle,
                 &current_ball_state,
             ),
-        };
+        );
 
         whistle_in_set_ball_position_pub
             .publish(&game_controller_state_filter.whistle_in_set_ball_position)

--- a/crates/nodes/game_controller_state_filter/src/lib.rs
+++ b/crates/nodes/game_controller_state_filter/src/lib.rs
@@ -66,7 +66,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let filtered_game_controller_state_pub = node
-        .publisher::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .publisher::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
 
@@ -96,8 +96,8 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             latest_known_ball_state = Some((ball_state, time))
         };
 
-        let filtered_game_controller_state = Some(
-            game_controller_state_filter.compute_filtered_game_controller_state(
+        let filtered_game_controller_state = game_controller_state_filter
+            .compute_filtered_game_controller_state(
                 node.clock().now(),
                 parameters,
                 &field_dimensions,
@@ -106,8 +106,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
                 &latest_known_ball_state,
                 &filtered_whistle,
                 &current_ball_state,
-            ),
-        );
+            );
 
         whistle_in_set_ball_position_pub
             .publish(&game_controller_state_filter.whistle_in_set_ball_position)

--- a/crates/nodes/localization/src/lib.rs
+++ b/crates/nodes/localization/src/lib.rs
@@ -58,7 +58,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let _parameters = node.bind_parameter_as::<Parameters>("localization")?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _primary_state_sub = node

--- a/crates/nodes/look_around/src/lib.rs
+++ b/crates/nodes/look_around/src/lib.rs
@@ -24,7 +24,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _current_mode_pub = node

--- a/crates/nodes/player_state_receiver/src/lib.rs
+++ b/crates/nodes/player_state_receiver/src/lib.rs
@@ -16,7 +16,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("player_state_receiver").build().await?;
     let filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let filtered_message_sub = node
@@ -36,9 +36,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     loop {
         tokio::select! {
             received_game_controller_state = filtered_game_controller_state_sub.recv() => {
-                let Some(game_controller_state) = received_game_controller_state? else {
-                    continue;
-                };
+                let game_controller_state = received_game_controller_state?;
                 clear_penalized_players(&mut player_states, &game_controller_state);
                 player_states_pub.publish(&player_states).await?;
             }

--- a/crates/nodes/player_state_receiver/src/lib.rs
+++ b/crates/nodes/player_state_receiver/src/lib.rs
@@ -16,7 +16,7 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("player_state_receiver").build().await?;
     let filtered_game_controller_state_sub = node
-        .subscriber::<TimeWrapper<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let filtered_message_sub = node
@@ -36,8 +36,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     loop {
         tokio::select! {
             received_game_controller_state = filtered_game_controller_state_sub.recv() => {
-                let game_controller_state = received_game_controller_state?;
-                clear_penalized_players(&mut player_states, &game_controller_state.inner);
+                let Some(game_controller_state) = received_game_controller_state? else {
+                    continue;
+                };
+                clear_penalized_players(&mut player_states, &game_controller_state);
                 player_states_pub.publish(&player_states).await?;
             }
             received_message = filtered_message_sub.recv() => {

--- a/crates/nodes/primary_state_filter/src/lib.rs
+++ b/crates/nodes/primary_state_filter/src/lib.rs
@@ -11,7 +11,6 @@ use types::{
     filtered_game_controller_state::FilteredGameControllerState,
     filtered_game_state::FilteredGameState,
     primary_state::PrimaryState,
-    time_wrapper::TimeWrapper,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
@@ -39,7 +38,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
 
     let filtered_game_controller_state_sub = node
-        .subscriber::<TimeWrapper<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
         .build()
         .await?;
     let buttons_sub = node
@@ -72,7 +71,9 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             received_filtered_game_controller_state = filtered_game_controller_state_sub.recv() => {
                 let Some(player_number) = player_number_cache.get_latest() else {continue};
 
-                let TimeWrapper {inner: filtered_game_controller_state ,.. } = received_filtered_game_controller_state?;
+                let Some(filtered_game_controller_state) = received_filtered_game_controller_state? else {
+                    continue;
+                };
 
                 primary_state_filter.update_with_filtered_game_contoller_state(
                     &filtered_game_controller_state,

--- a/crates/nodes/primary_state_filter/src/lib.rs
+++ b/crates/nodes/primary_state_filter/src/lib.rs
@@ -38,7 +38,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
 
     let filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let buttons_sub = node
@@ -71,9 +71,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             received_filtered_game_controller_state = filtered_game_controller_state_sub.recv() => {
                 let Some(player_number) = player_number_cache.get_latest() else {continue};
 
-                let Some(filtered_game_controller_state) = received_filtered_game_controller_state? else {
-                    continue;
-                };
+                let filtered_game_controller_state = received_filtered_game_controller_state?;
 
                 primary_state_filter.update_with_filtered_game_contoller_state(
                     &filtered_game_controller_state,

--- a/crates/nodes/rule_obstacle_composer/src/lib.rs
+++ b/crates/nodes/rule_obstacle_composer/src/lib.rs
@@ -35,7 +35,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _ball_state_sub = node.subscriber::<BallState>("ball_state")?.build().await?;

--- a/crates/nodes/search_suggestor/src/lib.rs
+++ b/crates/nodes/search_suggestor/src/lib.rs
@@ -52,7 +52,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _network_message_sub = node

--- a/crates/nodes/team_ball_receiver/src/lib.rs
+++ b/crates/nodes/team_ball_receiver/src/lib.rs
@@ -26,7 +26,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let _parameters = node.bind_parameter_as::<Parameters>("team_ball_receiver")?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _network_message_sub = node

--- a/crates/nodes/world_state_composer/src/lib.rs
+++ b/crates/nodes/world_state_composer/src/lib.rs
@@ -38,7 +38,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
     let _ball_sub = node.subscriber::<BallState>("ball_state")?.build().await?;
     let _filtered_game_controller_state_sub = node
-        .subscriber::<Option<FilteredGameControllerState>>("filtered_game_controller_state")?
+        .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")?
         .build()
         .await?;
     let _ground_to_field_sub = node

--- a/crates/nodes/world_to_field_provider/src/lib.rs
+++ b/crates/nodes/world_to_field_provider/src/lib.rs
@@ -6,10 +6,7 @@ use color_eyre::Result;
 use coordinate_systems::{Field, World};
 use linear_algebra::Isometry2;
 use ros_z::prelude::*;
-use types::{
-    field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState,
-    time_wrapper::TimeWrapper,
-};
+use types::{field_dimensions::GlobalFieldSide, game_controller_state::GameControllerState};
 
 pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
     Box::pin(run(ctx))
@@ -18,33 +15,24 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("world_to_field_provider").build().await?;
     let game_controller_state_sub = node
-        .subscriber::<TimeWrapper<Option<GameControllerState>>>("game_controller_state")?
+        .subscriber::<Option<GameControllerState>>("game_controller_state")?
         .build()
         .await?;
 
     let world_to_field_pub = node
-        .publisher::<TimeWrapper<Isometry2<World, Field>>>("world_to_field")?
+        .publisher::<Option<Isometry2<World, Field>>>("world_to_field")?
         .build()
         .await?;
 
     loop {
-        let game_controller_state_wrapper = game_controller_state_sub.recv().await?;
+        let game_controller_state = game_controller_state_sub.recv().await?;
 
-        let TimeWrapper {
-            time,
-            inner: Some(game_controller_state),
-        } = game_controller_state_wrapper
-        else {
-            continue;
-        };
-
-        let world_to_field = TimeWrapper {
-            time,
-            inner: match game_controller_state.global_field_side {
+        let world_to_field = game_controller_state.map(|game_controller_state| {
+            match game_controller_state.global_field_side {
                 GlobalFieldSide::Home => Isometry2::identity(),
                 GlobalFieldSide::Away => Isometry2::rotation(PI),
-            },
-        };
+            }
+        });
 
         world_to_field_pub.publish(&world_to_field).await?;
     }


### PR DESCRIPTION
## Summary
- Publish raw and filtered game-controller state as plain optional values.
- Align game-controller consumers with the optional state schema.
- Keep receive-time wrappers on network messages and player states.

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo nextest run`
- [x] `cargo test --doc`