### PR TITLE
Refactor and improve nearest cell in voronoi

### DIFF
--- a/crates/voronoi/src/lib.rs
+++ b/crates/voronoi/src/lib.rs
@@ -66,6 +66,10 @@ pub enum Ownership {
 }
 
 impl Ownership {
+    fn is_blocked(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+
     fn is_free(self) -> bool {
         matches!(self, Self::Free)
     }
@@ -194,7 +198,13 @@ impl VoronoiGrid {
             let player_number = robots[robot_index].1;
             let (sin_h, cos_h) = robot_headings[robot_index];
 
-            for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
+            for (neighbor_index, neighbor) in
+                neighbor_indices(current_index, self.width_tiles, self.height_tiles)
+            {
+                if self.tiles[neighbor_index].is_blocked() {
+                    continue;
+                }
+
                 let rotation_cost = rotation_cost(sin_h, cos_h, neighbor, orientation_bias);
                 let new_cost = current_cost + neighbor.step_cost + rotation_cost;
 
@@ -366,6 +376,9 @@ impl VoronoiGrid {
         mut matches: impl FnMut(Ownership) -> bool,
     ) -> Option<(usize, f32)> {
         let start_index = self.point_to_index(point)?;
+        if matches(self.tiles[start_index]) {
+            return Some((start_index, 0.0));
+        }
 
         let mut distance = vec![f32::INFINITY; self.tiles.len()];
         let mut queue = BinaryHeap::new();
@@ -381,7 +394,9 @@ impl VoronoiGrid {
             if matches(self.tiles[current_index]) {
                 return Some((current_index, current_cost));
             }
-            for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
+            for (neighbor_index, neighbor) in
+                neighbor_indices(current_index, self.width_tiles, self.height_tiles)
+            {
                 let new_cost = current_cost + neighbor.step_cost;
                 if new_cost < distance[neighbor_index] {
                     distance[neighbor_index] = new_cost;
@@ -392,30 +407,8 @@ impl VoronoiGrid {
         None
     }
 
-    fn neighbor_indices(&self, index: usize) -> Vec<(usize, Neighbor)> {
-        let mut neighbors = Vec::new();
-        let (x, y) = self.xy_from_index(index);
-        for neighbor in NEIGHBORS {
-            let nx = x as isize + neighbor.dx;
-            let ny = y as isize + neighbor.dy;
-            if !(0..self.width_tiles as isize).contains(&nx)
-                || !(0..self.height_tiles as isize).contains(&ny)
-            {
-                continue;
-            }
-            neighbors.push((self.index_from_xy(nx as usize, ny as usize), neighbor));
-        }
-        neighbors
-    }
-
     fn index_from_xy(&self, x: usize, y: usize) -> usize {
         y * (self.width_tiles) + x
-    }
-
-    fn xy_from_index(&self, index: usize) -> (usize, usize) {
-        let x = index % self.width_tiles;
-        let y = index / self.width_tiles;
-        (x, y)
     }
 
     fn rasterize_bounds(
@@ -452,4 +445,21 @@ fn rotation_cost(sin_h: f32, cos_h: f32, neighbor: Neighbor, orientation_bias: f
     let dot = (cos_h * neighbor.dx as f32 + sin_h * neighbor.dy as f32) * neighbor.inv_norm;
     let turn_factor = (1.0 - dot.clamp(-1.0, 1.0)) * 0.5;
     (turn_factor * orientation_bias).max(0.0)
+}
+
+fn neighbor_indices(
+    index: usize,
+    width_tiles: usize,
+    height_tiles: usize,
+) -> impl Iterator<Item = (usize, Neighbor)> {
+    let x = index % width_tiles;
+    let y = index / width_tiles;
+    NEIGHBORS.into_iter().filter_map(move |neighbor| {
+        let nx = x as isize + neighbor.dx;
+        let ny = y as isize + neighbor.dy;
+        if !(0..width_tiles as isize).contains(&nx) || !(0..height_tiles as isize).contains(&ny) {
+            return None;
+        }
+        Some((ny as usize * width_tiles + nx as usize, neighbor))
+    })
 }

--- a/crates/voronoi/src/lib.rs
+++ b/crates/voronoi/src/lib.rs
@@ -249,7 +249,7 @@ impl VoronoiGrid {
         for (robot_index, (robot_pose, player_number)) in robots.iter().enumerate() {
             if let Some(seed_cell) = self.nearest_matching_cell(
                 robot_pose.position(),
-                Ownership::Free,
+                |ownership| ownership == Ownership::Free,
                 &mut seed_distance,
                 &mut seed_queue,
             ) && seed_cell.cost < distance[seed_cell.index]
@@ -269,19 +269,24 @@ impl VoronoiGrid {
         let mut distance = vec![f32::INFINITY; self.tiles.len()];
         let mut queue = BinaryHeap::new();
 
-        self.nearest_matching_cell(point, Ownership::Free, &mut distance, &mut queue)
-            .map(|nearest_cell| self.tiles[nearest_cell.index])
+        self.nearest_matching_cell(
+            point,
+            |ownership| matches!(ownership, Ownership::Robot(_)),
+            &mut distance,
+            &mut queue,
+        )
+        .map(|nearest_cell| self.tiles[nearest_cell.index])
     }
 
     fn nearest_matching_cell(
         &self,
         point: Point2<Field>,
-        target_ownership: Ownership,
+        matches_ownership: impl Fn(Ownership) -> bool,
         distance: &mut [f32],
         queue: &mut BinaryHeap<Reverse<(NotNan<f32>, usize)>>,
     ) -> Option<NearestCell> {
         let start_index = self.point_to_index(point)?;
-        if self.tiles[start_index] == target_ownership {
+        if matches_ownership(self.tiles[start_index]) {
             return Some(NearestCell {
                 index: start_index,
                 cost: 0.0,
@@ -300,7 +305,7 @@ impl VoronoiGrid {
             if current_cost > distance[current_index] {
                 continue;
             }
-            if self.tiles[current_index] == target_ownership {
+            if matches_ownership(self.tiles[current_index]) {
                 for index in touched {
                     distance[index] = f32::INFINITY;
                 }

--- a/crates/voronoi/src/lib.rs
+++ b/crates/voronoi/src/lib.rs
@@ -66,10 +66,6 @@ pub enum Ownership {
 }
 
 impl Ownership {
-    fn is_blocked(self) -> bool {
-        matches!(self, Self::Blocked)
-    }
-
     fn is_free(self) -> bool {
         matches!(self, Self::Free)
     }
@@ -198,25 +194,7 @@ impl VoronoiGrid {
             let player_number = robots[robot_index].1;
             let (sin_h, cos_h) = robot_headings[robot_index];
 
-            let width_tiles = self.width_tiles;
-            let height_tiles = self.height_tiles;
-            let x = (current_index % width_tiles) as isize;
-            let y = (current_index / width_tiles) as isize;
-
-            for neighbor in NEIGHBORS {
-                let nx = x + neighbor.dx;
-                let ny = y + neighbor.dy;
-                if !(0..width_tiles as isize).contains(&nx)
-                    || !(0..height_tiles as isize).contains(&ny)
-                {
-                    continue;
-                }
-
-                let neighbor_index = self.index_from_xy(nx as usize, ny as usize);
-                if self.tiles[neighbor_index].is_blocked() {
-                    continue;
-                }
-
+            for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
                 let rotation_cost = rotation_cost(sin_h, cos_h, neighbor, orientation_bias);
                 let new_cost = current_cost + neighbor.step_cost + rotation_cost;
 
@@ -263,13 +241,14 @@ impl VoronoiGrid {
         queue: &mut Queue,
     ) {
         for (robot_index, (robot_pose, player_number)) in robots.iter().enumerate() {
-            if let Some(start_index) = self.nearest_non_blocked_cell_index(robot_pose.position())
-                && distance[start_index] > 0.0
+            if let Some((start_index, start_cost)) =
+                self.nearest_free_cell_index(robot_pose.position())
+                && start_cost < distance[start_index]
             {
-                distance[start_index] = 0.0;
+                distance[start_index] = start_cost;
                 self.tiles[start_index] = Ownership::Robot(*player_number);
                 queue.push(Reverse((
-                    NotNan::new(0.0).unwrap(),
+                    NotNan::new(start_cost).unwrap(),
                     start_index,
                     robot_index,
                 )));
@@ -377,55 +356,66 @@ impl VoronoiGrid {
         ))
     }
 
-    fn nearest_non_blocked_cell_index(&self, point: Point2<Field>) -> Option<usize> {
+    fn nearest_free_cell_index(&self, point: Point2<Field>) -> Option<(usize, f32)> {
+        self.nearest_cell_index(point, |ownership| ownership.is_free())
+    }
+
+    fn nearest_cell_index(
+        &self,
+        point: Point2<Field>,
+        mut matches: impl FnMut(Ownership) -> bool,
+    ) -> Option<(usize, f32)> {
         let start_index = self.point_to_index(point)?;
-        if self.tiles[start_index].is_free() {
-            return Some(start_index);
-        }
 
-        let width_tiles = self.width_tiles;
-        let height_tiles = self.height_tiles;
-        let start_x = start_index % width_tiles;
-        let start_y = start_index / width_tiles;
-        let max_radius = self.width_tiles.max(self.height_tiles);
+        let mut distance = vec![f32::INFINITY; self.tiles.len()];
+        let mut queue = BinaryHeap::new();
 
-        for radius in 1..=max_radius {
-            let min_x = start_x.saturating_sub(radius);
-            let max_x = (start_x + radius).min(width_tiles - 1);
-            let min_y = start_y.saturating_sub(radius);
-            let max_y = (start_y + radius).min(height_tiles - 1);
+        distance[start_index] = 0.0;
+        queue.push(Reverse((NotNan::new(0.0).unwrap(), start_index)));
 
-            for x in min_x..=max_x {
-                for y in [min_y, max_y] {
-                    let index = self.index_from_xy(x, y);
-                    if self.tiles[index].is_free() {
-                        return Some(index);
-                    }
-                }
+        while let Some(Reverse((current_cost, current_index))) = queue.pop() {
+            let current_cost = current_cost.into_inner();
+            if current_cost > distance[current_index] {
+                continue;
             }
-
-            if max_y > min_y {
-                for y in (min_y + 1)..max_y {
-                    for x in [min_x, max_x] {
-                        let index = self.index_from_xy(x, y);
-                        if self.tiles[index].is_free() {
-                            return Some(index);
-                        }
-                    }
+            if matches(self.tiles[current_index]) {
+                return Some((current_index, current_cost));
+            }
+            for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
+                let new_cost = current_cost + neighbor.step_cost;
+                if new_cost < distance[neighbor_index] {
+                    distance[neighbor_index] = new_cost;
+                    queue.push(Reverse((NotNan::new(new_cost).unwrap(), neighbor_index)));
                 }
             }
         }
-
         None
     }
 
-    pub fn nearest_non_blocked_ownership(&self, point: Point2<Field>) -> Option<Ownership> {
-        self.nearest_non_blocked_cell_index(point)
-            .map(|index| self.tiles[index])
+    fn neighbor_indices(&self, index: usize) -> Vec<(usize, Neighbor)> {
+        let mut neighbors = Vec::new();
+        let (x, y) = self.xy_from_index(index);
+        for neighbor in NEIGHBORS {
+            let nx = x as isize + neighbor.dx;
+            let ny = y as isize + neighbor.dy;
+            if !(0..self.width_tiles as isize).contains(&nx)
+                || !(0..self.height_tiles as isize).contains(&ny)
+            {
+                continue;
+            }
+            neighbors.push((self.index_from_xy(nx as usize, ny as usize), neighbor));
+        }
+        neighbors
     }
 
     fn index_from_xy(&self, x: usize, y: usize) -> usize {
         y * (self.width_tiles) + x
+    }
+
+    fn xy_from_index(&self, index: usize) -> (usize, usize) {
+        let x = index % self.width_tiles;
+        let y = index / self.width_tiles;
+        (x, y)
     }
 
     fn rasterize_bounds(

--- a/crates/voronoi/src/lib.rs
+++ b/crates/voronoi/src/lib.rs
@@ -16,6 +16,11 @@ const STRAIGHT_COST: f32 = 1.0;
 const DIAGONAL_COST: f32 = SQRT_2;
 const INV_SQRT_2: f32 = 1.0 / DIAGONAL_COST;
 
+struct SeedCell {
+    pub index: usize,
+    pub cost: f32,
+}
+
 #[derive(Copy, Clone, Debug)]
 struct Neighbor {
     pub dx: isize,
@@ -198,9 +203,7 @@ impl VoronoiGrid {
             let player_number = robots[robot_index].1;
             let (sin_h, cos_h) = robot_headings[robot_index];
 
-            for (neighbor_index, neighbor) in
-                neighbor_indices(current_index, self.width_tiles, self.height_tiles)
-            {
+            for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
                 if self.tiles[neighbor_index].is_blocked() {
                     continue;
                 }
@@ -250,20 +253,73 @@ impl VoronoiGrid {
         distance: &mut [f32],
         queue: &mut Queue,
     ) {
+        let mut seed_distance = vec![f32::INFINITY; self.tiles.len()];
+        let mut seed_queue = BinaryHeap::new();
+
         for (robot_index, (robot_pose, player_number)) in robots.iter().enumerate() {
-            if let Some((start_index, start_cost)) =
-                self.nearest_free_cell_index(robot_pose.position())
-                && start_cost < distance[start_index]
+            if let Some(seed_cell) =
+                self.nearest_free_seed(robot_pose.position(), &mut seed_distance, &mut seed_queue)
+                && seed_cell.cost < distance[seed_cell.index]
             {
-                distance[start_index] = start_cost;
-                self.tiles[start_index] = Ownership::Robot(*player_number);
+                distance[seed_cell.index] = seed_cell.cost;
+                self.tiles[seed_cell.index] = Ownership::Robot(*player_number);
                 queue.push(Reverse((
-                    NotNan::new(start_cost).unwrap(),
-                    start_index,
+                    NotNan::new(seed_cell.cost).unwrap(),
+                    seed_cell.index,
                     robot_index,
                 )));
             }
         }
+    }
+
+    fn nearest_free_seed(
+        &self,
+        point: Point2<Field>,
+        distance: &mut [f32],
+        queue: &mut BinaryHeap<Reverse<(NotNan<f32>, usize)>>,
+    ) -> Option<SeedCell> {
+        let start_index = self.point_to_index(point)?;
+        if self.tiles[start_index].is_free() {
+            return Some(SeedCell {
+                index: start_index,
+                cost: 0.0,
+            });
+        }
+
+        let mut touched = Vec::new();
+        queue.clear();
+
+        distance[start_index] = 0.0;
+        touched.push(start_index);
+        queue.push(Reverse((NotNan::new(0.0).unwrap(), start_index)));
+
+        while let Some(Reverse((current_cost, current_index))) = queue.pop() {
+            let current_cost = current_cost.into_inner();
+            if current_cost > distance[current_index] {
+                continue;
+            }
+            if self.tiles[current_index].is_free() {
+                for index in touched {
+                    distance[index] = f32::INFINITY;
+                }
+                return Some(SeedCell {
+                    index: current_index,
+                    cost: current_cost,
+                });
+            }
+            for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
+                let new_cost = current_cost + neighbor.step_cost;
+                if new_cost < distance[neighbor_index] {
+                    distance[neighbor_index] = new_cost;
+                    queue.push(Reverse((NotNan::new(new_cost).unwrap(), neighbor_index)));
+                    touched.push(neighbor_index);
+                }
+            }
+        }
+        for index in touched {
+            distance[index] = f32::INFINITY;
+        }
+        None
     }
 
     pub fn centroid_for_player(&self, player: PlayerNumber) -> Option<Point2<Field>> {
@@ -295,7 +351,7 @@ impl VoronoiGrid {
         if (0..self.width_tiles as isize).contains(&ix)
             && (0..self.height_tiles as isize).contains(&iy)
         {
-            Some(self.index_from_xy(ix as usize, iy as usize))
+            Some(index_from_xy(self.width_tiles, ix as usize, iy as usize))
         } else {
             None
         }
@@ -366,51 +422,6 @@ impl VoronoiGrid {
         ))
     }
 
-    fn nearest_free_cell_index(&self, point: Point2<Field>) -> Option<(usize, f32)> {
-        self.nearest_cell_index(point, |ownership| ownership.is_free())
-    }
-
-    fn nearest_cell_index(
-        &self,
-        point: Point2<Field>,
-        mut matches: impl FnMut(Ownership) -> bool,
-    ) -> Option<(usize, f32)> {
-        let start_index = self.point_to_index(point)?;
-        if matches(self.tiles[start_index]) {
-            return Some((start_index, 0.0));
-        }
-
-        let mut distance = vec![f32::INFINITY; self.tiles.len()];
-        let mut queue = BinaryHeap::new();
-
-        distance[start_index] = 0.0;
-        queue.push(Reverse((NotNan::new(0.0).unwrap(), start_index)));
-
-        while let Some(Reverse((current_cost, current_index))) = queue.pop() {
-            let current_cost = current_cost.into_inner();
-            if current_cost > distance[current_index] {
-                continue;
-            }
-            if matches(self.tiles[current_index]) {
-                return Some((current_index, current_cost));
-            }
-            for (neighbor_index, neighbor) in
-                neighbor_indices(current_index, self.width_tiles, self.height_tiles)
-            {
-                let new_cost = current_cost + neighbor.step_cost;
-                if new_cost < distance[neighbor_index] {
-                    distance[neighbor_index] = new_cost;
-                    queue.push(Reverse((NotNan::new(new_cost).unwrap(), neighbor_index)));
-                }
-            }
-        }
-        None
-    }
-
-    fn index_from_xy(&self, x: usize, y: usize) -> usize {
-        y * (self.width_tiles) + x
-    }
-
     fn rasterize_bounds(
         &mut self,
         min_x: f32,
@@ -427,7 +438,7 @@ impl VoronoiGrid {
 
         for y in min_y..=max_y {
             for x in min_x..=max_x {
-                let index = self.index_from_xy(x, y);
+                let index = index_from_xy(self.width_tiles, x, y);
                 let grid_point = self.index_to_point(index);
                 if contains(grid_point) {
                     self.tiles[index] = Ownership::Blocked;
@@ -436,8 +447,23 @@ impl VoronoiGrid {
         }
     }
 
-    pub fn ownership_at(&self, point: Point2<Field>) -> Option<Ownership> {
-        self.point_to_index(point).map(|index| self.tiles[index])
+    fn neighbor_indices(&self, index: usize) -> impl Iterator<Item = (usize, Neighbor)> + use<> {
+        let (x, y) = xy_from_index(self.width_tiles, index);
+        let width_tiles = self.width_tiles;
+        let height_tiles = self.height_tiles;
+
+        NEIGHBORS.into_iter().filter_map(move |neighbor| {
+            let nx = x as isize + neighbor.dx;
+            let ny = y as isize + neighbor.dy;
+            if !(0..width_tiles as isize).contains(&nx) || !(0..height_tiles as isize).contains(&ny)
+            {
+                return None;
+            }
+            Some((
+                index_from_xy(width_tiles, nx as usize, ny as usize),
+                neighbor,
+            ))
+        })
     }
 }
 
@@ -447,19 +473,12 @@ fn rotation_cost(sin_h: f32, cos_h: f32, neighbor: Neighbor, orientation_bias: f
     (turn_factor * orientation_bias).max(0.0)
 }
 
-fn neighbor_indices(
-    index: usize,
-    width_tiles: usize,
-    height_tiles: usize,
-) -> impl Iterator<Item = (usize, Neighbor)> {
+fn index_from_xy(width_tiles: usize, x: usize, y: usize) -> usize {
+    y * width_tiles + x
+}
+
+fn xy_from_index(width_tiles: usize, index: usize) -> (usize, usize) {
     let x = index % width_tiles;
     let y = index / width_tiles;
-    NEIGHBORS.into_iter().filter_map(move |neighbor| {
-        let nx = x as isize + neighbor.dx;
-        let ny = y as isize + neighbor.dy;
-        if !(0..width_tiles as isize).contains(&nx) || !(0..height_tiles as isize).contains(&ny) {
-            return None;
-        }
-        Some((ny as usize * width_tiles + nx as usize, neighbor))
-    })
+    (x, y)
 }

--- a/crates/voronoi/src/lib.rs
+++ b/crates/voronoi/src/lib.rs
@@ -16,7 +16,7 @@ const STRAIGHT_COST: f32 = 1.0;
 const DIAGONAL_COST: f32 = SQRT_2;
 const INV_SQRT_2: f32 = 1.0 / DIAGONAL_COST;
 
-struct SeedCell {
+struct NearestCell {
     pub index: usize,
     pub cost: f32,
 }
@@ -68,16 +68,6 @@ pub enum Ownership {
     Robot(PlayerNumber),
     #[default]
     Free,
-}
-
-impl Ownership {
-    fn is_blocked(self) -> bool {
-        matches!(self, Self::Blocked)
-    }
-
-    fn is_free(self) -> bool {
-        matches!(self, Self::Free)
-    }
 }
 
 #[derive(
@@ -204,7 +194,7 @@ impl VoronoiGrid {
             let (sin_h, cos_h) = robot_headings[robot_index];
 
             for (neighbor_index, neighbor) in self.neighbor_indices(current_index) {
-                if self.tiles[neighbor_index].is_blocked() {
+                if self.tiles[neighbor_index] == Ownership::Blocked {
                     continue;
                 }
 
@@ -257,9 +247,12 @@ impl VoronoiGrid {
         let mut seed_queue = BinaryHeap::new();
 
         for (robot_index, (robot_pose, player_number)) in robots.iter().enumerate() {
-            if let Some(seed_cell) =
-                self.nearest_free_seed(robot_pose.position(), &mut seed_distance, &mut seed_queue)
-                && seed_cell.cost < distance[seed_cell.index]
+            if let Some(seed_cell) = self.nearest_matching_cell(
+                robot_pose.position(),
+                Ownership::Free,
+                &mut seed_distance,
+                &mut seed_queue,
+            ) && seed_cell.cost < distance[seed_cell.index]
             {
                 distance[seed_cell.index] = seed_cell.cost;
                 self.tiles[seed_cell.index] = Ownership::Robot(*player_number);
@@ -272,15 +265,24 @@ impl VoronoiGrid {
         }
     }
 
-    fn nearest_free_seed(
+    pub fn nearest_non_blocked_ownership(&self, point: Point2<Field>) -> Option<Ownership> {
+        let mut distance = vec![f32::INFINITY; self.tiles.len()];
+        let mut queue = BinaryHeap::new();
+
+        self.nearest_matching_cell(point, Ownership::Free, &mut distance, &mut queue)
+            .map(|nearest_cell| self.tiles[nearest_cell.index])
+    }
+
+    fn nearest_matching_cell(
         &self,
         point: Point2<Field>,
+        target_ownership: Ownership,
         distance: &mut [f32],
         queue: &mut BinaryHeap<Reverse<(NotNan<f32>, usize)>>,
-    ) -> Option<SeedCell> {
+    ) -> Option<NearestCell> {
         let start_index = self.point_to_index(point)?;
-        if self.tiles[start_index].is_free() {
-            return Some(SeedCell {
+        if self.tiles[start_index] == target_ownership {
+            return Some(NearestCell {
                 index: start_index,
                 cost: 0.0,
             });
@@ -298,11 +300,11 @@ impl VoronoiGrid {
             if current_cost > distance[current_index] {
                 continue;
             }
-            if self.tiles[current_index].is_free() {
+            if self.tiles[current_index] == target_ownership {
                 for index in touched {
                     distance[index] = f32::INFINITY;
                 }
-                return Some(SeedCell {
+                return Some(NearestCell {
                     index: current_index,
                     cost: current_cost,
                 });
@@ -358,24 +360,20 @@ impl VoronoiGrid {
     }
 
     pub fn index_to_point(&self, index: usize) -> Point2<Field> {
-        let width_tiles = self.width_tiles;
-        let ix = (index % width_tiles) as f32;
-        let iy = (index / width_tiles) as f32;
+        let (x, y) = xy_from_index(self.width_tiles, index);
 
         point!(
-            self.bounds.grid_min.x() + ix * self.resolution + self.resolution / 2.0,
-            self.bounds.grid_min.y() + iy * self.resolution + self.resolution / 2.0
+            self.bounds.grid_min.x() + (x as f32) * self.resolution + self.resolution / 2.0,
+            self.bounds.grid_min.y() + (y as f32) * self.resolution + self.resolution / 2.0
         )
     }
 
     fn cell_overlaps_centroid_bounds(&self, index: usize) -> bool {
-        let width_tiles = self.width_tiles;
-        let x = (index % width_tiles) as f32;
-        let y = (index / width_tiles) as f32;
+        let (x, y) = xy_from_index(self.width_tiles, index);
 
-        let min_x = self.bounds.grid_min.x() + x * self.resolution;
+        let min_x = self.bounds.grid_min.x() + (x as f32) * self.resolution;
         let max_x = min_x + self.resolution;
-        let min_y = self.bounds.grid_min.y() + y * self.resolution;
+        let min_y = self.bounds.grid_min.y() + (y as f32) * self.resolution;
         let max_y = min_y + self.resolution;
 
         min_x < self.bounds.centroid_max.x()
@@ -464,6 +462,10 @@ impl VoronoiGrid {
                 neighbor,
             ))
         })
+    }
+
+    pub fn ownership_at(&self, point: Point2<Field>) -> Option<Ownership> {
+        self.point_to_index(point).map(|index| self.tiles[index])
     }
 }
 


### PR DESCRIPTION
## Why? What?

Change the nearest cell function to use a Djikstra and set the seeding cost depending on how far the difference between real position and seed position is.
Ive done that for better seeding Positioning and allowing robots to have no Voronoi area when they are to deep into a obstacle.

## How to Test
Move the calculate voronoi action into playing tree so that it is calculateted constantly. Then let the robot go into an obstical for exampele by standing infront of it.
The Robot should still have an owned area or no if there is another robot that would be faster to that seeding position.
