### PR TITLE
Align with ball in walk_to_centroid

### DIFF
--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -131,7 +131,6 @@ fn supporter_subtree() -> Node<Blackboard> {
             sequence!(action!(calculate_voronoi_grid), action!(walk_to_centroid)),
             action!(stand)
         ),
-        subtree!(look_at_ball_subtree)
     )
 }
 

--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -130,7 +130,8 @@ fn supporter_subtree() -> Node<Blackboard> {
         selection!(
             sequence!(action!(calculate_voronoi_grid), action!(walk_to_centroid)),
             action!(stand)
-        )
+        ),
+        subtree!(look_at_ball_subtree)
     )
 }
 

--- a/crates/nodes/behavior_node/src/walk.rs
+++ b/crates/nodes/behavior_node/src/walk.rs
@@ -252,11 +252,19 @@ pub fn walk_to_centroid(blackboard: &mut Blackboard) -> Status {
         &blackboard.voronoi_map,
     ) && let Some(centroid) = map.centroid_for_player(blackboard.world_state.robot.player_number)
     {
+        let orientation_mode = if let Some(ball) = blackboard.world_state.ball {
+            OrientationMode::LookAt {
+                target: ball.ball_in_ground,
+                tolerance: blackboard.parameters.walk_and_stand.orientation_tolerance,
+            }
+        } else {
+            OrientationMode::AlignWithPath
+        };
         walk_to(
             blackboard,
             Pose2::from(ground_to_field.inverse() * centroid),
-            blackboard.parameters.walk_speed.kicking,
-            OrientationMode::AlignWithPath,
+            blackboard.parameters.walk_speed.blocking,
+            orientation_mode,
             blackboard
                 .parameters
                 .walk_and_stand

--- a/crates/nodes/behavior_node/src/walk.rs
+++ b/crates/nodes/behavior_node/src/walk.rs
@@ -263,7 +263,7 @@ pub fn walk_to_centroid(blackboard: &mut Blackboard) -> Status {
         walk_to(
             blackboard,
             Pose2::from(ground_to_field.inverse() * centroid),
-            blackboard.parameters.walk_speed.blocking,
+            blackboard.parameters.walk_speed.kicking,
             orientation_mode,
             blackboard
                 .parameters

--- a/crates/world_state/src/behavior/tree.rs
+++ b/crates/world_state/src/behavior/tree.rs
@@ -126,7 +126,8 @@ fn supporter_subtree() -> Node<Blackboard> {
         selection!(
             sequence!(action!(calculate_voronoi_grid), action!(walk_to_centroid)),
             action!(stand)
-        )
+        ),
+        subtree!(look_at_ball_subtree)
     )
 }
 

--- a/crates/world_state/src/behavior/tree.rs
+++ b/crates/world_state/src/behavior/tree.rs
@@ -127,7 +127,6 @@ fn supporter_subtree() -> Node<Blackboard> {
             sequence!(action!(calculate_voronoi_grid), action!(walk_to_centroid)),
             action!(stand)
         ),
-        subtree!(look_at_ball_subtree)
     )
 }
 

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -254,11 +254,19 @@ pub fn walk_to_centroid(blackboard: &mut Blackboard) -> Status {
         &blackboard.voronoi_map,
     ) && let Some(centroid) = map.centroid_for_player(blackboard.world_state.robot.player_number)
     {
+        let orientation_mode = if let Some(ball) = blackboard.world_state.ball {
+            OrientationMode::LookAt {
+                target: ball.ball_in_ground,
+                tolerance: blackboard.parameters.walk_and_stand.orientation_tolerance,
+            }
+        } else {
+            OrientationMode::AlignWithPath
+        };
         walk_to(
             blackboard,
             Pose2::from(ground_to_field.inverse() * centroid),
             blackboard.parameters.walk_speed.kicking,
-            OrientationMode::AlignWithPath,
+            orientation_mode,
             blackboard
                 .parameters
                 .walk_and_stand


### PR DESCRIPTION
## Why? What?

Aligns with the ball and look at it when the robots goes to its voronoi centroid
- Fixes #

## Ideas for Next Iterations (Not This PR)

Probably in the future smarter rotation  and head movment to not walk backward toward the possition.

## How to Test
enforce that the robot to calculates the voronoi grid and walk_to_centroid afterward.
then the robot should walk aligned to the ball backwards to the centroid position. 