### PR TITLE
Twix Remote Control delay fix

### DIFF
--- a/tools/twix/src/panels/remote_control.rs
+++ b/tools/twix/src/panels/remote_control.rs
@@ -40,8 +40,6 @@ impl<'a> Panel<'a> for RemotePanel {
         let gait_parameter_value = robot.subscribe_json("parameters.rl_walking.gait_frequency");
         let remote_stop_toggle: BufferHandle<bool> =
             robot.subscribe_value("parameters.remote_stop_toggle");
-        let kick_mode_toggle: BufferHandle<bool> =
-            robot.subscribe_value("parameters.behavior.remote_control.kick_mode_toggle");
         let bg_running = Arc::new(AtomicBool::new(true));
 
         let robot_clone = robot.clone();
@@ -63,6 +61,8 @@ impl<'a> Panel<'a> for RemotePanel {
                 .unwrap_or(SystemTime::now());
 
             let mut start_was_pressed = false;
+            let mut north_was_pressed = false;
+            let mut south_was_pressed = false;
 
             let mut last_gamepad_id = None;
 
@@ -75,6 +75,11 @@ impl<'a> Panel<'a> for RemotePanel {
 
                 if gilrs.gamepads().next().is_none() {
                     let _ = sender.send((Step::default(), 1.0));
+
+                    set_kick_mode_toggle(&robot_clone, false);
+                    north_was_pressed = false;
+                    south_was_pressed = false;
+
                     if enabled_clone.load(Ordering::Relaxed) {
                         reset(&robot_clone);
                     }
@@ -151,7 +156,8 @@ impl<'a> Panel<'a> for RemotePanel {
                         current_value
                     };
 
-                    if is_pressed(Button::North) {
+                    let north_pressed = is_pressed(Button::North);
+                    if north_pressed && !north_was_pressed {
                         match remote_stop_toggle.get_last_value() {
                             Ok(Some(value)) => {
                                 let new_remote_stop_toggle = !value;
@@ -166,22 +172,13 @@ impl<'a> Panel<'a> for RemotePanel {
                             }
                         }
                     }
+                    north_was_pressed = north_pressed;
 
-                    if is_pressed(Button::South) {
-                        match kick_mode_toggle.get_last_value() {
-                            Ok(Some(value)) => {
-                                let new_kick_mode_toggle = !value;
-                                robot_clone.write(
-                                    "parameters.behavior.remote_control.kick_mode_toggle",
-                                    TextOrBinary::Text(new_kick_mode_toggle.into()),
-                                );
-                            }
-                            Ok(None) => {}
-                            Err(error) => {
-                                error!("failed to read kick_mode_toggle: {error:#?}")
-                            }
-                        }
+                    let south_pressed = is_pressed(Button::South);
+                    if south_pressed != south_was_pressed {
+                        set_kick_mode_toggle(&robot_clone, south_pressed);
                     }
+                    south_was_pressed = south_pressed;
 
                     if enabled_clone.load(Ordering::Relaxed) {
                         let now = SystemTime::now();
@@ -226,6 +223,13 @@ fn get_axis_value(gamepad: Gamepad, axis: Axis) -> Option<f32> {
 
 fn reset(robot: &Arc<Robot>) {
     update_step(robot, Step::<f32>::default(), 1.0);
+}
+
+fn set_kick_mode_toggle(robot: &Arc<Robot>, value: bool) {
+    robot.write(
+        "parameters.behavior.remote_control.kick_mode_toggle",
+        TextOrBinary::Text(value.into()),
+    );
 }
 
 fn update_step(robot: &Arc<Robot>, step: Step, gait_frequency: f64) {

--- a/tools/twix/src/panels/remote_control.rs
+++ b/tools/twix/src/panels/remote_control.rs
@@ -76,13 +76,13 @@ impl<'a> Panel<'a> for RemotePanel {
                 if gilrs.gamepads().next().is_none() {
                     let _ = sender.send((Step::default(), 1.0));
 
-                    set_kick_mode_toggle(&robot_clone, false);
-                    north_was_pressed = false;
-                    south_was_pressed = false;
-
                     if enabled_clone.load(Ordering::Relaxed) {
                         reset(&robot_clone);
+                    } else if south_was_pressed {
+                        set_kick_mode_toggle(&robot_clone, false);
                     }
+                    north_was_pressed = false;
+                    south_was_pressed = false;
                     continue;
                 }
 
@@ -223,6 +223,7 @@ fn get_axis_value(gamepad: Gamepad, axis: Axis) -> Option<f32> {
 
 fn reset(robot: &Arc<Robot>) {
     update_step(robot, Step::<f32>::default(), 1.0);
+    set_kick_mode_toggle(robot, false);
 }
 
 fn set_kick_mode_toggle(robot: &Arc<Robot>, value: bool) {
@@ -249,6 +250,7 @@ impl Drop for RemotePanel {
         if let Some(handle) = self.bg_handle.take() {
             let _ = handle.join();
         }
+        reset(&self.robot);
     }
 }
 

--- a/tools/twix/src/robot.rs
+++ b/tools/twix/src/robot.rs
@@ -28,6 +28,7 @@ use crate::{
 pub struct Robot {
     runtime: Runtime,
     client: ClientHandle,
+    write_client: ClientHandle,
     repository: Option<Repository>,
 }
 
@@ -35,12 +36,15 @@ impl Robot {
     pub fn new(address: String, repository: Option<Repository>) -> Self {
         let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
 
-        let (client, handle) = Client::new(address);
+        let (client, handle) = Client::new(address.clone());
+        let (write_client, write_handle) = Client::new(address);
         runtime.spawn(client.run());
+        runtime.spawn(write_client.run());
 
         Self {
             runtime,
             client: handle,
+            write_client: write_handle,
             repository,
         }
     }
@@ -48,21 +52,34 @@ impl Robot {
     pub fn connect(&self) {
         let client = self.client.clone();
         self.runtime.spawn(async move { client.connect().await });
+        let write_client = self.write_client.clone();
+        self.runtime
+            .spawn(async move { write_client.connect().await });
     }
 
     pub fn disconnect(&self) {
         let client = self.client.clone();
         self.runtime.spawn(async move { client.disconnect().await });
+        let write_client = self.write_client.clone();
+        self.runtime
+            .spawn(async move { write_client.disconnect().await });
     }
 
     pub fn connection_status(&self) -> Status {
-        self.runtime.block_on(async { self.client.status().await })
+        self.runtime.block_on(async {
+            merge_connection_status(self.client.status().await, self.write_client.status().await)
+        })
     }
 
     pub fn set_address(&self, address: String) {
         let client = self.client.clone();
+        let read_address = address.clone();
         self.runtime.spawn(async move {
-            client.set_address(address).await;
+            client.set_address(read_address).await;
+        });
+        let write_client = self.write_client.clone();
+        self.runtime.spawn(async move {
+            write_client.set_address(address).await;
         });
     }
 
@@ -164,7 +181,7 @@ impl Robot {
     }
 
     pub fn write(&self, path: impl Into<Path>, value: TextOrBinary) {
-        let client = self.client.clone();
+        let client = self.write_client.clone();
         let path = path.into();
         self.runtime.spawn(async move {
             if let Err(error) = client.write(path, value).await {
@@ -193,6 +210,14 @@ impl Robot {
             }
         });
         Ok(())
+    }
+}
+
+fn merge_connection_status(read_status: Status, write_status: Status) -> Status {
+    match (read_status, write_status) {
+        (Status::Connected, Status::Connected) => Status::Connected,
+        (Status::Connecting, _) | (_, Status::Connecting) => Status::Connecting,
+        _ => Status::Disconnected,
     }
 }
 


### PR DESCRIPTION
## Why? What?
The remote control is not very responsive and not very usable. This was because all changed parameters and input one got went over the same socket. So the large raw image files stalled the writing. Now there is one separate for writing parameters. 
With this the toggle buttons broke, since without the lag one saw the toggle change multiple times while the button was pressed. The kick mode is now just triggered on press. The safe mode now triggers on flanks.
This whole thing is needed for the video for Kai.

## How to Test
upload to the robot and try out the remote control. It should be more responsive now.