### PR TITLE
Expose ros-z graph change revisions

### DIFF
--- a/crates/ros-z-cli/src/model/watch.rs
+++ b/crates/ros-z-cli/src/model/watch.rs
@@ -1,14 +1,38 @@
-use ros_z::graph::GraphSnapshot;
+use ros_z::graph::{GraphRevision, GraphSnapshot};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum WatchEvent {
-    InitialState { snapshot: GraphSnapshot },
-    TopicDiscovered { name: String, type_name: String },
-    TopicRemoved { name: String },
-    NodeDiscovered { namespace: String, name: String },
-    NodeRemoved { namespace: String, name: String },
-    ServiceDiscovered { name: String, type_name: String },
-    ServiceRemoved { name: String },
+    InitialState {
+        snapshot: GraphSnapshot,
+    },
+    TopicDiscovered {
+        revision: GraphRevision,
+        name: String,
+        type_name: String,
+    },
+    TopicRemoved {
+        revision: GraphRevision,
+        name: String,
+    },
+    NodeDiscovered {
+        revision: GraphRevision,
+        namespace: String,
+        name: String,
+    },
+    NodeRemoved {
+        revision: GraphRevision,
+        namespace: String,
+        name: String,
+    },
+    ServiceDiscovered {
+        revision: GraphRevision,
+        name: String,
+        type_name: String,
+    },
+    ServiceRemoved {
+        revision: GraphRevision,
+        name: String,
+    },
 }

--- a/crates/ros-z-cli/src/render/text.rs
+++ b/crates/ros-z-cli/src/render/text.rs
@@ -251,22 +251,30 @@ fn write_schema(mut writer: impl Write, view: &SchemaView) -> io::Result<()> {
 pub fn print_watch_event(event: &WatchEvent) {
     match event {
         WatchEvent::InitialState { snapshot } => print_graph_snapshot(snapshot),
-        WatchEvent::TopicDiscovered { name, type_name } => {
+        WatchEvent::TopicDiscovered {
+            name, type_name, ..
+        } => {
             println!("topic + {name} ({type_name})");
         }
-        WatchEvent::TopicRemoved { name } => {
+        WatchEvent::TopicRemoved { name, .. } => {
             println!("topic - {name}");
         }
-        WatchEvent::NodeDiscovered { namespace, name } => {
+        WatchEvent::NodeDiscovered {
+            namespace, name, ..
+        } => {
             println!("node + {}", fully_qualified_node_name(namespace, name));
         }
-        WatchEvent::NodeRemoved { namespace, name } => {
+        WatchEvent::NodeRemoved {
+            namespace, name, ..
+        } => {
             println!("node - {}", fully_qualified_node_name(namespace, name));
         }
-        WatchEvent::ServiceDiscovered { name, type_name } => {
+        WatchEvent::ServiceDiscovered {
+            name, type_name, ..
+        } => {
             println!("service + {name} ({type_name})");
         }
-        WatchEvent::ServiceRemoved { name } => {
+        WatchEvent::ServiceRemoved { name, .. } => {
             println!("service - {name}");
         }
     }

--- a/crates/ros-z-cli/src/support/graph.rs
+++ b/crates/ros-z-cli/src/support/graph.rs
@@ -51,6 +51,7 @@ impl From<&GraphSnapshot> for SnapshotFingerprint {
 
 pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<WatchEvent> {
     let mut events = Vec::new();
+    let revision = current.revision;
 
     let previous_topics: BTreeMap<_, _> = previous
         .topics
@@ -65,6 +66,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (name, type_name) in &current_topics {
         if !previous_topics.contains_key(name) {
             events.push(WatchEvent::TopicDiscovered {
+                revision,
                 name: name.clone(),
                 type_name: type_name.clone(),
             });
@@ -72,7 +74,10 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     }
     for name in previous_topics.keys() {
         if !current_topics.contains_key(name) {
-            events.push(WatchEvent::TopicRemoved { name: name.clone() });
+            events.push(WatchEvent::TopicRemoved {
+                revision,
+                name: name.clone(),
+            });
         }
     }
 
@@ -89,6 +94,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (namespace, name) in &current_nodes {
         if !previous_nodes.contains(&(namespace.clone(), name.clone())) {
             events.push(WatchEvent::NodeDiscovered {
+                revision,
                 namespace: namespace.clone(),
                 name: name.clone(),
             });
@@ -97,6 +103,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (namespace, name) in &previous_nodes {
         if !current_nodes.contains(&(namespace.clone(), name.clone())) {
             events.push(WatchEvent::NodeRemoved {
+                revision,
                 namespace: namespace.clone(),
                 name: name.clone(),
             });
@@ -116,6 +123,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (name, type_name) in &current_services {
         if !previous_services.contains_key(name) {
             events.push(WatchEvent::ServiceDiscovered {
+                revision,
                 name: name.clone(),
                 type_name: type_name.clone(),
             });
@@ -123,7 +131,10 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     }
     for name in previous_services.keys() {
         if !current_services.contains_key(name) {
-            events.push(WatchEvent::ServiceRemoved { name: name.clone() });
+            events.push(WatchEvent::ServiceRemoved {
+                revision,
+                name: name.clone(),
+            });
         }
     }
 

--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, atomic::AtomicUsize},
-    time::Duration,
-};
+use std::sync::{Arc, atomic::AtomicUsize};
 
 use tracing::{debug, warn};
 use zenoh::{Session, Wait};
@@ -11,7 +8,7 @@ use crate::{
     config::{SessionConfigBuilder, session_config},
     entity::normalize_node_namespace,
     error::ConfigError,
-    graph::{Graph, GraphOptions},
+    graph::Graph,
     node::NodeBuilder,
     shm::{DEFAULT_SHM_POOL_SIZE, ShmConfig, ShmProviderBuilder},
     time::Clock,
@@ -50,7 +47,6 @@ pub struct ContextBuilder {
     shm_config: Option<Arc<ShmConfig>>,
     clock: Option<Clock>,
     runtime_parameter_inputs: RuntimeParameterInputs,
-    graph_options: GraphOptions,
 }
 
 impl ContextBuilder {
@@ -222,16 +218,6 @@ impl ContextBuilder {
     /// Inject a pre-configured clock.
     pub fn with_clock(mut self, clock: Clock) -> Self {
         self.clock = Some(clock);
-        self
-    }
-
-    pub fn with_graph_initial_query_timeout(mut self, timeout: Duration) -> Self {
-        self.graph_options.initial_liveliness_query_timeout = Some(timeout);
-        self
-    }
-
-    pub fn without_graph_initial_query(mut self) -> Self {
-        self.graph_options.initial_liveliness_query_timeout = None;
         self
     }
 
@@ -489,7 +475,7 @@ impl ContextBuilder {
             }
         }
 
-        let graph = Arc::new(Graph::new_with_options(&session, builder.graph_options).await?);
+        let graph = Arc::new(Graph::new(&session).await?);
 
         Ok(Context {
             session,

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::time::Duration;
 
 use itertools::Itertools;
+use tokio::time::Instant;
 
 use crate::{
     dynamic::{DynamicCdrCodec, DynamicError, DynamicPayload, DynamicSubscriber, Schema},
@@ -96,6 +97,25 @@ fn collect_topic_schema_candidates(
     collect_topic_schema_candidates_from_publishers(&publishers, qualified_topic)
 }
 
+fn schema_query_timeout(deadline: Instant) -> Option<Duration> {
+    let timeout = deadline.saturating_duration_since(Instant::now());
+    if timeout.is_zero() {
+        return None;
+    }
+    Some(timeout)
+}
+
+fn schema_query_timeout_error(
+    qualified_topic: &str,
+    last_error: Option<&DynamicError>,
+) -> DynamicError {
+    let mut message = format!("Timed out while discovering schema for topic: {qualified_topic}");
+    if let Some(error) = last_error {
+        message.push_str(&format!("; last candidate error: {error}"));
+    }
+    DynamicError::SchemaNotFound(message)
+}
+
 pub(crate) struct SchemaDiscovery {
     context: EndpointBuilderContext,
     timeout: Duration,
@@ -121,10 +141,14 @@ impl SchemaDiscovery {
         &self,
         qualified_topic: String,
     ) -> Result<DiscoveredTopicSchema, DynamicError> {
-        let candidates =
-            collect_topic_schema_candidates(self.context.graph.as_ref(), &qualified_topic)?;
+        let deadline = Instant::now() + self.timeout;
+        let candidates = self
+            .wait_for_topic_schema_candidates(&qualified_topic, deadline)
+            .await?;
 
-        let (root_name, schema, schema_hash) = self.try_schema_service(&candidates[..]).await?;
+        let (root_name, schema, schema_hash) = self
+            .try_schema_service(&qualified_topic, &candidates[..], deadline)
+            .await?;
 
         Ok(DiscoveredTopicSchema {
             qualified_topic,
@@ -134,16 +158,55 @@ impl SchemaDiscovery {
         })
     }
 
+    async fn wait_for_topic_schema_candidates(
+        &self,
+        qualified_topic: &str,
+        deadline: Instant,
+    ) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
+        let graph = &self.context.graph;
+        if tokio::time::timeout_at(
+            deadline,
+            graph.wait_until(|view| view.has_publishers_on(qualified_topic)),
+        )
+        .await
+        .is_err()
+        {
+            return Err(schema_query_timeout_error(qualified_topic, None));
+        }
+
+        collect_topic_schema_candidates(graph.as_ref(), qualified_topic)
+    }
+
     async fn try_schema_service(
         &self,
+        qualified_topic: &str,
         candidates: &[TopicSchemaCandidate],
+        deadline: Instant,
     ) -> Result<(String, Schema, SchemaHash), DynamicError> {
         let mut last_error = None;
 
         for candidate in candidates {
-            match super::schema_query::query_schema(&self.context, candidate, self.timeout).await {
-                Ok(result) => return Ok(result),
-                Err(error) => last_error = Some(error),
+            let Some(timeout) = schema_query_timeout(deadline) else {
+                return Err(schema_query_timeout_error(
+                    qualified_topic,
+                    last_error.as_ref(),
+                ));
+            };
+
+            match tokio::time::timeout_at(
+                deadline,
+                super::schema_query::query_schema(&self.context, candidate, timeout),
+            )
+            .await
+            {
+                Ok(Ok(result)) => return Ok(result),
+                Ok(Err(error)) => last_error = Some(error),
+                Err(_) => {
+                    return Err(schema_query_timeout_error(
+                        qualified_topic,
+                        last_error.as_ref(),
+                    ));
+                }
             }
         }
 
@@ -321,8 +384,21 @@ impl DynamicRawSubscriberDiscoveryBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
+    use crate::context::ContextBuilder;
     use crate::entity::{EndpointKind, NodeEntity, SchemaHash, TypeInfo};
+
+    fn unique_node_name(prefix: &str) -> String {
+        format!(
+            "{prefix}_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after Unix epoch")
+                .as_nanos()
+        )
+    }
 
     fn publisher(type_name: &str) -> EndpointEntity {
         EndpointEntity {
@@ -363,6 +439,84 @@ mod tests {
             type_info: TypeInfo::new(type_name, hash),
             qos: Default::default(),
         }
+    }
+
+    #[test]
+    fn schema_query_timeout_returns_none_for_elapsed_deadline() {
+        let deadline = Instant::now() - Duration::from_millis(1);
+
+        assert_eq!(schema_query_timeout(deadline), None);
+    }
+
+    #[test]
+    fn schema_query_timeout_returns_remaining_duration_for_future_deadline() {
+        let timeout = schema_query_timeout(Instant::now() + Duration::from_secs(1))
+            .expect("future deadline should leave time for one schema query");
+
+        assert!(timeout > Duration::ZERO);
+        assert!(timeout <= Duration::from_secs(1));
+    }
+
+    #[test]
+    fn schema_query_timeout_error_reports_timeout_without_candidate_error() {
+        let error = schema_query_timeout_error("/chatter", None);
+
+        let DynamicError::SchemaNotFound(message) = error else {
+            panic!("expected schema not found timeout, got {error:?}");
+        };
+        assert!(message.contains("Timed out"));
+        assert!(message.contains("/chatter"));
+    }
+
+    #[test]
+    fn schema_query_timeout_error_keeps_candidate_error_as_context() {
+        let error = schema_query_timeout_error(
+            "/chatter",
+            Some(&DynamicError::SerializationError(
+                "candidate failed".to_string(),
+            )),
+        );
+
+        let DynamicError::SchemaNotFound(message) = error else {
+            panic!("expected timeout schema not found, got {error:?}");
+        };
+        assert!(message.contains("Timed out"));
+        assert!(message.contains("/chatter"));
+        assert!(message.contains("candidate failed"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn schema_candidate_wait_reports_timeout_when_no_publishers_arrive() {
+        let context = ContextBuilder::default()
+            .build()
+            .await
+            .expect("test context should build");
+        let node = context
+            .create_node(unique_node_name("schema_candidate_timeout"))
+            .build()
+            .await
+            .expect("test node should build");
+        let discovery_context = EndpointBuilderContext::new(
+            node.session().clone(),
+            node.graph().clone(),
+            node.counter().clone(),
+            node.node_entity().clone(),
+            node.clock().clone(),
+            None,
+            node.schema_service().map(|service| service.registrar()),
+        );
+        let discovery = SchemaDiscovery::new(discovery_context, Duration::from_millis(1));
+
+        let error = discovery
+            .wait_for_topic_schema_candidates("/missing_schema_timeout", Instant::now())
+            .await
+            .expect_err("elapsed publisher wait should report timeout");
+
+        let DynamicError::SchemaNotFound(message) = error else {
+            panic!("expected timeout schema not found, got {error:?}");
+        };
+        assert!(message.contains("Timed out"));
+        assert!(message.contains("/missing_schema_timeout"));
     }
 
     #[test]

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -1,43 +1,42 @@
-use parking_lot::Mutex;
-use std::{sync::Arc, time::Duration};
-use tokio::sync::Notify;
-
 mod discovery;
 mod query;
 mod snapshot;
 mod state;
 
 use discovery::install_liveliness;
-pub use query::{GraphView, QosIncompatibility};
+pub use query::{GraphChangeSubscription, GraphView, QosIncompatibility};
 pub use snapshot::{GraphSnapshot, NodeSnapshot, ServiceSnapshot, TopicSnapshot};
-use state::GraphData;
+use state::GraphStore;
 
 use crate::Result;
 use crate::entity::{ADMIN_SPACE, Entity};
 use zenoh::{Session, pubsub::Subscriber, session::ZenohId};
 
-#[derive(Debug, Clone)]
-pub struct GraphOptions {
-    pub initial_liveliness_query_timeout: Option<Duration>,
-}
+/// Opaque token identifying a local graph state revision.
+///
+/// Values support equality and monotonic recency comparisons within one [`Graph`]. Ordering is
+/// intentionally exposed for revisions from the same graph instance or snapshot/subscription
+/// stream. Do not compare revisions from independently created graphs.
+///
+/// A changed revision means consumers should resync from [`Graph::view`] or [`Graph::snapshot`].
+/// Do not treat revisions as stable event counts or as proof that the distributed graph is
+/// complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(transparent)]
+pub struct GraphRevision(u64);
 
-impl Default for GraphOptions {
-    fn default() -> Self {
-        Self {
-            initial_liveliness_query_timeout: Some(Duration::from_secs(3)),
-        }
+impl GraphRevision {
+    /// Baseline revision before any observed effective graph changes.
+    pub const INITIAL: Self = Self(0);
+
+    pub(super) fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
     }
 }
 
 pub struct Graph {
-    data: Arc<Mutex<GraphData>>,
+    pub(crate) store: GraphStore,
     pub zid: ZenohId,
-    /// Notified whenever an entity appears or disappears in the graph.
-    ///
-    /// Publishers use this to implement `wait_for_subscribers`: they register
-    /// a `notified()` future before sampling the graph, then `await` it so no
-    /// arrival is missed between the sample and the wait.
-    pub(crate) change_notify: Arc<Notify>,
     _subscriber: Subscriber<()>,
 }
 
@@ -51,30 +50,38 @@ impl std::fmt::Debug for Graph {
 
 impl Graph {
     /// Create a new Graph using the native ros-z liveliness protocol.
+    ///
+    /// The graph is a live local observation of Zenoh liveliness. This returns after the
+    /// liveliness subscription has been declared; historical liveliness samples may still arrive
+    /// later and advance the graph revision.
     pub async fn new(session: &Session) -> Result<Self> {
-        Self::new_with_options(session, GraphOptions::default()).await
-    }
-
-    pub async fn new_with_options(session: &Session, options: GraphOptions) -> Result<Self> {
         let liveliness_pattern = format!("{}/**", ADMIN_SPACE);
         let zid = session.zid();
-        let graph_data = Arc::new(Mutex::new(GraphData::new()));
-        let change_notify = Arc::new(Notify::new());
-        let sub = install_liveliness(
-            session,
-            &liveliness_pattern,
-            &options,
-            graph_data.clone(),
-            change_notify.clone(),
-        )
-        .await?;
+        let store = GraphStore::new();
+        let sub = install_liveliness(session, &liveliness_pattern, store.clone()).await?;
 
         Ok(Self {
             _subscriber: sub,
-            data: graph_data,
-            change_notify,
+            store,
             zid,
         })
+    }
+
+    /// Return the current local graph change revision.
+    ///
+    /// The initial revision is `0`. Zenoh liveliness history and live events are reported through
+    /// the same revision stream. A revision change is a resync signal, not a graph-completeness
+    /// guarantee.
+    pub fn revision(&self) -> GraphRevision {
+        self.store.revision()
+    }
+
+    /// Subscribe to effective local graph changes.
+    ///
+    /// Subscriptions start from the current revision and keep only the latest revision. Treat each
+    /// observed change as a signal to inspect [`Graph::view`] again.
+    pub fn subscribe_changes(&self) -> GraphChangeSubscription {
+        GraphChangeSubscription::new(self.store.subscribe_changes())
     }
 
     /// Check if an entity belongs to the current session
@@ -90,24 +97,24 @@ impl Graph {
     /// immediately visible in graph queries without waiting for Zenoh liveliness propagation
     pub fn add_local_entity(&self, entity: Entity) -> Result<()> {
         let key_expr = entity.liveliness_key_expr()?;
-        self.data.lock().insert(key_expr, entity);
-        self.change_notify.notify_waiters();
+        self.store.insert(key_expr, entity);
         Ok(())
     }
 
     /// Remove a local entity from the graph
     pub fn remove_local_entity(&self, entity: &Entity) -> Result<()> {
         let key_expr = entity.liveliness_key_expr()?;
-        if self.data.lock().remove(&key_expr) {
-            self.change_notify.notify_waiters();
-        }
+        self.store.remove(&key_expr);
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::Arc,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
 
     use crate::{
         Error, Result,
@@ -127,24 +134,28 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn local_entity_add_notifies_graph_waiters() -> Result<()> {
+    async fn graph_wait_until_returns_immediately_when_predicate_is_true() -> Result<()> {
         let session = zenoh::open(zenoh::Config::default())
             .await
             .map_err(|source| Error::zenoh("open Zenoh session", source))?;
         let graph = Graph::new(&session).await?;
         let entity = Entity::Node(NodeEntity::new(
             session.zid(),
-            51,
-            unique_node_name("local_add_notify"),
+            55,
+            unique_node_name("wait_until_immediate"),
             String::new(),
         ));
-
-        let notified = graph.change_notify.notified();
+        let expected = entity.clone();
         graph.add_local_entity(entity)?;
 
-        tokio::time::timeout(Duration::from_millis(100), notified)
-            .await
-            .expect("local add should notify graph waiters");
+        let observed = tokio::time::timeout(
+            Duration::from_millis(100),
+            graph.wait_until(|view| view.entities().any(|candidate| candidate == &expected)),
+        )
+        .await
+        .expect("wait_until should return immediately for a true predicate");
+
+        assert!(observed);
         session
             .close()
             .await
@@ -153,25 +164,175 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn local_entity_remove_notifies_graph_waiters() -> Result<()> {
+    async fn graph_wait_until_observes_later_graph_revision() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Arc::new(Graph::new(&session).await?);
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
+            56,
+            unique_node_name("wait_until_later"),
+            String::new(),
+        ));
+        let expected = entity.clone();
+
+        let waiter = tokio::spawn({
+            let graph = Arc::clone(&graph);
+            async move {
+                graph
+                    .wait_until(|view| view.entities().any(|candidate| candidate == &expected))
+                    .await
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        graph.add_local_entity(entity)?;
+
+        let observed = tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .expect("wait_until should observe the graph revision")
+            .expect("wait_until task should not panic");
+
+        assert!(observed);
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn graph_change_subscription_current_does_not_block_revision_publication() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Arc::new(Graph::new(&session).await?);
+        let changes = graph.subscribe_changes();
+        let _held_revision = changes.current();
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
+            54,
+            unique_node_name("copied_revision_publish"),
+            String::new(),
+        ));
+
+        let update = tokio::task::spawn_blocking({
+            let graph = Arc::clone(&graph);
+            move || graph.add_local_entity(entity)
+        });
+
+        tokio::time::timeout(Duration::from_millis(100), update)
+            .await
+            .expect("copied public revisions must not block graph updates")
+            .expect("graph update task should not panic")?;
+
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn local_entity_add_and_remove_advance_graph_revision() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Graph::new(&session).await?;
+        let mut changes = graph.subscribe_changes();
+        let initial_revision: GraphRevision = graph.revision();
+        assert_eq!(initial_revision, GraphRevision::INITIAL);
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
+            51,
+            unique_node_name("local_update_revision"),
+            String::new(),
+        ));
+
+        graph.add_local_entity(entity.clone())?;
+
+        let add_revision = tokio::time::timeout(Duration::from_millis(100), changes.changed())
+            .await
+            .expect("local add should publish a graph revision")
+            .expect("graph revision sender should stay alive");
+        assert_ne!(add_revision, initial_revision);
+        assert_eq!(graph.revision(), add_revision);
+
+        graph.remove_local_entity(&entity)?;
+
+        let remove_revision = tokio::time::timeout(Duration::from_millis(100), changes.changed())
+            .await
+            .expect("local remove should publish a graph revision")
+            .expect("graph revision sender should stay alive");
+        assert_ne!(remove_revision, add_revision);
+        assert_eq!(graph.revision(), remove_revision);
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn snapshot_captures_current_graph_revision() -> Result<()> {
         let session = zenoh::open(zenoh::Config::default())
             .await
             .map_err(|source| Error::zenoh("open Zenoh session", source))?;
         let graph = Graph::new(&session).await?;
         let entity = Entity::Node(NodeEntity::new(
             session.zid(),
+            53,
+            unique_node_name("snapshot_revision"),
+            String::new(),
+        ));
+
+        let initial_snapshot = graph.snapshot();
+        assert_eq!(initial_snapshot.revision, GraphRevision::INITIAL);
+        let initial_snapshot_json =
+            serde_json::to_value(initial_snapshot).expect("graph snapshot should serialize");
+        assert_eq!(initial_snapshot_json["revision"], serde_json::json!(0));
+
+        graph.add_local_entity(entity)?;
+
+        assert_eq!(graph.snapshot().revision, graph.revision());
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unchanged_local_readd_does_not_advance_graph_revision() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Graph::new(&session).await?;
+        let mut changes = graph.subscribe_changes();
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
             52,
-            unique_node_name("local_remove_notify"),
+            unique_node_name("local_readd_revision"),
             String::new(),
         ));
 
         graph.add_local_entity(entity.clone())?;
-        let notified = graph.change_notify.notified();
-        graph.remove_local_entity(&entity)?;
-
-        tokio::time::timeout(Duration::from_millis(100), notified)
+        tokio::time::timeout(Duration::from_millis(100), changes.changed())
             .await
-            .expect("local remove should notify graph waiters");
+            .expect("first local add should publish a graph revision")
+            .expect("graph revision sender should stay alive");
+        let revision_after_first_add = graph.revision();
+
+        graph.add_local_entity(entity)?;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), changes.changed())
+                .await
+                .is_err(),
+            "unchanged local re-add must not publish a graph revision"
+        );
+        assert_eq!(graph.revision(), revision_after_first_add);
         session
             .close()
             .await

--- a/crates/ros-z/src/graph/discovery.rs
+++ b/crates/ros-z/src/graph/discovery.rs
@@ -1,95 +1,50 @@
-use parking_lot::Mutex;
-use std::sync::Arc;
-use tokio::sync::Notify;
 use tracing::{debug, warn};
 use zenoh::{Session, pubsub::Subscriber, sample::SampleKind};
 
 use crate::{Result, entity::LivelinessKE};
 
-use super::{GraphOptions, state::GraphData};
+use super::state::GraphStore;
 use ros_z_protocol::format::parse_liveliness;
 
 pub(super) async fn install_liveliness(
     session: &Session,
     pattern: &str,
-    options: &GraphOptions,
-    graph_data: Arc<Mutex<GraphData>>,
-    change_notify: Arc<Notify>,
+    graph_store: GraphStore,
 ) -> Result<Subscriber<()>> {
     debug!(pattern = %pattern, "declaring graph liveliness subscriber");
     let sub = session
         .liveliness()
         .declare_subscriber(pattern)
         .history(true)
-        .callback({
-            let graph_data = graph_data.clone();
-            move |sample| {
-                let key_expr = LivelinessKE(sample.key_expr().to_owned());
-                let sample_kind = sample.kind();
-                debug!(
-                    liveliness_key = %key_expr.0,
-                    kind = ?sample_kind,
-                    "received graph liveliness token"
-                );
+        .callback(move |sample| {
+            let key_expr = LivelinessKE(sample.key_expr().to_owned());
+            let sample_kind = sample.kind();
+            debug!(
+                liveliness_key = %key_expr.0,
+                kind = ?sample_kind,
+                "received graph liveliness token"
+            );
 
-                let changed = match sample_kind {
-                    SampleKind::Put => match parse_liveliness(&key_expr) {
-                        Ok(entity) => {
-                            graph_data.lock().insert(key_expr, entity);
-                            true
-                        }
-                        Err(error) => {
-                            warn!(
-                                liveliness_key = %key_expr.0,
-                                error = ?error,
-                                "failed to parse liveliness key; ignoring remote entity"
-                            );
-                            false
-                        }
-                    },
-                    SampleKind::Delete => graph_data.lock().remove(&key_expr),
-                };
-
-                if changed {
-                    change_notify.notify_waiters();
-                }
-            }
-        })
-        .await
-        .map_err(|source| crate::Error::zenoh("declare graph liveliness subscriber", source))?;
-
-    if let Some(timeout) = options.initial_liveliness_query_timeout {
-        let replies = session
-            .liveliness()
-            .get(pattern)
-            .timeout(timeout)
-            .await
-            .map_err(|source| crate::Error::zenoh("query initial graph liveliness", source))?;
-        let mut reply_count = 0;
-        while let Ok(reply) = replies.recv_async().await {
-            reply_count += 1;
-            if let Ok(sample) = reply.into_result() {
-                let key_expr = LivelinessKE(sample.key_expr().to_owned());
-                debug!(
-                    liveliness_key = %key_expr.0,
-                    "received initial graph liveliness token"
-                );
-                match parse_liveliness(&key_expr) {
+            match sample_kind {
+                SampleKind::Put => match parse_liveliness(&key_expr) {
                     Ok(entity) => {
-                        graph_data.lock().insert(key_expr, entity);
+                        graph_store.insert(key_expr, entity);
                     }
                     Err(error) => {
                         warn!(
                             liveliness_key = %key_expr.0,
                             error = ?error,
-                            "failed to parse initial liveliness key; ignoring remote entity"
+                            "failed to parse liveliness key; ignoring remote entity"
                         );
                     }
+                },
+                SampleKind::Delete => {
+                    graph_store.remove(&key_expr);
                 }
             }
-        }
-        debug!(reply_count, "initial graph liveliness query completed");
-    }
+        })
+        .await
+        .map_err(|source| crate::Error::zenoh("declare graph liveliness subscriber", source))?;
 
     Ok(sub)
 }

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -5,7 +5,7 @@ use parking_lot::MutexGuard;
 use crate::entity::{EndpointEntity, EndpointKind, Entity, NodeEntity, NodeKey};
 use crate::qos::{QosCompatibility, QosProfile};
 
-use super::{Graph, state::GraphData};
+use super::{Graph, GraphRevision, state::GraphState};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QosIncompatibility {
@@ -19,7 +19,44 @@ pub struct QosIncompatibility {
 ///
 /// Do not hold a `GraphView` across `.await` points or while calling other `Graph` methods.
 pub struct GraphView<'a> {
-    data: MutexGuard<'a, GraphData>,
+    state: MutexGuard<'a, GraphState>,
+}
+
+/// Subscription to effective local graph changes.
+///
+/// The subscription stores only the latest graph revision. Treat each observed revision as a signal
+/// to resync from [`Graph::view`] or [`Graph::snapshot`]; revisions do not carry per-change payloads
+/// and do not prove that the distributed graph is complete.
+pub struct GraphChangeSubscription {
+    changes: tokio::sync::watch::Receiver<GraphRevision>,
+}
+
+impl GraphChangeSubscription {
+    pub(super) fn new(changes: tokio::sync::watch::Receiver<GraphRevision>) -> Self {
+        Self { changes }
+    }
+
+    /// Return the currently observed graph revision without marking it as seen.
+    pub fn current(&self) -> GraphRevision {
+        *self.changes.borrow()
+    }
+
+    /// Mark the current revision as seen and return it.
+    ///
+    /// Call this before evaluating a graph predicate when implementing a wait loop. That arms the
+    /// subscription so a later [`Self::changed`] call waits for changes after the sampled graph
+    /// state instead of returning an already-observed revision.
+    pub fn mark_seen(&mut self) -> GraphRevision {
+        *self.changes.borrow_and_update()
+    }
+
+    /// Wait for a later graph revision.
+    ///
+    /// Returns `None` when the graph change sender has closed.
+    pub async fn changed(&mut self) -> Option<GraphRevision> {
+        self.changes.changed().await.ok()?;
+        Some(*self.changes.borrow_and_update())
+    }
 }
 
 impl Graph {
@@ -29,14 +66,42 @@ impl Graph {
     /// methods; those operations may need the same lock.
     pub fn view(&self) -> GraphView<'_> {
         GraphView {
-            data: self.data.lock(),
+            state: self.store.state(),
+        }
+    }
+
+    pub(crate) async fn wait_until<F>(&self, mut predicate: F) -> bool
+    where
+        F: for<'view> FnMut(GraphView<'view>) -> bool,
+    {
+        let mut changes = self.subscribe_changes();
+        loop {
+            changes.mark_seen();
+            let satisfied = {
+                let view = self.view();
+                predicate(view)
+            };
+            if satisfied {
+                return true;
+            }
+
+            if changes.changed().await.is_none() {
+                return false;
+            }
         }
     }
 }
 
 impl GraphView<'_> {
+    /// Return the graph revision for this locked view.
+    ///
+    /// This revision belongs to the same graph state as the entities read through this view.
+    pub fn revision(&self) -> GraphRevision {
+        self.state.revision()
+    }
+
     pub fn entities(&self) -> impl Iterator<Item = &Entity> + '_ {
-        self.data.entities()
+        self.state.entities()
     }
 
     pub fn nodes(&self) -> impl Iterator<Item = &NodeEntity> + '_ {
@@ -59,6 +124,22 @@ impl GraphView<'_> {
 
     pub fn subscriptions_on(&self, topic: impl AsRef<str>) -> Vec<EndpointEntity> {
         self.endpoints_named(EndpointKind::Subscription, topic)
+    }
+
+    pub fn publisher_count_on(&self, topic: impl AsRef<str>) -> usize {
+        self.endpoint_count_named(EndpointKind::Publisher, topic)
+    }
+
+    pub fn subscription_count_on(&self, topic: impl AsRef<str>) -> usize {
+        self.endpoint_count_named(EndpointKind::Subscription, topic)
+    }
+
+    pub fn has_publishers_on(&self, topic: impl AsRef<str>) -> bool {
+        self.has_endpoint_named(EndpointKind::Publisher, topic)
+    }
+
+    pub fn has_subscriptions_on(&self, topic: impl AsRef<str>) -> bool {
+        self.has_endpoint_named(EndpointKind::Subscription, topic)
     }
 
     pub fn services_named(&self, service_name: impl AsRef<str>) -> Vec<EndpointEntity> {
@@ -117,6 +198,19 @@ impl GraphView<'_> {
             .filter(|endpoint| endpoint.kind == kind && endpoint.topic == name)
             .cloned()
             .collect()
+    }
+
+    fn endpoint_count_named(&self, kind: EndpointKind, name: impl AsRef<str>) -> usize {
+        let name = name.as_ref();
+        self.endpoints()
+            .filter(|endpoint| endpoint.kind == kind && endpoint.topic == name)
+            .count()
+    }
+
+    fn has_endpoint_named(&self, kind: EndpointKind, name: impl AsRef<str>) -> bool {
+        let name = name.as_ref();
+        self.endpoints()
+            .any(|endpoint| endpoint.kind == kind && endpoint.topic == name)
     }
 
     fn names_and_types_for(
@@ -312,5 +406,16 @@ mod tests {
             .await
             .map_err(|source| Error::zenoh("close Zenoh session", source))?;
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn graph_change_subscription_changed_returns_none_after_sender_closes() {
+        let (sender, receiver) = tokio::sync::watch::channel(GraphRevision::INITIAL);
+        let mut changes = GraphChangeSubscription::new(receiver);
+        changes.mark_seen();
+
+        drop(sender);
+
+        assert_eq!(changes.changed().await, None);
     }
 }

--- a/crates/ros-z/src/graph/snapshot.rs
+++ b/crates/ros-z/src/graph/snapshot.rs
@@ -4,11 +4,16 @@ use serde::Serialize;
 
 use crate::entity::EndpointKind;
 
-use super::Graph;
+use super::{Graph, GraphRevision};
 
-/// A serializable snapshot of the native ros-z graph state
+/// A serializable point-in-time observation of the local native ros-z graph state.
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphSnapshot {
+    /// Revision of the local graph state used to produce this snapshot.
+    ///
+    /// This is a monotonic local progress token. It does not mean the distributed graph is complete
+    /// or settled.
+    pub revision: GraphRevision,
     pub timestamp: SystemTime,
     pub topics: Vec<TopicSnapshot>,
     pub nodes: Vec<NodeSnapshot>,
@@ -38,13 +43,14 @@ pub struct ServiceSnapshot {
 }
 
 impl Graph {
-    /// Create a serializable snapshot of the current graph state
+    /// Create a serializable point-in-time observation of the current local graph state.
     ///
-    /// This captures topics, nodes, and services with their metadata,
-    /// suitable for JSON serialization or other export formats.
+    /// This captures topics, nodes, services, and the local revision used to produce the snapshot.
+    /// The snapshot does not imply that the distributed graph is complete or settled.
     pub fn snapshot(&self) -> GraphSnapshot {
-        let (topics, nodes, services) = {
+        let (revision, topics, nodes, services) = {
             let view = self.view();
+            let revision = view.revision();
             let topics: Vec<TopicSnapshot> = view
                 .topic_names_and_types()
                 .into_iter()
@@ -82,10 +88,11 @@ impl Graph {
                 .map(|(name, type_name)| ServiceSnapshot { name, type_name })
                 .collect();
 
-            (topics, nodes, services)
+            (revision, topics, nodes, services)
         };
 
         GraphSnapshot {
+            revision,
             timestamp: SystemTime::now(),
             topics,
             nodes,

--- a/crates/ros-z/src/graph/state.rs
+++ b/crates/ros-z/src/graph/state.rs
@@ -1,9 +1,90 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
+use std::sync::Arc;
 
+use parking_lot::{Mutex, MutexGuard};
+use tokio::sync::watch;
+
+use super::GraphRevision;
 use crate::entity::{Entity, LivelinessKE};
 
 pub(super) struct GraphData {
     entities: HashMap<LivelinessKE, Entity>,
+}
+
+pub(super) struct GraphState {
+    data: GraphData,
+    revision: GraphRevision,
+}
+
+impl GraphState {
+    pub(super) fn revision(&self) -> GraphRevision {
+        self.revision
+    }
+
+    pub(super) fn entities(&self) -> impl Iterator<Item = &Entity> + '_ {
+        self.data.entities()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GraphStore {
+    state: Arc<Mutex<GraphState>>,
+    revision_tx: watch::Sender<GraphRevision>,
+}
+
+impl GraphStore {
+    pub(super) fn new() -> Self {
+        let (revision_tx, _) = watch::channel(GraphRevision::INITIAL);
+        Self {
+            state: Arc::new(Mutex::new(GraphState {
+                data: GraphData::new(),
+                revision: GraphRevision::INITIAL,
+            })),
+            revision_tx,
+        }
+    }
+
+    pub(super) fn revision(&self) -> GraphRevision {
+        self.state.lock().revision()
+    }
+
+    pub(super) fn subscribe_changes(&self) -> watch::Receiver<GraphRevision> {
+        self.revision_tx.subscribe()
+    }
+
+    pub(super) fn state(&self) -> MutexGuard<'_, GraphState> {
+        self.state.lock()
+    }
+
+    pub(super) fn insert(&self, key_expr: LivelinessKE, entity: Entity) -> bool {
+        self.apply_effective_change(|data| data.insert(key_expr, entity))
+    }
+
+    pub(super) fn remove(&self, key_expr: &LivelinessKE) -> bool {
+        self.apply_effective_change(|data| data.remove(key_expr))
+    }
+
+    fn apply_effective_change(&self, update: impl FnOnce(&mut GraphData) -> bool) -> bool {
+        let revision = {
+            let mut state = self.state.lock();
+            if !update(&mut state.data) {
+                return false;
+            }
+
+            let revision = state.revision.next();
+            state.revision = revision;
+            revision
+        };
+
+        self.revision_tx.send_if_modified(|current| {
+            if *current >= revision {
+                return false;
+            }
+            *current = revision;
+            true
+        });
+        true
+    }
 }
 
 impl GraphData {
@@ -13,8 +94,18 @@ impl GraphData {
         }
     }
 
-    pub(super) fn insert(&mut self, key_expr: LivelinessKE, entity: Entity) {
-        self.entities.insert(key_expr, entity);
+    pub(super) fn insert(&mut self, key_expr: LivelinessKE, entity: Entity) -> bool {
+        match self.entities.entry(key_expr) {
+            Entry::Vacant(entry) => {
+                entry.insert(entity);
+                true
+            }
+            Entry::Occupied(mut entry) if entry.get() != &entity => {
+                entry.insert(entity);
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
     }
 
     pub(super) fn remove(&mut self, key_expr: &LivelinessKE) -> bool {
@@ -54,36 +145,36 @@ mod tests {
     }
 
     #[test]
-    fn insert_stores_one_entity_by_liveliness_key() {
+    fn insert_reports_change_for_new_entity() {
         let mut data = GraphData::new();
         let entity = Entity::Node(node("inserted_node"));
         let key = key_for(&entity);
 
-        data.insert(key, entity.clone());
+        assert!(data.insert(key, entity.clone()));
         assert_eq!(data.entities().collect::<Vec<_>>(), vec![&entity]);
     }
 
     #[test]
-    fn duplicate_insert_upserts_without_duplicating() {
+    fn duplicate_insert_reports_no_change() {
         let mut data = GraphData::new();
         let entity = Entity::Node(node("duplicate_node"));
         let key = key_for(&entity);
 
-        data.insert(key.clone(), entity.clone());
-        data.insert(key, entity);
+        assert!(data.insert(key.clone(), entity.clone()));
+        assert!(!data.insert(key, entity));
         assert_eq!(data.entities().count(), 1);
     }
 
     #[test]
-    fn replacing_same_key_updates_existing_entity() {
+    fn replacing_same_key_reports_change() {
         let mut data = GraphData::new();
         let node = node("replace_node");
         let old = Entity::Endpoint(publisher(&node, 2, "/old_topic"));
         let new = Entity::Endpoint(publisher(&node, 3, "/new_topic"));
         let key = key_for(&old);
 
-        data.insert(key.clone(), old);
-        data.insert(key, new.clone());
+        assert!(data.insert(key.clone(), old));
+        assert!(data.insert(key, new.clone()));
         assert_eq!(data.entities().collect::<Vec<_>>(), vec![&new]);
     }
 
@@ -115,5 +206,27 @@ mod tests {
 
         assert!(!data.remove(&key));
         assert_eq!(data.entities().count(), 0);
+    }
+
+    #[test]
+    fn store_insert_and_remove_advance_revision_only_for_effective_changes() {
+        let store = GraphStore::new();
+        let entity = Entity::Node(node("store_revision_node"));
+        let key = key_for(&entity);
+
+        assert_eq!(store.revision(), GraphRevision::INITIAL);
+        assert!(store.insert(key.clone(), entity.clone()));
+        let insert_revision = store.revision();
+        assert!(insert_revision > GraphRevision::INITIAL);
+
+        assert!(!store.insert(key.clone(), entity.clone()));
+        assert_eq!(store.revision(), insert_revision);
+
+        assert!(store.remove(&key));
+        let remove_revision = store.revision();
+        assert!(remove_revision > insert_revision);
+
+        assert!(!store.remove(&key));
+        assert_eq!(store.revision(), remove_revision);
     }
 }

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -471,10 +471,15 @@ impl Node {
         )
     }
 
-    /// Discover the schema that publishers currently expose on a topic.
+    /// Discover the schema exposed by publishers on a topic.
     ///
     /// The topic name is qualified according to the same ros-z graph-name rules as the
     /// regular publisher and subscriber builder APIs.
+    ///
+    /// Discovery waits up to `discovery_timeout` for a matching publisher to appear in
+    /// the graph. Once publishers are available, the remaining timeout budget is used
+    /// to query their schema services. If no matching publisher appears before the
+    /// timeout expires, this returns [`DynamicError::SchemaNotFound`].
     pub async fn discover_topic_schema(
         &self,
         topic: &str,
@@ -491,6 +496,10 @@ impl Node {
     /// the builder queries publishers on the topic for their schema service and
     /// creates a dynamic subscriber from the discovered schema. This is useful
     /// when you don't know the message type at compile time.
+    ///
+    /// When the builder is built, `discovery_timeout` covers both waiting for a
+    /// matching publisher and querying schema services. If no matching publisher
+    /// appears before the timeout expires, build returns [`DynamicError::SchemaNotFound`].
     ///
     /// The topic name will be qualified as a ros-z graph name:
     /// - Absolute topics (starting with '/') are used as-is

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -432,7 +432,7 @@ where
 {
     /// Return the number of matched subscribers currently visible in the graph.
     pub fn subscriber_count(&self) -> usize {
-        self.graph.view().subscriptions_on(&self.entity.topic).len()
+        self.graph.view().subscription_count_on(&self.entity.topic)
     }
 
     /// Return whether at least one subscriber is currently matched.
@@ -457,30 +457,15 @@ where
     /// assert!(publisher.wait_for_subscribers(1, Duration::from_secs(5)).await);
     /// ```
     pub async fn wait_for_subscribers(&self, count: usize, timeout: Duration) -> bool {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            // Arm the notification *before* reading the count to avoid a TOCTOU
-            // race where a subscriber arrives between the count check and the await.
-            let notified = self.graph.change_notify.notified();
-            tokio::pin!(notified);
+        let topic = self.entity.topic.as_str();
+        let wait = self
+            .graph
+            .wait_until(move |view| view.subscription_count_on(topic) >= count);
 
-            let n = self.graph.view().subscriptions_on(&self.entity.topic).len();
-            if n >= count {
-                return true;
-            }
-
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return false;
-            }
-
-            // Sleep until either a graph change fires or the deadline passes.
-            if tokio::time::timeout(remaining, &mut notified)
-                .await
-                .is_err()
-            {
-                // Timeout — do one final check in case a late notification was missed.
-                return self.graph.view().subscriptions_on(&self.entity.topic).len() >= count;
+        match tokio::time::timeout(timeout, wait).await {
+            Ok(true) => true,
+            Ok(false) | Err(_) => {
+                self.graph.view().subscription_count_on(&self.entity.topic) >= count
             }
         }
     }

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -642,11 +642,12 @@ pub(crate) fn spawn_transient_local_replay_task(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut seen = initial_seen;
+        let mut changes = graph.subscribe_changes();
         loop {
             if coordinator.is_cancelled() {
                 return;
             }
-            let notified = graph.change_notify.notified();
+            changes.mark_seen();
             let discovered = begin_unseen_late_publishers(
                 &mut seen,
                 &coordinator,
@@ -672,7 +673,9 @@ pub(crate) fn spawn_transient_local_replay_task(
                 }
                 coordinator.finish_late_replay(publisher_global_id);
             }
-            notified.await;
+            if changes.changed().await.is_none() {
+                return;
+            }
         }
     })
 }

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -500,27 +500,14 @@ where
     /// assert!(subscriber.wait_for_publishers(1, Duration::from_secs(5)).await);
     /// ```
     pub async fn wait_for_publishers(&self, count: usize, timeout: Duration) -> bool {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            let notified = self.graph.change_notify.notified();
-            tokio::pin!(notified);
+        let topic = self.entity.topic.as_str();
+        let wait = self
+            .graph
+            .wait_until(move |view| view.publisher_count_on(topic) >= count);
 
-            let n = self.graph.view().publishers_on(&self.entity.topic).len();
-            if n >= count {
-                return true;
-            }
-
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return false;
-            }
-
-            if tokio::time::timeout(remaining, &mut notified)
-                .await
-                .is_err()
-            {
-                return self.graph.view().publishers_on(&self.entity.topic).len() >= count;
-            }
+        match tokio::time::timeout(timeout, wait).await {
+            Ok(true) => true,
+            Ok(false) | Err(_) => self.graph.view().publisher_count_on(&self.entity.topic) >= count,
         }
     }
 }
@@ -532,7 +519,7 @@ where
 {
     /// Return the number of matched publishers currently visible in the graph.
     pub fn publisher_count(&self) -> usize {
-        self.graph.view().publishers_on(&self.entity.topic).len()
+        self.graph.view().publisher_count_on(&self.entity.topic)
     }
 
     /// Return whether at least one publisher is currently matched.

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -7,17 +7,18 @@
 //! - Node discovery and information
 //! - Service availability checking
 
-use std::{num::NonZeroUsize, time::Duration};
+use std::{net::TcpListener, num::NonZeroUsize, time::Duration};
 
 use ros_z::{
     Message, ServiceTypeInfo,
     context::ContextBuilder,
     entity::{EndpointEntity, EndpointKind, Entity, NodeEntity, NodeKey, SchemaHash, TypeInfo},
-    graph::GraphView,
+    graph::{GraphChangeSubscription, GraphRevision, GraphView},
     message::Service,
     qos::{QosCompatibility, QosDurability, QosHistory, QosProfile, QosReliability},
 };
 use serde::{Deserialize, Serialize};
+use zenoh::config::WhatAmI;
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -84,6 +85,140 @@ fn unique_node_name(prefix: &str) -> String {
     )
 }
 
+fn unique_listen_endpoint() -> Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    Ok(format!("tcp/127.0.0.1:{port}"))
+}
+
+fn isolated_peer_config(
+    listen_endpoint: Option<&str>,
+    connect_endpoints: &[&str],
+) -> Result<zenoh::Config> {
+    let mut config = zenoh::Config::default();
+    config
+        .set_mode(Some(WhatAmI::Peer))
+        .map_err(|mode| format!("failed to set Zenoh mode to peer: {mode:?}"))?;
+    let listen_endpoints = listen_endpoint
+        .map(|endpoint| format!("[\"{endpoint}\"]"))
+        .unwrap_or_else(|| "[\"tcp/127.0.0.1:0\"]".to_string());
+    let connect_endpoints = if connect_endpoints.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "[{}]",
+            connect_endpoints
+                .iter()
+                .map(|endpoint| format!("\"{endpoint}\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    };
+    config.insert_json5("listen/endpoints", &listen_endpoints)?;
+    config.insert_json5("connect/endpoints", &connect_endpoints)?;
+    config.insert_json5("scouting/multicast/enabled", "false")?;
+    Ok(config)
+}
+
+async fn try_open_isolated_graph_sessions() -> Result<(zenoh::Session, zenoh::Session)> {
+    let graph_endpoint = unique_listen_endpoint()?;
+    let graph_session = zenoh::open(isolated_peer_config(Some(&graph_endpoint), &[])?).await?;
+    let remote_session = zenoh::open(isolated_peer_config(None, &[&graph_endpoint])?).await?;
+    Ok((graph_session, remote_session))
+}
+
+async fn open_isolated_graph_sessions() -> Result<(zenoh::Session, zenoh::Session)> {
+    let mut last_error = None;
+    for _ in 0..8 {
+        match try_open_isolated_graph_sessions().await {
+            Ok(sessions) => return Ok(sessions),
+            Err(error) => last_error = Some(error),
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    Err(last_error.unwrap_or_else(|| "failed to open isolated graph sessions".into()))
+}
+
+fn remote_node_entity(session: &zenoh::Session, id: usize, prefix: &str) -> Entity {
+    Entity::Node(NodeEntity::new(
+        session.zid(),
+        id,
+        unique_node_name(prefix),
+        String::new(),
+    ))
+}
+
+async fn declare_liveliness_token(
+    session: &zenoh::Session,
+    entity: &Entity,
+) -> Result<zenoh::liveliness::LivelinessToken> {
+    let liveliness_key_expr = entity.liveliness_key_expr()?;
+    session
+        .liveliness()
+        .declare_token(liveliness_key_expr.0)
+        .await
+}
+
+async fn wait_for_liveliness_token(
+    session: &zenoh::Session,
+    entity: &Entity,
+    timeout: Duration,
+) -> Result<()> {
+    let liveliness_key_expr = entity.liveliness_key_expr()?;
+    let started_at = std::time::Instant::now();
+    loop {
+        if started_at.elapsed() >= timeout {
+            return Err(format!(
+                "timed out waiting for liveliness token {}",
+                liveliness_key_expr.as_str()
+            )
+            .into());
+        }
+        let query_timeout = timeout
+            .saturating_sub(started_at.elapsed())
+            .min(Duration::from_millis(50));
+        let replies = session
+            .liveliness()
+            .get(liveliness_key_expr.as_str())
+            .timeout(query_timeout)
+            .await?;
+        while let Ok(reply) = replies.recv_async().await {
+            if let Ok(sample) = reply.into_result()
+                && sample.key_expr().as_str() == liveliness_key_expr.as_str()
+            {
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn wait_for_graph_revision_change(
+    changes: &mut GraphChangeSubscription,
+    previous_revision: GraphRevision,
+    timeout: Duration,
+) -> Result<GraphRevision> {
+    let revision = changes.mark_seen();
+    if revision != previous_revision {
+        return Ok(revision);
+    }
+
+    tokio::time::timeout(timeout, async {
+        loop {
+            let revision = changes
+                .changed()
+                .await
+                .ok_or("graph change subscription closed")?;
+            if revision != previous_revision {
+                return Ok(revision);
+            }
+        }
+    })
+    .await
+    .map_err(|_| {
+        format!("timed out waiting for graph revision change from {previous_revision:?}")
+    })?
+}
+
 async fn wait_for_count(
     node: &ros_z::node::Node,
     name: &str,
@@ -132,11 +267,11 @@ async fn wait_for_count_matching(
 }
 
 fn publisher_count(view: &GraphView<'_>, topic: &str) -> usize {
-    view.publishers_on(topic).len()
+    view.publisher_count_on(topic)
 }
 
 fn subscriber_count(view: &GraphView<'_>, topic: &str) -> usize {
-    view.subscriptions_on(topic).len()
+    view.subscription_count_on(topic)
 }
 
 fn service_count(view: &GraphView<'_>, service: &str) -> usize {
@@ -265,7 +400,9 @@ mod tests {
         graph.add_local_entity(Entity::Endpoint(service_endpoint.clone()))?;
         graph.add_local_entity(Entity::Endpoint(client_endpoint.clone()))?;
 
+        let graph_revision = graph.revision();
         let view: ros_z::graph::GraphView<'_> = graph.view();
+        assert_eq!(view.revision(), graph_revision);
         assert!(
             view.entities()
                 .any(|candidate| candidate == &Entity::Node(node.clone()))
@@ -278,6 +415,14 @@ mod tests {
         assert!(view.endpoints().any(|candidate| candidate == &publisher));
         assert_eq!(view.publishers_on(&topic), vec![publisher.clone()]);
         assert_eq!(view.subscriptions_on(&topic), vec![subscription]);
+        assert_eq!(view.publisher_count_on(&topic), 1);
+        assert_eq!(view.subscription_count_on(&topic), 1);
+        assert!(view.has_publishers_on(&topic));
+        assert!(view.has_subscriptions_on(&topic));
+        assert_eq!(view.publisher_count_on("/missing_topic"), 0);
+        assert_eq!(view.subscription_count_on("/missing_topic"), 0);
+        assert!(!view.has_publishers_on("/missing_topic"));
+        assert!(!view.has_subscriptions_on("/missing_topic"));
         assert_eq!(
             view.services_named(&service),
             vec![service_endpoint.clone()]
@@ -469,15 +614,6 @@ mod tests {
 
         assert!(graph.view().node_exists(&node_key));
         session.close().await?;
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn context_can_skip_initial_graph_liveliness_query() -> Result<()> {
-        let _ctx = ContextBuilder::default()
-            .without_graph_initial_query()
-            .build()
-            .await?;
         Ok(())
     }
 
@@ -1085,6 +1221,75 @@ mod tests {
         assert!(!pubs.is_empty(), "Expected to find publishers");
         assert!(!subs.is_empty(), "Expected to find subscribers");
 
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graph_change_subscription_reports_historical_liveliness_put_as_revision() -> Result<()>
+    {
+        let (graph_session, remote_session) = open_isolated_graph_sessions().await?;
+        let entity = remote_node_entity(&remote_session, 91, "graph_revision_history_remote");
+        let _token = declare_liveliness_token(&remote_session, &entity).await?;
+        wait_for_liveliness_token(&graph_session, &entity, Duration::from_secs(2)).await?;
+
+        let graph = ros_z::graph::Graph::new(&graph_session).await?;
+        let mut changes = graph.subscribe_changes();
+
+        let history_revision = wait_for_graph_revision_change(
+            &mut changes,
+            GraphRevision::INITIAL,
+            Duration::from_secs(2),
+        )
+        .await?;
+
+        assert_ne!(history_revision, GraphRevision::INITIAL);
+        assert!(
+            graph
+                .view()
+                .entities()
+                .any(|candidate| candidate == &entity)
+        );
+
+        graph_session.close().await?;
+        remote_session.close().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graph_change_subscription_reports_live_remote_put_and_delete() -> Result<()> {
+        let (graph_session, remote_session) = open_isolated_graph_sessions().await?;
+        let graph = ros_z::graph::Graph::new(&graph_session).await?;
+        let mut changes = graph.subscribe_changes();
+        let initial_revision = graph.revision();
+        let entity = remote_node_entity(&remote_session, 92, "graph_revision_live_put_delete");
+
+        let token = declare_liveliness_token(&remote_session, &entity).await?;
+
+        let put_revision =
+            wait_for_graph_revision_change(&mut changes, initial_revision, Duration::from_secs(2))
+                .await?;
+        assert_ne!(put_revision, initial_revision);
+        assert!(
+            graph
+                .view()
+                .entities()
+                .any(|candidate| candidate == &entity)
+        );
+
+        drop(token);
+        let delete_revision =
+            wait_for_graph_revision_change(&mut changes, put_revision, Duration::from_secs(2))
+                .await?;
+        assert_ne!(delete_revision, put_revision);
+        assert!(
+            !graph
+                .view()
+                .entities()
+                .any(|candidate| candidate == &entity)
+        );
+
+        graph_session.close().await?;
+        remote_session.close().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This PR adds revision tracking to the `ros-z` graph. Each graph mutation now advances a monotonic revision, and graph snapshots carry the revision that produced them. Code that waits for graph-dependent state can now wait for concrete graph changes instead of relying on repeated queries or local polling loops.

The change introduces shared wait primitives for graph consumers and migrates publisher/subscriber waits, transient-local replay, and dynamic schema discovery onto those primitives.

## Motivation

Several `ros-z` paths need to wait until graph state catches up with Zenoh liveliness updates. Before this PR, those paths implemented their own waiting behavior and deadline handling. That made it harder to reason about missed updates, stale snapshots, and timeout behavior.

Revision tracking gives the graph a single observable progress signal. Waiters can now ask: “Has the graph changed since the snapshot I looked at?” Dynamic schema discovery also uses one deadline budget while waiting for publishers and querying schema candidates.

## Reviewer Notes

Start with these areas:

- `crates/ros-z/src/graph.rs`
  - Defines graph revisions and snapshot-facing graph behavior.
  - Adds tests for revision ordering and snapshot revision behavior.

- `crates/ros-z/src/graph/state.rs`
  - Advances and publishes graph revisions after mutations.
  - Sends graph change notifications after releasing the graph mutex.

- `crates/ros-z/src/graph/query.rs`
  - Adds `Graph::wait_until`.
  - Adds `GraphChangeSubscription` so public subscribers observe copied revisions without exposing raw watch receivers.

- `crates/ros-z/src/graph/discovery.rs`
  - Drives graph revisions from Zenoh liveliness history and live `Put`/`Delete` events.

- `crates/ros-z/src/pubsub/`
  - Migrates publisher/subscriber waits and transient-local replay to the shared graph wait logic.

- `crates/ros-z/src/dynamic/discovery.rs`
  - Uses graph revision waits while discovering dynamic schemas.
  - Applies one absolute deadline across publisher waits and schema-service candidate queries.

This PR also removes the bounded initial graph query configuration path. Graph progress now comes from liveliness-driven revisions instead.

## Follow-up

- Transient-local replay with late-discovered publishers is tracked separately in [the issue created during this PR update](https://github.com/HULKs/hulk/issues/2643). PR #2633 exposes graph revisions and makes this easier to observe, but the replay correctness issue exists independently of this PR.

## Scope Notes

- `Graph` remains a live local observation of liveliness state. `Graph::new` intentionally does not define when the distributed graph is ready or complete.
- CLI/operator readiness policy should live above `Graph`, using graph revisions as one available signal. Open a follow-up issue after merge to define the desired `rosz` startup/settling behavior.
- Dynamic schema discovery keeps the normal lifecycle assumption that publishers remain present after discovery; publisher churn during discovery can be handled separately if it becomes observable in practice.

## API Notes

- This PR intentionally removes the configurable initial graph liveliness query path. `ros-z` has no downstream API users outside this mono-repo, so the PR does not keep compatibility shims for that configuration API.
- `Graph` is a live local observation of liveliness state. Graph revisions are local progress tokens, not readiness or completeness markers.
