### PR TITLE
Hydra bench no engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8188,6 +8188,7 @@ dependencies = [
  "futures-util",
  "glob",
  "indicatif",
+ "itertools 0.14.0",
  "lazy_static",
  "parameters",
  "pathdiff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "libc",
 ]
@@ -232,7 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cc",
  "jni 0.22.4",
  "libc",
@@ -264,6 +273,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotato"
@@ -364,7 +379,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -420,9 +435,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -463,7 +478,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -475,7 +490,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -486,7 +501,7 @@ checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -593,7 +608,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -631,7 +646,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -855,7 +870,7 @@ dependencies = [
  "path_planner",
  "ros-z",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "types",
  "voronoi",
 ]
@@ -915,9 +930,9 @@ dependencies = [
  "downcast-rs 2.0.2",
  "either",
  "petgraph",
- "ron 0.12.1",
+ "ron 0.12.2",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "thread_local",
  "tracing",
@@ -932,7 +947,7 @@ checksum = "7cf35516d0e7ac9ec25df533be1bf8cbaa20596a8e65f36838a3f7803a267d6d"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1001,7 +1016,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -1012,7 +1027,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "js-sys",
- "ron 0.12.1",
+ "ron 0.12.2",
  "serde",
  "stackfuture",
  "thiserror 2.0.18",
@@ -1032,7 +1047,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1056,7 +1071,7 @@ dependencies = [
  "derive_more",
  "downcast-rs 2.0.2",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "wgpu-types",
 ]
@@ -1099,10 +1114,10 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "nonmax",
  "radsort",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1115,7 +1130,7 @@ checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1148,7 +1163,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bumpalo",
  "concurrent-queue",
  "derive_more",
@@ -1158,7 +1173,7 @@ dependencies = [
  "nonmax",
  "serde",
  "slotmap",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "variadics_please",
 ]
@@ -1172,7 +1187,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1243,7 +1258,7 @@ checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1301,7 +1316,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1320,7 +1335,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "futures-lite",
  "guillotiere",
@@ -1459,7 +1474,7 @@ checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "toml_edit 0.23.10+spec-1.0.0",
 ]
 
@@ -1499,7 +1514,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "hexasphere",
@@ -1566,13 +1581,13 @@ dependencies = [
  "bevy_shader",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
  "nonmax",
  "offset-allocator",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "static_assertions",
  "thiserror 2.0.18",
  "tracing",
@@ -1620,10 +1635,10 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "nonmax",
  "radsort",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1655,7 +1670,7 @@ dependencies = [
  "inventory",
  "petgraph",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "smol_str",
  "thiserror 2.0.18",
  "uuid",
@@ -1673,7 +1688,7 @@ dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "uuid",
 ]
 
@@ -1704,7 +1719,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "downcast-rs 2.0.2",
@@ -1718,7 +1733,7 @@ dependencies = [
  "nonmax",
  "offset-allocator",
  "send_wrapper",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "tracing",
  "variadics_please",
@@ -1736,7 +1751,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1755,7 +1770,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "derive_more",
- "ron 0.12.1",
+ "ron 0.12.2",
  "serde",
  "thiserror 2.0.18",
  "uuid",
@@ -1826,7 +1841,7 @@ dependencies = [
  "bevy_text",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -1871,7 +1886,7 @@ dependencies = [
  "bevy_utils",
  "cosmic-text",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "sys-locale",
  "thiserror 2.0.18",
  "tracing",
@@ -1990,7 +2005,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2000,8 +2015,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2060,9 +2075,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "bytemuck",
  "serde_core",
@@ -2261,7 +2276,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2278,9 +2293,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -2315,7 +2330,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -2329,7 +2344,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -2378,15 +2393,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.62"
+name = "cast"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -2484,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
@@ -2495,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2505,6 +2526,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -2568,7 +2616,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2606,7 +2654,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "source_analyzer",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
 ]
 
@@ -2816,7 +2864,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2904,7 +2952,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -2924,7 +2972,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fontdb",
  "harfrust",
  "linebender_resource_handle",
@@ -2967,6 +3015,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3115,7 +3198,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3128,7 +3211,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3141,7 +3224,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3152,7 +3235,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3163,7 +3246,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3174,7 +3257,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3182,6 +3265,38 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "depp"
@@ -3200,7 +3315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3244,7 +3359,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -3266,7 +3380,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3276,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3298,7 +3412,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -3366,7 +3480,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -3374,13 +3488,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3505,7 +3619,7 @@ source = "git+https://github.com/HULKs/egui/?rev=c310aad9c54618e8845b6707899e267
 dependencies = [
  "accesskit",
  "ahash",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "emath 0.33.3 (git+https://github.com/HULKs/egui/?rev=c310aad9c54618e8845b6707899e2678fec8b842)",
  "epaint",
  "log",
@@ -3513,7 +3627,7 @@ dependencies = [
  "profiling",
  "ron 0.11.0",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "unicode-segmentation",
 ]
 
@@ -3673,7 +3787,7 @@ checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3725,7 +3839,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3745,7 +3859,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3757,7 +3871,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3778,7 +3892,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3789,7 +3903,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3810,7 +3924,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4187,7 +4301,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4306,7 +4420,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4430,35 +4544,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "gilrs"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa85c2e35dc565c90511917897ea4eae16b77f2773d5223536f7b602536d462"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -4469,16 +4580,16 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23f2cc5144060a7f8d9e02d3fce5d06705376568256a509cdbc3c24d47e4f04"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
 dependencies = [
  "inotify",
  "js-sys",
  "libc",
  "libudev-sys",
  "log",
- "nix 0.30.1",
+ "nix 0.31.3",
  "objc2-core-foundation",
  "objc2-io-kit",
  "uuid",
@@ -4511,7 +4622,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4716,7 +4827,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4737,7 +4848,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg_aliases 0.2.1",
  "cgl",
  "dispatch2",
@@ -4803,7 +4914,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "gpu-alloc-types",
 ]
 
@@ -4813,7 +4924,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4834,7 +4945,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -4845,7 +4956,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4890,9 +5001,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4938,11 +5049,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0caaee032384c10dd597af4579c67dee16650d862a9ccbe1233ff1a379abc07"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "read-fonts 0.36.0",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
 ]
 
 [[package]]
@@ -5118,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -5510,10 +5621,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hydra-bench"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "color-eyre",
+ "criterion",
+ "ndarray",
+ "ort",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5525,7 +5649,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "tokio",
  "want",
 ]
@@ -5578,7 +5702,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5647,7 +5771,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "zerovec",
 ]
 
@@ -5693,12 +5817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5711,7 +5829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "utf8_iter",
 ]
 
@@ -5837,11 +5955,11 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -5974,10 +6092,11 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -5987,13 +6106,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6039,7 +6158,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6067,7 +6186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6082,13 +6201,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -6204,7 +6322,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6224,15 +6342,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "led_handler"
@@ -6281,14 +6393,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -6414,9 +6526,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "look_around"
@@ -6577,15 +6689,15 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -6630,7 +6742,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
@@ -6729,9 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -6879,7 +6991,7 @@ checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "codespan-reporting",
@@ -6958,7 +7070,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7035,7 +7147,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -7065,7 +7177,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "derive_builder",
  "getset",
@@ -7085,7 +7197,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7105,19 +7217,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
- "cfg-if 1.0.4",
- "cfg_aliases 0.2.1",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
@@ -7129,7 +7229,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
@@ -7236,7 +7336,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.6",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "zeroize",
 ]
 
@@ -7264,7 +7364,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7337,7 +7437,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7380,7 +7480,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -7396,7 +7496,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -7409,7 +7509,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -7433,7 +7533,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -7445,7 +7545,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -7456,7 +7556,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -7499,7 +7599,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -7512,7 +7612,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -7523,7 +7623,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "objc2-core-foundation",
 ]
@@ -7534,7 +7634,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -7557,7 +7657,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -7569,7 +7669,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -7592,7 +7692,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -7624,7 +7724,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -7705,12 +7805,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
+name = "oorandom"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "foreign-types 0.3.2",
  "libc",
@@ -7726,7 +7832,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7737,9 +7843,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -7764,9 +7870,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
@@ -7857,6 +7963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "parameter_tester"
 version = "0.1.0"
 dependencies = [
@@ -7928,7 +8044,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "windows-link 0.2.1",
 ]
 
@@ -7940,7 +8056,7 @@ checksum = "61cb992a61782917b0876f313fceec5f50470fcf8b0e59865db816ff68cd6287"
 dependencies = [
  "approx",
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "downcast-rs 2.0.2",
  "either",
  "foldhash 0.2.0",
@@ -7951,7 +8067,7 @@ dependencies = [
  "num-traits",
  "ordered-float 5.3.0",
  "simba",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
 ]
 
@@ -7981,7 +8097,7 @@ dependencies = [
  "linear_algebra",
  "log",
  "ordered-float 4.6.0",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "types",
 ]
 
@@ -8006,7 +8122,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8125,7 +8241,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8202,7 +8318,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicase",
 ]
 
@@ -8216,7 +8332,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8255,7 +8371,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8340,6 +8456,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "pnet"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8384,7 +8528,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8436,7 +8580,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -8524,7 +8668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8556,7 +8700,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -8602,7 +8746,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8622,7 +8766,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
 ]
 
@@ -8667,7 +8811,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8678,7 +8822,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -8746,9 +8890,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c2ec80932c5c3b2d4fbc578c9b56b2d4502098587edb8bef5b6bfcad43682e"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -8764,7 +8908,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8777,7 +8921,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8804,9 +8948,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -8815,7 +8959,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8824,9 +8968,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -8854,16 +8998,16 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -8914,7 +9058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -9075,9 +9219,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types 0.11.3",
@@ -9113,16 +9257,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -9153,14 +9297,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9181,9 +9325,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renderdoc-sys"
@@ -9331,7 +9475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "serde",
  "serde_derive",
  "unicode-ident",
@@ -9339,11 +9483,11 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -9428,7 +9572,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9613,7 +9757,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_repr",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "socketpair",
  "speedy",
  "static_assertions",
@@ -9649,7 +9793,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_repr",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "socketpair",
  "speedy",
  "static_assertions",
@@ -9685,7 +9829,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -9698,7 +9842,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -9707,9 +9851,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -9722,9 +9866,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -9855,15 +9999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9907,7 +10042,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9934,12 +10069,6 @@ dependencies = [
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "search_suggestor"
@@ -9976,7 +10105,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -10078,7 +10207,7 @@ source = "git+https://github.com/HULKs/serde.git?rev=ef30eb8fdd0ee12e4e6f3f5615c
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10089,7 +10218,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10123,7 +10252,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10158,9 +10287,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -10178,14 +10307,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10203,28 +10332,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10294,6 +10422,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -10378,12 +10512,12 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
- "read-fonts 0.37.0",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -10403,9 +10537,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smallvec"
@@ -10419,7 +10553,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -10444,7 +10578,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -10497,9 +10631,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -10537,7 +10671,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
  "threadbound",
  "toposort-scc",
@@ -10561,7 +10695,7 @@ checksum = "658f2ca5276b92c3dfd65fa88316b4e032ace68f88d7570b43967784c0bac5ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10588,7 +10722,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -10612,9 +10746,9 @@ dependencies = [
 
 [[package]]
 name = "stabby"
-version = "72.1.1"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976399a0c48ea769ef7f5dc303bb88240ab8d84008647a6b2303eced3dab3945"
+checksum = "a7b834ec7ced12095fea1e4b07dcb7e8cf2b59b18afa3eac52494d835965a5ec"
 dependencies = [
  "rustversion",
  "stabby-abi",
@@ -10622,9 +10756,9 @@ dependencies = [
 
 [[package]]
 name = "stabby-abi"
-version = "72.1.1"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b54832a9a1f92a0e55e74a5c0332744426edc515bb3fbad82f10b874a87f0d"
+checksum = "ff1a4f477858a5bdf927c9fab7f579899de9b13e39f8b3b3b300c89fbab632f4"
 dependencies = [
  "rustc_version",
  "rustversion",
@@ -10634,15 +10768,14 @@ dependencies = [
 
 [[package]]
 name = "stabby-macros"
-version = "72.1.1"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a768b1e51e4dbfa4fa52ae5c01241c0a41e2938fdffbb84add0c8238092f9091"
+checksum = "b31c4b2434980b67ad83f300a58088ba14d59454dcd79ba3d87419bbd924d31e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.6",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10759,11 +10892,11 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
+checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
 dependencies = [
- "skrifa 0.40.0",
+ "skrifa 0.42.1",
  "yazi",
  "zeno",
 ]
@@ -10781,9 +10914,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10807,7 +10940,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10843,7 +10976,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -10920,7 +11053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -10954,7 +11087,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "memchr",
- "mio 1.2.0",
+ "mio 1.2.1",
  "terminal-trx",
  "windows-sys 0.59.0",
  "xterm-color",
@@ -10997,7 +11130,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11008,7 +11141,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11017,7 +11150,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "libc",
  "log",
@@ -11056,12 +11189,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -11071,15 +11203,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -11130,6 +11262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11176,11 +11318,11 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.2.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -11193,7 +11335,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11352,9 +11494,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -11410,7 +11552,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -11454,7 +11596,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11523,7 +11665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -11569,9 +11711,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
 dependencies = [
  "glob",
  "serde",
@@ -11717,7 +11859,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11728,9 +11870,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "types"
@@ -11832,9 +11974,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -11886,7 +12028,7 @@ checksum = "3b5bb2756c16fb66f80cfbf5fb0e0c09a7001e739f453c9ec241b9c8b1556fda"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11963,11 +12105,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "rand 0.10.1",
  "serde_core",
@@ -11994,7 +12136,7 @@ checksum = "8c44ce98e7227a04eeb4cf9c784109a5c9710e54849ceb4f09f8597247897f1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unzip-n",
 ]
 
@@ -12012,7 +12154,7 @@ checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12150,27 +12292,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -12181,9 +12314,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12191,9 +12324,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12201,58 +12334,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -12265,7 +12364,7 @@ dependencies = [
  "downcast-rs 1.2.1",
  "rustix 1.1.4",
  "scoped-tls",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "wayland-sys",
 ]
 
@@ -12275,7 +12374,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -12287,7 +12386,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -12305,11 +12404,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -12321,7 +12420,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -12334,7 +12433,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -12347,7 +12446,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -12360,7 +12459,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -12392,9 +12491,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12428,18 +12527,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12457,7 +12556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "document-features",
@@ -12469,7 +12568,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -12488,7 +12587,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases 0.2.1",
  "document-features",
@@ -12502,7 +12601,7 @@ dependencies = [
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
@@ -12548,7 +12647,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block",
  "bytemuck",
  "cfg-if 1.0.4",
@@ -12578,7 +12677,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
@@ -12593,7 +12692,7 @@ version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -12867,7 +12966,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12878,7 +12977,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12889,7 +12988,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12900,7 +12999,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12911,7 +13010,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12922,7 +13021,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13386,7 +13485,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -13455,97 +13554,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "world_state"
@@ -13577,7 +13588,7 @@ dependencies = [
  "ros-z",
  "ros2",
  "serde",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "types",
  "voronoi",
 ]
@@ -13706,7 +13717,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -13749,9 +13760,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13766,24 +13777,24 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "yuv"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c90da4fb561f9750984de2c5e7f0ba01035d2eb29d69a7f375b1caef37fdf4"
+checksum = "5d85a782d94ee43f078bcfd6fa82d4e6a5b2d1cfbbad168e4df5a9f7b39ef48c"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -13832,7 +13843,7 @@ checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -13840,14 +13851,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -14271,7 +14282,7 @@ checksum = "9310b02a8f6dc4bd04d9ce6b318b9d00182aeeeeca60410003307d63a2569a3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "zenoh-keyexpr",
 ]
 
@@ -14325,7 +14336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd3d0c1558f909c9a74bde5e398c5733f81eb954818451baac2a6c09f48d6a5e"
 dependencies = [
  "lazy_static",
- "ron 0.12.1",
+ "ron 0.12.2",
  "serde",
  "tokio",
  "tracing",
@@ -14372,7 +14383,7 @@ dependencies = [
  "ahash",
  "prometheus-client",
  "serde_json",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "zenoh-keyexpr",
  "zenoh-protocol",
 ]
@@ -14489,22 +14500,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14524,15 +14535,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -14564,7 +14575,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14619,9 +14630,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -14633,26 +14644,26 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
  "winnow 1.0.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,15 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,12 +264,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotato"
@@ -2200,13 +2185,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "a4e308e67087593070530a666f7fe8815cbd2e61d8f5b7313b71b7d721d1dfde"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2393,12 +2378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,33 +2505,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -3015,41 +2967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if 1.0.4",
-]
-
-[[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
 ]
 
 [[package]]
@@ -5626,7 +5543,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
- "criterion",
  "ndarray",
  "ort",
  "serde",
@@ -7805,12 +7721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7961,16 +7871,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "parameter_tester"
@@ -8175,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.27.0"
+version = "7.28.0"
 dependencies = [
  "aliveness",
  "argument_parsers",
@@ -8454,34 +8354,6 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -11260,16 +11132,6 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
   "tools/annotato",
   "tools/depp",
   "tools/fanta",
+  "tools/hydra-bench",
   "tools/mujoco-simulator/mujoco-rust-server",
   "tools/parameter_tester",
   "tools/pepsi",

--- a/crates/repository/src/upload.rs
+++ b/crates/repository/src/upload.rs
@@ -49,7 +49,7 @@ impl Repository {
     }
 }
 
-pub fn get_hulk_binary(profile: &str, binary_name: &str) -> String {
+pub fn get_binary(profile: &str, binary_name: &str) -> String {
     // the target directory is "debug" with --profile dev...
     let profile_directory = match profile {
         "dev" => "debug",

--- a/tools/hydra-bench/Cargo.toml
+++ b/tools/hydra-bench/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hydra-bench"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[package.metadata.pepsi]
+cross-compile = true
+
+[dependencies]
+clap = { workspace = true }
+color-eyre = { workspace = true }
+ndarray = { workspace = true }
+ort = { workspace = true, features = ["cuda", "tensorrt", "load-dynamic"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[[bin]]
+name = "hydra-bench"
+path = "src/bin/main.rs"

--- a/tools/hydra-bench/src/bin/main.rs
+++ b/tools/hydra-bench/src/bin/main.rs
@@ -1,0 +1,124 @@
+use std::{hint::black_box, path::Path, time::Duration, time::Instant};
+
+use clap::Parser;
+use color_eyre::{Result, eyre::Context, eyre::ensure};
+use hydra_bench::{CliArguments, run_inference, sample_image, setup};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct BenchmarkReport {
+    warmup: usize,
+    iterations: usize,
+    results: Vec<BenchmarkResult>,
+}
+
+#[derive(Serialize)]
+struct BenchmarkResult {
+    onnx_path: String,
+    count: usize,
+    avg_ms: f64,
+    p50_ms: f64,
+    p90_ms: f64,
+    p99_ms: f64,
+    min_ms: f64,
+    max_ms: f64,
+    latencies_ms: Vec<f64>,
+}
+
+fn main() -> Result<()> {
+    let args = CliArguments::parse();
+    color_eyre::install()?;
+    std::fs::create_dir_all(&args.cache_path).wrap_err("failed to create cache path")?;
+
+    let warmup = args.warmup;
+    let iterations = args.iterations;
+    ensure!(iterations > 0, "iterations must be > 0");
+
+    let mut results = Vec::with_capacity(args.onnx_paths.len());
+    for onnx_path in &args.onnx_paths {
+        results.push(benchmark_model(&args, onnx_path)?);
+    }
+
+    if args.json {
+        let report = BenchmarkReport {
+            warmup,
+            iterations,
+            results,
+        };
+        if let Some(output) = args.output {
+            if let Some(parent) = output
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent).wrap_err("failed to create output directory")?;
+            }
+            let file = std::fs::File::create(&output)
+                .wrap_err_with(|| format!("failed to create output file {}", output.display()))?;
+            serde_json::to_writer_pretty(file, &report).wrap_err("failed to write JSON")?;
+        } else {
+            serde_json::to_writer_pretty(std::io::stdout(), &report)
+                .wrap_err("failed to write JSON")?;
+            println!();
+        }
+    } else {
+        for result in &results {
+            println!(
+                "onnx_path={} count={} avg_ms={} p50_ms={} p90_ms={} p99_ms={} min_ms={} max_ms={}",
+                result.onnx_path,
+                result.count,
+                result.avg_ms,
+                result.p50_ms,
+                result.p90_ms,
+                result.p99_ms,
+                result.min_ms,
+                result.max_ms,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn benchmark_model(args: &CliArguments, onnx_path: &Path) -> Result<BenchmarkResult> {
+    let mut session = setup(onnx_path, &args.cache_path)?;
+    let sample_image = sample_image();
+
+    for _ in 0..args.warmup {
+        drop(run_inference(&mut session, black_box(&sample_image))?);
+    }
+
+    let iterations = args.iterations;
+    let mut latencies = Vec::with_capacity(iterations);
+
+    for _ in 0..iterations {
+        let start = Instant::now();
+        drop(run_inference(&mut session, black_box(&sample_image))?);
+        let elapsed = start.elapsed();
+        latencies.push(elapsed);
+    }
+
+    latencies.sort_unstable();
+    let avg = latencies.iter().sum::<Duration>() / latencies.len() as u32;
+    let result = BenchmarkResult {
+        onnx_path: onnx_path.display().to_string(),
+        count: latencies.len(),
+        avg_ms: ms(avg),
+        p50_ms: ms(percentile(&latencies, 50.0)),
+        p90_ms: ms(percentile(&latencies, 90.0)),
+        p99_ms: ms(percentile(&latencies, 99.0)),
+        min_ms: ms(latencies[0]),
+        max_ms: ms(latencies[latencies.len() - 1]),
+        latencies_ms: latencies.iter().copied().map(ms).collect(),
+    };
+
+    Ok(result)
+}
+
+fn percentile(sorted: &[Duration], percentile: f64) -> Duration {
+    let index = ((percentile / 100.0) * (sorted.len() - 1) as f64).round() as usize;
+    sorted[index]
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/tools/hydra-bench/src/bin/main.rs
+++ b/tools/hydra-bench/src/bin/main.rs
@@ -1,8 +1,15 @@
-use std::{hint::black_box, path::Path, time::Duration, time::Instant};
+use std::{
+    hint::black_box,
+    path::Path,
+    sync::{Arc, Barrier, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
 
 use clap::Parser;
 use color_eyre::{Result, eyre::Context, eyre::ensure};
 use hydra_bench::{CliArguments, run_inference, sample_image, setup};
+use ort::session::Session;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -35,8 +42,24 @@ fn main() -> Result<()> {
     ensure!(iterations > 0, "iterations must be > 0");
 
     let mut results = Vec::with_capacity(args.onnx_paths.len());
-    for onnx_path in &args.onnx_paths {
-        results.push(benchmark_model(&args, onnx_path)?);
+    if args.parallel {
+        let barrier = Barrier::new(args.onnx_paths.len());
+        let results = Arc::new(Mutex::new(&mut results));
+        thread::scope(|scope| {
+            for onnx_path in &args.onnx_paths {
+                let session = setup(onnx_path, &args.cache_path).unwrap();
+                scope.spawn(|| {
+                    let result = benchmark_model(&args, onnx_path, &barrier, session).unwrap();
+                    results.lock().unwrap().push(result)
+                });
+            }
+        })
+    } else {
+        let barrier = Barrier::new(1);
+        for onnx_path in &args.onnx_paths {
+            let session = setup(onnx_path, &args.cache_path)?;
+            results.push(benchmark_model(&args, onnx_path, &barrier, session)?);
+        }
     }
 
     if args.json {
@@ -79,8 +102,12 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn benchmark_model(args: &CliArguments, onnx_path: &Path) -> Result<BenchmarkResult> {
-    let mut session = setup(onnx_path, &args.cache_path)?;
+fn benchmark_model(
+    args: &CliArguments,
+    onnx_path: &Path,
+    barrier: &Barrier,
+    mut session: Session,
+) -> Result<BenchmarkResult> {
     let sample_image = sample_image();
 
     for _ in 0..args.warmup {
@@ -91,6 +118,7 @@ fn benchmark_model(args: &CliArguments, onnx_path: &Path) -> Result<BenchmarkRes
     let mut latencies = Vec::with_capacity(iterations);
 
     for _ in 0..iterations {
+        barrier.wait();
         let start = Instant::now();
         drop(run_inference(&mut session, black_box(&sample_image))?);
         let elapsed = start.elapsed();

--- a/tools/hydra-bench/src/lib.rs
+++ b/tools/hydra-bench/src/lib.rs
@@ -1,0 +1,72 @@
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use color_eyre::Result;
+use ndarray::Array3;
+use ort::{
+    execution_providers::{CUDAExecutionProvider, TensorRTExecutionProvider},
+    inputs,
+    session::{Session, SessionOutputs, builder::GraphOptimizationLevel},
+    value::TensorRef,
+};
+
+#[derive(Debug, Parser)]
+pub struct CliArguments {
+    /// Paths to onnx models
+    #[arg(required = true, num_args = 1..)]
+    pub onnx_paths: Vec<PathBuf>,
+
+    /// Path to cache folder
+    #[arg(long, default_value = "/home/booster/hulk/etc/neural_networks/")]
+    pub cache_path: PathBuf,
+
+    /// Warmup inferences before measuring
+    #[arg(long, default_value_t = 10)]
+    pub warmup: usize,
+
+    /// Measured inferences
+    #[arg(short, long, default_value_t = 100)]
+    pub iterations: usize,
+
+    /// Print benchmark results as JSON
+    #[arg(long)]
+    pub json: bool,
+
+    /// Write benchmark results to this file instead of stdout
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+pub fn run_inference<'a>(
+    session: &'a mut Session,
+    sample_image: &Array3<u8>,
+) -> Result<SessionOutputs<'a>> {
+    Ok(session
+        .run(inputs!["raw_bytes_input" => TensorRef::from_array_view(sample_image.view())?])?)
+}
+
+pub fn setup(
+    onnx_path: impl AsRef<Path>,
+    cache_path: impl AsRef<Path>,
+) -> Result<Session, color_eyre::eyre::Error> {
+    let tensor_rt = TensorRTExecutionProvider::default()
+        .with_device_id(0)
+        .with_fp16(true)
+        .with_engine_cache(true)
+        .with_engine_cache_path(cache_path.as_ref().display())
+        .build()
+        .error_on_failure();
+    let cuda = CUDAExecutionProvider::default().build();
+    let session = Session::builder()?
+        .with_execution_providers([tensor_rt, cuda])?
+        .with_optimization_level(GraphOptimizationLevel::Level3)?
+        .with_intra_threads(2)?
+        .commit_from_file(onnx_path.as_ref())?;
+    Ok(session)
+}
+
+pub fn sample_image() -> Array3<u8> {
+    const IMAGE_WIDTH: usize = 544;
+    const IMAGE_HEIGHT: usize = 448;
+    Array3::<u8>::default([IMAGE_HEIGHT / 2, IMAGE_WIDTH / 2, 6])
+}

--- a/tools/hydra-bench/src/lib.rs
+++ b/tools/hydra-bench/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use color_eyre::Result;
-use ndarray::Array3;
+use ndarray::Array4;
 use ort::{
     execution_providers::{CUDAExecutionProvider, TensorRTExecutionProvider},
     inputs,
@@ -39,10 +39,9 @@ pub struct CliArguments {
 
 pub fn run_inference<'a>(
     session: &'a mut Session,
-    sample_image: &Array3<u8>,
+    sample_image: &Array4<f32>,
 ) -> Result<SessionOutputs<'a>> {
-    Ok(session
-        .run(inputs!["raw_bytes_input" => TensorRef::from_array_view(sample_image.view())?])?)
+    Ok(session.run(inputs!["images" => TensorRef::from_array_view(sample_image.view())?])?)
 }
 
 pub fn setup(
@@ -65,8 +64,8 @@ pub fn setup(
     Ok(session)
 }
 
-pub fn sample_image() -> Array3<u8> {
+pub fn sample_image() -> Array4<f32> {
     const IMAGE_WIDTH: usize = 544;
     const IMAGE_HEIGHT: usize = 448;
-    Array3::<u8>::default([IMAGE_HEIGHT / 2, IMAGE_WIDTH / 2, 6])
+    Array4::<f32>::default([1, 3, IMAGE_HEIGHT, IMAGE_WIDTH])
 }

--- a/tools/hydra-bench/src/lib.rs
+++ b/tools/hydra-bench/src/lib.rs
@@ -35,6 +35,10 @@ pub struct CliArguments {
     /// Write benchmark results to this file instead of stdout
     #[arg(long)]
     pub output: Option<PathBuf>,
+
+    /// Whether to benchmark all networks in parallel
+    #[arg(long)]
+    pub parallel: bool,
 }
 
 pub fn run_inference<'a>(

--- a/tools/machine-learning/multi-task-yolo/.gitignore
+++ b/tools/machine-learning/multi-task-yolo/.gitignore
@@ -7,4 +7,4 @@
 
 assets/output/
 assets/datasets
-runs/
+runs

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -17,6 +17,7 @@ color-eyre = { workspace = true }
 futures-util = { workspace = true }
 glob = { workspace = true }
 indicatif = { workspace = true }
+itertools = { workspace = true }
 lazy_static = { workspace = true }
 parameters = { workspace = true }
 pathdiff = { workspace = true }

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.27.0"
+version = "7.28.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -438,24 +438,30 @@ impl CommandExt for Command {
         self.stderr(Stdio::piped());
         let mut process = self.spawn().unwrap();
         let mut stdout_lines = BufReader::new(process.stdout.take().unwrap()).split(line_delimiter);
-        let mut stderr_lines = BufReader::new(process.stderr.take().unwrap()).split(line_delimiter);
+        let mut stderr_lines = BufReader::new(process.stderr.take().unwrap()).split(b'\n');
+        let mut stdout = String::new();
         let mut stderr = String::new();
 
         loop {
             select! {
                 Ok(Some(buffer)) = stdout_lines.next_segment() => {
                     if let Ok(text) = str::from_utf8(&buffer) {
+                        writeln!(&mut stdout, "{text}")?;
                         let message = if name.is_empty() {
                             text.to_string()
                         } else {
                             format!("{name}: {text}")
                         };
                         progress_bar.set_message(message);
+                        if line_delimiter == b'\n' {
+                            progress_bar.println(text);
+                        }
                     }
                 }
                 Ok(Some(buffer)) = stderr_lines.next_segment() => {
                     if let Ok(text) = str::from_utf8(&buffer) {
                         writeln!(&mut stderr, "{text}")?;
+                        progress_bar.println(text);
                     }
                 }
                 else => break,
@@ -464,7 +470,9 @@ impl CommandExt for Command {
 
         match process.wait().await?.code() {
             Some(0) => Ok(()),
-            Some(code) => bail!("{name}: process exited with error code {code}\n{stderr}"),
+            Some(code) => bail!(
+                "{name}: process exited with error code {code}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            ),
             None => bail!("process was killed"),
         }
     }

--- a/tools/pepsi/src/hydra_bench.rs
+++ b/tools/pepsi/src/hydra_bench.rs
@@ -1,0 +1,309 @@
+use std::path::{Component, PathBuf};
+
+use argument_parsers::RobotAddress;
+use clap::Args;
+use color_eyre::{
+    Result,
+    eyre::{Context, ContextCompat, ensure},
+};
+use pathdiff::diff_paths;
+use repository::{Repository, upload::get_binary};
+use robot::Robot;
+use tempfile::tempdir;
+use tokio::fs::{create_dir_all, symlink};
+
+use crate::{
+    cargo::{self, CargoCommand, build, cargo, environment::EnvironmentArguments},
+    gammaray::CommandExt,
+    progress_indicator::ProgressIndicator,
+    tensorrt_compile,
+};
+
+#[derive(Args)]
+pub struct Arguments {
+    #[command(flatten)]
+    pub hydra_bench: HydraBenchArguments,
+
+    #[command(flatten)]
+    pub environment: EnvironmentArguments,
+
+    #[command(flatten, next_help_heading = "Cargo Options")]
+    pub build: build::Arguments,
+}
+
+#[derive(Args)]
+pub struct HydraBenchArguments {
+    /// The robot to use for benchmarking
+    pub host: RobotAddress,
+
+    /// Paths to onnx models
+    #[arg(required = true, num_args = 1..)]
+    pub onnx_paths: Vec<PathBuf>,
+
+    /// Local directory for JSON benchmark results
+    #[arg(long, default_value = "target/hydra-bench-results")]
+    pub output: PathBuf,
+
+    /// Remote directory for JSON benchmark results, relative to ~/hulk
+    #[arg(long, default_value = "logs/hydra-bench-results")]
+    pub remote_output: PathBuf,
+
+    /// Path to the TensorRT cache folder inside the runtime container
+    #[arg(long, default_value = "/home/booster/hulk/etc/neural_networks/")]
+    pub cache_path: PathBuf,
+
+    /// Warmup inferences before measuring
+    #[arg(long, default_value_t = 10)]
+    pub warmup: usize,
+
+    /// Measured inferences
+    #[arg(short, long, default_value_t = 100)]
+    pub iterations: usize,
+
+    /// Number of TensorRT compile jobs to run concurrently
+    #[arg(short, long, default_value_t = 1)]
+    pub jobs: usize,
+
+    /// Do not build before uploading
+    #[arg(long)]
+    pub no_build: bool,
+}
+
+pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Result<()> {
+    ensure!(
+        !arguments.hydra_bench.remote_output.is_absolute(),
+        "remote output directory must be relative to ~/hulk"
+    );
+    if arguments.hydra_bench.output.is_file() {
+        color_eyre::eyre::bail!(
+            "output must be a directory, but {} is a file",
+            arguments.hydra_bench.output.display()
+        );
+    }
+    let robot = Robot::try_new_with_ping(arguments.hydra_bench.host.ip).await?;
+    let multiprogress = ProgressIndicator::new();
+    let progress_build = multiprogress.task("Build hydra-bench", false);
+    let progress_upload = multiprogress.task("Upload", false);
+    let progress_compile = multiprogress.task("Compile TensorRT", false);
+    let progress_benchmark = multiprogress.task("Benchmark", false);
+    let progress_download = multiprogress.task("Download", false);
+
+    let hydra_bench_binary_path = get_binary(arguments.build.profile(), "hydra-bench");
+    let tensorrt_compile_binary_path =
+        get_binary(arguments.build.profile(), tensorrt_compile::BINARY_NAME);
+    if !arguments.hydra_bench.no_build {
+        progress_build.enable_steady_tick();
+        let hydra_bench_cargo_arguments = cargo::Arguments {
+            manifest: Some(
+                repository
+                    .root
+                    .join("tools/hydra-bench/Cargo.toml")
+                    .into_os_string(),
+            ),
+            environment: arguments.environment.clone(),
+            cargo: arguments.build.clone(),
+        };
+        cargo(
+            hydra_bench_cargo_arguments,
+            repository,
+            &[&hydra_bench_binary_path],
+        )
+        .await
+        .wrap_err("failed to build hydra-bench")
+        .inspect_err(|_| progress_build.progress.finish())?;
+        let tensorrt_compile_cargo_arguments = cargo::Arguments {
+            manifest: Some(tensorrt_compile::manifest(repository)),
+            environment: arguments.environment,
+            cargo: arguments.build,
+        };
+        tensorrt_compile::build_binary(
+            tensorrt_compile_cargo_arguments,
+            repository,
+            &progress_build,
+        )
+        .await
+        .wrap_err("failed to build tensorrt-compile")
+        .inspect_err(|_| progress_build.progress.finish())?;
+        progress_build.finish_with_success(());
+    } else {
+        progress_build.finish_with_success("Skipped");
+    }
+
+    let onnx_paths = arguments
+        .hydra_bench
+        .onnx_paths
+        .iter()
+        .map(|onnx_path| relative_to_repository(onnx_path, repository))
+        .collect::<Result<Vec<_>>>()?;
+
+    let remote_output = &arguments.hydra_bench.remote_output;
+    let remote_output_path = format!("hulk/{}", remote_output.display());
+    let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
+    progress_upload.enable_steady_tick();
+    robot
+        .ssh_to_robot()?
+        .arg(format!("sudo rm -rf {}", shell_quote(&remote_output_path)))
+        .run_with_log(
+            "removing old benchmark results",
+            &progress_upload.progress,
+            b'\n',
+        )
+        .await
+        .inspect_err(|_| progress_upload.progress.finish())?;
+    repository
+        .populate_upload_directory(
+            &upload_directory,
+            &[&hydra_bench_binary_path, &tensorrt_compile_binary_path],
+        )
+        .await
+        .wrap_err("failed to populate upload directory")?;
+    let uploaded_models = link_benchmark_models(&onnx_paths, &upload_directory, repository).await?;
+    robot
+        .upload(upload_directory, "hulk", true, |status| {
+            progress_upload.set_message(format!("Uploading: {status}"))
+        })
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to upload benchmark inputs to {}",
+                arguments.hydra_bench.host.ip
+            )
+        })
+        .inspect_err(|_| progress_upload.progress.finish())?;
+    progress_upload.finish_with_success(());
+
+    progress_benchmark.enable_steady_tick();
+    robot
+        .ssh_to_robot()?
+        .arg(format!("mkdir -p {}", shell_quote(&remote_output_path)))
+        .run_with_log(
+            "preparing output directory",
+            &progress_benchmark.progress,
+            b'\n',
+        )
+        .await
+        .inspect_err(|_| progress_benchmark.progress.finish())?;
+
+    progress_compile.enable_steady_tick();
+    tensorrt_compile::compile_models(
+        &robot,
+        &uploaded_models,
+        arguments.hydra_bench.jobs,
+        &progress_compile.progress,
+    )
+    .await
+    .inspect_err(|_| progress_compile.progress.finish())?;
+    progress_compile.finish_with_success(());
+
+    let mut result_paths = Vec::new();
+    for (onnx_path, uploaded_model) in onnx_paths.iter().zip(uploaded_models) {
+        let result_path = remote_output.join(result_file_name(&onnx_path)?);
+        let command = format!(
+            "sudo podman exec --user $(id -u booster) hulk ./bin/hydra-bench --json --output {} --cache-path {} --warmup {} --iterations {} {}",
+            shell_quote(&result_path.display().to_string()),
+            shell_quote(&arguments.hydra_bench.cache_path.display().to_string()),
+            arguments.hydra_bench.warmup,
+            arguments.hydra_bench.iterations,
+            shell_quote(&uploaded_model.display().to_string()),
+        );
+        robot
+            .ssh_to_robot()?
+            .arg(format!("cd hulk && {command}"))
+            .run_with_log("benchmarking", &progress_benchmark.progress, b'\n')
+            .await
+            .inspect_err(|_| progress_benchmark.progress.finish())?;
+        result_paths.push(result_path);
+    }
+    progress_benchmark.finish_with_success(());
+
+    progress_download.enable_steady_tick();
+    tensorrt_compile::download_neural_networks(&robot, repository, &progress_download.progress)
+        .await
+        .inspect_err(|_| progress_download.progress.finish())?;
+    tokio::fs::create_dir_all(&arguments.hydra_bench.output)
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to create output directory {}",
+                arguments.hydra_bench.output.display()
+            )
+        })?;
+    for result_path in result_paths {
+        robot
+            .rsync_with_robot()?
+            .arg("--mkpath")
+            .arg("--info=progress2")
+            .arg(format!("{}:hulk/{}", robot.address, result_path.display()))
+            .arg(format!("{}/", arguments.hydra_bench.output.display()))
+            .rsync_with_log("downloading benchmark results", &progress_download.progress)
+            .await
+            .inspect_err(|_| progress_download.progress.finish())?;
+    }
+    progress_download.finish_with_success(arguments.hydra_bench.output.display().to_string());
+
+    Ok(())
+}
+
+fn relative_to_repository(path: &PathBuf, repository: &Repository) -> Result<PathBuf> {
+    if path.is_absolute() {
+        diff_paths(path, &repository.root).wrap_err("could not determine relative onnx path")
+    } else {
+        Ok(path.clone())
+    }
+}
+
+fn result_file_name(onnx_path: &PathBuf) -> Result<String> {
+    let mut name_parts = onnx_path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(component) => component.to_str().map(sanitize_file_name_part),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let file_name = name_parts
+        .pop()
+        .wrap_err_with(|| format!("could not determine file name of {}", onnx_path.display()))?;
+    let stem = file_name.strip_suffix(".onnx").unwrap_or(&file_name);
+    name_parts.push(stem.to_string());
+    Ok(format!("{}.json", name_parts.join("__")))
+}
+
+async fn link_benchmark_models(
+    onnx_paths: &[PathBuf],
+    upload_directory: impl AsRef<std::path::Path>,
+    repository: &Repository,
+) -> Result<Vec<PathBuf>> {
+    let upload_directory = upload_directory.as_ref();
+    let model_directory = PathBuf::from("benchmark-models");
+    create_dir_all(upload_directory.join(&model_directory))
+        .await
+        .wrap_err("failed to create benchmark model upload directory")?;
+
+    let mut uploaded_models = Vec::new();
+    for onnx_path in onnx_paths {
+        let uploaded_model =
+            model_directory.join(result_file_name(onnx_path)?.replace(".json", ".onnx"));
+        symlink(
+            repository.root.join(onnx_path),
+            upload_directory.join(&uploaded_model),
+        )
+        .await
+        .wrap_err_with(|| format!("failed to link model {}", onnx_path.display()))?;
+        uploaded_models.push(uploaded_model);
+    }
+
+    Ok(uploaded_models)
+}
+
+fn sanitize_file_name_part(part: &str) -> String {
+    part.chars()
+        .map(|character| match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '-' | '_' => character,
+            _ => '_',
+        })
+        .collect()
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}

--- a/tools/pepsi/src/hydra_bench.rs
+++ b/tools/pepsi/src/hydra_bench.rs
@@ -6,6 +6,7 @@ use color_eyre::{
     Result,
     eyre::{Context, ContextCompat, ensure},
 };
+use itertools::Itertools;
 use pathdiff::diff_paths;
 use repository::{Repository, upload::get_binary};
 use robot::Robot;
@@ -67,6 +68,10 @@ pub struct HydraBenchArguments {
     /// Do not build before uploading
     #[arg(long)]
     pub no_build: bool,
+
+    /// Whether to benchmark all networks in parallel
+    #[arg(long)]
+    pub parallel: bool,
 }
 
 pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Result<()> {
@@ -196,15 +201,23 @@ pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Resul
         .inspect_err(|_| progress_benchmark.progress.finish())?;
 
     let mut result_paths = Vec::new();
-    for (onnx_path, uploaded_model) in onnx_paths.iter().zip(uploaded_models) {
-        let result_path = remote_output.join(result_file_name(onnx_path)?);
+    if arguments.hydra_bench.parallel {
+        let result_path = remote_output.join(
+            onnx_paths
+                .iter()
+                .map(|onnx_path| onnx_path.file_stem().unwrap().len().to_string())
+                .join("_"),
+        );
         let command = format!(
-            "sudo podman exec --user $(id -u booster) hulk ./bin/hydra-bench --json --output {} --cache-path {} --warmup {} --iterations {} {}",
+            "sudo podman exec --user $(id -u booster) hulk ./bin/hydra-bench --json --output {} --cache-path {} --warmup {} --iterations {} --parallel {}",
             shell_quote(&result_path.display().to_string()),
             shell_quote(&arguments.hydra_bench.cache_path.display().to_string()),
             arguments.hydra_bench.warmup,
             arguments.hydra_bench.iterations,
-            shell_quote(&uploaded_model.display().to_string()),
+            uploaded_models
+                .iter()
+                .map(|uploaded_model| shell_quote(&uploaded_model.display().to_string()))
+                .join(" "),
         );
         robot
             .ssh_to_robot()?
@@ -213,6 +226,25 @@ pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Resul
             .await
             .inspect_err(|_| progress_benchmark.progress.finish())?;
         result_paths.push(result_path);
+    } else {
+        for (onnx_path, uploaded_model) in onnx_paths.iter().zip(uploaded_models) {
+            let result_path = remote_output.join(result_file_name(onnx_path)?);
+            let command = format!(
+                "sudo podman exec --user $(id -u booster) hulk ./bin/hydra-bench --json --output {} --cache-path {} --warmup {} --iterations {} {}",
+                shell_quote(&result_path.display().to_string()),
+                shell_quote(&arguments.hydra_bench.cache_path.display().to_string()),
+                arguments.hydra_bench.warmup,
+                arguments.hydra_bench.iterations,
+                shell_quote(&uploaded_model.display().to_string()),
+            );
+            robot
+                .ssh_to_robot()?
+                .arg(format!("cd hulk && {command}"))
+                .run_with_log("benchmarking", &progress_benchmark.progress, b'\n')
+                .await
+                .inspect_err(|_| progress_benchmark.progress.finish())?;
+            result_paths.push(result_path);
+        }
     }
     progress_benchmark.finish_with_success(());
 

--- a/tools/pepsi/src/hydra_bench.rs
+++ b/tools/pepsi/src/hydra_bench.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use argument_parsers::RobotAddress;
 use clap::Args;
@@ -197,7 +197,7 @@ pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Resul
 
     let mut result_paths = Vec::new();
     for (onnx_path, uploaded_model) in onnx_paths.iter().zip(uploaded_models) {
-        let result_path = remote_output.join(result_file_name(&onnx_path)?);
+        let result_path = remote_output.join(result_file_name(onnx_path)?);
         let command = format!(
             "sudo podman exec --user $(id -u booster) hulk ./bin/hydra-bench --json --output {} --cache-path {} --warmup {} --iterations {} {}",
             shell_quote(&result_path.display().to_string()),
@@ -244,15 +244,15 @@ pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Resul
     Ok(())
 }
 
-fn relative_to_repository(path: &PathBuf, repository: &Repository) -> Result<PathBuf> {
+fn relative_to_repository(path: &Path, repository: &Repository) -> Result<PathBuf> {
     if path.is_absolute() {
         diff_paths(path, &repository.root).wrap_err("could not determine relative onnx path")
     } else {
-        Ok(path.clone())
+        Ok(path.to_path_buf())
     }
 }
 
-fn result_file_name(onnx_path: &PathBuf) -> Result<String> {
+fn result_file_name(onnx_path: &Path) -> Result<String> {
     let mut name_parts = onnx_path
         .components()
         .filter_map(|component| match component {

--- a/tools/pepsi/src/hydra_bench.rs
+++ b/tools/pepsi/src/hydra_bench.rs
@@ -172,6 +172,17 @@ pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Resul
         .inspect_err(|_| progress_upload.progress.finish())?;
     progress_upload.finish_with_success(());
 
+    progress_compile.enable_steady_tick();
+    tensorrt_compile::compile_models(
+        &robot,
+        &uploaded_models,
+        arguments.hydra_bench.jobs,
+        &progress_compile.progress,
+    )
+    .await
+    .inspect_err(|_| progress_compile.progress.finish())?;
+    progress_compile.finish_with_success(());
+
     progress_benchmark.enable_steady_tick();
     robot
         .ssh_to_robot()?
@@ -183,17 +194,6 @@ pub async fn hydra_bench(arguments: Arguments, repository: &Repository) -> Resul
         )
         .await
         .inspect_err(|_| progress_benchmark.progress.finish())?;
-
-    progress_compile.enable_steady_tick();
-    tensorrt_compile::compile_models(
-        &robot,
-        &uploaded_models,
-        arguments.hydra_bench.jobs,
-        &progress_compile.progress,
-    )
-    .await
-    .inspect_err(|_| progress_compile.progress.finish())?;
-    progress_compile.finish_with_success(());
 
     let mut result_paths = Vec::new();
     for (onnx_path, uploaded_model) in onnx_paths.iter().zip(uploaded_models) {

--- a/tools/pepsi/src/main.rs
+++ b/tools/pepsi/src/main.rs
@@ -17,6 +17,7 @@ use completions::completions;
 use game_branch::game_branch;
 use gammaray::gammaray;
 use hulk::hulk;
+use hydra_bench::hydra_bench;
 use location::location;
 use log::logs;
 use ping::ping;
@@ -45,6 +46,7 @@ mod game_branch;
 mod gammaray;
 mod git;
 mod hulk;
+mod hydra_bench;
 mod location;
 mod log;
 mod ping;
@@ -109,6 +111,8 @@ enum Command {
     /// Flash a HULKs-OS image to Robots
     #[command(visible_alias = "gammastrahl")]
     Gammaray(gammaray::Arguments),
+    /// Run Hydra neural-network latency benchmarks on a robot
+    HydraBench(hydra_bench::Arguments),
     /// Control the HULK service
     Hulk(hulk::Arguments),
     /// Install a Rust binary
@@ -248,6 +252,9 @@ async fn main() -> Result<()> {
         Command::Gammaray(arguments) => gammaray(arguments, &repository?)
             .await
             .wrap_err("failed to execute gammaray command")?,
+        Command::HydraBench(arguments) => hydra_bench(arguments, &repository?)
+            .await
+            .wrap_err("failed to execute hydra-bench command")?,
         Command::Hulk(arguments) => hulk(arguments)
             .await
             .wrap_err("failed to execute hulk command")?,

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -8,7 +8,7 @@ use color_eyre::{
 
 use argument_parsers::RobotAddress;
 use indicatif::ProgressBar;
-use repository::{Repository, upload::get_hulk_binary};
+use repository::{Repository, upload::get_binary};
 use robot::{Network, Robot, SystemctlAction};
 use tempfile::tempdir;
 
@@ -105,7 +105,7 @@ pub async fn pre_game(arguments: Arguments, repository: &Repository) -> Result<(
         true => "hulk_booster",
         false => "hulk_ros_z",
     };
-    let hulk_binary = get_hulk_binary(arguments.build.profile(), binary_name);
+    let hulk_binary = get_binary(arguments.build.profile(), binary_name);
 
     let cargo_arguments = cargo::Arguments {
         manifest: Some(

--- a/tools/pepsi/src/tensorrt_compile.rs
+++ b/tools/pepsi/src/tensorrt_compile.rs
@@ -1,14 +1,15 @@
-use std::{path::PathBuf, process::Stdio, time::Duration};
+use std::{ffi::OsString, path::PathBuf, process::Stdio, time::Duration};
 
 use clap::Args;
 use color_eyre::{
     Result,
-    eyre::{Context, ContextCompat, bail, eyre},
+    eyre::{Context, ContextCompat, bail, ensure, eyre},
 };
 
 use argument_parsers::RobotAddress;
+use indicatif::ProgressBar;
 use pathdiff::diff_paths;
-use repository::Repository;
+use repository::{Repository, upload::get_binary};
 use robot::Robot;
 use tempfile::tempdir;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -20,6 +21,8 @@ use crate::{
     gammaray::CommandExt,
     progress_indicator::{ProgressIndicator, Task},
 };
+
+pub const BINARY_NAME: &str = "tensorrt-compile";
 
 #[derive(Args)]
 pub struct Arguments {
@@ -53,16 +56,11 @@ pub async fn tensorrt_compile(arguments: Arguments, repository: &Repository) -> 
     let progress_compile = multiprogres.task("Compile", false);
     let progress_download = multiprogres.task("Download", false);
 
-    let binary_path = get_binary_path(arguments.build.profile());
+    let binary_path = get_binary(arguments.build.profile(), BINARY_NAME);
     if !arguments.tensorrt_compile.no_build {
         progress_build.enable_steady_tick();
         let cargo_arguments = cargo::Arguments {
-            manifest: Some(
-                repository
-                    .root
-                    .join("tools/tensorrt-compile/Cargo.toml")
-                    .into_os_string(),
-            ),
+            manifest: Some(manifest(repository)),
             environment: arguments.environment,
             cargo: arguments.build,
         };
@@ -70,6 +68,7 @@ pub async fn tensorrt_compile(arguments: Arguments, repository: &Repository) -> 
             .await
             .wrap_err("failed to build")
             .inspect_err(|_| progress_build.progress.finish())?;
+        progress_build.finish_with_success(());
     } else {
         progress_build.finish_with_success("Skipped");
     }
@@ -97,32 +96,14 @@ pub async fn tensorrt_compile(arguments: Arguments, repository: &Repository) -> 
     progress_upload.finish_with_success(());
 
     progress_compile.enable_steady_tick();
-    let onnx_path = if arguments.tensorrt_compile.onnx_path.is_absolute() {
-        diff_paths(arguments.tensorrt_compile.onnx_path, &repository.root)
-            .wrap_err("could not determinte relative onnx path")?
-    } else {
-        arguments.tensorrt_compile.onnx_path
-    };
-    robot
-        .ssh_to_robot()?
-        .arg(format!(
-            r#"sudo podman exec hulk ./bin/tensorrt-compile {} 2>&1"#,
-            onnx_path.display(),
-        ))
-        .run_with_log("", &progress_compile.progress, b'\n')
+    let onnx_path = relative_to_repository(arguments.tensorrt_compile.onnx_path, repository)?;
+    compile_model(&robot, &onnx_path, &progress_compile.progress)
         .await
         .inspect_err(|_| progress_compile.progress.finish())?;
     progress_compile.finish_with_success(progress_compile.progress.message());
 
     progress_download.enable_steady_tick();
-    robot
-        .rsync_with_robot()?
-        .arg(format!("{}:hulk/etc/neural_networks/", robot.address))
-        .arg(format!(
-            "{}/",
-            repository.root.join("etc/neural_networks").display()
-        ))
-        .rsync_with_log("", &progress_download.progress)
+    download_neural_networks(&robot, repository, &progress_download.progress)
         .await
         .inspect_err(|_| progress_download.progress.finish())?;
     progress_download.finish_with_success(());
@@ -130,22 +111,100 @@ pub async fn tensorrt_compile(arguments: Arguments, repository: &Repository) -> 
     Ok(())
 }
 
-pub fn get_binary_path(profile: &str) -> String {
-    // the target directory is "debug" with --profile dev...
-    let profile_directory = match profile {
-        "dev" => "debug",
-        other => other,
-    };
-
-    format!("target/aarch64-unknown-linux-gnu/{profile_directory}/tensorrt-compile")
+pub fn manifest(repository: &Repository) -> OsString {
+    repository
+        .root
+        .join("tools/tensorrt-compile/Cargo.toml")
+        .into_os_string()
 }
 
-async fn build_binary(
+pub fn relative_to_repository(onnx_path: PathBuf, repository: &Repository) -> Result<PathBuf> {
+    if onnx_path.is_absolute() {
+        diff_paths(onnx_path, &repository.root).wrap_err("could not determine relative onnx path")
+    } else {
+        Ok(onnx_path)
+    }
+}
+
+pub async fn compile_models(
+    robot: &Robot,
+    onnx_paths: &[PathBuf],
+    jobs: usize,
+    progress_bar: &ProgressBar,
+) -> Result<()> {
+    ensure!(jobs > 0, "jobs must be > 0");
+    if onnx_paths.len() == 1 {
+        return compile_model(robot, &onnx_paths[0], progress_bar).await;
+    }
+
+    let mut command = String::from(
+        "cd hulk || exit 1; \
+         pids=; count=0; status=0",
+    );
+    for onnx_path in onnx_paths {
+        let compile_command = format!(
+            "sudo podman exec --user $(id -u booster) hulk ./bin/{BINARY_NAME} {}",
+            shell_quote(&onnx_path.display().to_string()),
+        );
+        command.push_str(&format!(
+            "; (printf 'compiling {}\\n'; {compile_command}) & \
+             pids=\"$pids $!\"; count=$((count + 1)); \
+             if [ \"$count\" -ge \"{jobs}\" ]; then \
+                for pid in $pids; do wait $pid || status=1; done; \
+                pids=; count=0; \
+             fi",
+            shell_escape_for_double_quotes(&onnx_path.display().to_string()),
+        ));
+    }
+    command.push_str("; for pid in $pids; do wait $pid || status=1; done; exit $status");
+
+    robot
+        .ssh_to_robot()?
+        .arg(command)
+        .run_with_log("compiling TensorRT engines", progress_bar, b'\n')
+        .await
+        .wrap_err("failed to compile TensorRT engines")
+}
+
+pub async fn compile_model(
+    robot: &Robot,
+    onnx_path: &PathBuf,
+    progress_bar: &ProgressBar,
+) -> Result<()> {
+    let compile_command = format!(
+        "sudo podman exec --user $(id -u booster) hulk ./bin/{BINARY_NAME} {}",
+        shell_quote(&onnx_path.display().to_string()),
+    );
+    let name = format!("compiling {}", onnx_path.display());
+    robot
+        .ssh_to_robot()?
+        .arg(format!("cd hulk && {compile_command}"))
+        .run_with_log(&name, progress_bar, b'\n')
+        .await
+}
+
+pub async fn download_neural_networks(
+    robot: &Robot,
+    repository: &Repository,
+    progress_bar: &ProgressBar,
+) -> Result<()> {
+    robot
+        .rsync_with_robot()?
+        .arg(format!("{}:hulk/etc/neural_networks/", robot.address))
+        .arg(format!(
+            "{}/",
+            repository.root.join("etc/neural_networks").display()
+        ))
+        .rsync_with_log("downloading neural networks", progress_bar)
+        .await
+}
+
+pub async fn build_binary(
     cargo_arguments: cargo::Arguments<build::Arguments>,
     repository: &Repository,
     progress_bar: &Task,
 ) -> Result<()> {
-    let binary_path = get_binary_path(cargo_arguments.cargo.profile());
+    let binary_path = get_binary(cargo_arguments.cargo.profile(), BINARY_NAME);
     let mut command = construct_cargo_command(cargo_arguments, repository, &[binary_path])
         .await
         .expect("failed to construct cargo command");
@@ -168,7 +227,17 @@ async fn build_binary(
         progress_bar.finish_with_error(&eyre!("failed with code {}", status.code().unwrap()));
         bail!("process failed");
     }
-    progress_bar.finish_with_success(());
-
     Ok(())
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn shell_escape_for_double_quotes(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
 }

--- a/tools/pepsi/src/tensorrt_compile.rs
+++ b/tools/pepsi/src/tensorrt_compile.rs
@@ -1,4 +1,9 @@
-use std::{ffi::OsString, path::PathBuf, process::Stdio, time::Duration};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::Stdio,
+    time::Duration,
+};
 
 use clap::Args;
 use color_eyre::{
@@ -168,7 +173,7 @@ pub async fn compile_models(
 
 pub async fn compile_model(
     robot: &Robot,
-    onnx_path: &PathBuf,
+    onnx_path: &Path,
     progress_bar: &ProgressBar,
 ) -> Result<()> {
     let compile_command = format!(

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -7,7 +7,7 @@ use color_eyre::{
     eyre::{WrapErr, bail},
 };
 use futures_util::{StreamExt, stream::FuturesUnordered};
-use repository::{Repository, upload::get_hulk_binary};
+use repository::{Repository, upload::get_binary};
 use robot::{Robot, SystemctlAction};
 use tempfile::tempdir;
 
@@ -125,7 +125,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
         true => "hulk_booster",
         false => "hulk_ros_z",
     };
-    let hulk_binary = get_hulk_binary(arguments.build.profile(), binary_name);
+    let hulk_binary = get_binary(arguments.build.profile(), binary_name);
 
     let cargo_arguments = cargo::Arguments {
         manifest: Some(

--- a/tools/tensorrt-compile/src/main.rs
+++ b/tools/tensorrt-compile/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use color_eyre::{Result, eyre::Context};
-use ndarray::Array3;
+use ndarray::Array4;
 use ort::{
     execution_providers::{CUDAExecutionProvider, TensorRTExecutionProvider},
     inputs,
@@ -21,8 +21,8 @@ struct CliArguments {
 }
 
 fn main() -> Result<()> {
-    const IMAGE_WIDTH: usize = 544;
-    const IMAGE_HEIGHT: usize = 448;
+    const IMAGE_WIDTH: usize = 640;
+    const IMAGE_HEIGHT: usize = 640;
 
     let args = CliArguments::parse();
     color_eyre::install()?;
@@ -43,9 +43,8 @@ fn main() -> Result<()> {
         .with_intra_threads(2)?
         .commit_from_file(args.onnx_path)?;
 
-    let sample_image = Array3::<u8>::default([IMAGE_HEIGHT / 2, IMAGE_WIDTH / 2, 6]);
-    let _ = session
-        .run(inputs!["raw_bytes_input" => TensorRef::from_array_view(sample_image.view())?])?;
+    let sample_image = Array4::<f32>::default([1, 3, IMAGE_HEIGHT, IMAGE_WIDTH]);
+    let _ = session.run(inputs!["images" => TensorRef::from_array_view(sample_image.view())?])?;
 
     eprintln!("object detection setup complete");
 


### PR DESCRIPTION
## Why? What?

Adds a pepsi command and a tool for benchmarking onnx models on an ssh target.
It measures execution latency of a single model or multiple models in lockstep-parallel.

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

`pepsi hydra-bench 99 tools/machine-learning/multi-task-yolo/runs/train/*/weights/best.onnx`

This will
- build the benchmark binary and the tensorrt-compile binary
- rsync both binaries and all given neural nets to peter-fox ("robot" nr. 99)
- run tensorrt-compile
- return the compiled engines
- run the hydra-bench binary with each neural network one at a time
- return the benchmark result json