### PR TITLE
Yoink ros-z from pepsi deps for Android (Redeclaration Variant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8024,7 +8024,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.26.0"
+version = "7.27.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/argument_parsers/Cargo.toml
+++ b/crates/argument_parsers/Cargo.toml
@@ -7,6 +7,6 @@ homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }
-hsl_network_messages = { workspace = true }
+hsl_network_messages = { path = "../hsl_network_messages", default-features = false }
 regex = { workspace = true }
 robot = { workspace = true }

--- a/crates/coordinate_systems/Cargo.toml
+++ b/crates/coordinate_systems/Cargo.toml
@@ -9,5 +9,9 @@ homepage.workspace = true
 approx = { workspace = true }
 approx_derive = { workspace = true }
 path_serde = { workspace = true }
-ros-z = { workspace = true }
+ros-z = { workspace = true, optional = true }
 serde = { workspace = true }
+
+[features]
+default = ["ros_z"]
+ros_z = ["dep:ros-z"]

--- a/crates/coordinate_systems/src/lib.rs
+++ b/crates/coordinate_systems/src/lib.rs
@@ -20,8 +20,8 @@ macro_rules! generate_coordinate_system {
                 PathSerialize,
                 PathDeserialize,
                 PathIntrospect,
-                ros_z::Message,
             )]
+            #[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
             #[abs_diff_eq(epsilon_type = f32)]
             $(#[$doc])*
             pub struct $i;

--- a/crates/hsl_network_messages/Cargo.toml
+++ b/crates/hsl_network_messages/Cargo.toml
@@ -6,16 +6,20 @@ license.workspace = true
 homepage.workspace = true
 
 [build-dependencies]
-bindgen = { workspace = true }
+bindgen = { workspace = true, optional = true }
 
 [dependencies]
 approx = { workspace = true }
 color-eyre = { workspace = true }
-coordinate_systems = { workspace = true }
-linear_algebra = { workspace = true }
+coordinate_systems = { workspace = true, optional = true }
+linear_algebra = { workspace = true, optional = true }
 path_serde = { workspace = true }
-ros-z = { workspace = true }
+ros-z = { workspace = true, optional = true }
 serde = { workspace = true }
+
+[features]
+default = ["ros_z"]
+ros_z = ["dep:bindgen", "dep:coordinate_systems", "dep:linear_algebra", "dep:ros-z"]
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/crates/hsl_network_messages/Cargo.toml
+++ b/crates/hsl_network_messages/Cargo.toml
@@ -6,20 +6,20 @@ license.workspace = true
 homepage.workspace = true
 
 [build-dependencies]
-bindgen = { workspace = true, optional = true }
+bindgen = { workspace = true }
 
 [dependencies]
 approx = { workspace = true }
 color-eyre = { workspace = true }
-coordinate_systems = { workspace = true, optional = true }
-linear_algebra = { workspace = true, optional = true }
+coordinate_systems = { path = "../coordinate_systems", default-features = false }
+linear_algebra = { path = "../linear_algebra", default-features = false }
 path_serde = { workspace = true }
 ros-z = { workspace = true, optional = true }
 serde = { workspace = true }
 
 [features]
 default = ["ros_z"]
-ros_z = ["dep:bindgen", "dep:coordinate_systems", "dep:linear_algebra", "dep:ros-z"]
+ros_z = ["coordinate_systems/ros_z", "dep:ros-z", "linear_algebra/ros_z"]
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/crates/hsl_network_messages/build.rs
+++ b/crates/hsl_network_messages/build.rs
@@ -1,12 +1,5 @@
-#[cfg(feature = "ros_z")]
-use std::{env, path::PathBuf};
-
-#[cfg(feature = "ros_z")]
-use bindgen::Builder;
-
-#[cfg(feature = "ros_z")]
 fn main() {
-    let bindings = Builder::default()
+    let bindings = bindgen::Builder::default()
         .header("headers/RoboCupGameControlData.hpp")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .layout_tests(false)
@@ -14,11 +7,8 @@ fn main() {
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Failed to write bindings");
 }
-
-#[cfg(not(feature = "ros_z"))]
-fn main() {}

--- a/crates/hsl_network_messages/build.rs
+++ b/crates/hsl_network_messages/build.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "ros_z")]
 use std::{env, path::PathBuf};
 
+#[cfg(feature = "ros_z")]
 use bindgen::Builder;
 
+#[cfg(feature = "ros_z")]
 fn main() {
     let bindings = Builder::default()
         .header("headers/RoboCupGameControlData.hpp")
@@ -16,3 +19,6 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Failed to write bindings");
 }
+
+#[cfg(not(feature = "ros_z"))]
+fn main() {}

--- a/crates/hsl_network_messages/src/game_controller_return_message.rs
+++ b/crates/hsl_network_messages/src/game_controller_return_message.rs
@@ -3,7 +3,6 @@ use std::{ffi::c_char, mem::size_of, ptr::read, slice::from_raw_parts, time::Dur
 use color_eyre::{Report, Result, eyre::bail};
 use coordinate_systems::{Field, Ground};
 use linear_algebra::{Pose2, point};
-use ros_z::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -14,7 +13,8 @@ use crate::{
     },
 };
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Message)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub struct GameControllerReturnMessage {
     pub player_number: PlayerNumber,
     pub fallen: bool,

--- a/crates/hsl_network_messages/src/game_controller_state_message.rs
+++ b/crates/hsl_network_messages/src/game_controller_state_message.rs
@@ -8,7 +8,6 @@ use std::{
 
 use color_eyre::{Report, Result, eyre::bail};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
-use ros_z::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -28,7 +27,8 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathIntrospect, Message)]
+#[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathIntrospect)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub struct GameControllerStateMessage {
     pub competition_type: CompetitionType,
     pub stopped: bool,
@@ -206,16 +206,9 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
 }
 
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    Deserialize,
-    Serialize,
-    PathSerialize,
-    PathDeserialize,
-    PathIntrospect,
-    Message,
+    Clone, Copy, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum CompetitionType {
     Small,
     Middle,
@@ -244,8 +237,8 @@ impl CompetitionType {
     PathDeserialize,
     PathIntrospect,
     PartialEq,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum GamePhase {
     #[default]
     Normal,
@@ -284,8 +277,8 @@ impl GamePhase {
     PathSerialize,
     PathDeserialize,
     PathIntrospect,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum GameState {
     Initial,
     Ready,
@@ -318,8 +311,8 @@ impl GameState {
     PathSerialize,
     PathDeserialize,
     PathIntrospect,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum Team {
     Hulks,
     Opponent,
@@ -351,8 +344,8 @@ impl TryFrom<u8> for Team {
     PathDeserialize,
     PathIntrospect,
     PartialEq,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum SubState {
     #[default]
     DirectFreeKick,
@@ -389,8 +382,8 @@ impl SubState {
     PathSerialize,
     PathDeserialize,
     PathIntrospect,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum Half {
     First,
     Second,
@@ -408,9 +401,8 @@ impl TryFrom<u8> for Half {
     }
 }
 
-#[derive(
-    Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect, Message,
-)]
+#[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub struct TeamState {
     pub team_number: u8,
     pub field_player_color: TeamColor,
@@ -423,9 +415,8 @@ pub struct TeamState {
     pub players: Vec<Player>,
 }
 
-#[derive(
-    Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect, Message,
-)]
+#[derive(Clone, Debug, Deserialize, Serialize, PathSerialize, PathDeserialize, PathIntrospect)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum TeamColor {
     Blue,
     Red,
@@ -459,13 +450,15 @@ impl TryFrom<u8> for TeamColor {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Message)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum PenaltyShoot {
     Successful,
     Unsuccessful,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Message)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub struct Player {
     pub penalty: Option<Penalty>,
     pub warning: u8,
@@ -495,8 +488,8 @@ impl TryFrom<RobotInfo> for Player {
     PathDeserialize,
     PathIntrospect,
     PartialEq,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum Penalty {
     IllegalPosition { remaining: Duration },
     MotionInSet { remaining: Duration },

--- a/crates/hsl_network_messages/src/lib.rs
+++ b/crates/hsl_network_messages/src/lib.rs
@@ -1,19 +1,24 @@
+#[cfg(feature = "ros_z")]
 mod bindings;
+#[cfg(feature = "ros_z")]
 mod game_controller_return_message;
+#[cfg(feature = "ros_z")]
 mod game_controller_state_message;
 
-use std::{
-    fmt::{self, Display, Formatter},
-    time::Duration,
-};
+use std::fmt::{self, Display, Formatter};
+#[cfg(feature = "ros_z")]
+use std::time::Duration;
 
+#[cfg(feature = "ros_z")]
 use coordinate_systems::Field;
+#[cfg(feature = "ros_z")]
 use linear_algebra::{Point2, Pose2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
-use ros_z::Message;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "ros_z")]
 pub use game_controller_return_message::GameControllerReturnMessage;
+#[cfg(feature = "ros_z")]
 pub use game_controller_state_message::{
     GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player,
     SubState, Team, TeamColor, TeamState,
@@ -28,19 +33,23 @@ pub use game_controller_state_message::{
     PathDeserialize,
     PathIntrospect,
     PathSerialize,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
+#[cfg(feature = "ros_z")]
 pub enum HulkMessage {
     State(StateMessage),
 }
 
+#[cfg(feature = "ros_z")]
 impl Default for HulkMessage {
     fn default() -> Self {
         HulkMessage::State(StateMessage::default())
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Message)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
+#[cfg(feature = "ros_z")]
 pub struct StrikerMessage {
     pub player_number: PlayerNumber,
     pub pose: Pose2<Field>,
@@ -58,8 +67,9 @@ pub struct StrikerMessage {
     PathDeserialize,
     PathIntrospect,
     PathSerialize,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
+#[cfg(feature = "ros_z")]
 pub struct StateMessage {
     pub player_number: PlayerNumber,
     pub pose: Pose2<Field>,
@@ -76,8 +86,9 @@ pub struct StateMessage {
     PathIntrospect,
     PathSerialize,
     Serialize,
-    Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
+#[cfg(feature = "ros_z")]
 pub struct BallPosition<Frame> {
     pub position: Point2<Frame>,
     pub age: Duration,
@@ -101,8 +112,8 @@ pub const NONE_TEAM_NUMBER: u8 = 255;
     PathIntrospect,
     PathSerialize,
     Serialize,
-    ros_z::Message,
 )]
+#[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
 pub enum PlayerNumber {
     One,
     Two,
@@ -126,7 +137,7 @@ impl Display for PlayerNumber {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ros_z"))]
 mod tests {
     use super::*;
     #[test]

--- a/crates/hsl_network_messages/src/lib.rs
+++ b/crates/hsl_network_messages/src/lib.rs
@@ -1,46 +1,33 @@
-#[cfg(feature = "ros_z")]
 mod bindings;
-#[cfg(feature = "ros_z")]
 mod game_controller_return_message;
-#[cfg(feature = "ros_z")]
 mod game_controller_state_message;
 
 use std::fmt::{self, Display, Formatter};
-#[cfg(feature = "ros_z")]
-use std::time::Duration;
 
-#[cfg(feature = "ros_z")]
-use coordinate_systems::Field;
-#[cfg(feature = "ros_z")]
-use linear_algebra::{Point2, Pose2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 use serde::{Deserialize, Serialize};
+use {
+    coordinate_systems::Field,
+    linear_algebra::{Point2, Pose2},
+    std::time::Duration,
+};
 
-#[cfg(feature = "ros_z")]
-pub use game_controller_return_message::GameControllerReturnMessage;
-#[cfg(feature = "ros_z")]
-pub use game_controller_state_message::{
-    GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player,
-    SubState, Team, TeamColor, TeamState,
+pub use {
+    game_controller_return_message::GameControllerReturnMessage,
+    game_controller_state_message::{
+        GameControllerStateMessage, GamePhase, GameState, Half, Penalty, PenaltyShoot, Player,
+        SubState, Team, TeamColor, TeamState,
+    },
 };
 
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    Deserialize,
-    Serialize,
-    PathDeserialize,
-    PathIntrospect,
-    PathSerialize,
+    Clone, Copy, Debug, Deserialize, Serialize, PathDeserialize, PathIntrospect, PathSerialize,
 )]
 #[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
-#[cfg(feature = "ros_z")]
 pub enum HulkMessage {
     State(StateMessage),
 }
 
-#[cfg(feature = "ros_z")]
 impl Default for HulkMessage {
     fn default() -> Self {
         HulkMessage::State(StateMessage::default())
@@ -49,7 +36,6 @@ impl Default for HulkMessage {
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
-#[cfg(feature = "ros_z")]
 pub struct StrikerMessage {
     pub player_number: PlayerNumber,
     pub pose: Pose2<Field>,
@@ -69,7 +55,6 @@ pub struct StrikerMessage {
     PathSerialize,
 )]
 #[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
-#[cfg(feature = "ros_z")]
 pub struct StateMessage {
     pub player_number: PlayerNumber,
     pub pose: Pose2<Field>,
@@ -88,7 +73,6 @@ pub struct StateMessage {
     Serialize,
 )]
 #[cfg_attr(feature = "ros_z", derive(ros_z::Message))]
-#[cfg(feature = "ros_z")]
 pub struct BallPosition<Frame> {
     pub position: Point2<Frame>,
     pub age: Duration,
@@ -137,7 +121,7 @@ impl Display for PlayerNumber {
     }
 }
 
-#[cfg(all(test, feature = "ros_z"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     #[test]

--- a/crates/linear_algebra/Cargo.toml
+++ b/crates/linear_algebra/Cargo.toml
@@ -10,7 +10,11 @@ approx = { workspace = true }
 nalgebra = { workspace = true }
 num-traits = { workspace = true }
 path_serde = { workspace = true }
-ros-z = { workspace = true }
-ros-z-schema = { workspace = true }
+ros-z = { workspace = true, optional = true }
+ros-z-schema = { workspace = true, optional = true }
 serde = { workspace = true }
 simba = { workspace = true }
+
+[features]
+default = ["ros_z"]
+ros_z = ["dep:ros-z", "dep:ros-z-schema"]

--- a/crates/linear_algebra/src/framed.rs
+++ b/crates/linear_algebra/src/framed.rs
@@ -8,10 +8,13 @@ use std::{
 
 use approx::{AbsDiffEq, RelativeEq};
 use num_traits::Num;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize};
 
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize, deserialize, serialize};
+#[cfg(feature = "ros_z")]
 use ros_z::{Message, MessageSchema, SchemaBuilder, SerdeCdrCodec};
+#[cfg(feature = "ros_z")]
+use serde::de::DeserializeOwned;
 
 #[derive(Debug)]
 // `repr(transparent)` ensures this struct has the same memory layout as `inner`.
@@ -51,6 +54,7 @@ where
     }
 }
 
+#[cfg(feature = "ros_z")]
 impl<Frame, Inner> Message for Framed<Frame, Inner>
 where
     Frame: Send + Sync + 'static,
@@ -63,6 +67,7 @@ where
     }
 }
 
+#[cfg(feature = "ros_z")]
 impl<Frame, Inner> MessageSchema for Framed<Frame, Inner>
 where
     Frame: Send + Sync + 'static,

--- a/crates/linear_algebra/src/transform.rs
+++ b/crates/linear_algebra/src/transform.rs
@@ -2,8 +2,11 @@ use std::{collections::HashSet, marker::PhantomData, ops::Mul};
 
 use approx::{AbsDiffEq, RelativeEq};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize, deserialize, serialize};
+#[cfg(feature = "ros_z")]
 use ros_z::{Message, MessageSchema, SchemaBuilder, SerdeCdrCodec};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+#[cfg(feature = "ros_z")]
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 use crate::framed::Framed;
 
@@ -44,6 +47,7 @@ where
     }
 }
 
+#[cfg(feature = "ros_z")]
 impl<From, To, Inner> Message for Transform<From, To, Inner>
 where
     From: Send + Sync + 'static,
@@ -57,6 +61,7 @@ where
     }
 }
 
+#[cfg(feature = "ros_z")]
 impl<From, To, Inner> MessageSchema for Transform<From, To, Inner>
 where
     From: Send + Sync + 'static,

--- a/crates/repository/Cargo.toml
+++ b/crates/repository/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 [dependencies]
 color-eyre = { workspace = true }
 futures-util = { workspace = true }
-hsl_network_messages = { workspace = true }
+hsl_network_messages = { path = "../hsl_network_messages", default-features = false }
 hula_types = { workspace = true }
 itertools = { workspace = true }
 parameters = { workspace = true }

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.26.0"
+version = "7.27.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -16,7 +16,7 @@ clap_complete = { workspace = true }
 color-eyre = { workspace = true }
 futures-util = { workspace = true }
 glob = { workspace = true }
-hsl_network_messages = { workspace = true }
+hsl_network_messages = { path = "../../crates/hsl_network_messages", default-features = false }
 indicatif = { workspace = true }
 lazy_static = { workspace = true }
 parameters = { workspace = true }


### PR DESCRIPTION
## Why? What?

This PR removes ros-z from the dependency tree of pepsi to make it compile on android.
This PR redeclares some dependencies where ros-z support is not necessary to avoid having to disable ros-z support for e.g. `linear-algebra` workspace-wide and having to reenable it in dozens of crates like in #2593.

- Fixes #2516 
- Closes #2593
- Closes #2608

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)


## How to Test

Try building pepsi on your android device.
Alternatively, use `check`.
```
pepsi check pepsi --target aarch64-linux-android
```
Cross-linking requires some manual setup beyond the `rustup toolchain add`, so `cargo build` will likely fail.