### PR TITLE
Add min walk speed and dynamic target speed

### DIFF
--- a/crates/nodes/behavior_node/src/node.rs
+++ b/crates/nodes/behavior_node/src/node.rs
@@ -69,10 +69,60 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
     Box::pin(run(ctx))
 }
 
+fn validate_behavior_parameters(
+    parameters: &BehaviorParameters,
+) -> std::result::Result<(), String> {
+    let walk_speed = &parameters.walk_speed;
+    let mut errors = Vec::new();
+
+    if !walk_speed.velocity_fade_distance.is_finite() || walk_speed.velocity_fade_distance <= 0.0 {
+        errors.push(format!(
+            "walk_speed.velocity_fade_distance must be finite and strictly positive (got {})",
+            walk_speed.velocity_fade_distance
+        ));
+    }
+
+    let minimum_speed_is_valid =
+        walk_speed.minimum_speed.is_finite() && walk_speed.minimum_speed >= 0.0;
+    if !minimum_speed_is_valid {
+        errors.push(format!(
+            "walk_speed.minimum_speed must be finite and non-negative (got {})",
+            walk_speed.minimum_speed
+        ));
+    }
+
+    for (field, speed) in [
+        ("walk_speed.kicking", walk_speed.kicking),
+        ("walk_speed.search", walk_speed.search),
+        ("walk_speed.blocking", walk_speed.blocking),
+    ] {
+        if !speed.is_finite() {
+            errors.push(format!("{field} must be finite (got {speed})"));
+            continue;
+        }
+        if speed < 0.0 {
+            errors.push(format!("{field} must be non-negative (got {speed})"));
+        }
+        if minimum_speed_is_valid && speed < walk_speed.minimum_speed {
+            errors.push(format!(
+                "{field} must be greater than or equal to walk_speed.minimum_speed (got {speed} < {})",
+                walk_speed.minimum_speed
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("behavior_node").build().await?;
 
     let parameters = node.bind_parameter_as::<BehaviorParameters>("behavior_node")?;
+    parameters.add_validation_hook(validate_behavior_parameters)?;
     let field_dimensions_cache = node
         .create_cache::<FieldDimensions>("field_dimensions", 1)?
         .with_qos(QosProfile {

--- a/crates/nodes/behavior_node/src/walk.rs
+++ b/crates/nodes/behavior_node/src/walk.rs
@@ -82,7 +82,7 @@ pub fn plan(
 pub fn walk_to(
     blackboard: &mut Blackboard,
     target_pose: Pose2<Ground>,
-    walk_speed: f32,
+    maximal_walk_speed: f32,
     orientation_mode: OrientationMode,
     distance_to_be_aligned: f32,
     hysteresis: nalgebra::Vector2<f32>,
@@ -104,6 +104,14 @@ pub fn walk_to(
             parameters.target_reached_thresholds.y,
             0.0..=hysteresis.y,
         );
+
+        let minimal_walk_speed = blackboard.parameters.walk_speed.minimum_speed;
+        let velocity_fade_distance = blackboard.parameters.walk_speed.velocity_fade_distance;
+
+        // Desmos: https://www.desmos.com/calculator/ss94dje2ke
+        let walk_speed = maximal_walk_speed
+            - (maximal_walk_speed - minimal_walk_speed)
+                * (-(2.0 * distance_to_walk / velocity_fade_distance).powf(2.0)).exp();
 
         if is_reached {
             blackboard.body_motion = Some(BodyMotion::Stand);

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -708,6 +708,8 @@ pub struct WalkSpeedParameters {
     pub kicking: f32,
     pub search: f32,
     pub blocking: f32,
+    pub minimum_speed: f32,
+    pub velocity_fade_distance: f32,
 }
 
 impl Default for WalkSpeedParameters {
@@ -716,6 +718,8 @@ impl Default for WalkSpeedParameters {
             kicking: 1.0,
             search: 1.0,
             blocking: 1.0,
+            minimum_speed: 0.2,
+            velocity_fade_distance: 1.0,
         }
     }
 }

--- a/crates/world_state/src/behavior/walk.rs
+++ b/crates/world_state/src/behavior/walk.rs
@@ -84,7 +84,7 @@ pub fn plan(
 pub fn walk_to(
     blackboard: &mut Blackboard,
     target_pose: Pose2<Ground>,
-    walk_speed: f32,
+    maximal_walk_speed: f32,
     orientation_mode: OrientationMode,
     distance_to_be_aligned: f32,
     hysteresis: nalgebra::Vector2<f32>,
@@ -106,6 +106,14 @@ pub fn walk_to(
             parameters.target_reached_thresholds.y,
             0.0..=hysteresis.y,
         );
+
+        let minimal_walk_speed = blackboard.parameters.walk_speed.minimum_speed;
+        let velocity_fade_distance = blackboard.parameters.walk_speed.velocity_fade_distance;
+
+        // Desmos: https://www.desmos.com/calculator/ss94dje2ke
+        let walk_speed = maximal_walk_speed
+            - (maximal_walk_speed - minimal_walk_speed)
+                * (-(2.0 * distance_to_walk / velocity_fade_distance).powf(2.0)).exp();
 
         if is_reached {
             blackboard.body_motion = Some(BodyMotion::Stand);

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -444,7 +444,9 @@
     "walk_speed": {
       "kicking": 0.5,
       "search": 0.5,
-      "blocking": 0.5
+      "blocking": 0.5,
+      "minimum_speed": 0.2,
+      "velocity_fade_distance": 1.0
     },
     "role_positions": {
       "defender_aggressive_ring_radius": 2.0,

--- a/etc/parameters/ros_z/base/behavior_node.json5
+++ b/etc/parameters/ros_z/base/behavior_node.json5
@@ -58,6 +58,8 @@
     support: 0.75,
     walk_to_kickoff: 0.5,
     walk_to_penalty_kick: 0.5,
+    minimum_speed: 0.2,
+    velocity_fade_distance: 1.0,
   },
   role_positions: {
     defender_aggressive_ring_radius: 2.0,


### PR DESCRIPTION
## Why? What?

- Fixes: #2615

Currently the robot overshoots his position targets when max speed is significantly increased. With this PR the speed is automatically throttled down to a minimum speed after coming into range of the target position. The minimum speed and the distance from where the slow-down begins are both behavior parameters.

## Known issues

This does not help when the turning rate is too slow, in this case the robot could walk a large circle around the position before directly approaching it. 

## How to Test

Upload to the robot and use Twix to manually increase the max speed. When directly approaching the target the robot should slow down before reaching its target position. A situation where the robot tries to reach a position that's anchored in the field coordinate system can be triggered by using the game controller and making the robot walk to kickoff for example.