### PR TITLE
feat(ros-z-cli): add topic frequency estimation

### DIFF
--- a/crates/ros-z-cli/Cargo.toml
+++ b/crates/ros-z-cli/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { workspace = true, features = [
   "signal",
   "time",
 ] }
+zenoh = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-zenoh = { workspace = true }

--- a/crates/ros-z-cli/src/app/context.rs
+++ b/crates/ros-z-cli/src/app/context.rs
@@ -6,7 +6,7 @@ use std::{
 use color_eyre::eyre::{Result, WrapErr};
 use ros_z::{
     context::{Context, ContextBuilder},
-    dynamic::DynamicSubscriber,
+    dynamic::{DynamicRawSubscriberDiscoveryBuilder, DynamicSubscriber},
     graph::GraphSnapshot,
     node::Node,
     parameter::RemoteParameterClient,
@@ -93,6 +93,16 @@ impl AppContext {
             .build()
             .await
             .wrap_err_with(|| format!("failed to subscribe to {topic}"))
+    }
+
+    pub fn create_raw_subscriber_builder(
+        &self,
+        topic: &str,
+        discovery_timeout: Duration,
+    ) -> DynamicRawSubscriberDiscoveryBuilder {
+        self.node
+            .dynamic_subscriber_auto(topic, discovery_timeout)
+            .raw()
     }
 
     pub fn parameter_client(&self, target_fqn: &str) -> Result<RemoteParameterClient> {

--- a/crates/ros-z-cli/src/cli.rs
+++ b/crates/ros-z-cli/src/cli.rs
@@ -1,5 +1,29 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use std::{num::NonZeroUsize, time::Duration};
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
+
+fn parse_positive_nonzero_usize(value: &str) -> Result<NonZeroUsize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|error| format!("invalid positive integer '{value}': {error}"))?;
+    NonZeroUsize::new(parsed).ok_or_else(|| "value must be greater than zero".to_string())
+}
+
+fn parse_positive_duration(value: &str) -> Result<Duration, String> {
+    let parsed = value
+        .parse::<f64>()
+        .map_err(|error| format!("invalid positive duration '{value}': {error}"))?;
+    if parsed <= 0.0 || !parsed.is_finite() {
+        return Err("duration must be finite and greater than zero".to_string());
+    }
+    let duration = Duration::try_from_secs_f64(parsed)
+        .map_err(|error| format!("invalid duration '{value}': {error}"))?;
+    if duration.is_zero() {
+        return Err("duration is too small to represent".to_string());
+    }
+    Ok(duration)
+}
 
 /// Graph entity kind accepted by `rosz list`.
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -53,6 +77,39 @@ pub enum Command {
     Online(OnlineCommand),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HzLimit {
+    Continuous,
+    Count(NonZeroUsize),
+    Duration(Duration),
+}
+
+#[derive(Debug, Args)]
+pub struct HzArgs {
+    /// Topic to measure.
+    pub topic: String,
+    /// Number of recent intervals used for rolling statistics.
+    #[arg(long, default_value = "10", value_parser = parse_positive_nonzero_usize)]
+    pub window: NonZeroUsize,
+    /// Stop after receiving this many samples.
+    #[arg(long, conflicts_with = "duration", value_parser = parse_positive_nonzero_usize)]
+    count: Option<NonZeroUsize>,
+    /// Stop after this many seconds.
+    #[arg(long, conflicts_with = "count", value_parser = parse_positive_duration)]
+    duration: Option<Duration>,
+}
+
+impl HzArgs {
+    pub fn limit(&self) -> HzLimit {
+        match (self.count, self.duration) {
+            (Some(count), None) => HzLimit::Count(count),
+            (None, Some(duration)) => HzLimit::Duration(duration),
+            (None, None) => HzLimit::Continuous,
+            (Some(_), Some(_)) => unreachable!("clap rejects count and duration together"),
+        }
+    }
+}
+
 /// Top-level commands that operate on a ros-z graph.
 #[derive(Debug, Subcommand)]
 pub enum OnlineCommand {
@@ -73,6 +130,8 @@ pub enum OnlineCommand {
         #[arg(long)]
         timeout: Option<f64>,
     },
+    /// Estimate topic message frequency
+    Hz(HzArgs),
     /// Show metadata for a topic, service, or node
     Info {
         #[arg(value_enum)]
@@ -143,9 +202,11 @@ pub enum ParameterCommand {
 
 #[cfg(test)]
 mod tests {
+    use std::{num::NonZeroUsize, time::Duration};
+
     use clap::{Parser, error::ErrorKind};
 
-    use super::{Cli, Command, ListTarget, OnlineCommand, ParameterCommand};
+    use super::{Cli, Command, HzLimit, ListTarget, OnlineCommand, ParameterCommand};
 
     #[test]
     fn parses_echo_command_with_defaults() {
@@ -166,6 +227,102 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_hz_command_with_default_window() {
+        let cli = Cli::parse_from(["rosz", "hz", "/chatter"]);
+
+        match cli.command {
+            Command::Online(OnlineCommand::Hz(args)) => {
+                assert_eq!(args.topic, "/chatter");
+                assert_eq!(args.window, NonZeroUsize::new(10).unwrap());
+                assert_eq!(args.limit(), HzLimit::Continuous);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_hz_command_with_window_and_count() {
+        let cli = Cli::parse_from(["rosz", "hz", "/chatter", "--window", "20", "--count", "5"]);
+
+        match cli.command {
+            Command::Online(OnlineCommand::Hz(args)) => {
+                assert_eq!(args.topic, "/chatter");
+                assert_eq!(args.window, NonZeroUsize::new(20).unwrap());
+                assert_eq!(args.limit(), HzLimit::Count(NonZeroUsize::new(5).unwrap()));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_hz_duration_as_duration() {
+        let cli = Cli::parse_from(["rosz", "hz", "/chatter", "--duration", "1.5"]);
+
+        match cli.command {
+            Command::Online(OnlineCommand::Hz(args)) => {
+                assert_eq!(args.limit(), HzLimit::Duration(Duration::from_millis(1500)));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_hz_duration_overflow() {
+        let error = Cli::try_parse_from(["rosz", "hz", "/chatter", "--duration", "1e300"])
+            .expect_err("oversized duration should fail validation");
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_hz_count_duration_conflict() {
+        let error = Cli::try_parse_from([
+            "rosz",
+            "hz",
+            "/chatter",
+            "--count",
+            "5",
+            "--duration",
+            "1.0",
+        ])
+        .expect_err("count and duration should conflict");
+
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn rejects_hz_zero_window() {
+        let error = Cli::try_parse_from(["rosz", "hz", "/chatter", "--window", "0"])
+            .expect_err("zero window should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_hz_zero_count() {
+        let error = Cli::try_parse_from(["rosz", "hz", "/chatter", "--count", "0"])
+            .expect_err("zero count should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_hz_non_positive_duration() {
+        let error = Cli::try_parse_from(["rosz", "hz", "/chatter", "--duration", "0"])
+            .expect_err("zero duration should fail");
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_hz_duration_that_rounds_to_zero() {
+        let error = Cli::try_parse_from(["rosz", "hz", "/chatter", "--duration", "1e-12"])
+            .expect_err("duration rounding to zero should fail validation");
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/ros-z-cli/src/commands/hz.rs
+++ b/crates/ros-z-cli/src/commands/hz.rs
@@ -1,0 +1,323 @@
+use std::{
+    future::Future,
+    io::{self, Write},
+    num::NonZeroUsize,
+    pin::Pin,
+    time::{Duration, Instant},
+};
+
+use color_eyre::eyre::{Result, WrapErr, eyre};
+use ros_z::{attachment::Attachment, pubsub::RawSubscriber};
+use tokio::time::{MissedTickBehavior, Sleep};
+
+use crate::{
+    app::AppContext,
+    cli::HzLimit,
+    model::hz::{HzEstimator, HzReport},
+    render::{OutputMode, json, text},
+};
+
+const TYPE_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+const REPORT_PERIOD: Duration = Duration::from_secs(1);
+
+#[derive(Default)]
+struct HzReceiveState {
+    warned_invalid_attachment: bool,
+}
+
+fn decode_attachment_for_hz(
+    attachment: Option<&zenoh::bytes::ZBytes>,
+    state: &mut HzReceiveState,
+) -> Option<Attachment> {
+    let attachment = attachment?;
+
+    match Attachment::try_from(attachment) {
+        Ok(attachment) => Some(attachment),
+        Err(error) => {
+            if !state.warned_invalid_attachment {
+                let _ = writeln!(
+                    io::stderr(),
+                    "warning: failed to decode ros-z attachment for hz source stats: {error}"
+                );
+                state.warned_invalid_attachment = true;
+            }
+            None
+        }
+    }
+}
+
+pub async fn run(
+    app: &AppContext,
+    output_mode: OutputMode,
+    topic: &str,
+    window: NonZeroUsize,
+    limit: HzLimit,
+) -> Result<()> {
+    let mut subscriber = app
+        .create_raw_subscriber_builder(topic, TYPE_DISCOVERY_TIMEOUT)
+        .build()
+        .await
+        .wrap_err_with(|| format!("failed to subscribe to {topic}"))?;
+    let mut estimator = HzEstimator::new(topic.to_string(), window);
+    let mut receive_state = HzReceiveState::default();
+
+    match limit {
+        HzLimit::Count(count) => {
+            run_count(
+                &mut subscriber,
+                &mut estimator,
+                &mut receive_state,
+                output_mode,
+                count,
+            )
+            .await
+        }
+        HzLimit::Duration(duration) => {
+            run_duration(
+                &mut subscriber,
+                &mut estimator,
+                &mut receive_state,
+                output_mode,
+                duration,
+            )
+            .await
+        }
+        HzLimit::Continuous => {
+            run_continuous(
+                &mut subscriber,
+                &mut estimator,
+                &mut receive_state,
+                output_mode,
+            )
+            .await
+        }
+    }
+}
+
+async fn run_count(
+    subscriber: &mut RawSubscriber,
+    estimator: &mut HzEstimator,
+    state: &mut HzReceiveState,
+    output_mode: OutputMode,
+    count: NonZeroUsize,
+) -> Result<()> {
+    for _ in 0..count.get() {
+        receive_one(subscriber, estimator, state).await?;
+    }
+    print_report(&estimator.report(), output_mode)
+}
+
+async fn run_duration(
+    subscriber: &mut RawSubscriber,
+    estimator: &mut HzEstimator,
+    state: &mut HzReceiveState,
+    output_mode: OutputMode,
+    duration: Duration,
+) -> Result<()> {
+    let deadline = tokio::time::Instant::now()
+        .checked_add(duration)
+        .ok_or_else(|| eyre!("duration is too large for monotonic clock deadline"))?;
+    let mut reports = tokio::time::interval(REPORT_PERIOD);
+    reports.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    reports.tick().await;
+    let deadline_sleep = tokio::time::sleep_until(deadline);
+    tokio::pin!(deadline_sleep);
+
+    loop {
+        match select_duration_event(
+            receive_one(subscriber, estimator, state),
+            tokio::signal::ctrl_c(),
+            &mut reports,
+            deadline_sleep.as_mut(),
+        )
+        .await
+        {
+            DurationEvent::Deadline => {
+                print_report(&estimator.report(), output_mode)?;
+                return Ok(());
+            }
+            DurationEvent::Receive(result) => result?,
+            DurationEvent::Report => {
+                if should_print_periodic_report(tokio::time::Instant::now(), deadline) {
+                    print_report(&estimator.report(), output_mode)?;
+                }
+            }
+            DurationEvent::Interrupted(signal) => {
+                signal.wrap_err("failed to listen for Ctrl-C")?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+enum DurationEvent<Receive> {
+    Deadline,
+    Receive(Receive),
+    Report,
+    Interrupted(std::io::Result<()>),
+}
+
+async fn select_duration_event<Receive, Interrupt>(
+    receive: Receive,
+    interrupt: Interrupt,
+    reports: &mut tokio::time::Interval,
+    mut deadline_sleep: Pin<&mut Sleep>,
+) -> DurationEvent<Receive::Output>
+where
+    Receive: Future,
+    Interrupt: Future<Output = std::io::Result<()>>,
+{
+    if deadline_sleep.deadline() <= tokio::time::Instant::now() {
+        return DurationEvent::Deadline;
+    }
+
+    tokio::select! {
+        biased;
+        _ = deadline_sleep.as_mut() => DurationEvent::Deadline,
+        _ = reports.tick() => DurationEvent::Report,
+        signal = interrupt => DurationEvent::Interrupted(signal),
+        result = receive => DurationEvent::Receive(result),
+    }
+}
+
+fn should_print_periodic_report(now: tokio::time::Instant, deadline: tokio::time::Instant) -> bool {
+    now < deadline
+}
+
+async fn run_continuous(
+    subscriber: &mut RawSubscriber,
+    estimator: &mut HzEstimator,
+    state: &mut HzReceiveState,
+    output_mode: OutputMode,
+) -> Result<()> {
+    let mut reports = tokio::time::interval(REPORT_PERIOD);
+    reports.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    reports.tick().await;
+
+    loop {
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => {
+                signal.wrap_err("failed to listen for Ctrl-C")?;
+                return Ok(());
+            }
+            result = receive_one(subscriber, estimator, state) => result?,
+            _ = reports.tick() => print_report(&estimator.report(), output_mode)?,
+        }
+    }
+}
+
+async fn receive_one(
+    subscriber: &mut RawSubscriber,
+    estimator: &mut HzEstimator,
+    state: &mut HzReceiveState,
+) -> Result<()> {
+    let sample = subscriber.recv().await?;
+    estimator.observe_receive(Instant::now());
+
+    if let Some(attachment) = decode_attachment_for_hz(sample.attachment(), state) {
+        estimator.observe_source(attachment.source_global_id, attachment.source_time());
+    }
+
+    Ok(())
+}
+
+fn print_report(report: &HzReport, output_mode: OutputMode) -> Result<()> {
+    match output_mode {
+        OutputMode::Json => json::print_line(report),
+        OutputMode::Text => {
+            text::print_hz_report(report);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_periodic_report_is_not_due_at_deadline() {
+        let started = tokio::time::Instant::now();
+        let deadline = started + REPORT_PERIOD;
+
+        assert!(should_print_periodic_report(started, deadline));
+        assert!(!should_print_periodic_report(deadline, deadline));
+        assert!(!should_print_periodic_report(
+            deadline + Duration::from_nanos(1),
+            deadline
+        ));
+    }
+
+    #[tokio::test]
+    async fn duration_deadline_wins_over_ready_receive() {
+        let mut reports = tokio::time::interval(REPORT_PERIOD);
+        reports.tick().await;
+        let deadline = tokio::time::Instant::now();
+
+        let deadline_sleep = tokio::time::sleep_until(deadline);
+        tokio::pin!(deadline_sleep);
+
+        let event = select_duration_event(
+            std::future::ready("received"),
+            std::future::pending::<std::io::Result<()>>(),
+            &mut reports,
+            deadline_sleep.as_mut(),
+        )
+        .await;
+
+        assert!(matches!(event, DurationEvent::Deadline));
+    }
+
+    #[tokio::test]
+    async fn duration_report_wins_over_ready_receive_when_due() {
+        let mut reports = tokio::time::interval(Duration::from_millis(1));
+        reports.tick().await;
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        let deadline = tokio::time::Instant::now() + REPORT_PERIOD;
+
+        let deadline_sleep = tokio::time::sleep_until(deadline);
+        tokio::pin!(deadline_sleep);
+
+        let event = select_duration_event(
+            std::future::ready("received"),
+            std::future::pending::<std::io::Result<()>>(),
+            &mut reports,
+            deadline_sleep.as_mut(),
+        )
+        .await;
+
+        assert!(matches!(event, DurationEvent::Report));
+    }
+
+    #[tokio::test]
+    async fn duration_interrupt_wins_over_ready_receive_when_report_not_due() {
+        let mut reports = tokio::time::interval(REPORT_PERIOD);
+        reports.tick().await;
+        let deadline = tokio::time::Instant::now() + REPORT_PERIOD;
+
+        let deadline_sleep = tokio::time::sleep_until(deadline);
+        tokio::pin!(deadline_sleep);
+
+        let event = select_duration_event(
+            std::future::ready("received"),
+            std::future::ready(Ok(())),
+            &mut reports,
+            deadline_sleep.as_mut(),
+        )
+        .await;
+
+        assert!(matches!(event, DurationEvent::Interrupted(Ok(()))));
+    }
+
+    #[test]
+    fn invalid_attachment_sets_warning_state_once() {
+        let malformed = zenoh::bytes::ZBytes::from(vec![0x01]);
+        let mut state = HzReceiveState::default();
+
+        assert!(decode_attachment_for_hz(Some(&malformed), &mut state).is_none());
+        assert!(state.warned_invalid_attachment);
+
+        assert!(decode_attachment_for_hz(Some(&malformed), &mut state).is_none());
+        assert!(state.warned_invalid_attachment);
+    }
+}

--- a/crates/ros-z-cli/src/commands/mod.rs
+++ b/crates/ros-z-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod echo;
 pub mod graph;
+pub mod hz;
 pub mod info;
 pub mod list;
 pub mod parameter;

--- a/crates/ros-z-cli/src/lib.rs
+++ b/crates/ros-z-cli/src/lib.rs
@@ -62,6 +62,9 @@ async fn run_online_command(
             count,
             timeout,
         } => commands::echo::run(&app, output_mode, &topic, count, timeout).await,
+        OnlineCommand::Hz(args) => {
+            commands::hz::run(&app, output_mode, &args.topic, args.window, args.limit()).await
+        }
         OnlineCommand::Info { target, name } => {
             commands::info::run(&app, output_mode, target, &name).await
         }

--- a/crates/ros-z-cli/src/model/hz.rs
+++ b/crates/ros-z-cli/src/model/hz.rs
@@ -1,0 +1,341 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    num::NonZeroUsize,
+    time::{Duration, Instant},
+};
+
+use ros_z::{ENDPOINT_GLOBAL_ID_SIZE, EndpointGlobalId, time::Time};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HzReport {
+    pub topic: String,
+    pub receive: HzStats,
+    pub sources: Vec<SourceHzStats>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HzStats {
+    pub rate_hz: Option<f64>,
+    pub min_seconds: Option<f64>,
+    pub max_seconds: Option<f64>,
+    pub stddev_seconds: Option<f64>,
+    pub intervals: usize,
+    pub window_limit: usize,
+    pub samples: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceHzStats {
+    pub source: String,
+    #[serde(flatten)]
+    pub stats: HzStats,
+}
+
+pub struct HzEstimator {
+    topic: String,
+    receive: IntervalWindow,
+    last_receive: Option<Instant>,
+    sources: BTreeMap<EndpointGlobalId, SourceWindow>,
+    window_limit: NonZeroUsize,
+}
+
+impl HzEstimator {
+    pub fn new(topic: String, window_limit: NonZeroUsize) -> Self {
+        Self {
+            topic,
+            receive: IntervalWindow::new(window_limit),
+            last_receive: None,
+            sources: BTreeMap::new(),
+            window_limit,
+        }
+    }
+
+    pub fn observe_receive(&mut self, received_at: Instant) {
+        self.receive.observe_sample();
+        if let Some(previous) = self.last_receive.replace(received_at) {
+            self.receive
+                .observe_interval(received_at.saturating_duration_since(previous));
+        }
+    }
+
+    pub fn observe_source(&mut self, source: EndpointGlobalId, source_time: Time) {
+        self.sources
+            .entry(source)
+            .or_insert_with(|| SourceWindow::new(self.window_limit))
+            .observe(source_time);
+    }
+
+    pub fn report(&self) -> HzReport {
+        HzReport {
+            topic: self.topic.clone(),
+            receive: self.receive.stats(),
+            sources: self
+                .sources
+                .iter()
+                .map(|(source, window)| SourceHzStats {
+                    source: format_source_id(*source),
+                    stats: window.stats(),
+                })
+                .collect(),
+        }
+    }
+}
+
+struct SourceWindow {
+    intervals: IntervalWindow,
+    last_source_time: Option<Time>,
+}
+
+impl SourceWindow {
+    fn new(window_limit: NonZeroUsize) -> Self {
+        Self {
+            intervals: IntervalWindow::new(window_limit),
+            last_source_time: None,
+        }
+    }
+
+    fn observe(&mut self, source_time: Time) {
+        self.intervals.observe_sample();
+        if let Some(previous) = self.last_source_time.replace(source_time) {
+            self.intervals
+                .observe_interval(source_time.duration_since(previous));
+        }
+    }
+
+    fn stats(&self) -> HzStats {
+        self.intervals.stats()
+    }
+}
+
+struct IntervalWindow {
+    max_len: NonZeroUsize,
+    intervals: VecDeque<Duration>,
+    samples: usize,
+}
+
+impl IntervalWindow {
+    fn new(max_len: NonZeroUsize) -> Self {
+        Self {
+            max_len,
+            intervals: VecDeque::new(),
+            samples: 0,
+        }
+    }
+
+    fn observe_sample(&mut self) {
+        self.samples += 1;
+    }
+
+    fn observe_interval(&mut self, interval: Duration) {
+        self.intervals.push_back(interval);
+        while self.intervals.len() > self.max_len.get() {
+            self.intervals.pop_front();
+        }
+    }
+
+    fn stats(&self) -> HzStats {
+        let intervals = self.intervals.len();
+        let base = HzStats {
+            rate_hz: None,
+            min_seconds: None,
+            max_seconds: None,
+            stddev_seconds: None,
+            intervals,
+            window_limit: self.max_len.get(),
+            samples: self.samples,
+        };
+
+        if self.intervals.is_empty() {
+            return base;
+        }
+
+        let mut sum = 0.0;
+        let mut min = f64::INFINITY;
+        let mut max = f64::NEG_INFINITY;
+        for seconds in self.intervals.iter().map(Duration::as_secs_f64) {
+            sum += seconds;
+            min = min.min(seconds);
+            max = max.max(seconds);
+        }
+        if sum <= f64::EPSILON {
+            return base;
+        }
+
+        let mean = sum / intervals as f64;
+        let variance = self
+            .intervals
+            .iter()
+            .map(Duration::as_secs_f64)
+            .map(|seconds| {
+                let delta = seconds - mean;
+                delta * delta
+            })
+            .sum::<f64>()
+            / intervals.saturating_sub(1).max(1) as f64;
+
+        HzStats {
+            rate_hz: Some(intervals as f64 / sum),
+            min_seconds: Some(min),
+            max_seconds: Some(max),
+            stddev_seconds: Some(variance.sqrt()),
+            intervals,
+            window_limit: self.max_len.get(),
+            samples: self.samples,
+        }
+    }
+}
+
+fn format_source_id(source: EndpointGlobalId) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
+    let mut output = String::with_capacity(ENDPOINT_GLOBAL_ID_SIZE * 2);
+    for byte in source.as_bytes() {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroUsize;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    fn source(byte: u8) -> EndpointGlobalId {
+        EndpointGlobalId::from([byte; ENDPOINT_GLOBAL_ID_SIZE])
+    }
+
+    fn window(limit: usize) -> NonZeroUsize {
+        NonZeroUsize::new(limit).expect("test window limit must be non-zero")
+    }
+
+    #[test]
+    fn receive_report_uses_interval_statistics() {
+        let start = Instant::now();
+        let mut estimator = HzEstimator::new("/chatter".to_string(), window(10));
+
+        estimator.observe_receive(start);
+        estimator.observe_receive(start + Duration::from_millis(100));
+        estimator.observe_receive(start + Duration::from_millis(300));
+
+        let report = estimator.report();
+        let receive = report.receive;
+        assert_close(receive.rate_hz.expect("rate"), 2.0 / 0.3);
+        assert_close(receive.min_seconds.expect("min"), 0.1);
+        assert_close(receive.max_seconds.expect("max"), 0.2);
+        assert_close(receive.stddev_seconds.expect("stddev"), 0.005f64.sqrt());
+        assert_eq!(receive.intervals, 2);
+        assert_eq!(receive.window_limit, 10);
+        assert_eq!(receive.samples, 3);
+    }
+
+    #[test]
+    fn receive_window_truncates_old_intervals() {
+        let start = Instant::now();
+        let mut estimator = HzEstimator::new("/chatter".to_string(), window(2));
+
+        estimator.observe_receive(start);
+        estimator.observe_receive(start + Duration::from_millis(100));
+        estimator.observe_receive(start + Duration::from_millis(300));
+        estimator.observe_receive(start + Duration::from_millis(600));
+
+        let receive = estimator.report().receive;
+        assert_close(receive.rate_hz.expect("rate"), 2.0 / 0.5);
+        assert_close(receive.min_seconds.expect("min"), 0.2);
+        assert_close(receive.max_seconds.expect("max"), 0.3);
+        assert_eq!(receive.intervals, 2);
+        assert_eq!(receive.window_limit, 2);
+        assert_eq!(receive.samples, 4);
+    }
+
+    #[test]
+    fn receive_report_keeps_sample_count_before_first_interval() {
+        let mut estimator = HzEstimator::new("/chatter".to_string(), window(10));
+        estimator.observe_receive(Instant::now());
+
+        let report = estimator.report();
+
+        assert_eq!(report.receive.samples, 1);
+        assert_eq!(report.receive.intervals, 0);
+        assert_eq!(report.receive.window_limit, 10);
+        assert_eq!(report.receive.rate_hz, None);
+        assert_eq!(report.receive.min_seconds, None);
+        assert_eq!(report.receive.max_seconds, None);
+        assert_eq!(report.receive.stddev_seconds, None);
+        assert!(report.sources.is_empty());
+    }
+
+    #[test]
+    fn source_report_keeps_sample_count_before_first_interval() {
+        let mut estimator = HzEstimator::new("/chatter".to_string(), window(10));
+        estimator.observe_source(source(0x01), Time::from_nanos(0));
+
+        let report = estimator.report();
+
+        assert_eq!(report.sources.len(), 1);
+        assert_eq!(report.sources[0].source, "01010101010101010101010101010101");
+        assert_eq!(report.sources[0].stats.samples, 1);
+        assert_eq!(report.sources[0].stats.intervals, 0);
+        assert_eq!(report.sources[0].stats.window_limit, 10);
+        assert_eq!(report.sources[0].stats.rate_hz, None);
+    }
+
+    #[test]
+    fn report_serializes_no_rate_statistics_as_nulls() {
+        let mut estimator = HzEstimator::new("/chatter".to_string(), window(10));
+        estimator.observe_receive(Instant::now());
+        estimator.observe_source(source(0x01), Time::from_nanos(0));
+
+        let json = serde_json::to_value(estimator.report()).expect("serialize hz report");
+        let receive = &json["receive"];
+        assert!(receive["rate_hz"].is_null());
+        assert!(receive["min_seconds"].is_null());
+        assert!(receive["max_seconds"].is_null());
+        assert!(receive["stddev_seconds"].is_null());
+        assert_eq!(receive["samples"].as_u64(), Some(1));
+        assert_eq!(receive["intervals"].as_u64(), Some(0));
+        assert_eq!(receive["window_limit"].as_u64(), Some(10));
+
+        let source = &json["sources"][0];
+        assert!(source["rate_hz"].is_null());
+        assert!(source["min_seconds"].is_null());
+        assert!(source["max_seconds"].is_null());
+        assert!(source["stddev_seconds"].is_null());
+        assert_eq!(source["samples"].as_u64(), Some(1));
+        assert_eq!(source["intervals"].as_u64(), Some(0));
+        assert_eq!(source["window_limit"].as_u64(), Some(10));
+    }
+
+    #[test]
+    fn source_windows_are_independent() {
+        let mut estimator = HzEstimator::new("/chatter".to_string(), window(10));
+
+        estimator.observe_source(source(0x01), Time::from_nanos(0));
+        estimator.observe_source(source(0x02), Time::from_nanos(0));
+        estimator.observe_source(source(0x01), Time::from_nanos(100_000_000));
+        estimator.observe_source(source(0x02), Time::from_nanos(200_000_000));
+
+        let report = estimator.report();
+        assert_eq!(report.sources.len(), 2);
+        assert_close(
+            report.sources[0].stats.rate_hz.expect("first source rate"),
+            10.0,
+        );
+        assert_close(
+            report.sources[1].stats.rate_hz.expect("second source rate"),
+            5.0,
+        );
+        assert_eq!(report.sources[0].stats.intervals, 1);
+        assert_eq!(report.sources[0].stats.window_limit, 10);
+        assert_eq!(report.sources[0].stats.samples, 2);
+        assert_eq!(report.sources[1].stats.samples, 2);
+    }
+}

--- a/crates/ros-z-cli/src/model/hz.rs
+++ b/crates/ros-z-cli/src/model/hz.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ros_z::{ENDPOINT_GLOBAL_ID_SIZE, EndpointGlobalId, time::Time};
+use ros_z::{EndpointGlobalId, time::Time};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,7 +74,7 @@ impl HzEstimator {
                 .sources
                 .iter()
                 .map(|(source, window)| SourceHzStats {
-                    source: format_source_id(*source),
+                    source: source.to_string(),
                     stats: window.stats(),
                 })
                 .collect(),
@@ -186,20 +186,10 @@ impl IntervalWindow {
     }
 }
 
-fn format_source_id(source: EndpointGlobalId) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-
-    let mut output = String::with_capacity(ENDPOINT_GLOBAL_ID_SIZE * 2);
-    for byte in source.as_bytes() {
-        output.push(HEX[(byte >> 4) as usize] as char);
-        output.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    output
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ros_z::ENDPOINT_GLOBAL_ID_SIZE;
     use std::num::NonZeroUsize;
 
     fn assert_close(actual: f64, expected: f64) {

--- a/crates/ros-z-cli/src/model/mod.rs
+++ b/crates/ros-z-cli/src/model/mod.rs
@@ -1,5 +1,6 @@
 pub mod echo;
 pub mod graph;
+pub mod hz;
 pub mod info;
 pub mod parameter;
 pub mod schema;

--- a/crates/ros-z-cli/src/render/text.rs
+++ b/crates/ros-z-cli/src/render/text.rs
@@ -6,6 +6,7 @@ use crate::{
     model::{
         echo::EchoHeader,
         graph::{NodeSummary, ServiceSummary, TopicSummary},
+        hz::{HzReport, HzStats},
         info::{EndpointSummary, NamedType, NodeInfo, ServiceInfo, TopicInfo},
         parameter::{
             ParameterMutationView, ParameterSnapshotView, ParameterValueView,
@@ -189,6 +190,71 @@ pub fn print_echo_message(message: &str, count: Option<usize>, seen: usize) {
     }
 }
 
+pub fn print_hz_report(report: &HzReport) {
+    println!("{}", hz_report_line(&report.topic, &report.receive));
+
+    for source in &report.sources {
+        println!("{}", source_hz_report_line(&source.source, &source.stats));
+    }
+}
+
+fn hz_report_line(topic: &str, stats: &HzStats) -> String {
+    match hz_rate_fields(stats) {
+        Some((rate_hz, min_seconds, max_seconds, stddev_seconds)) => format!(
+            "{}  recv={}  min={}  max={}  stddev={}  intervals={}/{}  samples={}",
+            topic,
+            format_hz(rate_hz),
+            format_seconds(min_seconds),
+            format_seconds(max_seconds),
+            format_seconds(stddev_seconds),
+            stats.intervals,
+            stats.window_limit,
+            stats.samples,
+        ),
+        None => format!(
+            "{}  not enough samples for rate estimate  intervals={}/{}  samples={}",
+            topic, stats.intervals, stats.window_limit, stats.samples
+        ),
+    }
+}
+
+fn source_hz_report_line(source: &str, stats: &HzStats) -> String {
+    match hz_rate_fields(stats) {
+        Some((rate_hz, min_seconds, max_seconds, stddev_seconds)) => format!(
+            "  source={}  rate={}  min={}  max={}  stddev={}  intervals={}/{}  samples={}",
+            source,
+            format_hz(rate_hz),
+            format_seconds(min_seconds),
+            format_seconds(max_seconds),
+            format_seconds(stddev_seconds),
+            stats.intervals,
+            stats.window_limit,
+            stats.samples,
+        ),
+        None => format!(
+            "  source={}  not enough samples for rate estimate  intervals={}/{}  samples={}",
+            source, stats.intervals, stats.window_limit, stats.samples
+        ),
+    }
+}
+
+fn hz_rate_fields(stats: &HzStats) -> Option<(f64, f64, f64, f64)> {
+    Some((
+        stats.rate_hz?,
+        stats.min_seconds?,
+        stats.max_seconds?,
+        stats.stddev_seconds?,
+    ))
+}
+
+fn format_hz(rate_hz: f64) -> String {
+    format!("{rate_hz:.2}Hz")
+}
+
+fn format_seconds(seconds: f64) -> String {
+    format!("{seconds:.3}s")
+}
+
 pub fn print_schema(view: &SchemaView) {
     if let Err(error) = write_schema(&mut io::stdout(), view) {
         eprintln!("failed to write schema: {error}");
@@ -337,6 +403,59 @@ fn schema_field_kind_name(kind: SchemaFieldKindView) -> &'static str {
         SchemaFieldKindView::Array => "array",
         SchemaFieldKindView::Sequence => "sequence",
         SchemaFieldKindView::Map => "map",
+    }
+}
+
+#[cfg(test)]
+mod hz_tests {
+    use super::*;
+
+    fn no_rate_stats() -> HzStats {
+        HzStats {
+            rate_hz: None,
+            min_seconds: None,
+            max_seconds: None,
+            stddev_seconds: None,
+            intervals: 0,
+            window_limit: 10,
+            samples: 1,
+        }
+    }
+
+    fn rate_stats() -> HzStats {
+        HzStats {
+            rate_hz: Some(20.0),
+            min_seconds: Some(0.04),
+            max_seconds: Some(0.06),
+            stddev_seconds: Some(0.01),
+            intervals: 2,
+            window_limit: 10,
+            samples: 3,
+        }
+    }
+
+    #[test]
+    fn hz_report_line_includes_samples_without_rate() {
+        assert_eq!(
+            hz_report_line("/chatter", &no_rate_stats()),
+            "/chatter  not enough samples for rate estimate  intervals=0/10  samples=1"
+        );
+    }
+
+    #[test]
+    fn source_hz_report_line_includes_samples_without_rate() {
+        assert_eq!(
+            source_hz_report_line("0101", &no_rate_stats()),
+            "  source=0101  not enough samples for rate estimate  intervals=0/10  samples=1"
+        );
+    }
+
+    #[test]
+    fn hz_report_line_keeps_compact_rate_format() {
+        assert_eq!(
+            hz_report_line("/chatter", &rate_stats()),
+            "/chatter  recv=20.00Hz  min=0.040s  max=0.060s  stddev=0.010s  intervals=2/10  samples=3"
+        );
     }
 }
 

--- a/crates/ros-z-cli/tests/e2e.rs
+++ b/crates/ros-z-cli/tests/e2e.rs
@@ -397,12 +397,28 @@ struct PublishingFixture {
 
 impl PublishingFixture {
     async fn new(env: &TestEnv, topic: &str) -> TestResult<Self> {
+        Self::new_with_schema_service(env, topic, true).await
+    }
+
+    async fn new_without_schema_service(env: &TestEnv, topic: &str) -> TestResult<Self> {
+        Self::new_with_schema_service(env, topic, false).await
+    }
+
+    async fn new_with_schema_service(
+        env: &TestEnv,
+        topic: &str,
+        enable_schema_service: bool,
+    ) -> TestResult<Self> {
         let context = env.create_context().await?;
-        let node = context
+        let node_builder = context
             .create_node("schema_fixture")
-            .with_namespace("/cli_e2e")
-            .build()
-            .await?;
+            .with_namespace("/cli_e2e");
+        let node_builder = if enable_schema_service {
+            node_builder
+        } else {
+            node_builder.without_schema_service()
+        };
+        let node = node_builder.build().await?;
         let publisher = node.publisher::<Telemetry>(topic).build().await?;
 
         Ok(Self {
@@ -629,6 +645,66 @@ async fn echo_receives_dynamic_message_from_fixture_publisher() -> TestResult {
         .map(|value| value.as_f64().expect("temperature number"))
         .collect::<Vec<_>>();
     assert_eq!(temperatures, [20.0, 20.5]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hz_reports_receive_and_source_rates_without_schema_service() -> TestResult {
+    let env = TestEnv::new();
+    let fixture =
+        PublishingFixture::new_without_schema_service(&env, "/cli_e2e/hz_telemetry").await?;
+    fixture.start_publishing();
+
+    let lines = env
+        .rosz()
+        .json_command(["hz", fixture.topic.as_str(), "--count", "5"])
+        .run_json_lines();
+
+    let report = lines.last().expect("one hz report");
+    assert_eq!(report["topic"], fixture.topic);
+    assert!(
+        report["receive"]["rate_hz"]
+            .as_f64()
+            .is_some_and(|rate| rate > 0.0),
+        "hz report should include positive receive rate:\n{}",
+        serde_json::to_string_pretty(report).expect("hz report json")
+    );
+    assert_eq!(report["receive"]["window_limit"].as_u64(), Some(10));
+    assert_eq!(report["receive"]["samples"].as_u64(), Some(5));
+    assert!(report["receive"]["min_seconds"].as_f64().is_some());
+    assert!(report["receive"]["max_seconds"].as_f64().is_some());
+    assert!(report["receive"]["stddev_seconds"].as_f64().is_some());
+    assert!(
+        report["receive"]["intervals"]
+            .as_u64()
+            .is_some_and(|intervals| intervals > 0),
+        "hz report should include interval count:\n{}",
+        serde_json::to_string_pretty(report).expect("hz report json")
+    );
+    assert!(
+        report["sources"]
+            .as_array()
+            .is_some_and(|sources| !sources.is_empty()),
+        "hz report should include source stats:\n{}",
+        serde_json::to_string_pretty(report).expect("hz report json")
+    );
+    let first_source = &report["sources"].as_array().expect("source array")[0];
+    assert!(
+        first_source["source"]
+            .as_str()
+            .is_some_and(|source| !source.is_empty())
+    );
+    assert!(
+        first_source["rate_hz"]
+            .as_f64()
+            .is_some_and(|rate| rate > 0.0)
+    );
+    assert!(
+        first_source["samples"]
+            .as_u64()
+            .is_some_and(|samples| samples >= 2)
+    );
 
     Ok(())
 }

--- a/crates/ros-z-protocol/src/entity.rs
+++ b/crates/ros-z-protocol/src/entity.rs
@@ -83,6 +83,15 @@ impl EndpointGlobalId {
     }
 }
 
+impl Display for EndpointGlobalId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for byte in self.as_bytes() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
 impl From<[u8; ENDPOINT_GLOBAL_ID_SIZE]> for EndpointGlobalId {
     fn from(bytes: [u8; ENDPOINT_GLOBAL_ID_SIZE]) -> Self {
         Self::new(bytes)
@@ -515,6 +524,16 @@ mod tests {
         assert_eq!(EndpointGlobalId::from(bytes).as_bytes(), &bytes);
         let roundtrip: [u8; ENDPOINT_GLOBAL_ID_SIZE] = EndpointGlobalId::from(bytes).into();
         assert_eq!(roundtrip, bytes);
+    }
+
+    #[test]
+    fn endpoint_global_id_displays_lowercase_fixed_width_hex() {
+        let id = EndpointGlobalId::from([
+            0x00, 0x01, 0x0a, 0x0f, 0x10, 0x2b, 0x7f, 0x80, 0xab, 0xcd, 0xef, 0xf0, 0x12, 0x34,
+            0x56, 0x78,
+        ]);
+
+        assert_eq!(id.to_string(), "00010a0f102b7f80abcdeff012345678");
     }
 
     #[test]

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -30,6 +30,63 @@ impl DiscoveredTopicSchema {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct TopicSchemaFingerprint {
+    pub topic: String,
+    pub node_namespace: String,
+    pub node_name: String,
+    pub type_info: TypeInfo,
+}
+
+impl TopicSchemaFingerprint {
+    pub fn from_publisher(endpoint: &EndpointEntity) -> Self {
+        Self {
+            topic: endpoint.topic.clone(),
+            node_namespace: endpoint.node.namespace.clone(),
+            node_name: endpoint.node.name.clone(),
+            type_info: endpoint.type_info.clone(),
+        }
+    }
+}
+
+impl fmt::Display for TopicSchemaFingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}:{}@{}",
+            self.node_namespace, self.node_name, self.type_info.name, self.type_info.hash
+        )
+    }
+}
+
+pub fn topic_schema_fingerprints_from_publishers(
+    publishers: &[EndpointEntity],
+) -> Vec<TopicSchemaFingerprint> {
+    let mut fingerprints = publishers
+        .iter()
+        .map(TopicSchemaFingerprint::from_publisher)
+        .collect_vec();
+    fingerprints.sort_by(|left, right| {
+        (
+            &left.topic,
+            &left.node_namespace,
+            &left.node_name,
+            &left.type_info.name,
+            &left.type_info.hash.0,
+        )
+            .cmp(&(
+                &right.topic,
+                &right.node_namespace,
+                &right.node_name,
+                &right.type_info.name,
+                &right.type_info.hash.0,
+            ))
+    });
+    fingerprints.dedup();
+    fingerprints
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TopicSchemaCandidate {
     pub node_name: String,
     pub namespace: String,
@@ -38,12 +95,12 @@ pub(crate) struct TopicSchemaCandidate {
 }
 
 impl TopicSchemaCandidate {
-    fn from_endpoint(endpoint: &EndpointEntity) -> Self {
+    fn from_fingerprint(fingerprint: &TopicSchemaFingerprint) -> Self {
         Self {
-            node_name: endpoint.node.name.clone(),
-            namespace: endpoint.node.namespace.clone(),
-            type_name: endpoint.type_info.name.clone(),
-            schema_hash: endpoint.type_info.hash,
+            node_name: fingerprint.node_name.clone(),
+            namespace: fingerprint.node_namespace.clone(),
+            type_name: fingerprint.type_info.name.clone(),
+            schema_hash: fingerprint.type_info.hash,
         }
     }
 
@@ -70,10 +127,9 @@ pub(crate) fn collect_topic_schema_candidates_from_publishers(
     publishers: &[EndpointEntity],
     qualified_topic: &str,
 ) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
-    let candidates = publishers
+    let candidates = topic_schema_fingerprints_from_publishers(publishers)
         .iter()
-        .map(TopicSchemaCandidate::from_endpoint)
-        .unique()
+        .map(TopicSchemaCandidate::from_fingerprint)
         .collect_vec();
 
     if candidates.is_empty() {
@@ -179,21 +235,16 @@ fn no_schema_services_error(
     }
 }
 
-fn schema_service_query_deadline_error(
+fn schema_discovery_timeout_error(
     qualified_topic: &str,
     candidates: &[TopicSchemaCandidate],
+    source: Option<DynamicError>,
 ) -> DynamicError {
-    DynamicError::runtime(
-        "query visible schema service",
-        std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            format!(
-                "schema discovery deadline expired before querying visible schema services for topic '{}' among candidates: {:?}",
-                qualified_topic,
-                candidates.iter().map(ToString::to_string).collect_vec()
-            ),
-        ),
-    )
+    DynamicError::SchemaDiscoveryTimeout {
+        topic: qualified_topic.to_string(),
+        candidates: candidates.iter().map(ToString::to_string).collect_vec(),
+        source: source.map(|error| Box::new(error) as crate::error::BoxError),
+    }
 }
 
 async fn wait_for_topic_schema_candidates(
@@ -349,9 +400,11 @@ impl SchemaDiscovery {
 
         for candidate in &candidates {
             let Some(timeout) = schema_query_timeout(deadline) else {
-                return Err(last_error.unwrap_or_else(|| {
-                    schema_service_query_deadline_error(qualified_topic, &candidates)
-                }));
+                return Err(schema_discovery_timeout_error(
+                    qualified_topic,
+                    &candidates,
+                    last_error,
+                ));
             };
 
             match tokio::time::timeout_at(
@@ -363,15 +416,17 @@ impl SchemaDiscovery {
                 Ok(Ok(result)) => return Ok(result),
                 Ok(Err(error)) => last_error = Some(error),
                 Err(_) => {
-                    return Err(last_error.unwrap_or_else(|| {
-                        schema_service_query_deadline_error(qualified_topic, &candidates)
-                    }));
+                    return Err(schema_discovery_timeout_error(
+                        qualified_topic,
+                        &candidates,
+                        last_error,
+                    ));
                 }
             }
         }
 
         Err(last_error
-            .unwrap_or_else(|| schema_service_query_deadline_error(qualified_topic, &candidates)))
+            .unwrap_or_else(|| schema_discovery_timeout_error(qualified_topic, &candidates, None)))
     }
 }
 
@@ -761,16 +816,50 @@ mod tests {
             .await
             .expect_err("elapsed query budget should fail without denying service visibility");
 
-        let DynamicError::Runtime { operation, source } = error else {
-            panic!("expected runtime timeout for visible schema service, got {error:?}");
+        let DynamicError::SchemaDiscoveryTimeout {
+            topic,
+            candidates,
+            source,
+        } = error
+        else {
+            panic!("expected schema discovery timeout, got {error:?}");
         };
-        assert_eq!(operation, "query visible schema service");
-        assert!(
-            source.to_string().contains("deadline expired"),
-            "unexpected timeout message: {source}"
-        );
+        assert_eq!(topic, "/chatter");
+        assert_eq!(candidates.len(), 1);
+        assert!(candidates[0].contains("talker"));
+        assert!(candidates[0].contains("std_msgs::String"));
+        assert!(source.is_none());
 
         session.close().await.expect("close Zenoh session");
+    }
+
+    #[test]
+    fn schema_discovery_timeout_error_preserves_previous_candidate_error_as_source() {
+        let candidate = TopicSchemaCandidate {
+            node_name: "talker".to_string(),
+            namespace: "/".to_string(),
+            type_name: "std_msgs::String".to_string(),
+            schema_hash: SchemaHash([1; 32]),
+        };
+        let previous_error = DynamicError::NoSchemaServices {
+            topic: "/chatter".to_string(),
+            candidates: vec![candidate.to_string()],
+        };
+
+        let error = schema_discovery_timeout_error("/chatter", &[candidate], Some(previous_error));
+
+        let DynamicError::SchemaDiscoveryTimeout {
+            topic,
+            candidates,
+            source,
+        } = error
+        else {
+            panic!("expected schema discovery timeout, got {error:?}");
+        };
+        assert_eq!(topic, "/chatter");
+        assert_eq!(candidates.len(), 1);
+        assert!(candidates[0].contains("talker"));
+        assert!(source.is_some());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -924,6 +1013,29 @@ mod tests {
             .expect("valid candidate service name");
 
         assert_eq!(service_name, "/robot/talker/get_schema");
+    }
+
+    #[test]
+    fn topic_schema_fingerprints_from_publishers_returns_canonical_schema_identity() {
+        let hash = SchemaHash([7; 32]);
+        let talker_b = publisher_with_hash_from_node("std_msgs::String", hash, "talker_b", 3);
+        let mut duplicate_talker_b =
+            publisher_with_hash_from_node("std_msgs::String", hash, "talker_b", 3);
+        duplicate_talker_b.id = 99;
+        let talker_a = publisher_with_hash_from_node("std_msgs::String", hash, "talker_a", 2);
+
+        let fingerprints =
+            topic_schema_fingerprints_from_publishers(&[talker_b, duplicate_talker_b, talker_a]);
+
+        assert_eq!(fingerprints.len(), 2);
+        assert_eq!(fingerprints[0].topic, "/chatter");
+        assert_eq!(fingerprints[0].node_namespace, "/");
+        assert_eq!(fingerprints[0].node_name, "talker_a");
+        assert_eq!(
+            fingerprints[0].type_info,
+            TypeInfo::new("std_msgs::String", hash)
+        );
+        assert_eq!(fingerprints[1].node_name, "talker_b");
     }
 
     #[test]

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -7,11 +7,11 @@ use tokio::time::Instant;
 use crate::{
     dynamic::{DynamicCdrCodec, DynamicError, DynamicPayload, DynamicSubscriber, Schema},
     endpoint_builder::{EndpointBuilderContext, MessageEndpointType},
-    entity::{EndpointEntity, SchemaHash, TypeInfo},
+    entity::{EndpointEntity, EndpointKind, SchemaHash, TypeInfo},
     graph::Graph,
-    pubsub::{RawSubscriber, SubscriberBuilder, SubscriberOptions},
+    pubsub::{RawPayload, RawPayloadCodec, RawSubscriber, SubscriberBuilder, SubscriberOptions},
     qos::QosProfile,
-    topic_name::qualify_topic_name,
+    topic_name::{qualify_remote_private_service_name, qualify_topic_name},
 };
 use tracing::info;
 
@@ -30,95 +30,79 @@ impl DiscoveredTopicSchema {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub struct TopicSchemaFingerprint {
-    pub topic: String,
-    pub node_namespace: String,
+pub(crate) struct TopicSchemaCandidate {
     pub node_name: String,
-    pub type_info: TypeInfo,
+    pub namespace: String,
+    pub type_name: String,
+    pub schema_hash: SchemaHash,
 }
 
-impl TopicSchemaFingerprint {
-    pub fn from_publisher(endpoint: &EndpointEntity) -> Self {
+impl TopicSchemaCandidate {
+    fn from_endpoint(endpoint: &EndpointEntity) -> Self {
         Self {
-            topic: endpoint.topic.clone(),
-            node_namespace: endpoint.node.namespace.clone(),
             node_name: endpoint.node.name.clone(),
-            type_info: endpoint.type_info.clone(),
+            namespace: endpoint.node.namespace.clone(),
+            type_name: endpoint.type_info.name.clone(),
+            schema_hash: endpoint.type_info.hash,
         }
+    }
+
+    pub(crate) fn schema_service_name(
+        &self,
+        operation: &'static str,
+    ) -> Result<String, DynamicError> {
+        qualify_remote_private_service_name("get_schema", &self.namespace, &self.node_name)
+            .map_err(|source| DynamicError::name(operation, source))
     }
 }
 
-impl fmt::Display for TopicSchemaFingerprint {
+impl fmt::Display for TopicSchemaCandidate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}/{}:{}@{}",
-            self.node_namespace, self.node_name, self.type_info.name, self.type_info.hash
+            self.namespace, self.node_name, self.type_name, self.schema_hash
         )
     }
 }
 
-pub fn topic_schema_fingerprints_from_publishers(
-    publishers: &[EndpointEntity],
-) -> Vec<TopicSchemaFingerprint> {
-    let mut fingerprints = publishers
-        .iter()
-        .map(TopicSchemaFingerprint::from_publisher)
-        .collect_vec();
-    fingerprints.sort_by(|left, right| {
-        (
-            &left.topic,
-            &left.node_namespace,
-            &left.node_name,
-            &left.type_info.name,
-            &left.type_info.hash.0,
-        )
-            .cmp(&(
-                &right.topic,
-                &right.node_namespace,
-                &right.node_name,
-                &right.type_info.name,
-                &right.type_info.hash.0,
-            ))
-    });
-    fingerprints.dedup();
-    fingerprints
-}
-
-pub(crate) fn collect_topic_schema_fingerprints_from_publishers(
+pub(crate) fn collect_topic_schema_candidates_from_publishers(
     publishers: &[EndpointEntity],
     qualified_topic: &str,
-) -> Result<Vec<TopicSchemaFingerprint>, DynamicError> {
-    let fingerprints = topic_schema_fingerprints_from_publishers(publishers);
-
-    if fingerprints.is_empty() {
-        return Err(DynamicError::SchemaNotFound(format!(
-            "No publishers found for topic: {qualified_topic}"
-        )));
-    }
-
-    if !fingerprints
+) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
+    let candidates = publishers
         .iter()
-        .map(|fingerprint| (&fingerprint.type_info.name, fingerprint.type_info.hash))
-        .all_equal()
-    {
-        return Err(DynamicError::SchemaConflict {
+        .map(TopicSchemaCandidate::from_endpoint)
+        .unique()
+        .collect_vec();
+
+    if candidates.is_empty() {
+        return Err(DynamicError::NoPublishers {
             topic: qualified_topic.to_string(),
-            candidates: fingerprints.iter().map(ToString::to_string).collect_vec(),
         });
     }
 
-    Ok(fingerprints)
+    if !candidates
+        .iter()
+        .map(|candidate| (&candidate.type_name, candidate.schema_hash))
+        .all_equal()
+    {
+        return Err(DynamicError::TopicTypeConflict {
+            topic: qualified_topic.to_string(),
+            candidates: candidates.iter().map(ToString::to_string).collect_vec(),
+        });
+    }
+
+    Ok(candidates)
 }
 
 fn collect_topic_schema_candidates(
     graph: &Graph,
     qualified_topic: &str,
-) -> Result<Vec<TopicSchemaFingerprint>, DynamicError> {
+) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
     let publishers = graph.view().publishers_on(qualified_topic);
 
-    collect_topic_schema_fingerprints_from_publishers(&publishers, qualified_topic)
+    collect_topic_schema_candidates_from_publishers(&publishers, qualified_topic)
 }
 
 fn schema_query_timeout(deadline: Instant) -> Option<Duration> {
@@ -129,15 +113,152 @@ fn schema_query_timeout(deadline: Instant) -> Option<Duration> {
     Some(timeout)
 }
 
-fn schema_query_timeout_error(
-    qualified_topic: &str,
-    last_error: Option<&DynamicError>,
-) -> DynamicError {
-    let mut message = format!("Timed out while discovering schema for topic: {qualified_topic}");
-    if let Some(error) = last_error {
-        message.push_str(&format!("; last candidate error: {error}"));
+fn qualify_topic_for_discovery(
+    topic: &str,
+    namespace: &str,
+    node_name: &str,
+) -> Result<String, DynamicError> {
+    qualify_topic_name(topic, namespace, node_name).map_err(|source| DynamicError::TopicName {
+        topic: topic.to_string(),
+        source,
+    })
+}
+
+fn collect_visible_schema_service_candidates(
+    candidates: &[TopicSchemaCandidate],
+    visible_services: &[EndpointEntity],
+) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
+    let mut visible_candidates = Vec::new();
+
+    for candidate in candidates {
+        let service_name =
+            candidate.schema_service_name("checking remote schema service visibility")?;
+        if visible_services
+            .iter()
+            .any(|service| service.kind == EndpointKind::Service && service.topic == service_name)
+        {
+            visible_candidates.push(candidate.clone());
+        }
     }
-    DynamicError::SchemaNotFound(message)
+
+    Ok(visible_candidates)
+}
+
+struct SchemaServiceCandidateSnapshot {
+    compatible: Vec<TopicSchemaCandidate>,
+    visible: Vec<TopicSchemaCandidate>,
+}
+
+fn collect_schema_service_candidate_snapshot(
+    graph: &Graph,
+    qualified_topic: &str,
+) -> Result<SchemaServiceCandidateSnapshot, DynamicError> {
+    let view = graph.view();
+    let publishers = view.publishers_on(qualified_topic);
+    let compatible = collect_topic_schema_candidates_from_publishers(&publishers, qualified_topic)?;
+    let visible_services = view
+        .endpoints()
+        .filter(|endpoint| endpoint.kind == EndpointKind::Service)
+        .cloned()
+        .collect_vec();
+    let visible = collect_visible_schema_service_candidates(&compatible, &visible_services)?;
+
+    Ok(SchemaServiceCandidateSnapshot {
+        compatible,
+        visible,
+    })
+}
+
+fn no_schema_services_error(
+    qualified_topic: &str,
+    candidates: &[TopicSchemaCandidate],
+) -> DynamicError {
+    DynamicError::NoSchemaServices {
+        topic: qualified_topic.to_string(),
+        candidates: candidates.iter().map(ToString::to_string).collect_vec(),
+    }
+}
+
+fn schema_service_query_deadline_error(
+    qualified_topic: &str,
+    candidates: &[TopicSchemaCandidate],
+) -> DynamicError {
+    DynamicError::runtime(
+        "query visible schema service",
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "schema discovery deadline expired before querying visible schema services for topic '{}' among candidates: {:?}",
+                qualified_topic,
+                candidates.iter().map(ToString::to_string).collect_vec()
+            ),
+        ),
+    )
+}
+
+async fn wait_for_topic_schema_candidates(
+    graph: &Graph,
+    qualified_topic: &str,
+    deadline: Instant,
+) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
+    let mut changes = graph.subscribe_changes();
+
+    loop {
+        changes.mark_seen();
+
+        match collect_topic_schema_candidates(graph, qualified_topic) {
+            Ok(candidates) => return Ok(candidates),
+            Err(DynamicError::NoPublishers { .. }) => {}
+            Err(error) => return Err(error),
+        }
+
+        let Some(timeout) = schema_query_timeout(deadline) else {
+            return collect_topic_schema_candidates(graph, qualified_topic);
+        };
+
+        match tokio::time::timeout(timeout, changes.changed()).await {
+            Ok(Some(_)) => {}
+            Ok(None) | Err(_) => return collect_topic_schema_candidates(graph, qualified_topic),
+        }
+    }
+}
+
+async fn wait_for_visible_schema_service_candidates(
+    graph: &Graph,
+    qualified_topic: &str,
+    deadline: Instant,
+) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
+    let mut changes = graph.subscribe_changes();
+
+    loop {
+        changes.mark_seen();
+
+        let snapshot = collect_schema_service_candidate_snapshot(graph, qualified_topic)?;
+        if !snapshot.visible.is_empty() {
+            return Ok(snapshot.visible);
+        }
+
+        let Some(timeout) = schema_query_timeout(deadline) else {
+            return Err(no_schema_services_error(
+                qualified_topic,
+                &snapshot.compatible,
+            ));
+        };
+
+        match tokio::time::timeout(timeout, changes.changed()).await {
+            Ok(Some(_)) | Err(_) => {}
+            Ok(None) => {
+                let snapshot = collect_schema_service_candidate_snapshot(graph, qualified_topic)?;
+                if !snapshot.visible.is_empty() {
+                    return Ok(snapshot.visible);
+                }
+                return Err(no_schema_services_error(
+                    qualified_topic,
+                    &snapshot.compatible,
+                ));
+            }
+        }
+    }
 }
 
 pub(crate) struct SchemaDiscovery {
@@ -150,29 +271,60 @@ impl SchemaDiscovery {
         Self { context, timeout }
     }
 
+    async fn discover_candidates(
+        &self,
+        topic: &str,
+    ) -> Result<(String, Vec<TopicSchemaCandidate>, tokio::time::Instant), DynamicError> {
+        let qualified_topic = qualify_topic_for_discovery(
+            topic,
+            &self.context.node.namespace,
+            &self.context.node.name,
+        )?;
+
+        self.discover_qualified_candidates(qualified_topic).await
+    }
+
+    async fn discover_qualified_candidates(
+        &self,
+        qualified_topic: String,
+    ) -> Result<(String, Vec<TopicSchemaCandidate>, tokio::time::Instant), DynamicError> {
+        let deadline = tokio::time::Instant::now() + self.timeout;
+        let candidates = wait_for_topic_schema_candidates(
+            self.context.graph.as_ref(),
+            &qualified_topic,
+            deadline,
+        )
+        .await?;
+
+        Ok((qualified_topic, candidates, deadline))
+    }
+
+    pub(crate) async fn discover_qualified(
+        &self,
+        qualified_topic: String,
+    ) -> Result<DiscoveredTopicSchema, DynamicError> {
+        let (qualified_topic, _candidates, deadline) =
+            self.discover_qualified_candidates(qualified_topic).await?;
+        self.discover_from_candidates(qualified_topic, deadline)
+            .await
+    }
+
     pub(crate) async fn discover(
         &self,
         topic: &str,
     ) -> Result<DiscoveredTopicSchema, DynamicError> {
-        let qualified_topic =
-            qualify_topic_name(topic, &self.context.node.namespace, &self.context.node.name)
-                .map_err(|error| DynamicError::name("discovering topic schema", error))?;
-
-        self.discover_qualified(qualified_topic).await
+        let (qualified_topic, _candidates, deadline) = self.discover_candidates(topic).await?;
+        self.discover_from_candidates(qualified_topic, deadline)
+            .await
     }
 
-    async fn discover_qualified(
+    async fn discover_from_candidates(
         &self,
         qualified_topic: String,
+        deadline: Instant,
     ) -> Result<DiscoveredTopicSchema, DynamicError> {
-        let deadline = Instant::now() + self.timeout;
-        let candidates = self
-            .wait_for_topic_schema_candidates(&qualified_topic, deadline)
-            .await?;
-
-        let (root_name, schema, schema_hash) = self
-            .try_schema_service(&qualified_topic, &candidates[..], deadline)
-            .await?;
+        let (root_name, schema, schema_hash) =
+            self.try_schema_service(&qualified_topic, deadline).await?;
 
         Ok(DiscoveredTopicSchema {
             qualified_topic,
@@ -182,39 +334,24 @@ impl SchemaDiscovery {
         })
     }
 
-    async fn wait_for_topic_schema_candidates(
-        &self,
-        qualified_topic: &str,
-        deadline: Instant,
-    ) -> Result<Vec<TopicSchemaFingerprint>, DynamicError> {
-        let graph = &self.context.graph;
-        if tokio::time::timeout_at(
-            deadline,
-            graph.wait_until(|view| view.has_publishers_on(qualified_topic)),
-        )
-        .await
-        .is_err()
-        {
-            return Err(schema_query_timeout_error(qualified_topic, None));
-        }
-
-        collect_topic_schema_candidates(graph.as_ref(), qualified_topic)
-    }
-
     async fn try_schema_service(
         &self,
         qualified_topic: &str,
-        candidates: &[TopicSchemaFingerprint],
         deadline: Instant,
     ) -> Result<(String, Schema, SchemaHash), DynamicError> {
         let mut last_error = None;
+        let candidates = wait_for_visible_schema_service_candidates(
+            self.context.graph.as_ref(),
+            qualified_topic,
+            deadline,
+        )
+        .await?;
 
-        for candidate in candidates {
+        for candidate in &candidates {
             let Some(timeout) = schema_query_timeout(deadline) else {
-                return Err(schema_query_timeout_error(
-                    qualified_topic,
-                    last_error.as_ref(),
-                ));
+                return Err(last_error.unwrap_or_else(|| {
+                    schema_service_query_deadline_error(qualified_topic, &candidates)
+                }));
             };
 
             match tokio::time::timeout_at(
@@ -226,17 +363,15 @@ impl SchemaDiscovery {
                 Ok(Ok(result)) => return Ok(result),
                 Ok(Err(error)) => last_error = Some(error),
                 Err(_) => {
-                    return Err(schema_query_timeout_error(
-                        qualified_topic,
-                        last_error.as_ref(),
-                    ));
+                    return Err(last_error.unwrap_or_else(|| {
+                        schema_service_query_deadline_error(qualified_topic, &candidates)
+                    }));
                 }
             }
         }
 
-        Err(last_error.unwrap_or_else(|| {
-            DynamicError::SchemaNotFound("No schema service source succeeded".to_string())
-        }))
+        Err(last_error
+            .unwrap_or_else(|| schema_service_query_deadline_error(qualified_topic, &candidates)))
     }
 }
 
@@ -255,7 +390,7 @@ pub struct DynamicSubscriberDiscoveryBuilder {
     options: SubscriberOptions,
 }
 
-/// Builder for raw dynamic subscribers that discover schema metadata at build time.
+/// Builder for raw dynamic subscribers that discover type metadata at build time.
 #[derive(Debug)]
 pub struct DynamicRawSubscriberDiscoveryBuilder {
     context: EndpointBuilderContext,
@@ -288,6 +423,35 @@ async fn discover_dynamic_subscriber_builder(
         context,
         topic,
         MessageEndpointType::prevalidated_dynamic(discovered.type_info(), discovered.schema),
+    )
+    .options(options))
+}
+
+async fn discover_raw_subscriber_builder(
+    context: EndpointBuilderContext,
+    topic: String,
+    discovery_timeout: Duration,
+    options: SubscriberOptions,
+) -> crate::Result<SubscriberBuilder<RawPayload, RawPayloadCodec>> {
+    let qualified_topic = qualify_topic_name(&topic, &context.node.namespace, &context.node.name)
+        .map_err(|source| crate::Error::topic_name(topic.clone(), source))?;
+    let (_, candidates, _) = SchemaDiscovery::new(context.clone(), discovery_timeout)
+        .discover_qualified_candidates(qualified_topic.clone())
+        .await?;
+    let candidate = &candidates[0];
+    let type_info = TypeInfo::new(&candidate.type_name, candidate.schema_hash);
+
+    info!(
+        "[NOD] Discovered raw topic {}: {} (hash: {})",
+        qualified_topic,
+        type_info.name,
+        type_info.hash.to_hash_string()
+    );
+
+    Ok(SubscriberBuilder::<RawPayload, RawPayloadCodec>::new(
+        context,
+        topic,
+        MessageEndpointType::type_info_only(type_info),
     )
     .options(options))
 }
@@ -337,9 +501,9 @@ impl DynamicSubscriberDiscoveryBuilder {
 
     /// Switch this discovery builder to raw sample delivery.
     ///
-    /// Schema discovery still runs at build time so the subscriber advertises
-    /// the discovered dynamic type metadata, but received samples are returned
-    /// without deserialization.
+    /// Publisher type discovery still runs at build time so the subscriber
+    /// advertises the discovered dynamic type metadata, but received samples are
+    /// returned without deserialization and schema-service lookup.
     pub fn raw(self) -> DynamicRawSubscriberDiscoveryBuilder {
         DynamicRawSubscriberDiscoveryBuilder {
             context: self.context,
@@ -389,7 +553,7 @@ impl DynamicRawSubscriberDiscoveryBuilder {
         self
     }
 
-    /// Discover the topic schema and build a raw dynamic subscriber.
+    /// Discover topic type metadata and build a raw dynamic subscriber.
     pub async fn build(self) -> crate::Result<RawSubscriber> {
         let Self {
             context,
@@ -398,7 +562,7 @@ impl DynamicRawSubscriberDiscoveryBuilder {
             options,
         } = self;
 
-        discover_dynamic_subscriber_builder(context, topic, discovery_timeout, options)
+        discover_raw_subscriber_builder(context, topic, discovery_timeout, options)
             .await?
             .raw()
             .build()
@@ -408,21 +572,8 @@ impl DynamicRawSubscriberDiscoveryBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use super::*;
-    use crate::context::ContextBuilder;
     use crate::entity::{EndpointKind, NodeEntity, SchemaHash, TypeInfo};
-
-    fn unique_node_name(prefix: &str) -> String {
-        format!(
-            "{prefix}_{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("system clock should be after Unix epoch")
-                .as_nanos()
-        )
-    }
 
     fn publisher(type_name: &str) -> EndpointEntity {
         EndpointEntity {
@@ -465,27 +616,314 @@ mod tests {
         }
     }
 
-    #[test]
-    fn topic_schema_fingerprints_from_publishers_returns_canonical_schema_identity() {
-        let hash = SchemaHash([7; 32]);
-        let talker_b = publisher_with_hash_from_node("std_msgs::String", hash, "talker_b", 3);
-        let mut duplicate_talker_b =
-            publisher_with_hash_from_node("std_msgs::String", hash, "talker_b", 3);
-        duplicate_talker_b.id = 99;
-        let talker_a = publisher_with_hash_from_node("std_msgs::String", hash, "talker_a", 2);
+    fn schema_service_for_node(node_name: &str, node_id: usize) -> EndpointEntity {
+        EndpointEntity {
+            id: 100 + node_id,
+            node: NodeEntity {
+                z_id: Default::default(),
+                id: node_id,
+                name: node_name.to_string(),
+                namespace: "/".to_string(),
+            },
+            kind: EndpointKind::Service,
+            topic: format!("/{node_name}/get_schema"),
+            type_info: TypeInfo::new("ros_z::GetSchema", SchemaHash::zero()),
+            qos: Default::default(),
+        }
+    }
 
-        let fingerprints =
-            topic_schema_fingerprints_from_publishers(&[talker_b, duplicate_talker_b, talker_a]);
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn topic_candidate_wait_returns_existing_publishers_at_expired_deadline() {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .expect("open Zenoh session");
+        let graph = Graph::new(&session).await.expect("create graph");
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(publisher(
+                "std_msgs::String",
+            )))
+            .expect("add publisher");
 
-        assert_eq!(fingerprints.len(), 2);
-        assert_eq!(fingerprints[0].topic, "/chatter");
-        assert_eq!(fingerprints[0].node_namespace, "/");
-        assert_eq!(fingerprints[0].node_name, "talker_a");
-        assert_eq!(
-            fingerprints[0].type_info,
-            TypeInfo::new("std_msgs::String", hash)
+        let candidates =
+            wait_for_topic_schema_candidates(&graph, "/chatter", tokio::time::Instant::now())
+                .await
+                .expect("publisher is visible at expired deadline");
+
+        assert_eq!(candidates.len(), 1);
+
+        session.close().await.expect("close Zenoh session");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn visible_schema_service_wait_returns_existing_services_at_expired_deadline() {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .expect("open Zenoh session");
+        let graph = Graph::new(&session).await.expect("create graph");
+        let hash = SchemaHash([1; 32]);
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node("std_msgs::String", hash, "talker", 2),
+            ))
+            .expect("add publisher");
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(schema_service_for_node(
+                "talker", 2,
+            )))
+            .expect("add schema service");
+
+        let visible = wait_for_visible_schema_service_candidates(
+            &graph,
+            "/chatter",
+            tokio::time::Instant::now(),
+        )
+        .await
+        .expect("schema service is visible at expired deadline");
+
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].node_name, "talker");
+
+        session.close().await.expect("close Zenoh session");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn visible_schema_service_wait_reports_no_schema_services_at_deadline() {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .expect("open Zenoh session");
+        let graph = Graph::new(&session).await.expect("create graph");
+        let hash = SchemaHash([1; 32]);
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node(
+                    "std_msgs::String",
+                    hash,
+                    "talker_without_service",
+                    2,
+                ),
+            ))
+            .expect("add publisher");
+
+        let error = wait_for_visible_schema_service_candidates(
+            &graph,
+            "/chatter",
+            tokio::time::Instant::now(),
+        )
+        .await
+        .expect_err("publisher without visible schema service should fail at deadline");
+
+        let DynamicError::NoSchemaServices { topic, candidates } = error else {
+            panic!("expected no schema services error, got {error:?}");
+        };
+        assert_eq!(topic, "/chatter");
+        assert_eq!(candidates.len(), 1);
+        assert!(candidates[0].contains("talker_without_service"));
+        assert!(candidates[0].contains("std_msgs::String"));
+
+        session.close().await.expect("close Zenoh session");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn try_schema_service_reports_timeout_when_visible_service_budget_elapsed() {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .expect("open Zenoh session");
+        let graph = std::sync::Arc::new(Graph::new(&session).await.expect("create graph"));
+        let hash = SchemaHash([1; 32]);
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node("std_msgs::String", hash, "talker", 2),
+            ))
+            .expect("add publisher");
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(schema_service_for_node(
+                "talker", 2,
+            )))
+            .expect("add visible schema service");
+        let context = EndpointBuilderContext::new(
+            session.clone(),
+            graph,
+            std::sync::Arc::new(crate::context::GlobalCounter::default()),
+            NodeEntity {
+                z_id: Default::default(),
+                id: 10,
+                name: "listener".to_string(),
+                namespace: "/".to_string(),
+            },
+            crate::time::Clock::default(),
+            None,
+            None,
         );
-        assert_eq!(fingerprints[1].node_name, "talker_b");
+        let discovery = SchemaDiscovery::new(context, Duration::ZERO);
+
+        let error = discovery
+            .try_schema_service("/chatter", tokio::time::Instant::now())
+            .await
+            .expect_err("elapsed query budget should fail without denying service visibility");
+
+        let DynamicError::Runtime { operation, source } = error else {
+            panic!("expected runtime timeout for visible schema service, got {error:?}");
+        };
+        assert_eq!(operation, "query visible schema service");
+        assert!(
+            source.to_string().contains("deadline expired"),
+            "unexpected timeout message: {source}"
+        );
+
+        session.close().await.expect("close Zenoh session");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn visible_schema_service_wait_rejects_current_conflicts_before_visible_service() {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .expect("open Zenoh session");
+        let graph = Graph::new(&session).await.expect("create graph");
+        let hash = SchemaHash([3; 32]);
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node("std_msgs::String", hash, "talker", 2),
+            ))
+            .expect("add first publisher");
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node("custom_msgs::StringLike", hash, "other_talker", 3),
+            ))
+            .expect("add conflicting publisher");
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(schema_service_for_node(
+                "talker", 2,
+            )))
+            .expect("add schema service");
+
+        let error = wait_for_visible_schema_service_candidates(
+            &graph,
+            "/chatter",
+            tokio::time::Instant::now(),
+        )
+        .await
+        .expect_err("current publisher conflicts should win over visible services");
+
+        let DynamicError::TopicTypeConflict { topic, candidates } = error else {
+            panic!("expected topic type conflict, got {error:?}");
+        };
+        assert_eq!(topic, "/chatter");
+        assert_eq!(candidates.len(), 2);
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.contains("std_msgs::String"))
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.contains("custom_msgs::StringLike"))
+        );
+
+        session.close().await.expect("close Zenoh session");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn visible_schema_service_wait_rechecks_topic_candidates_after_graph_change() {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .expect("open Zenoh session");
+        let graph = Graph::new(&session).await.expect("create graph");
+        let hash = SchemaHash([1; 32]);
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node("std_msgs::String", hash, "talker", 2),
+            ))
+            .expect("add initial publisher");
+
+        let wait = wait_for_visible_schema_service_candidates(
+            &graph,
+            "/chatter",
+            tokio::time::Instant::now() + Duration::from_secs(1),
+        );
+        tokio::pin!(wait);
+
+        tokio::select! {
+            result = &mut wait => panic!("wait finished before late schema service appeared: {result:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
+
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(
+                publisher_with_hash_from_node("std_msgs::String", hash, "late_talker", 3),
+            ))
+            .expect("add late publisher");
+        graph
+            .add_local_entity(crate::entity::Entity::Endpoint(schema_service_for_node(
+                "late_talker",
+                3,
+            )))
+            .expect("add late schema service");
+
+        let visible = wait.await.expect("late schema service becomes visible");
+
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].node_name, "late_talker");
+
+        session.close().await.expect("close Zenoh session");
+    }
+
+    #[test]
+    fn discovery_topic_qualification_errors_preserve_original_topic() {
+        let error = qualify_topic_for_discovery("", "/", "listener")
+            .expect_err("empty topic fails discovery topic qualification");
+
+        let DynamicError::TopicName { topic, source } = error else {
+            panic!("expected topic-name error");
+        };
+
+        assert_eq!(topic, "");
+        assert_eq!(source, crate::topic_name::TopicNameError::Empty);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn discover_topic_schema_rejects_empty_topic_name() {
+        let context = crate::context::ContextBuilder::default()
+            .disable_multicast_scouting()
+            .with_json("connect/endpoints", serde_json::json!([]))
+            .build()
+            .await
+            .expect("create test context");
+        let node = context
+            .create_node("listener")
+            .without_schema_service()
+            .build()
+            .await
+            .expect("create test node");
+
+        let result = node
+            .discover_topic_schema("", Duration::from_millis(1))
+            .await;
+        context.shutdown().expect("shutdown test context");
+        let error = result.expect_err("empty topic fails discovery API");
+
+        let DynamicError::TopicName { topic, source } = error else {
+            panic!("expected topic-name error");
+        };
+
+        assert_eq!(topic, "");
+        assert_eq!(source, crate::topic_name::TopicNameError::Empty);
+    }
+
+    #[test]
+    fn candidate_schema_service_name_uses_get_schema_private_service() {
+        let candidate = TopicSchemaCandidate {
+            node_name: "talker".to_string(),
+            namespace: "/robot".to_string(),
+            type_name: "std_msgs::String".to_string(),
+            schema_hash: SchemaHash::zero(),
+        };
+
+        let service_name = candidate
+            .schema_service_name("testing schema service helper")
+            .expect("valid candidate service name");
+
+        assert_eq!(service_name, "/robot/talker/get_schema");
     }
 
     #[test]
@@ -504,88 +942,46 @@ mod tests {
         assert!(timeout <= Duration::from_secs(1));
     }
 
-    #[test]
-    fn schema_query_timeout_error_reports_timeout_without_candidate_error() {
-        let error = schema_query_timeout_error("/chatter", None);
-
-        let DynamicError::SchemaNotFound(message) = error else {
-            panic!("expected schema not found timeout, got {error:?}");
-        };
-        assert!(message.contains("Timed out"));
-        assert!(message.contains("/chatter"));
-    }
-
-    #[test]
-    fn schema_query_timeout_error_keeps_candidate_error_as_context() {
-        let error = schema_query_timeout_error(
-            "/chatter",
-            Some(&DynamicError::SerializationError(
-                "candidate failed".to_string(),
-            )),
-        );
-
-        let DynamicError::SchemaNotFound(message) = error else {
-            panic!("expected timeout schema not found, got {error:?}");
-        };
-        assert!(message.contains("Timed out"));
-        assert!(message.contains("/chatter"));
-        assert!(message.contains("candidate failed"));
-    }
-
     #[tokio::test(flavor = "multi_thread")]
-    async fn schema_candidate_wait_reports_timeout_when_no_publishers_arrive() {
-        let context = ContextBuilder::default()
-            .build()
+    async fn schema_candidate_wait_reports_no_publishers_when_none_arrive() {
+        let session = zenoh::open(zenoh::Config::default())
             .await
-            .expect("test context should build");
-        let node = context
-            .create_node(unique_node_name("schema_candidate_timeout"))
-            .build()
-            .await
-            .expect("test node should build");
-        let discovery_context = EndpointBuilderContext::new(
-            node.session().clone(),
-            node.graph().clone(),
-            node.counter().clone(),
-            node.node_entity().clone(),
-            node.clock().clone(),
-            None,
-            node.schema_service().map(|service| service.registrar()),
-        );
-        let discovery = SchemaDiscovery::new(discovery_context, Duration::from_millis(1));
+            .expect("open Zenoh session");
+        let graph = Graph::new(&session).await.expect("create graph");
 
-        let error = discovery
-            .wait_for_topic_schema_candidates("/missing_schema_timeout", Instant::now())
-            .await
-            .expect_err("elapsed publisher wait should report timeout");
+        let error =
+            wait_for_topic_schema_candidates(&graph, "/missing_schema_timeout", Instant::now())
+                .await
+                .expect_err("elapsed publisher wait should report missing publishers");
 
-        let DynamicError::SchemaNotFound(message) = error else {
-            panic!("expected timeout schema not found, got {error:?}");
+        let DynamicError::NoPublishers { topic } = error else {
+            panic!("expected no publishers, got {error:?}");
         };
-        assert!(message.contains("Timed out"));
-        assert!(message.contains("/missing_schema_timeout"));
+        assert_eq!(topic, "/missing_schema_timeout");
+
+        session.close().await.expect("close Zenoh session");
     }
 
     #[test]
     fn publisher_schema_candidates_keep_native_advertised_type_name() {
-        let candidates = collect_topic_schema_fingerprints_from_publishers(
+        let candidates = collect_topic_schema_candidates_from_publishers(
             &[publisher("std_msgs::String")],
             "/chatter",
         )
         .expect("candidate");
 
-        assert_eq!(candidates[0].type_info.name, "std_msgs::String");
+        assert_eq!(candidates[0].type_name, "std_msgs::String");
     }
 
     #[test]
     fn publisher_schema_candidates_do_not_normalize_dds_shaped_names() {
-        let candidates = collect_topic_schema_fingerprints_from_publishers(
+        let candidates = collect_topic_schema_candidates_from_publishers(
             &[publisher("std_msgs::msg::dds_::String_")],
             "/chatter",
         )
         .expect("candidate");
 
-        assert_eq!(candidates[0].type_info.name, "std_msgs::msg::dds_::String_");
+        assert_eq!(candidates[0].type_name, "std_msgs::msg::dds_::String_");
     }
 
     #[test]
@@ -605,12 +1001,11 @@ mod tests {
             qos: Default::default(),
         };
 
-        let candidates =
-            collect_topic_schema_fingerprints_from_publishers(&[publisher], "/chatter")
-                .expect("candidate");
+        let candidates = collect_topic_schema_candidates_from_publishers(&[publisher], "/chatter")
+            .expect("candidate");
 
-        assert_eq!(candidates[0].type_info.name, "std_msgs::String");
-        assert_eq!(candidates[0].type_info.hash, hash);
+        assert_eq!(candidates[0].type_name, "std_msgs::String");
+        assert_eq!(candidates[0].schema_hash, hash);
     }
 
     #[test]
@@ -621,16 +1016,57 @@ mod tests {
             publisher_with_hash_from_node("std_msgs::String", hash, "talker_b", 3),
         ];
 
-        let candidates = collect_topic_schema_fingerprints_from_publishers(&publishers, "/chatter")
+        let candidates = collect_topic_schema_candidates_from_publishers(&publishers, "/chatter")
             .expect("matching publishers should remain query candidates");
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].node_name, "talker_a");
-        assert_eq!(candidates[0].type_info.name, "std_msgs::String");
-        assert_eq!(candidates[0].type_info.hash, hash);
+        assert_eq!(candidates[0].type_name, "std_msgs::String");
+        assert_eq!(candidates[0].schema_hash, hash);
         assert_eq!(candidates[1].node_name, "talker_b");
-        assert_eq!(candidates[1].type_info.name, "std_msgs::String");
-        assert_eq!(candidates[1].type_info.hash, hash);
+        assert_eq!(candidates[1].type_name, "std_msgs::String");
+        assert_eq!(candidates[1].schema_hash, hash);
+    }
+
+    #[test]
+    fn visible_schema_services_filter_compatible_candidates_before_querying() {
+        let hash = SchemaHash([1; 32]);
+        let publishers = vec![
+            publisher_with_hash_from_node("std_msgs::String", hash, "talker_without_service", 2),
+            publisher_with_hash_from_node("std_msgs::String", hash, "talker_with_service", 3),
+        ];
+        let candidates = collect_topic_schema_candidates_from_publishers(&publishers, "/chatter")
+            .expect("matching publishers should remain query candidates");
+        let visible_services = vec![schema_service_for_node("talker_with_service", 3)];
+
+        let visible_candidates =
+            collect_visible_schema_service_candidates(&candidates, &visible_services)
+                .expect("valid candidate service names");
+
+        assert_eq!(visible_candidates.len(), 1);
+        assert_eq!(visible_candidates[0].node_name, "talker_with_service");
+        assert_eq!(
+            TypeInfo::new(
+                &visible_candidates[0].type_name,
+                visible_candidates[0].schema_hash,
+            ),
+            TypeInfo::new("std_msgs::String", hash)
+        );
+    }
+
+    #[test]
+    fn schema_candidates_reject_missing_publishers_with_topic_error() {
+        let error = collect_topic_schema_candidates_from_publishers(&[], "/missing")
+            .expect_err("missing publishers should fail");
+
+        assert!(matches!(
+            &error,
+            DynamicError::NoPublishers { topic } if topic == "/missing"
+        ));
+        assert_eq!(
+            error.to_string(),
+            "no publishers found for topic '/missing'"
+        );
     }
 
     #[test]
@@ -640,11 +1076,11 @@ mod tests {
             publisher_with_hash("std_msgs::String", SchemaHash([2; 32])),
         ];
 
-        let error = collect_topic_schema_fingerprints_from_publishers(&publishers, "/chatter")
+        let error = collect_topic_schema_candidates_from_publishers(&publishers, "/chatter")
             .expect_err("different schema hashes should conflict");
 
-        let DynamicError::SchemaConflict { topic, candidates } = error else {
-            panic!("expected schema conflict, got {error:?}");
+        let DynamicError::TopicTypeConflict { topic, candidates } = error else {
+            panic!("expected topic type conflict, got {error:?}");
         };
 
         assert_eq!(topic, "/chatter");
@@ -667,11 +1103,11 @@ mod tests {
             publisher_with_hash("custom_msgs::StringLike", hash),
         ];
 
-        let error = collect_topic_schema_fingerprints_from_publishers(&publishers, "/chatter")
+        let error = collect_topic_schema_candidates_from_publishers(&publishers, "/chatter")
             .expect_err("different type names should conflict even with same hash");
 
-        let DynamicError::SchemaConflict { topic, candidates } = error else {
-            panic!("expected schema conflict, got {error:?}");
+        let DynamicError::TopicTypeConflict { topic, candidates } = error else {
+            panic!("expected topic type conflict, got {error:?}");
         };
 
         assert_eq!(topic, "/chatter");

--- a/crates/ros-z/src/dynamic/error.rs
+++ b/crates/ros-z/src/dynamic/error.rs
@@ -126,6 +126,17 @@ pub enum DynamicError {
         candidates: Vec<String>,
     },
 
+    /// Schema discovery timed out while querying visible schema services.
+    #[error(
+        "schema discovery timed out while querying visible schema services for topic '{topic}' among candidates: {candidates:?}"
+    )]
+    SchemaDiscoveryTimeout {
+        topic: String,
+        candidates: Vec<String>,
+        #[source]
+        source: Option<crate::error::BoxError>,
+    },
+
     /// Active publishers advertise incompatible type metadata for one topic.
     #[error("topic '{topic}' has incompatible publisher type metadata: {candidates:?}")]
     TopicTypeConflict {

--- a/crates/ros-z/src/dynamic/error.rs
+++ b/crates/ros-z/src/dynamic/error.rs
@@ -44,8 +44,8 @@ pub enum DynamicError {
         source: ros_z_schema::SchemaError,
     },
 
-    /// Name qualification error.
-    #[error("failed to qualify name while {operation}: {source}")]
+    /// Schema service name qualification error.
+    #[error("failed to qualify schema service name while {operation}: {source}")]
     Name {
         operation: &'static str,
         #[source]
@@ -90,6 +90,14 @@ pub enum DynamicError {
     #[error("schema '{0}' not found in registry")]
     SchemaNotFound(String),
 
+    /// Topic name qualification failed during dynamic discovery.
+    #[error("invalid topic name '{topic}': {source}")]
+    TopicName {
+        topic: String,
+        #[source]
+        source: crate::topic_name::TopicNameError,
+    },
+
     /// Schema service call failed.
     #[error("schema service failed for node '{node}' on service '{service}': {source}")]
     SchemaService {
@@ -105,9 +113,22 @@ pub enum DynamicError {
     )]
     MissingNodeIdentity { topic: String },
 
-    /// Active publishers advertise incompatible schema identities for one topic.
-    #[error("topic '{topic}' has incompatible dynamic schema candidates: {candidates:?}")]
-    SchemaConflict {
+    /// No publishers are currently known for a topic that requires publisher metadata.
+    #[error("no publishers found for topic '{topic}'")]
+    NoPublishers { topic: String },
+
+    /// Compatible publishers exist, but none expose a visible schema service.
+    #[error(
+        "no visible schema services found for topic '{topic}' among compatible publishers: {candidates:?}"
+    )]
+    NoSchemaServices {
+        topic: String,
+        candidates: Vec<String>,
+    },
+
+    /// Active publishers advertise incompatible type metadata for one topic.
+    #[error("topic '{topic}' has incompatible publisher type metadata: {candidates:?}")]
+    TopicTypeConflict {
         topic: String,
         candidates: Vec<String>,
     },
@@ -154,5 +175,23 @@ impl DynamicError {
             service: service.into(),
             source,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_schema_services_error_names_topic_and_candidates() {
+        let error = DynamicError::NoSchemaServices {
+            topic: "/chatter".to_string(),
+            candidates: vec!["/talker:std_msgs::String@abc123".to_string()],
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "no visible schema services found for topic '/chatter' among compatible publishers: [\"/talker:std_msgs::String@abc123\"]"
+        );
     }
 }

--- a/crates/ros-z/src/dynamic/mod.rs
+++ b/crates/ros-z/src/dynamic/mod.rs
@@ -83,7 +83,6 @@ mod tests;
 pub use codec::{DynamicCdrCodec, DynamicPayload};
 pub use discovery::{
     DiscoveredTopicSchema, DynamicRawSubscriberDiscoveryBuilder, DynamicSubscriberDiscoveryBuilder,
-    TopicSchemaFingerprint, topic_schema_fingerprints_from_publishers,
 };
 pub use error::DynamicError;
 pub use json::{

--- a/crates/ros-z/src/dynamic/mod.rs
+++ b/crates/ros-z/src/dynamic/mod.rs
@@ -83,6 +83,7 @@ mod tests;
 pub use codec::{DynamicCdrCodec, DynamicPayload};
 pub use discovery::{
     DiscoveredTopicSchema, DynamicRawSubscriberDiscoveryBuilder, DynamicSubscriberDiscoveryBuilder,
+    TopicSchemaFingerprint, topic_schema_fingerprints_from_publishers,
 };
 pub use error::DynamicError;
 pub use json::{

--- a/crates/ros-z/src/dynamic/schema_query.rs
+++ b/crates/ros-z/src/dynamic/schema_query.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tracing::{debug, warn};
 
 use super::schema_service::{GetSchema, GetSchemaRequest, GetSchemaResponse};
-use super::{discovery::TopicSchemaFingerprint, error::DynamicError, schema::Schema};
+use super::{discovery::TopicSchemaCandidate, error::DynamicError, schema::Schema};
 use crate::endpoint_builder::{EndpointBuilderContext, service_endpoint_type};
 use crate::entity::SchemaHash;
 use crate::{service::ServiceClientBuilder, topic_name::qualify_remote_private_service_name};
@@ -49,10 +49,10 @@ fn request_schema_hash(discovered_hash: &SchemaHash) -> String {
     discovered_hash.to_hash_string()
 }
 
-fn build_schema_request(fingerprint: &TopicSchemaFingerprint) -> GetSchemaRequest {
+fn build_schema_request(candidate: &TopicSchemaCandidate) -> GetSchemaRequest {
     GetSchemaRequest {
-        root_type_name: fingerprint.type_info.name.clone(),
-        schema_hash: request_schema_hash(&fingerprint.type_info.hash),
+        root_type_name: candidate.type_name.clone(),
+        schema_hash: request_schema_hash(&candidate.schema_hash),
     }
 }
 
@@ -97,26 +97,18 @@ fn validate_response_hash(
 
 pub(crate) async fn query_schema(
     context: &EndpointBuilderContext,
-    fingerprint: &TopicSchemaFingerprint,
+    candidate: &TopicSchemaCandidate,
     timeout: Duration,
 ) -> Result<(String, Schema, SchemaHash), DynamicError> {
     debug!(
         "[SCH] Querying schema: node={}/{}, type={}",
-        fingerprint.node_namespace, fingerprint.node_name, fingerprint.type_info.name
+        candidate.namespace, candidate.node_name, candidate.type_name
     );
 
-    let service_name = qualify_remote_private_service_name(
-        "get_schema",
-        &fingerprint.node_namespace,
-        &fingerprint.node_name,
-    )
-    .map_err(|error| DynamicError::name("querying remote schema", error))?;
-    let node_fqn = qualify_remote_private_service_name(
-        "",
-        &fingerprint.node_namespace,
-        &fingerprint.node_name,
-    )
-    .map_err(|error| DynamicError::name("querying remote schema", error))?;
+    let service_name = candidate.schema_service_name("querying remote schema")?;
+    let node_fqn =
+        qualify_remote_private_service_name("", &candidate.namespace, &candidate.node_name)
+            .map_err(|error| DynamicError::name("querying remote schema", error))?;
 
     let client = ServiceClientBuilder::<GetSchema>::new(
         context.clone(),
@@ -126,7 +118,7 @@ pub(crate) async fn query_schema(
     .build()
     .await
     .map_err(|error| DynamicError::runtime("create schema service client", error))?;
-    let request = build_schema_request(fingerprint);
+    let request = build_schema_request(candidate);
 
     let response = match client.call_with_timeout_async(&request, timeout).await {
         Ok(response) => response,
@@ -139,7 +131,7 @@ pub(crate) async fn query_schema(
     };
 
     if response.successful {
-        schema_from_response_for_fingerprint(&response, fingerprint)
+        schema_from_response_for_candidate(&response, candidate)
     } else {
         warn!("[SCH] Schema query failed: {}", response.failure_reason);
         Err(DynamicError::SerializationError(response.failure_reason))
@@ -192,9 +184,9 @@ pub fn schema_from_response_with_hash(
     response_schema(response)
 }
 
-pub(crate) fn schema_from_response_for_fingerprint(
+pub(crate) fn schema_from_response_for_candidate(
     response: &GetSchemaResponse,
-    fingerprint: &TopicSchemaFingerprint,
+    candidate: &TopicSchemaCandidate,
 ) -> Result<(String, Schema, SchemaHash), DynamicError> {
     if !response.successful {
         return Err(DynamicError::SerializationError(format!(
@@ -203,8 +195,8 @@ pub(crate) fn schema_from_response_for_fingerprint(
         )));
     }
 
-    let schema_hash = validate_response_hash(response, Some(fingerprint.type_info.hash))?;
-    let root_name = response_root_name_or_expected(response, &fingerprint.type_info.name)?;
+    let schema_hash = validate_response_hash(response, Some(candidate.schema_hash))?;
+    let root_name = response_root_name_or_expected(response, &candidate.type_name)?;
     let schema = response_schema(response)?;
     Ok((root_name.to_string(), schema, schema_hash))
 }
@@ -214,8 +206,6 @@ mod tests {
     use ros_z_schema::{SchemaBundle, StructDef, TypeDef, TypeDefinition, TypeName};
 
     use super::*;
-    use crate::entity::TypeInfo;
-
     fn empty_struct_bundle(root_type: &str) -> SchemaBundle {
         let root_type = TypeName::new(root_type).unwrap();
         SchemaBundle {
@@ -229,7 +219,7 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_schema_response_rejects_mismatched_root_even_when_hash_matches() {
+    fn candidate_schema_response_rejects_mismatched_root_even_when_hash_matches() {
         let schema = empty_struct_bundle("test_msgs::Wrong");
         let schema_hash = ros_z_schema::compute_hash(&schema).unwrap();
         let response = GetSchemaResponse {
@@ -238,14 +228,14 @@ mod tests {
             schema,
             failure_reason: String::new(),
         };
-        let fingerprint = TopicSchemaFingerprint {
-            topic: "/chatter".to_string(),
-            node_namespace: "/robot".to_string(),
+        let candidate = TopicSchemaCandidate {
+            namespace: "/robot".to_string(),
             node_name: "talker".to_string(),
-            type_info: TypeInfo::new("test_msgs::Expected", schema_hash),
+            type_name: "test_msgs::Expected".to_string(),
+            schema_hash,
         };
 
-        let error = schema_from_response_for_fingerprint(&response, &fingerprint).unwrap_err();
+        let error = schema_from_response_for_candidate(&response, &candidate).unwrap_err();
 
         assert!(error.to_string().contains("root"));
         assert!(error.to_string().contains("test_msgs::Expected"));

--- a/crates/ros-z/src/endpoint_builder.rs
+++ b/crates/ros-z/src/endpoint_builder.rs
@@ -110,6 +110,9 @@ pub(crate) enum MessageEndpointType {
         schema: Schema,
         validation: DynamicSchemaValidation,
     },
+    TypeInfoOnly {
+        type_info: TypeInfo,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -131,6 +134,10 @@ impl std::fmt::Debug for MessageEndpointType {
                 .field("type_info", type_info)
                 .field("validation", validation)
                 .finish_non_exhaustive(),
+            Self::TypeInfoOnly { type_info } => f
+                .debug_struct("MessageEndpointType::TypeInfoOnly")
+                .field("type_info", type_info)
+                .finish(),
         }
     }
 }
@@ -150,6 +157,10 @@ impl MessageEndpointType {
             schema,
             validation: DynamicSchemaValidation::Prevalidated,
         }
+    }
+
+    pub(crate) fn type_info_only(type_info: TypeInfo) -> Self {
+        Self::TypeInfoOnly { type_info }
     }
 }
 
@@ -252,6 +263,13 @@ impl MessageEndpointType {
                     .map_err(|source| Self::dynamic_schema_error("publisher", topic, source))?;
                 Ok((type_info, Some(schema)))
             }
+            Self::TypeInfoOnly { .. } => Err(Self::dynamic_schema_error(
+                "publisher",
+                topic,
+                DynamicError::SerializationError(
+                    "type-only message endpoint metadata cannot be used for publishers".into(),
+                ),
+            )),
         }
     }
 
@@ -275,6 +293,7 @@ impl MessageEndpointType {
                 )?;
                 Ok((type_info, Some(schema)))
             }
+            Self::TypeInfoOnly { type_info } => Ok((type_info, None)),
         }
     }
 }

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -471,7 +471,15 @@ impl Node {
         )
     }
 
-    /// Discover the schema exposed by publishers on a topic.
+    /// Discover the schema that publishers expose on a topic.
+    ///
+    /// This method qualifies `topic`, waits up to `discovery_timeout` for at
+    /// least one publisher on that qualified topic, waits for a visible schema
+    /// service from a compatible publisher, and then queries that service.
+    ///
+    /// Returns an error when the topic name is invalid, no publisher appears
+    /// before the timeout expires, active publishers advertise conflicting type
+    /// metadata, or schema service discovery/querying fails.
     ///
     /// The topic name is qualified according to the same ros-z graph-name rules as the
     /// regular publisher and subscriber builder APIs.
@@ -479,7 +487,7 @@ impl Node {
     /// Discovery waits up to `discovery_timeout` for a matching publisher to appear in
     /// the graph. Once publishers are available, the remaining timeout budget is used
     /// to query their schema services. If no matching publisher appears before the
-    /// timeout expires, this returns [`DynamicError::SchemaNotFound`].
+    /// timeout expires, this returns [`DynamicError::NoPublishers`].
     pub async fn discover_topic_schema(
         &self,
         topic: &str,
@@ -492,14 +500,16 @@ impl Node {
 
     /// Create a dynamic subscriber builder with automatic schema discovery.
     ///
-    /// This method returns a discovery builder immediately. When you build it,
-    /// the builder queries publishers on the topic for their schema service and
-    /// creates a dynamic subscriber from the discovered schema. This is useful
-    /// when you don't know the message type at compile time.
+    /// This method returns a discovery builder immediately. Building the default
+    /// dynamic subscriber waits for publishers and queries a compatible
+    /// publisher's schema service before creating the subscriber. Switching to
+    /// [`raw`](crate::dynamic::DynamicSubscriberDiscoveryBuilder::raw) only
+    /// discovers publisher type metadata. Use this when the message type is not
+    /// known at compile time.
     ///
     /// When the builder is built, `discovery_timeout` covers both waiting for a
     /// matching publisher and querying schema services. If no matching publisher
-    /// appears before the timeout expires, build returns [`DynamicError::SchemaNotFound`].
+    /// appears before the timeout expires, build returns [`DynamicError::NoPublishers`].
     ///
     /// The topic name will be qualified as a ros-z graph name:
     /// - Absolute topics (starting with '/') are used as-is
@@ -515,6 +525,12 @@ impl Node {
     ///
     /// A dynamic subscriber discovery builder. Schema discovery runs when the
     /// builder is built.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the topic name is invalid, no publishers appear
+    /// before the timeout expires, active publishers advertise conflicting type
+    /// metadata, or schema discovery fails.
     ///
     /// # Example
     ///

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -8,7 +8,7 @@ mod subscriber;
 
 pub use metadata::{PublicationId, Received};
 pub use publisher::{PreparedPublication, Publisher, PublisherBuilder};
-pub use raw::{RawSubscriber, RawSubscriberBuilder};
+pub use raw::{RawPayload, RawPayloadCodec, RawSubscriber, RawSubscriberBuilder};
 pub(crate) use subscriber::SubscriberOptions;
 pub use subscriber::{Subscriber, SubscriberBuilder};
 

--- a/crates/ros-z/src/pubsub/raw.rs
+++ b/crates/ros-z/src/pubsub/raw.rs
@@ -1,12 +1,34 @@
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 
 use zenoh::sample::Sample;
 
 use crate::Result;
+use crate::message::WireDecoder;
 use crate::pubsub::subscriber::{SubscriberBuilder, SubscriberResources};
 use crate::qos::QosProfile;
 use crate::queue::BoundedQueue;
+
+/// Marker payload for schema-free raw subscribers.
+///
+/// The raw subscriber path never decodes payload bytes into this type. It only
+/// needs a concrete payload/codec pair so it can reuse the normal subscriber
+/// builder and advertise discovered topic type metadata.
+pub struct RawPayload;
+
+/// No-op decoder used by schema-free raw subscribers.
+pub struct RawPayloadCodec;
+
+impl WireDecoder for RawPayloadCodec {
+    type Input<'a> = &'a [u8];
+    type Output = RawPayload;
+    type Error = Infallible;
+
+    fn deserialize(_input: Self::Input<'_>) -> std::result::Result<Self::Output, Self::Error> {
+        Ok(RawPayload)
+    }
+}
 
 /// Subscriber that receives raw Zenoh samples.
 ///

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -685,22 +685,11 @@ impl TransientLocalCache {
     }
 }
 
-fn format_endpoint_global_id_hex(endpoint_global_id: EndpointGlobalId) -> String {
-    endpoint_global_id
-        .as_bytes()
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect()
-}
-
 pub(crate) fn transient_local_replay_key(
     topic_key_expr: impl std::fmt::Display,
     publisher_global_id: EndpointGlobalId,
 ) -> String {
-    format!(
-        "{topic_key_expr}/__ros_z_transient_local/{}",
-        format_endpoint_global_id_hex(publisher_global_id)
-    )
+    format!("{topic_key_expr}/__ros_z_transient_local/{publisher_global_id}")
 }
 
 pub(crate) fn transient_local_cache_capacity(

--- a/crates/ros-z/tests/pubsub.rs
+++ b/crates/ros-z/tests/pubsub.rs
@@ -343,7 +343,7 @@ async fn endpoint_factories_defer_topic_errors_to_build() {
         .expect_err("invalid schema-discovery topic should fail before graph lookup");
     assert!(matches!(
         schema_discovery_error,
-        ros_z::dynamic::DynamicError::Name { .. }
+        ros_z::dynamic::DynamicError::TopicName { topic, .. } if topic == "bad%topic"
     ));
 }
 


### PR DESCRIPTION
## Overview

Adds `rosz hz` for topic frequency estimation. The command reports local receive-rate stats plus per-publisher source-rate stats, with compact text output and JSON-lines support.

## Motivation

`rosz echo` is useful for inspecting payloads, but frequency checks only need raw samples and timing metadata. This gives operators a quick `ros2 topic hz`-style check without requiring schema discovery or payload decoding.

## Implementation Guide

- `ros-z`: extends automatic dynamic subscriber discovery with `.raw()`, discovering publisher `TypeInfo` from graph metadata and building a raw subscriber without querying schema services.
- `ros-z-cli`: adds `hz` parsing, rolling interval stats, count/duration/continuous modes, compact text rendering, and JSON report objects.
- Tests cover parser validation, rolling stats, duration scheduling edge cases, and an e2e publisher with schema service disabled.

## Verification

- `cargo fmt --check`
- `cargo test --doc -p ros-z`
- `cargo nextest run -p ros-z`
- `cargo nextest run -p ros-z-cli`
