### PR TITLE
Fix Playing Subtree

### DIFF
--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -79,7 +79,11 @@ fn playing_subtree() -> Node<Blackboard> {
             negation!(condition!(has_ball_position)),
             subtree!(search_subtree)
         ),
-        sequence!(condition!(is_closest_to_ball), subtree!(striker_subtree)),
+        sequence!(
+            action!(calculate_voronoi_grid),
+            condition!(is_closest_to_ball),
+            subtree!(striker_subtree)
+        ),
         subtree!(supporter_subtree),
     )
 }
@@ -127,10 +131,7 @@ fn striker_subtree() -> Node<Blackboard> {
 fn supporter_subtree() -> Node<Blackboard> {
     sequence!(
         subtree!(look_at_ball_subtree),
-        selection!(
-            sequence!(action!(calculate_voronoi_grid), action!(walk_to_centroid)),
-            action!(stand)
-        ),
+        selection!(action!(walk_to_centroid), action!(stand)),
     )
 }
 


### PR DESCRIPTION
## Why? What?

add calculate_voronoi before is_closeset to ball so that it is calculatetd before it is used in the new framework
- Fixes #

## How to Test

Check if the Robot follows the Ball when it is closest to it in playing .
You could check that with 2 robots on the field with different playernumbers or in the simulator.