### PR TITLE
Yoink ros-z from pepsi deps for Android (Duplicate Playernumber Variant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,8 +401,8 @@ name = "argument_parsers"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
- "hsl_network_messages",
  "regex",
+ "repository",
  "robot",
 ]
 
@@ -8040,7 +8040,6 @@ dependencies = [
  "color-eyre",
  "futures-util",
  "glob",
- "hsl_network_messages",
  "indicatif",
  "lazy_static",
  "parameters",
@@ -9167,7 +9166,6 @@ version = "0.1.0"
 dependencies = [
  "color-eyre",
  "futures-util",
- "hsl_network_messages",
  "hula_types",
  "itertools 0.14.0",
  "parameters",

--- a/crates/argument_parsers/Cargo.toml
+++ b/crates/argument_parsers/Cargo.toml
@@ -7,6 +7,6 @@ homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }
-hsl_network_messages = { workspace = true }
 regex = { workspace = true }
+repository = { workspace = true }
 robot = { workspace = true }

--- a/crates/argument_parsers/src/lib.rs
+++ b/crates/argument_parsers/src/lib.rs
@@ -10,7 +10,7 @@ use color_eyre::{
 };
 use regex::Regex;
 
-use hsl_network_messages::PlayerNumber;
+use repository::PlayerNumber;
 use robot::{Network, SystemctlAction};
 
 pub const SYSTEMCTL_ACTION_POSSIBLE_VALUES: &[&str] =

--- a/crates/repository/Cargo.toml
+++ b/crates/repository/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 [dependencies]
 color-eyre = { workspace = true }
 futures-util = { workspace = true }
-hsl_network_messages = { workspace = true }
 hula_types = { workspace = true }
 itertools = { workspace = true }
 parameters = { workspace = true }

--- a/crates/repository/src/lib.rs
+++ b/crates/repository/src/lib.rs
@@ -23,6 +23,8 @@ pub mod symlink;
 pub mod team;
 pub mod upload;
 
+pub use player_number::PlayerNumber;
+
 /// The HULK repository.
 #[derive(Debug, Clone)]
 pub struct Repository {

--- a/crates/repository/src/player_number.rs
+++ b/crates/repository/src/player_number.rs
@@ -1,12 +1,40 @@
+use std::fmt::{self, Display, Formatter};
+
 use color_eyre::{Result, eyre::Context};
-use hsl_network_messages::PlayerNumber;
 use hula_types::hardware::Ids;
 use parameters::{
     directory::{Id, Location, Scope, serialize},
     json::nest_value_at_path,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::Repository;
+
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub enum PlayerNumber {
+    One,
+    Two,
+    #[default]
+    Three,
+    Four,
+    Five,
+}
+
+impl Display for PlayerNumber {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let number = match self {
+            PlayerNumber::One => "1",
+            PlayerNumber::Two => "2",
+            PlayerNumber::Three => "3",
+            PlayerNumber::Four => "4",
+            PlayerNumber::Five => "5",
+        };
+
+        write!(formatter, "{number}")
+    }
+}
 
 impl Repository {
     pub async fn configure_player_number(

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -16,7 +16,6 @@ clap_complete = { workspace = true }
 color-eyre = { workspace = true }
 futures-util = { workspace = true }
 glob = { workspace = true }
-hsl_network_messages = { workspace = true }
 indicatif = { workspace = true }
 lazy_static = { workspace = true }
 parameters = { workspace = true }

--- a/tools/pepsi/src/deploy_config.rs
+++ b/tools/pepsi/src/deploy_config.rs
@@ -12,9 +12,8 @@ use toml::from_str;
 use argument_parsers::{
     RobotAddress, RobotAddressPlayerAssignment, RobotNumberPlayerAssignment, parse_network,
 };
-use hsl_network_messages::PlayerNumber;
 use parameters::directory::LocationTarget;
-use repository::Repository;
+use repository::{PlayerNumber, Repository};
 use robot::Network;
 
 use crate::player_number::{Arguments, check_for_duplication, player_number};


### PR DESCRIPTION
## Why? What?

This PR removes ros-z from the dependency tree of pepsi to make it compile on android.
Instead of feature gating all the ros-z derives like in #2592 and #2593, it simply duplicates the `PlayerNumber` type for pepsi.

- Fixes #2516 
- Closes #2592 
- Closes #2593

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)


## How to Test

Try building pepsi on your android device.
Alternatively, use `check`.
```
pepsi check pepsi --target aarch64-linux-android
```
Cross-linking requires some manual setup beyond the `rustup toolchain add`, so `cargo build` will likely fail.