### PR TITLE
fix: set ballstate to None if no ballposition

### DIFF
--- a/crates/nodes/ball_state_composer/src/lib.rs
+++ b/crates/nodes/ball_state_composer/src/lib.rs
@@ -81,6 +81,8 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         tokio::select! {
             received_ball_position = ball_position_sub.recv() => {
                 let Some(ball_position) = received_ball_position? else {
+                    ball_state_pub.publish(&None).await?;
+                    last_ball_state = None;
                     continue;
                 };
 


### PR DESCRIPTION
## Why? What?
in the new framework our ballstate never was set to None, now it is

## How to Test

upload to the robot and look at the ball_state topic