### PR TITLE
Enable jetson clocks again

### DIFF
--- a/tools/k1-setup/hulk.service
+++ b/tools/k1-setup/hulk.service
@@ -5,6 +5,7 @@ After=hulk-runtime.service
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/jetson_clocks
 ExecStartPre=/usr/local/bin/podman wait --condition running hulk
 ExecStart=/usr/bin/launch-hulk
 ExecStop=/usr/local/bin/podman exec hulk pkill -SIGTERM hulk


### PR DESCRIPTION
## Why? What?

Reenables jetson clocks. Have to confirm the binary is actually at `/usr/bin/jetson_clocks`, don't have a robot at this time

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
