### PR TITLE
Add ros-z-debug topic observer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9433,6 +9433,7 @@ dependencies = [
  "parking_lot",
  "ros-z",
  "ros-z-schema",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/ros-z-cli/src/model/watch.rs
+++ b/crates/ros-z-cli/src/model/watch.rs
@@ -1,14 +1,38 @@
-use ros_z::graph::GraphSnapshot;
+use ros_z::graph::{GraphRevision, GraphSnapshot};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum WatchEvent {
-    InitialState { snapshot: GraphSnapshot },
-    TopicDiscovered { name: String, type_name: String },
-    TopicRemoved { name: String },
-    NodeDiscovered { namespace: String, name: String },
-    NodeRemoved { namespace: String, name: String },
-    ServiceDiscovered { name: String, type_name: String },
-    ServiceRemoved { name: String },
+    InitialState {
+        snapshot: GraphSnapshot,
+    },
+    TopicDiscovered {
+        revision: GraphRevision,
+        name: String,
+        type_name: String,
+    },
+    TopicRemoved {
+        revision: GraphRevision,
+        name: String,
+    },
+    NodeDiscovered {
+        revision: GraphRevision,
+        namespace: String,
+        name: String,
+    },
+    NodeRemoved {
+        revision: GraphRevision,
+        namespace: String,
+        name: String,
+    },
+    ServiceDiscovered {
+        revision: GraphRevision,
+        name: String,
+        type_name: String,
+    },
+    ServiceRemoved {
+        revision: GraphRevision,
+        name: String,
+    },
 }

--- a/crates/ros-z-cli/src/render/text.rs
+++ b/crates/ros-z-cli/src/render/text.rs
@@ -251,22 +251,30 @@ fn write_schema(mut writer: impl Write, view: &SchemaView) -> io::Result<()> {
 pub fn print_watch_event(event: &WatchEvent) {
     match event {
         WatchEvent::InitialState { snapshot } => print_graph_snapshot(snapshot),
-        WatchEvent::TopicDiscovered { name, type_name } => {
+        WatchEvent::TopicDiscovered {
+            name, type_name, ..
+        } => {
             println!("topic + {name} ({type_name})");
         }
-        WatchEvent::TopicRemoved { name } => {
+        WatchEvent::TopicRemoved { name, .. } => {
             println!("topic - {name}");
         }
-        WatchEvent::NodeDiscovered { namespace, name } => {
+        WatchEvent::NodeDiscovered {
+            namespace, name, ..
+        } => {
             println!("node + {}", fully_qualified_node_name(namespace, name));
         }
-        WatchEvent::NodeRemoved { namespace, name } => {
+        WatchEvent::NodeRemoved {
+            namespace, name, ..
+        } => {
             println!("node - {}", fully_qualified_node_name(namespace, name));
         }
-        WatchEvent::ServiceDiscovered { name, type_name } => {
+        WatchEvent::ServiceDiscovered {
+            name, type_name, ..
+        } => {
             println!("service + {name} ({type_name})");
         }
-        WatchEvent::ServiceRemoved { name } => {
+        WatchEvent::ServiceRemoved { name, .. } => {
             println!("service - {name}");
         }
     }

--- a/crates/ros-z-cli/src/support/graph.rs
+++ b/crates/ros-z-cli/src/support/graph.rs
@@ -51,6 +51,7 @@ impl From<&GraphSnapshot> for SnapshotFingerprint {
 
 pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<WatchEvent> {
     let mut events = Vec::new();
+    let revision = current.revision;
 
     let previous_topics: BTreeMap<_, _> = previous
         .topics
@@ -65,6 +66,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (name, type_name) in &current_topics {
         if !previous_topics.contains_key(name) {
             events.push(WatchEvent::TopicDiscovered {
+                revision,
                 name: name.clone(),
                 type_name: type_name.clone(),
             });
@@ -72,7 +74,10 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     }
     for name in previous_topics.keys() {
         if !current_topics.contains_key(name) {
-            events.push(WatchEvent::TopicRemoved { name: name.clone() });
+            events.push(WatchEvent::TopicRemoved {
+                revision,
+                name: name.clone(),
+            });
         }
     }
 
@@ -89,6 +94,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (namespace, name) in &current_nodes {
         if !previous_nodes.contains(&(namespace.clone(), name.clone())) {
             events.push(WatchEvent::NodeDiscovered {
+                revision,
                 namespace: namespace.clone(),
                 name: name.clone(),
             });
@@ -97,6 +103,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (namespace, name) in &previous_nodes {
         if !current_nodes.contains(&(namespace.clone(), name.clone())) {
             events.push(WatchEvent::NodeRemoved {
+                revision,
                 namespace: namespace.clone(),
                 name: name.clone(),
             });
@@ -116,6 +123,7 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     for (name, type_name) in &current_services {
         if !previous_services.contains_key(name) {
             events.push(WatchEvent::ServiceDiscovered {
+                revision,
                 name: name.clone(),
                 type_name: type_name.clone(),
             });
@@ -123,7 +131,10 @@ pub fn diff_snapshots(previous: &GraphSnapshot, current: &GraphSnapshot) -> Vec<
     }
     for name in previous_services.keys() {
         if !current_services.contains_key(name) {
-            events.push(WatchEvent::ServiceRemoved { name: name.clone() });
+            events.push(WatchEvent::ServiceRemoved {
+                revision,
+                name: name.clone(),
+            });
         }
     }
 

--- a/crates/ros-z-debug/Cargo.toml
+++ b/crates/ros-z-debug/Cargo.toml
@@ -16,4 +16,5 @@ tokio-util = { workspace = true }
 
 [dev-dependencies]
 ros-z-schema = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }

--- a/crates/ros-z-debug/src/cache.rs
+++ b/crates/ros-z-debug/src/cache.rs
@@ -64,6 +64,10 @@ impl<V> CachedSubscription<V> {
     ) -> Result<CachedSubscriptionUpdateReceiver, CachedSubscriptionUpdateClosed> {
         self.state.subscribe_updates()
     }
+
+    pub(crate) fn close_retaining_samples(&self) {
+        self.state.close();
+    }
 }
 
 /// Handle that renders retained dynamic payloads as JSON on demand.

--- a/crates/ros-z-debug/src/cache.rs
+++ b/crates/ros-z-debug/src/cache.rs
@@ -8,14 +8,14 @@ use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    JsonRenderPolicy, RetentionPolicy, SampleRecord, SubscriptionStatus,
-    SubscriptionStatusSnapshot, SubscriptionUpdate, SubscriptionUpdateClosed,
-    SubscriptionUpdateReceiver, dynamic_payload_to_json, history::TimeIndexedHistory,
+    CachedSubscriptionStatus, CachedSubscriptionStatusSnapshot, CachedSubscriptionUpdate,
+    CachedSubscriptionUpdateClosed, CachedSubscriptionUpdateReceiver, JsonRenderPolicy,
+    RetentionPolicy, SampleRecord, dynamic_payload_to_json, history::TimeIndexedHistory,
 };
 
 const UPDATE_BUFFER_CAPACITY: usize = 256;
 
-pub(crate) trait ManagedSubscription: Send + Sync {
+pub(crate) trait ManagedCachedSubscription: Send + Sync {
     fn close(&self);
 }
 
@@ -23,11 +23,11 @@ pub(crate) trait ManagedSubscription: Send + Sync {
 ///
 /// Cloning the handle keeps the subscription alive. Dropping the last handle
 /// cancels the receive task.
-pub struct SubscriptionHandle<V> {
-    state: Arc<SubscriptionState<V>>,
+pub struct CachedSubscription<V> {
+    state: Arc<CachedSubscriptionState<V>>,
 }
 
-impl<V> Clone for SubscriptionHandle<V> {
+impl<V> Clone for CachedSubscription<V> {
     fn clone(&self) -> Self {
         Self {
             state: Arc::clone(&self.state),
@@ -35,9 +35,9 @@ impl<V> Clone for SubscriptionHandle<V> {
     }
 }
 
-impl<V> SubscriptionHandle<V> {
+impl<V> CachedSubscription<V> {
     /// Return the current status snapshot.
-    pub fn status(&self) -> SubscriptionStatusSnapshot {
+    pub fn status(&self) -> CachedSubscriptionStatusSnapshot {
         self.state.status()
     }
 
@@ -61,27 +61,27 @@ impl<V> SubscriptionHandle<V> {
     /// [`Self::window`] to inspect retained data.
     pub fn subscribe_updates(
         &self,
-    ) -> Result<SubscriptionUpdateReceiver, SubscriptionUpdateClosed> {
+    ) -> Result<CachedSubscriptionUpdateReceiver, CachedSubscriptionUpdateClosed> {
         self.state.subscribe_updates()
     }
 }
 
 /// Handle that renders retained dynamic payloads as JSON on demand.
-pub struct JsonSubscriptionHandle {
-    dynamic: SubscriptionHandle<DynamicPayload>,
+pub struct CachedJsonSubscription {
+    dynamic: CachedSubscription<DynamicPayload>,
     policy: JsonRenderPolicy,
 }
 
-impl JsonSubscriptionHandle {
+impl CachedJsonSubscription {
     pub(crate) fn new(
-        dynamic: SubscriptionHandle<DynamicPayload>,
+        dynamic: CachedSubscription<DynamicPayload>,
         policy: JsonRenderPolicy,
     ) -> Self {
         Self { dynamic, policy }
     }
 
     /// Return the current status snapshot.
-    pub fn status(&self) -> SubscriptionStatusSnapshot {
+    pub fn status(&self) -> CachedSubscriptionStatusSnapshot {
         self.dynamic.status()
     }
 
@@ -109,30 +109,33 @@ impl JsonSubscriptionHandle {
     /// or [`Self::window_json`] to inspect retained data.
     pub fn subscribe_updates(
         &self,
-    ) -> Result<SubscriptionUpdateReceiver, SubscriptionUpdateClosed> {
+    ) -> Result<CachedSubscriptionUpdateReceiver, CachedSubscriptionUpdateClosed> {
         self.dynamic.subscribe_updates()
     }
 }
 
-pub(crate) struct SubscriptionState<V> {
+pub(crate) struct CachedSubscriptionState<V> {
     latest: ArcSwapOption<SampleRecord<V>>,
     history: Option<Mutex<TimeIndexedHistory<V>>>,
-    meta: Mutex<SubscriptionMeta>,
+    meta: Mutex<CachedSubscriptionMeta>,
     cancellation_token: CancellationToken,
 }
 
-enum SubscriptionMeta {
+enum CachedSubscriptionMeta {
     Open {
-        status: SubscriptionStatusSnapshot,
-        updates: broadcast::Sender<SubscriptionUpdate>,
+        status: CachedSubscriptionStatusSnapshot,
+        updates: broadcast::Sender<CachedSubscriptionUpdate>,
     },
     Closed {
-        status: SubscriptionStatusSnapshot,
+        status: CachedSubscriptionStatusSnapshot,
     },
 }
 
-impl<V> SubscriptionState<V> {
-    pub(crate) fn new(status: SubscriptionStatusSnapshot, retention: RetentionPolicy) -> Self {
+impl<V> CachedSubscriptionState<V> {
+    pub(crate) fn new(
+        status: CachedSubscriptionStatusSnapshot,
+        retention: RetentionPolicy,
+    ) -> Self {
         let history = match retention {
             RetentionPolicy::LatestOnly => None,
             RetentionPolicy::TimeWindow(_) => Some(Mutex::new(TimeIndexedHistory::new(retention))),
@@ -143,13 +146,13 @@ impl<V> SubscriptionState<V> {
         Self {
             latest: ArcSwapOption::empty(),
             history,
-            meta: Mutex::new(SubscriptionMeta::Open { status, updates }),
+            meta: Mutex::new(CachedSubscriptionMeta::Open { status, updates }),
             cancellation_token: CancellationToken::new(),
         }
     }
 
     pub(crate) fn spawn<F, Fut>(
-        status: SubscriptionStatusSnapshot,
+        status: CachedSubscriptionStatusSnapshot,
         retention: RetentionPolicy,
         receive_loop: F,
     ) -> Arc<Self>
@@ -167,8 +170,8 @@ impl<V> SubscriptionState<V> {
         state
     }
 
-    pub(crate) fn handle(self: &Arc<Self>) -> SubscriptionHandle<V> {
-        SubscriptionHandle {
+    pub(crate) fn handle(self: &Arc<Self>) -> CachedSubscription<V> {
+        CachedSubscription {
             state: Arc::clone(self),
         }
     }
@@ -180,20 +183,20 @@ impl<V> SubscriptionState<V> {
     pub(crate) fn close(&self) {
         let mut meta = self.meta.lock();
         let closed_status = match &mut *meta {
-            SubscriptionMeta::Open { status, .. } => {
-                status.set_status(SubscriptionStatus::Closed);
+            CachedSubscriptionMeta::Open { status, .. } => {
+                status.set_status(CachedSubscriptionStatus::Closed);
                 status.clone()
             }
-            SubscriptionMeta::Closed { .. } => return,
+            CachedSubscriptionMeta::Closed { .. } => return,
         };
         let updates = match std::mem::replace(
             &mut *meta,
-            SubscriptionMeta::Closed {
+            CachedSubscriptionMeta::Closed {
                 status: closed_status,
             },
         ) {
-            SubscriptionMeta::Open { updates, .. } => updates,
-            SubscriptionMeta::Closed { .. } => unreachable!("closed state was handled above"),
+            CachedSubscriptionMeta::Open { updates, .. } => updates,
+            CachedSubscriptionMeta::Closed { .. } => unreachable!("closed state was handled above"),
         };
         drop(meta);
 
@@ -203,7 +206,7 @@ impl<V> SubscriptionState<V> {
 
     pub(crate) fn store_latest(&self, record: Arc<SampleRecord<V>>) {
         let mut meta = self.meta.lock();
-        let SubscriptionMeta::Open { status, updates } = &mut *meta else {
+        let CachedSubscriptionMeta::Open { status, updates } = &mut *meta else {
             return;
         };
 
@@ -212,19 +215,19 @@ impl<V> SubscriptionState<V> {
         }
         self.latest.store(Some(record));
 
-        let status_changed = status.status() != &SubscriptionStatus::Ready;
-        status.set_status(SubscriptionStatus::Ready);
+        let status_changed = status.status() != &CachedSubscriptionStatus::Ready;
+        status.set_status(CachedSubscriptionStatus::Ready);
         let snapshot = status_changed.then(|| status.clone());
 
         if let Some(snapshot) = snapshot {
-            let _ = updates.send(SubscriptionUpdate::StatusChanged(snapshot));
+            let _ = updates.send(CachedSubscriptionUpdate::StatusChanged(snapshot));
         }
-        let _ = updates.send(SubscriptionUpdate::DataChanged);
+        let _ = updates.send(CachedSubscriptionUpdate::DataChanged);
     }
 
-    pub(crate) fn set_receive_error(&self, status: SubscriptionStatus) {
+    pub(crate) fn set_receive_error(&self, status: CachedSubscriptionStatus) {
         let mut meta = self.meta.lock();
-        let SubscriptionMeta::Open {
+        let CachedSubscriptionMeta::Open {
             status: current_status,
             updates,
         } = &mut *meta
@@ -237,15 +240,14 @@ impl<V> SubscriptionState<V> {
         let snapshot = status_changed.then(|| current_status.clone());
 
         if let Some(snapshot) = snapshot {
-            let _ = updates.send(SubscriptionUpdate::StatusChanged(snapshot));
+            let _ = updates.send(CachedSubscriptionUpdate::StatusChanged(snapshot));
         }
     }
 
-    fn status(&self) -> SubscriptionStatusSnapshot {
+    fn status(&self) -> CachedSubscriptionStatusSnapshot {
         match &*self.meta.lock() {
-            SubscriptionMeta::Open { status, .. } | SubscriptionMeta::Closed { status } => {
-                status.clone()
-            }
+            CachedSubscriptionMeta::Open { status, .. }
+            | CachedSubscriptionMeta::Closed { status } => status.clone(),
         }
     }
 
@@ -259,28 +261,30 @@ impl<V> SubscriptionState<V> {
             .map_or_else(Vec::new, |history| history.lock().window(start, end))
     }
 
-    fn subscribe_updates(&self) -> Result<SubscriptionUpdateReceiver, SubscriptionUpdateClosed> {
+    fn subscribe_updates(
+        &self,
+    ) -> Result<CachedSubscriptionUpdateReceiver, CachedSubscriptionUpdateClosed> {
         let meta = self.meta.lock();
-        let SubscriptionMeta::Open { updates, .. } = &*meta else {
-            return Err(SubscriptionUpdateClosed);
+        let CachedSubscriptionMeta::Open { updates, .. } = &*meta else {
+            return Err(CachedSubscriptionUpdateClosed);
         };
 
-        Ok(SubscriptionUpdateReceiver::new(updates.subscribe()))
+        Ok(CachedSubscriptionUpdateReceiver::new(updates.subscribe()))
     }
 }
 
-impl<V> Drop for SubscriptionState<V> {
+impl<V> Drop for CachedSubscriptionState<V> {
     fn drop(&mut self) {
         self.cancellation_token.cancel();
     }
 }
 
-impl<V> ManagedSubscription for SubscriptionState<V>
+impl<V> ManagedCachedSubscription for CachedSubscriptionState<V>
 where
     V: Send + Sync,
 {
     fn close(&self) {
-        SubscriptionState::close(self);
+        CachedSubscriptionState::close(self);
     }
 }
 
@@ -293,10 +297,11 @@ mod tests {
         time::Time,
     };
 
-    use super::{JsonSubscriptionHandle, SubscriptionState};
+    use super::{CachedJsonSubscription, CachedSubscriptionState};
     use crate::{
-        JsonRenderPolicy, RetentionPolicy, SampleMetadata, SampleRecord, SubscriptionStatus,
-        SubscriptionStatusSnapshot, SubscriptionUpdate, SubscriptionUpdateClosed, TopicSelector,
+        CachedSubscriptionStatus, CachedSubscriptionStatusSnapshot, CachedSubscriptionUpdate,
+        CachedSubscriptionUpdateClosed, JsonRenderPolicy, RetentionPolicy, SampleMetadata,
+        SampleRecord, TopicReference,
     };
 
     struct NonClonePayload(u32);
@@ -318,7 +323,7 @@ mod tests {
 
     fn test_metadata() -> Arc<SampleMetadata> {
         Arc::new(SampleMetadata {
-            requested_topic: TopicSelector::new("camera").unwrap(),
+            topic_reference: TopicReference::new("camera").unwrap(),
             resolved_topic: "/camera".to_string(),
             type_info: test_type_info(),
         })
@@ -364,8 +369,8 @@ mod tests {
 
     #[test]
     fn latest_returns_arc_record_without_cloning_payload() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let record = sample_record(NonClonePayload(7));
@@ -379,8 +384,8 @@ mod tests {
 
     #[test]
     fn time_window_handle_returns_stored_records_in_window() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
         ));
         let first = sample_record_at(NonClonePayload(1), Time::from_nanos(1));
@@ -399,8 +404,8 @@ mod tests {
 
     #[test]
     fn time_window_handle_returns_empty_for_inverted_window() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
         ));
         state.store_latest(sample_record_at(NonClonePayload(1), Time::from_nanos(1)));
@@ -414,8 +419,8 @@ mod tests {
 
     #[test]
     fn latest_only_handle_returns_empty_window_but_keeps_latest() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let record = sample_record_at(NonClonePayload(3), Time::from_nanos(3));
@@ -433,8 +438,8 @@ mod tests {
 
     #[test]
     fn update_receiver_reports_data_changed_after_store_latest() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -445,20 +450,20 @@ mod tests {
         let first_update = updates.try_recv();
         assert!(matches!(
             first_update,
-            Ok(Some(SubscriptionUpdate::StatusChanged(snapshot)))
-                if snapshot.status() == &SubscriptionStatus::Ready
+            Ok(Some(CachedSubscriptionUpdate::StatusChanged(snapshot)))
+                if snapshot.status() == &CachedSubscriptionStatus::Ready
         ));
         assert!(matches!(
             updates.try_recv(),
-            Ok(Some(SubscriptionUpdate::DataChanged))
+            Ok(Some(CachedSubscriptionUpdate::DataChanged))
         ));
         assert!(matches!(updates.try_recv(), Ok(None)));
     }
 
     #[test]
     fn update_receiver_does_not_replay_updates_sent_before_subscription() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -471,21 +476,21 @@ mod tests {
 
     #[test]
     fn update_receiver_reports_error_message_in_status_update() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
 
-        state.set_receive_error(SubscriptionStatus::decode_error(
+        state.set_receive_error(CachedSubscriptionStatus::decode_error(
             "failed to deserialize sample",
         ));
 
         assert!(matches!(
             updates.try_recv(),
-            Ok(Some(SubscriptionUpdate::StatusChanged(snapshot)))
-                if matches!(snapshot.status(), SubscriptionStatus::DecodeError { .. })
+            Ok(Some(CachedSubscriptionUpdate::StatusChanged(snapshot)))
+                if matches!(snapshot.status(), CachedSubscriptionStatus::DecodeError { .. })
                     && snapshot.message() == Some("failed to deserialize sample")
         ));
         assert!(matches!(updates.try_recv(), Ok(None)));
@@ -493,25 +498,29 @@ mod tests {
 
     #[test]
     fn update_receiver_reports_status_changed_for_repeated_error_with_new_message() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
 
-        state.set_receive_error(SubscriptionStatus::decode_error("first decode failure"));
+        state.set_receive_error(CachedSubscriptionStatus::decode_error(
+            "first decode failure",
+        ));
         assert!(matches!(
             updates.try_recv(),
-            Ok(Some(SubscriptionUpdate::StatusChanged(snapshot)))
+            Ok(Some(CachedSubscriptionUpdate::StatusChanged(snapshot)))
                 if snapshot.message() == Some("first decode failure")
         ));
 
-        state.set_receive_error(SubscriptionStatus::decode_error("second decode failure"));
+        state.set_receive_error(CachedSubscriptionStatus::decode_error(
+            "second decode failure",
+        ));
 
         assert!(matches!(
             updates.try_recv(),
-            Ok(Some(SubscriptionUpdate::StatusChanged(snapshot)))
+            Ok(Some(CachedSubscriptionUpdate::StatusChanged(snapshot)))
                 if snapshot.message() == Some("second decode failure")
         ));
         assert!(matches!(updates.try_recv(), Ok(None)));
@@ -519,20 +528,23 @@ mod tests {
 
     #[test]
     fn status_becomes_ready_after_storing_latest() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
 
         state.store_latest(sample_record(NonClonePayload(1)));
 
-        assert_eq!(state.handle().status().status(), &SubscriptionStatus::Ready);
+        assert_eq!(
+            state.handle().status().status(),
+            &CachedSubscriptionStatus::Ready
+        );
     }
 
     #[test]
     fn update_receiver_closes_when_subscription_closes() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -540,14 +552,17 @@ mod tests {
 
         state.close();
 
-        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert_eq!(handle.status().status(), &CachedSubscriptionStatus::Closed);
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 
     #[test]
     fn subscribing_after_close_returns_closed() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -556,14 +571,14 @@ mod tests {
 
         assert!(matches!(
             handle.subscribe_updates(),
-            Err(SubscriptionUpdateClosed)
+            Err(CachedSubscriptionUpdateClosed)
         ));
     }
 
     #[test]
     fn close_keeps_previously_retained_latest_sample() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -574,13 +589,13 @@ mod tests {
 
         let latest = handle.latest().unwrap();
         assert!(Arc::ptr_eq(&latest, &record));
-        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert_eq!(handle.status().status(), &CachedSubscriptionStatus::Closed);
     }
 
     #[test]
     fn close_keeps_previously_retained_time_window_samples() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
         ));
         let handle = state.handle();
@@ -595,13 +610,13 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert!(Arc::ptr_eq(&records[0], &first));
         assert!(Arc::ptr_eq(&records[1], &second));
-        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert_eq!(handle.status().status(), &CachedSubscriptionStatus::Closed);
     }
 
     #[test]
     fn close_does_not_emit_closed_status_update() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -609,14 +624,17 @@ mod tests {
 
         state.close();
 
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 
     #[tokio::test]
     async fn spawned_receive_task_exits_when_subscription_closes() {
         let (exited_sender, exited_receiver) = tokio::sync::oneshot::channel();
-        let state = SubscriptionState::<NonClonePayload>::spawn(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = CachedSubscriptionState::<NonClonePayload>::spawn(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
             move |_state, cancellation| async move {
                 cancellation.cancelled().await;
@@ -635,8 +653,8 @@ mod tests {
     #[tokio::test]
     async fn spawned_receive_task_exits_when_last_handle_drops() {
         let (exited_sender, exited_receiver) = tokio::sync::oneshot::channel();
-        let state = SubscriptionState::<NonClonePayload>::spawn(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = CachedSubscriptionState::<NonClonePayload>::spawn(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
             move |_state, cancellation| async move {
                 cancellation.cancelled().await;
@@ -656,8 +674,8 @@ mod tests {
 
     #[test]
     fn store_latest_after_close_keeps_closed_terminal() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -666,33 +684,41 @@ mod tests {
         state.close();
         state.store_latest(sample_record(NonClonePayload(1)));
 
-        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
+        assert_eq!(handle.status().status(), &CachedSubscriptionStatus::Closed);
         assert!(handle.latest().is_none());
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 
     #[test]
     fn receive_error_after_close_keeps_closed_terminal() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
 
         state.close();
-        state.set_receive_error(SubscriptionStatus::decode_error("late decode failure"));
+        state.set_receive_error(CachedSubscriptionStatus::decode_error(
+            "late decode failure",
+        ));
 
         let status = handle.status();
-        assert_eq!(status.status(), &SubscriptionStatus::Closed);
+        assert_eq!(status.status(), &CachedSubscriptionStatus::Closed);
         assert_eq!(status.message(), None);
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 
     #[test]
     fn close_is_idempotent() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -701,54 +727,57 @@ mod tests {
         state.close();
         state.close();
 
-        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert_eq!(handle.status().status(), &CachedSubscriptionStatus::Closed);
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 
     #[test]
     fn json_handle_projects_latest_dynamic_payload() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         state.store_latest(dynamic_record_at(42, Time::zero()));
-        let handle = JsonSubscriptionHandle::new(state.handle(), JsonRenderPolicy::default());
+        let handle = CachedJsonSubscription::new(state.handle(), JsonRenderPolicy::default());
 
         assert_eq!(handle.latest_json(), Some(serde_json::json!(42)));
     }
 
     #[test]
     fn json_handle_subscribes_to_underlying_dynamic_updates() {
-        let state = Arc::new(SubscriptionState::<DynamicPayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<DynamicPayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
-        let handle = JsonSubscriptionHandle::new(state.handle(), JsonRenderPolicy::default());
+        let handle = CachedJsonSubscription::new(state.handle(), JsonRenderPolicy::default());
         let mut updates = handle.subscribe_updates().unwrap();
 
         state.store_latest(dynamic_record_at(1, Time::zero()));
 
         assert!(matches!(
             updates.try_recv(),
-            Ok(Some(SubscriptionUpdate::StatusChanged(snapshot)))
-                if snapshot.status() == &SubscriptionStatus::Ready
+            Ok(Some(CachedSubscriptionUpdate::StatusChanged(snapshot)))
+                if snapshot.status() == &CachedSubscriptionStatus::Ready
         ));
         assert!(matches!(
             updates.try_recv(),
-            Ok(Some(SubscriptionUpdate::DataChanged))
+            Ok(Some(CachedSubscriptionUpdate::DataChanged))
         ));
         assert!(matches!(updates.try_recv(), Ok(None)));
     }
 
     #[test]
     fn json_handle_projects_dynamic_payload_window() {
-        let state = Arc::new(SubscriptionState::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
         ));
         state.store_latest(dynamic_record_at(1, Time::from_nanos(1)));
         state.store_latest(dynamic_record_at(2, Time::from_nanos(2)));
-        let handle = JsonSubscriptionHandle::new(state.handle(), JsonRenderPolicy::default());
+        let handle = CachedJsonSubscription::new(state.handle(), JsonRenderPolicy::default());
 
         assert_eq!(
             handle.window_json(Time::from_nanos(1), Time::from_nanos(2)),
@@ -758,8 +787,8 @@ mod tests {
 
     #[test]
     fn dropping_last_handle_cancels_subscription_state() {
-        let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let cancellation = state.cancellation_token();
@@ -776,14 +805,19 @@ mod tests {
     #[test]
     fn update_receiver_closes_after_subscription_state_is_dropped() {
         let mut updates = {
-            let state = Arc::new(SubscriptionState::<NonClonePayload>::new(
-                SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+            let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
+                CachedSubscriptionStatusSnapshot::new(
+                    CachedSubscriptionStatus::WaitingForFirstSample,
+                ),
                 RetentionPolicy::LatestOnly,
             ));
 
             state.handle().subscribe_updates().unwrap()
         };
 
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 }

--- a/crates/ros-z-debug/src/error.rs
+++ b/crates/ros-z-debug/src/error.rs
@@ -6,28 +6,33 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-    #[error(transparent)]
-    RosZ(#[from] ros_z::Error),
-
-    #[error("invalid topic selector '{selector}': {source}")]
-    InvalidTopicSelector {
-        selector: String,
+    #[error("invalid topic reference '{topic}'")]
+    InvalidTopicReference {
+        topic: String,
         #[source]
         source: TopicNameError,
     },
 
-    #[error(
-        "private topic selector '{selector}' requires target node context; debug topic selectors currently resolve against a target namespace only"
-    )]
-    UnsupportedPrivateTopicSelector { selector: String },
-
-    #[error("invalid target namespace '{target_namespace}': {source}")]
+    #[error("invalid target namespace '{target_namespace}'")]
     InvalidTargetNamespace {
         target_namespace: String,
         #[source]
         source: TopicNameError,
     },
 
+    #[error("invalid target node name '{target_node_name}'")]
+    InvalidTargetNodeName {
+        target_node_name: String,
+        #[source]
+        source: TopicNameError,
+    },
+
+    #[error("private topic reference '{topic}' requires a target node name")]
+    MissingTargetNodeName { topic: String },
+
     #[error("invalid retention policy: {0}")]
     InvalidRetention(String),
+
+    #[error(transparent)]
+    RosZ(#[from] ros_z::Error),
 }

--- a/crates/ros-z-debug/src/event.rs
+++ b/crates/ros-z-debug/src/event.rs
@@ -3,23 +3,23 @@ use tokio::sync::broadcast::{
     error::{RecvError, TryRecvError},
 };
 
-use crate::SubscriptionStatusSnapshot;
+use crate::CachedSubscriptionStatusSnapshot;
 
 /// Live notification emitted by a retained debug subscription.
 ///
 /// Updates are only delivered to receivers that were already subscribed when the
-/// event happened. Terminal closure is represented by `SubscriptionUpdateClosed`,
-/// not by a `SubscriptionUpdate` variant.
+/// event happened. Terminal closure is represented by `CachedSubscriptionUpdateClosed`,
+/// not by a `CachedSubscriptionUpdate` variant.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub enum SubscriptionUpdate {
+pub enum CachedSubscriptionUpdate {
     /// A new sample was retained as the latest value.
     DataChanged,
     /// A non-terminal subscription status snapshot changed.
     ///
-    /// Terminal close is reported by `SubscriptionUpdateClosed`; use the
+    /// Terminal close is reported by `CachedSubscriptionUpdateClosed`; use the
     /// subscription handle's `status()` to inspect retained status.
-    StatusChanged(SubscriptionStatusSnapshot),
+    StatusChanged(CachedSubscriptionStatusSnapshot),
     /// This receiver fell behind and missed updates.
     Lagged { dropped: u64 },
 }
@@ -29,33 +29,35 @@ pub enum SubscriptionUpdate {
 /// After this error, no future updates can arrive on that receiver. Use the
 /// subscription handle's retained state methods to inspect final status and data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("subscription update stream closed")]
-pub struct SubscriptionUpdateClosed;
+#[error("cached subscription update stream closed")]
+pub struct CachedSubscriptionUpdateClosed;
 
 /// Receiver for future live updates from a retained debug subscription.
 ///
-/// Create receivers with `SubscriptionHandle::subscribe_updates` or
-/// `JsonSubscriptionHandle::subscribe_updates`.
-pub struct SubscriptionUpdateReceiver {
-    receiver: Receiver<SubscriptionUpdate>,
+/// Create receivers with `CachedSubscription::subscribe_updates` or
+/// `CachedJsonSubscription::subscribe_updates`.
+pub struct CachedSubscriptionUpdateReceiver {
+    receiver: Receiver<CachedSubscriptionUpdate>,
 }
 
-impl SubscriptionUpdateReceiver {
-    pub(crate) fn new(receiver: Receiver<SubscriptionUpdate>) -> Self {
+impl CachedSubscriptionUpdateReceiver {
+    pub(crate) fn new(receiver: Receiver<CachedSubscriptionUpdate>) -> Self {
         Self { receiver }
     }
 
     /// Wait for the next live subscription update.
     ///
     /// Receivers observe updates sent after they subscribed; old updates are not
-    /// replayed. `Err(SubscriptionUpdateClosed)` means the subscription update
+    /// replayed. `Err(CachedSubscriptionUpdateClosed)` means the subscription update
     /// stream ended and no future updates can arrive. Use the owning handle's
     /// `status()`, `latest()`, or `window()` methods to inspect retained state.
-    pub async fn recv(&mut self) -> Result<SubscriptionUpdate, SubscriptionUpdateClosed> {
+    pub async fn recv(
+        &mut self,
+    ) -> Result<CachedSubscriptionUpdate, CachedSubscriptionUpdateClosed> {
         match self.receiver.recv().await {
             Ok(update) => Ok(update),
             Err(RecvError::Lagged(dropped)) => Ok(lagged_update(dropped)),
-            Err(RecvError::Closed) => Err(SubscriptionUpdateClosed),
+            Err(RecvError::Closed) => Err(CachedSubscriptionUpdateClosed),
         }
     }
 
@@ -63,37 +65,45 @@ impl SubscriptionUpdateReceiver {
     ///
     /// Receivers observe updates sent after they subscribed; old updates are not
     /// replayed. `Ok(None)` means no update is currently queued.
-    /// `Err(SubscriptionUpdateClosed)` means the live update stream ended and no
+    /// `Err(CachedSubscriptionUpdateClosed)` means the live update stream ended and no
     /// future updates can arrive.
-    pub fn try_recv(&mut self) -> Result<Option<SubscriptionUpdate>, SubscriptionUpdateClosed> {
+    pub fn try_recv(
+        &mut self,
+    ) -> Result<Option<CachedSubscriptionUpdate>, CachedSubscriptionUpdateClosed> {
         match self.receiver.try_recv() {
             Ok(update) => Ok(Some(update)),
             Err(TryRecvError::Lagged(dropped)) => Ok(Some(lagged_update(dropped))),
             Err(TryRecvError::Empty) => Ok(None),
-            Err(TryRecvError::Closed) => Err(SubscriptionUpdateClosed),
+            Err(TryRecvError::Closed) => Err(CachedSubscriptionUpdateClosed),
         }
     }
 }
 
-fn lagged_update(dropped: u64) -> SubscriptionUpdate {
-    SubscriptionUpdate::Lagged { dropped }
+fn lagged_update(dropped: u64) -> CachedSubscriptionUpdate {
+    CachedSubscriptionUpdate::Lagged { dropped }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SubscriptionUpdate, SubscriptionUpdateClosed, SubscriptionUpdateReceiver};
+    use super::{
+        CachedSubscriptionUpdate, CachedSubscriptionUpdateClosed, CachedSubscriptionUpdateReceiver,
+    };
 
     #[test]
     fn closed_error_has_display_message() {
-        let error: Box<dyn std::error::Error + Send + Sync> = Box::new(SubscriptionUpdateClosed);
+        let error: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(CachedSubscriptionUpdateClosed);
 
-        assert_eq!(error.to_string(), "subscription update stream closed");
+        assert_eq!(
+            error.to_string(),
+            "cached subscription update stream closed"
+        );
     }
 
     #[test]
     fn try_recv_returns_none_when_no_update_is_available() {
         let (_sender, receiver) = tokio::sync::broadcast::channel(1);
-        let mut receiver = SubscriptionUpdateReceiver::new(receiver);
+        let mut receiver = CachedSubscriptionUpdateReceiver::new(receiver);
 
         assert!(matches!(receiver.try_recv(), Ok(None)));
     }
@@ -101,40 +111,43 @@ mod tests {
     #[test]
     fn try_recv_returns_closed_when_sender_is_dropped() {
         let (sender, receiver) = tokio::sync::broadcast::channel(1);
-        let mut receiver = SubscriptionUpdateReceiver::new(receiver);
+        let mut receiver = CachedSubscriptionUpdateReceiver::new(receiver);
         drop(sender);
 
-        assert!(matches!(receiver.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 
     #[test]
     fn try_recv_reports_lagged_update_when_receiver_falls_behind() {
         let (sender, receiver) = tokio::sync::broadcast::channel(1);
-        let mut receiver = SubscriptionUpdateReceiver::new(receiver);
+        let mut receiver = CachedSubscriptionUpdateReceiver::new(receiver);
 
-        sender.send(SubscriptionUpdate::DataChanged).unwrap();
-        sender.send(SubscriptionUpdate::DataChanged).unwrap();
+        sender.send(CachedSubscriptionUpdate::DataChanged).unwrap();
+        sender.send(CachedSubscriptionUpdate::DataChanged).unwrap();
 
         let dropped: u64 = match receiver.try_recv().unwrap().unwrap() {
-            SubscriptionUpdate::Lagged { dropped } => dropped,
+            CachedSubscriptionUpdate::Lagged { dropped } => dropped,
             update => panic!("expected lagged update, got {update:?}"),
         };
         assert_eq!(dropped, 1);
         assert!(matches!(
             receiver.try_recv(),
-            Ok(Some(SubscriptionUpdate::DataChanged))
+            Ok(Some(CachedSubscriptionUpdate::DataChanged))
         ));
     }
 
     #[tokio::test]
     async fn recv_returns_closed_after_sender_closes() {
         let (sender, receiver) = tokio::sync::broadcast::channel(1);
-        let mut receiver = SubscriptionUpdateReceiver::new(receiver);
+        let mut receiver = CachedSubscriptionUpdateReceiver::new(receiver);
         drop(sender);
 
         assert!(matches!(
             receiver.recv().await,
-            Err(SubscriptionUpdateClosed)
+            Err(CachedSubscriptionUpdateClosed)
         ));
     }
 }

--- a/crates/ros-z-debug/src/factory.rs
+++ b/crates/ros-z-debug/src/factory.rs
@@ -5,45 +5,54 @@ use ros_z::{Message, dynamic::DynamicPayload, node::Node};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    JsonRenderPolicy, JsonSubscriptionHandle, Result, RetentionPolicy, SampleMetadata,
-    SampleRecord, SubscriptionHandle, SubscriptionStatus, SubscriptionStatusSnapshot,
-    TopicSelector,
-    subscription::{ManagedSubscription, SubscriptionState},
-    topic::normalize_target_namespace,
+    CachedJsonSubscription, CachedSubscription, CachedSubscriptionStatus,
+    CachedSubscriptionStatusSnapshot, JsonRenderPolicy, Result, RetentionPolicy, SampleMetadata,
+    SampleRecord, TargetIdentity, TopicReference,
+    cache::{CachedSubscriptionState, ManagedCachedSubscription},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct ManagerOptions {
-    /// Namespace used to resolve relative topic selectors.
+pub struct CachedSubscriptionOptions {
+    /// Target identity used to resolve topic references.
     ///
-    /// This names the robot or target namespace being inspected, not the
-    /// namespace of the debug node that owns the subscriptions.
-    target_namespace: String,
+    /// This names the robot or target node being inspected, not the debug node
+    /// that owns the subscriptions.
+    target_identity: TargetIdentity,
     /// Timeout used while querying schema services for dynamic subscriptions.
     schema_discovery_timeout: Duration,
 }
 
-impl Default for ManagerOptions {
+impl Default for CachedSubscriptionOptions {
     fn default() -> Self {
         Self {
-            target_namespace: "/".to_string(),
+            target_identity: TargetIdentity::new("/").expect("root namespace is valid"),
             schema_discovery_timeout: Duration::from_secs(5),
         }
     }
 }
 
-impl ManagerOptions {
+impl CachedSubscriptionOptions {
     /// Create options with a validated target namespace.
-    pub fn with_target_namespace(target_namespace: impl Into<String>) -> Result<Self> {
+    pub fn with_target_namespace(namespace: impl Into<String>) -> Result<Self> {
         let mut options = Self::default();
-        options.set_target_namespace(target_namespace)?;
+        options.set_target_namespace(namespace)?;
         Ok(options)
     }
 
-    /// Namespace used to resolve relative topic selectors.
+    /// Identity used to resolve topic references.
+    pub fn target_identity(&self) -> &TargetIdentity {
+        &self.target_identity
+    }
+
+    /// Namespace used to resolve relative topic references.
     pub fn target_namespace(&self) -> &str {
-        &self.target_namespace
+        self.target_identity.namespace()
+    }
+
+    /// Node name used to resolve private topic references, when configured.
+    pub fn target_node_name(&self) -> Option<&str> {
+        self.target_identity.node_name()
     }
 
     /// Timeout used while querying schema services for dynamic subscriptions.
@@ -52,12 +61,14 @@ impl ManagerOptions {
     }
 
     /// Update the target namespace after validating it as a graph namespace.
-    pub fn set_target_namespace(
-        &mut self,
-        target_namespace: impl Into<String>,
-    ) -> Result<&mut Self> {
-        let target_namespace = target_namespace.into();
-        self.target_namespace = normalize_target_namespace(&target_namespace)?;
+    pub fn set_target_namespace(&mut self, namespace: impl Into<String>) -> Result<&mut Self> {
+        self.target_identity.set_namespace(namespace)?;
+        Ok(self)
+    }
+
+    /// Update the target node name after validating it as a graph component.
+    pub fn set_target_node_name(&mut self, node_name: impl Into<String>) -> Result<&mut Self> {
+        self.target_identity.set_node_name(node_name)?;
         Ok(self)
     }
 
@@ -70,60 +81,73 @@ impl ManagerOptions {
 
 /// Owns debug subscriptions created from a `ros-z` node.
 ///
-/// Handles returned by this manager retain the latest sample, optional history,
-/// status, and live subscription update streams. Dropping the manager closes
+/// Handles returned by this factory retain the latest sample, optional history,
+/// status, and live subscription update streams. Dropping the factory closes
 /// subscriptions it can still reach; dropping the last handle for a subscription
 /// cancels its receive task.
-pub struct SubscriptionManager {
+pub struct CachedSubscriptionFactory {
     node: Arc<Node>,
-    options: ManagerOptions,
-    subscriptions: SubscriptionRegistry,
+    options: CachedSubscriptionOptions,
+    subscriptions: CachedSubscriptionRegistry,
 }
 
-impl SubscriptionManager {
-    /// Create a manager for subscriptions owned by `node`.
-    pub fn new(node: Arc<Node>, options: ManagerOptions) -> Self {
+impl CachedSubscriptionFactory {
+    /// Create a factory for subscriptions owned by `node`.
+    pub fn new(node: Arc<Node>, options: CachedSubscriptionOptions) -> Self {
         Self {
             node,
             options,
-            subscriptions: SubscriptionRegistry::default(),
+            subscriptions: CachedSubscriptionRegistry::default(),
         }
     }
 
     /// Start building a typed debug subscription.
     ///
-    /// Relative topics resolve against [`ManagerOptions::target_namespace`].
+    /// Relative topics resolve against [`CachedSubscriptionOptions::target_namespace`].
+    /// Private topics resolve against [`CachedSubscriptionOptions::target_node_name`].
     /// The default retention policy is [`RetentionPolicy::LatestOnly`].
-    pub fn subscribe_typed<T>(&self, topic: impl Into<String>) -> TypedSubscriptionBuilder<'_, T> {
-        TypedSubscriptionBuilder {
-            manager: self,
-            topic: topic.into(),
+    pub fn subscribe_typed<T>(
+        &self,
+        topic: impl Into<String>,
+    ) -> Result<CachedTypedSubscriptionBuilder<'_, T>> {
+        Ok(CachedTypedSubscriptionBuilder {
+            factory: self,
+            topic: TopicReference::new(topic.into())?,
             retention: RetentionPolicy::LatestOnly,
             value: PhantomData,
-        }
+        })
     }
 
     /// Start building a dynamic debug subscription.
     ///
-    /// Relative topics resolve against [`ManagerOptions::target_namespace`].
+    /// Relative topics resolve against [`CachedSubscriptionOptions::target_namespace`].
+    /// Private topics resolve against [`CachedSubscriptionOptions::target_node_name`].
     /// Dynamic subscriptions discover the schema from currently visible
     /// publishers during `build()` or `build_json()`. Schema service queries use
-    /// [`ManagerOptions::schema_discovery_timeout`].
-    pub fn subscribe_dynamic(&self, topic: impl Into<String>) -> DynamicSubscriptionBuilder<'_> {
-        DynamicSubscriptionBuilder {
-            manager: self,
-            topic: topic.into(),
+    /// [`CachedSubscriptionOptions::schema_discovery_timeout`].
+    pub fn subscribe_dynamic(
+        &self,
+        topic: impl Into<String>,
+    ) -> Result<CachedDynamicSubscriptionBuilder<'_>> {
+        Ok(CachedDynamicSubscriptionBuilder {
+            factory: self,
+            topic: TopicReference::new(topic.into())?,
             retention: RetentionPolicy::LatestOnly,
-        }
+        })
     }
 
     pub(crate) fn node(&self) -> &Arc<Node> {
         &self.node
     }
 
-    /// Namespace used to resolve relative topic selectors.
+    /// Namespace used to resolve relative topic references.
     pub fn target_namespace(&self) -> &str {
         self.options.target_namespace()
+    }
+
+    /// Node name used to resolve private topic references, when configured.
+    pub fn target_node_name(&self) -> Option<&str> {
+        self.options.target_node_name()
     }
 
     pub(crate) fn close(&self) {
@@ -131,23 +155,23 @@ impl SubscriptionManager {
     }
 }
 
-impl Drop for SubscriptionManager {
+impl Drop for CachedSubscriptionFactory {
     fn drop(&mut self) {
         self.close();
     }
 }
 
 #[derive(Default)]
-pub(crate) struct SubscriptionRegistry {
-    subscriptions: Mutex<Vec<std::sync::Weak<dyn ManagedSubscription>>>,
+pub(crate) struct CachedSubscriptionRegistry {
+    subscriptions: Mutex<Vec<std::sync::Weak<dyn ManagedCachedSubscription>>>,
 }
 
-impl SubscriptionRegistry {
-    pub(crate) fn register<V>(&self, state: &Arc<SubscriptionState<V>>)
+impl CachedSubscriptionRegistry {
+    pub(crate) fn register<V>(&self, state: &Arc<CachedSubscriptionState<V>>)
     where
         V: Send + Sync + 'static,
     {
-        let state: Arc<dyn ManagedSubscription> = state.clone();
+        let state: Arc<dyn ManagedCachedSubscription> = state.clone();
         let mut subscriptions = self.subscriptions.lock();
         subscriptions.retain(|subscription| subscription.strong_count() > 0);
         subscriptions.push(Arc::downgrade(&state));
@@ -166,28 +190,28 @@ impl SubscriptionRegistry {
 }
 
 /// Builder for typed debug subscriptions.
-pub struct TypedSubscriptionBuilder<'a, T> {
-    pub(crate) manager: &'a SubscriptionManager,
-    pub(crate) topic: String,
+pub struct CachedTypedSubscriptionBuilder<'a, T> {
+    pub(crate) factory: &'a CachedSubscriptionFactory,
+    pub(crate) topic: TopicReference,
     pub(crate) retention: RetentionPolicy,
     value: PhantomData<T>,
 }
 
-impl<T> TypedSubscriptionBuilder<'_, T> {
+impl<T> CachedTypedSubscriptionBuilder<'_, T> {
     /// Configure how many samples the handle retains.
     pub fn retention(mut self, retention: RetentionPolicy) -> Self {
         self.retention = retention;
         self
     }
 
-    /// Manager that will own the subscription.
-    pub fn manager(&self) -> &SubscriptionManager {
-        self.manager
+    /// Factory that will own the subscription.
+    pub fn factory(&self) -> &CachedSubscriptionFactory {
+        self.factory
     }
 
-    /// Topic selector requested by the caller.
+    /// Topic reference requested by the caller.
     pub fn topic(&self) -> &str {
-        &self.topic
+        self.topic.as_str()
     }
 
     /// Configured retention policy.
@@ -196,29 +220,32 @@ impl<T> TypedSubscriptionBuilder<'_, T> {
     }
 
     /// Build the typed subscription and spawn its receive task.
-    pub async fn build(self) -> Result<SubscriptionHandle<T>>
+    pub async fn build(self) -> Result<CachedSubscription<T>>
     where
         T: Message + Send + Sync + 'static,
         T::Codec: Send + Sync,
     {
-        let retention = self.retention;
-        let requested_topic = TopicSelector::new(self.topic)?;
-        let resolved_topic = requested_topic.resolve(self.manager.target_namespace())?;
-        let subscriber = self
-            .manager
+        let Self {
+            factory,
+            topic,
+            retention,
+            value: _,
+        } = self;
+        let resolved_topic = topic.resolve(factory.options.target_identity())?;
+        let subscriber = factory
             .node()
             .subscriber::<T>(&resolved_topic)?
             .build()
             .await?;
         let type_info = subscriber.entity().type_info.clone();
         let metadata = Arc::new(SampleMetadata {
-            requested_topic,
+            topic_reference: topic,
             resolved_topic: resolved_topic.clone(),
             type_info: type_info.clone(),
         });
-        let state = SubscriptionState::spawn(
-            SubscriptionStatusSnapshot::with_metadata(
-                SubscriptionStatus::WaitingForFirstSample,
+        let state = CachedSubscriptionState::spawn(
+            CachedSubscriptionStatusSnapshot::with_metadata(
+                CachedSubscriptionStatus::WaitingForFirstSample,
                 resolved_topic,
                 type_info,
             ),
@@ -228,7 +255,7 @@ impl<T> TypedSubscriptionBuilder<'_, T> {
             },
         );
         let handle = state.handle();
-        self.manager.subscriptions.register(&state);
+        factory.subscriptions.register(&state);
 
         Ok(handle)
     }
@@ -238,29 +265,29 @@ impl<T> TypedSubscriptionBuilder<'_, T> {
 ///
 /// Dynamic builders use currently visible publishers to find one consistent
 /// schema for the resolved topic. Building fails if no matching publisher/schema
-/// is visible, or if schema service queries do not complete within the manager's
+/// is visible, or if schema service queries do not complete within the factory's
 /// configured discovery timeout.
-pub struct DynamicSubscriptionBuilder<'a> {
-    pub(crate) manager: &'a SubscriptionManager,
-    pub(crate) topic: String,
+pub struct CachedDynamicSubscriptionBuilder<'a> {
+    pub(crate) factory: &'a CachedSubscriptionFactory,
+    pub(crate) topic: TopicReference,
     pub(crate) retention: RetentionPolicy,
 }
 
-impl DynamicSubscriptionBuilder<'_> {
+impl CachedDynamicSubscriptionBuilder<'_> {
     /// Configure how many samples the handle retains.
     pub fn retention(mut self, retention: RetentionPolicy) -> Self {
         self.retention = retention;
         self
     }
 
-    /// Manager that will own the subscription.
-    pub fn manager(&self) -> &SubscriptionManager {
-        self.manager
+    /// Factory that will own the subscription.
+    pub fn factory(&self) -> &CachedSubscriptionFactory {
+        self.factory
     }
 
-    /// Topic selector requested by the caller.
+    /// Topic reference requested by the caller.
     pub fn topic(&self) -> &str {
-        &self.topic
+        self.topic.as_str()
     }
 
     /// Configured retention policy.
@@ -272,41 +299,40 @@ impl DynamicSubscriptionBuilder<'_> {
     ///
     /// Schema discovery requires at least one currently visible publisher on the
     /// resolved topic, consistent type metadata, and a reachable schema service.
-    pub async fn build(self) -> Result<SubscriptionHandle<DynamicPayload>> {
+    pub async fn build(self) -> Result<CachedSubscription<DynamicPayload>> {
         self.build_dynamic_payload().await
     }
 
     /// Build a dynamic JSON subscription with `policy`.
     ///
     /// Schema discovery has the same requirements as [`Self::build`].
-    pub async fn build_json(self, policy: JsonRenderPolicy) -> Result<JsonSubscriptionHandle> {
+    pub async fn build_json(self, policy: JsonRenderPolicy) -> Result<CachedJsonSubscription> {
         let dynamic = self.build_dynamic_payload().await?;
-        Ok(JsonSubscriptionHandle::new(dynamic, policy))
+        Ok(CachedJsonSubscription::new(dynamic, policy))
     }
 
-    async fn build_dynamic_payload(self) -> Result<SubscriptionHandle<DynamicPayload>> {
-        let retention = self.retention;
-        let requested_topic = TopicSelector::new(self.topic)?;
-        let resolved_topic = requested_topic.resolve(self.manager.target_namespace())?;
-        let subscriber = self
-            .manager
+    async fn build_dynamic_payload(self) -> Result<CachedSubscription<DynamicPayload>> {
+        let Self {
+            factory,
+            topic,
+            retention,
+        } = self;
+        let resolved_topic = topic.resolve(factory.options.target_identity())?;
+        let subscriber = factory
             .node()
-            .dynamic_subscriber_auto(
-                &resolved_topic,
-                self.manager.options.schema_discovery_timeout(),
-            )
+            .dynamic_subscriber_auto(&resolved_topic, factory.options.schema_discovery_timeout())
             .await?
             .build()
             .await?;
         let type_info = subscriber.entity().type_info.clone();
         let metadata = Arc::new(SampleMetadata {
-            requested_topic,
+            topic_reference: topic,
             resolved_topic: resolved_topic.clone(),
             type_info: type_info.clone(),
         });
-        let state = SubscriptionState::spawn(
-            SubscriptionStatusSnapshot::with_metadata(
-                SubscriptionStatus::WaitingForFirstSample,
+        let state = CachedSubscriptionState::spawn(
+            CachedSubscriptionStatusSnapshot::with_metadata(
+                CachedSubscriptionStatus::WaitingForFirstSample,
                 resolved_topic,
                 type_info,
             ),
@@ -316,7 +342,7 @@ impl DynamicSubscriptionBuilder<'_> {
             },
         );
         let handle = state.handle();
-        self.manager.subscriptions.register(&state);
+        factory.subscriptions.register(&state);
 
         Ok(handle)
     }
@@ -324,7 +350,7 @@ impl DynamicSubscriptionBuilder<'_> {
 
 async fn receive_typed_loop<T>(
     subscriber: ros_z::pubsub::Subscriber<T>,
-    state: std::sync::Weak<SubscriptionState<T>>,
+    state: std::sync::Weak<CachedSubscriptionState<T>>,
     cancellation: CancellationToken,
     metadata: Arc<SampleMetadata>,
 ) where
@@ -363,7 +389,7 @@ async fn receive_typed_loop<T>(
 
 async fn receive_dynamic_loop(
     subscriber: ros_z::pubsub::Subscriber<DynamicPayload, ros_z::dynamic::DynamicCdrCodec>,
-    state: std::sync::Weak<SubscriptionState<DynamicPayload>>,
+    state: std::sync::Weak<CachedSubscriptionState<DynamicPayload>>,
     cancellation: CancellationToken,
     metadata: Arc<SampleMetadata>,
 ) {
@@ -412,7 +438,7 @@ fn receive_error_diagnostic(error: &ros_z::Error, metadata: &SampleMetadata) -> 
     message
 }
 
-fn classify_receive_error(error: &ros_z::Error, message: String) -> SubscriptionStatus {
+fn classify_receive_error(error: &ros_z::Error, message: String) -> CachedSubscriptionStatus {
     if matches!(
         error,
         ros_z::Error::Wire(source) if matches!(
@@ -421,9 +447,9 @@ fn classify_receive_error(error: &ros_z::Error, message: String) -> Subscription
                 | ros_z::error::WireError::SampleAttachmentDecode { .. }
         )
     ) {
-        SubscriptionStatus::protocol_error(message)
+        CachedSubscriptionStatus::protocol_error(message)
     } else {
-        SubscriptionStatus::decode_error(message)
+        CachedSubscriptionStatus::decode_error(message)
     }
 }
 
@@ -432,26 +458,27 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        ManagerOptions, SubscriptionRegistry, classify_receive_error, receive_error_diagnostic,
+        CachedSubscriptionOptions, CachedSubscriptionRegistry, classify_receive_error,
+        receive_error_diagnostic,
     };
     use crate::{
-        Error, RetentionPolicy, SampleMetadata, SubscriptionStatus, SubscriptionStatusSnapshot,
-        SubscriptionUpdateClosed, TopicSelector, subscription::SubscriptionState,
+        CachedSubscriptionStatus, CachedSubscriptionStatusSnapshot, CachedSubscriptionUpdateClosed,
+        Error, RetentionPolicy, SampleMetadata, TopicReference, cache::CachedSubscriptionState,
     };
 
     struct TestPayload;
 
     fn test_metadata() -> SampleMetadata {
         SampleMetadata {
-            requested_topic: TopicSelector::new("debug").unwrap(),
+            topic_reference: TopicReference::new("debug").unwrap(),
             resolved_topic: "/debug".to_string(),
             type_info: ros_z::TypeInfo::new("test_msgs::DebugValue", ros_z::SchemaHash::zero()),
         }
     }
 
     #[test]
-    fn manager_options_reject_invalid_target_namespace() {
-        let error = ManagerOptions::with_target_namespace("alpha%bad").unwrap_err();
+    fn cached_subscription_options_reject_invalid_target_namespace() {
+        let error = CachedSubscriptionOptions::with_target_namespace("alpha%bad").unwrap_err();
 
         assert!(matches!(
             error,
@@ -461,10 +488,34 @@ mod tests {
     }
 
     #[test]
-    fn manager_options_normalize_valid_target_namespace() {
-        let options = ManagerOptions::with_target_namespace("alpha/").unwrap();
+    fn cached_subscription_options_normalize_valid_target_namespace() {
+        let options = CachedSubscriptionOptions::with_target_namespace("alpha/").unwrap();
 
         assert_eq!(options.target_namespace(), "/alpha");
+    }
+
+    #[test]
+    fn cached_subscription_options_set_target_node_name() {
+        let mut options = CachedSubscriptionOptions::with_target_namespace("/42").unwrap();
+
+        options.set_target_node_name("behavior_node").unwrap();
+
+        assert_eq!(options.target_node_name(), Some("behavior_node"));
+    }
+
+    #[test]
+    fn cached_subscription_options_keep_previous_node_name_on_invalid_update() {
+        let mut options = CachedSubscriptionOptions::with_target_namespace("/42").unwrap();
+        options.set_target_node_name("behavior_node").unwrap();
+
+        let error = options.set_target_node_name("bad%node").unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidTargetNodeName { ref target_node_name, .. }
+                if target_node_name == "bad%node"
+        ));
+        assert_eq!(options.target_node_name(), Some("behavior_node"));
     }
 
     #[test]
@@ -473,7 +524,7 @@ mod tests {
 
         assert!(matches!(
             classify_receive_error(&error, "missing attachment".to_string()),
-            SubscriptionStatus::ProtocolError { ref message } if message == "missing attachment"
+            CachedSubscriptionStatus::ProtocolError { ref message } if message == "missing attachment"
         ));
     }
 
@@ -486,7 +537,7 @@ mod tests {
 
         assert!(matches!(
             classify_receive_error(&error, "decode failed".to_string()),
-            SubscriptionStatus::DecodeError { ref message } if message == "decode failed"
+            CachedSubscriptionStatus::DecodeError { ref message } if message == "decode failed"
         ));
     }
 
@@ -506,9 +557,9 @@ mod tests {
 
     #[test]
     fn registry_closes_subscriptions_while_handles_remain_alive() {
-        let registry = SubscriptionRegistry::default();
-        let state = Arc::new(SubscriptionState::<TestPayload>::new(
-            SubscriptionStatusSnapshot::new(SubscriptionStatus::WaitingForFirstSample),
+        let registry = CachedSubscriptionRegistry::default();
+        let state = Arc::new(CachedSubscriptionState::<TestPayload>::new(
+            CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
         ));
         let handle = state.handle();
@@ -518,7 +569,10 @@ mod tests {
 
         registry.close_all();
 
-        assert_eq!(handle.status().status(), &SubscriptionStatus::Closed);
-        assert!(matches!(updates.try_recv(), Err(SubscriptionUpdateClosed)));
+        assert_eq!(handle.status().status(), &CachedSubscriptionStatus::Closed);
+        assert!(matches!(
+            updates.try_recv(),
+            Err(CachedSubscriptionUpdateClosed)
+        ));
     }
 }

--- a/crates/ros-z-debug/src/history.rs
+++ b/crates/ros-z-debug/src/history.rs
@@ -122,7 +122,7 @@ mod tests {
     use super::TimeIndexedHistory;
     use crate::{
         DEFAULT_TIME_WINDOW_MAX_SAMPLES, RetentionPolicy, SampleMetadata, SampleRecord,
-        TopicSelector,
+        TopicReference,
     };
 
     fn test_type_info() -> ros_z::TypeInfo {
@@ -142,7 +142,7 @@ mod tests {
 
     fn test_metadata() -> Arc<SampleMetadata> {
         Arc::new(SampleMetadata {
-            requested_topic: TopicSelector::new("debug").unwrap(),
+            topic_reference: TopicReference::new("debug").unwrap(),
             resolved_topic: "/debug".to_string(),
             type_info: test_type_info(),
         })

--- a/crates/ros-z-debug/src/lib.rs
+++ b/crates/ros-z-debug/src/lib.rs
@@ -1,55 +1,87 @@
 //! Read-only subscription helpers for `ros-z` debug tooling.
 //!
-//! `SubscriptionManager` owns debug subscriptions and keeps the latest sample,
+//! `CachedSubscriptionFactory` owns debug subscriptions and keeps the latest sample,
 //! optional time-window history, status, and live update notifications. Relative
-//! topic selectors resolve against [`ManagerOptions::target_namespace`], then
-//! the manager subscribes to the absolute topic name through `ros-z`.
+//! topic references resolve against [`CachedSubscriptionOptions::target_namespace`],
+//! then the factory subscribes to the absolute topic name through `ros-z`.
 //!
 //! ```rust
 //! use std::sync::Arc;
 //!
 //! use ros_z::context::ContextBuilder;
-//! use ros_z_debug::{ManagerOptions, RetentionPolicy, SubscriptionManager};
+//! use ros_z_debug::{CachedSubscriptionFactory, CachedSubscriptionOptions, RetentionPolicy};
 //!
 //! # async fn demo() -> ros_z_debug::Result<()> {
 //! let context = ContextBuilder::default().build().await?;
 //! let node = Arc::new(context.create_node("debug").build().await?);
-//! let options = ManagerOptions::with_target_namespace("/robot_1")?;
+//! let options = CachedSubscriptionOptions::with_target_namespace("/robot_1")?;
 //!
-//! let manager = SubscriptionManager::new(node, options);
-//! let handle = manager
-//!     .subscribe_typed::<String>("status")
+//! let factory = CachedSubscriptionFactory::new(node, options);
+//! let cache = factory
+//!     .subscribe_typed::<String>("status")?
 //!     .retention(RetentionPolicy::LatestOnly)
 //!     .build()
 //!     .await?;
 //!
-//! let latest = handle.latest();
+//! let latest = cache.latest();
 //! # let _ = latest;
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ```rust
+//! use std::sync::Arc;
+//!
+//! use ros_z::context::ContextBuilder;
+//! use ros_z_debug::{TopicObserver, TopicObserverOptions};
+//!
+//! # async fn observe_demo() -> ros_z_debug::Result<()> {
+//! let context = ContextBuilder::default().build().await?;
+//! let node = Arc::new(context.create_node("observer").build().await?);
+//! let observer = TopicObserver::new(
+//!     node,
+//!     TopicObserverOptions::with_namespace("/robot_1")?,
+//! );
+//! let observation = observer.observe_dynamic("status")?.spawn();
+//! let status = observation.status();
+//! # let _ = status;
+//! # Ok(())
+//! # }
+//! ```
 
+mod cache;
 mod error;
 mod event;
+mod factory;
 mod history;
-mod manager;
+mod observation;
 mod retention;
 mod sample;
 mod status;
-mod subscription;
 mod topic;
 
+pub use cache::{CachedJsonSubscription, CachedSubscription};
 pub use error::{Error, Result};
-pub use event::{SubscriptionUpdate, SubscriptionUpdateClosed, SubscriptionUpdateReceiver};
-pub use manager::{
-    DynamicSubscriptionBuilder, ManagerOptions, SubscriptionManager, TypedSubscriptionBuilder,
+pub use event::{
+    CachedSubscriptionUpdate, CachedSubscriptionUpdateClosed, CachedSubscriptionUpdateReceiver,
+};
+pub use factory::{
+    CachedDynamicSubscriptionBuilder, CachedSubscriptionFactory, CachedSubscriptionOptions,
+    CachedTypedSubscriptionBuilder,
+};
+pub use observation::{
+    DynamicTopicObservation, DynamicTopicObservationBuilder, TopicObservation,
+    TopicObservationBlockReason, TopicObservationBuilder, TopicObservationStatus,
+    TopicObservationUpdate, TopicObservationUpdateClosed, TopicObservationUpdateReceiver,
+    TopicObserver, TopicObserverOptions,
 };
 pub use retention::{DEFAULT_TIME_WINDOW_MAX_SAMPLES, RetentionPolicy, RetentionWindow};
 pub use ros_z::dynamic::{
     ByteRenderPolicy, DynamicJsonRenderPolicy as JsonRenderPolicy, NonFiniteFloatRenderPolicy,
     dynamic_payload_to_json, dynamic_value_to_json,
 };
-pub use sample::{SampleMetadata, SampleRecord};
-pub use status::{SubscriptionStatus, SubscriptionStatusSnapshot};
-pub use subscription::{JsonSubscriptionHandle, SubscriptionHandle};
-pub use topic::{ProjectedTopic, ProjectedTopicScope, TopicProjection, TopicSelector};
+pub use sample::{JsonSampleRecord, SampleMetadata, SampleRecord};
+pub use status::{CachedSubscriptionStatus, CachedSubscriptionStatusSnapshot};
+pub use topic::{
+    ProjectedTopic, ProjectedTopicScope, TargetIdentity, TopicProjection, TopicReference,
+};

--- a/crates/ros-z-debug/src/lib.rs
+++ b/crates/ros-z-debug/src/lib.rs
@@ -29,6 +29,9 @@
 //! # }
 //! ```
 //!
+//! `TopicObserver` spawns observations that keep running after the observer handle
+//! is dropped. Drop the returned observation handle to stop its background task.
+//!
 //! ```rust
 //! use std::sync::Arc;
 //!

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -1,0 +1,1368 @@
+use std::{
+    future::Future,
+    marker::PhantomData,
+    sync::{Arc, Weak},
+    time::Duration,
+};
+
+use parking_lot::Mutex;
+use ros_z::{Message, dynamic::DynamicPayload, node::Node, time::Time};
+use tokio::sync::{broadcast, watch};
+
+use crate::{
+    CachedSubscription, CachedSubscriptionFactory, CachedSubscriptionOptions,
+    CachedSubscriptionStatusSnapshot, CachedSubscriptionUpdate, CachedSubscriptionUpdateReceiver,
+    Error, Result, RetentionPolicy, TargetIdentity, TopicReference,
+};
+
+const UPDATE_BUFFER_CAPACITY: usize = 256;
+
+/// Lifecycle state for a topic observation.
+///
+/// Observations rebuild their underlying cached subscription when the requested
+/// topic or target identity changes. Status snapshots retain the previous cache
+/// metadata while rebuilding or retrying so callers can keep displaying useful
+/// state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TopicObservationStatus {
+    /// The observation is resolving or building its first cache.
+    Building,
+    /// The observation has an active cache.
+    Observing {
+        /// Current status of the active cache.
+        cache: CachedSubscriptionStatusSnapshot,
+    },
+    /// The observation is replacing an active cache after a retarget or reconnect.
+    Rebuilding {
+        /// Last active cache status before the rebuild started.
+        previous_cache: CachedSubscriptionStatusSnapshot,
+    },
+    /// The observation failed to build and is waiting for a retry signal.
+    Retrying {
+        /// Last active cache status, if the observation had one before retrying.
+        previous_cache: Option<CachedSubscriptionStatusSnapshot>,
+        /// Diagnostic message from the failed build.
+        error: String,
+    },
+    /// The request cannot currently be resolved without additional target identity.
+    Blocked {
+        /// Last active cache status, if the observation had one before blocking.
+        previous_cache: Option<CachedSubscriptionStatusSnapshot>,
+        /// Reason the observation cannot currently proceed.
+        reason: TopicObservationBlockReason,
+    },
+    /// The observation is closed and will not emit future updates.
+    Closed,
+}
+
+/// Reason a topic observation is blocked before it can build a cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TopicObservationBlockReason {
+    /// A private topic reference such as `~trace` needs a target node name.
+    MissingTargetNodeName { topic: String },
+}
+
+/// Live notification emitted by a topic observation.
+///
+/// Updates are only delivered to receivers that were already subscribed when the
+/// event happened. Terminal closure is represented by
+/// [`TopicObservationUpdateClosed`], not by an update variant.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum TopicObservationUpdate {
+    /// The observation's retained latest or windowed data changed.
+    DataChanged,
+    /// The observation status changed.
+    StatusChanged(TopicObservationStatus),
+    /// This receiver fell behind and missed updates.
+    Lagged { dropped: u64 },
+}
+
+/// Error returned when a topic observation's live update stream has ended.
+///
+/// After this error, no future updates can arrive on that receiver. Use the
+/// observation handle's retained state methods to inspect final status and data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("topic observation update stream closed")]
+pub struct TopicObservationUpdateClosed;
+
+/// Receiver for future live updates from a topic observation.
+///
+/// Create receivers with `TopicObservation::subscribe_updates` or
+/// `DynamicTopicObservation::subscribe_updates`.
+pub struct TopicObservationUpdateReceiver {
+    receiver: broadcast::Receiver<TopicObservationUpdate>,
+}
+
+impl TopicObservationUpdateReceiver {
+    pub(crate) fn new(receiver: broadcast::Receiver<TopicObservationUpdate>) -> Self {
+        Self { receiver }
+    }
+
+    /// Wait for the next live observation update.
+    ///
+    /// Receivers observe updates sent after they subscribed; old updates are not
+    /// replayed. `Err(TopicObservationUpdateClosed)` means the observation update
+    /// stream ended and no future updates can arrive. Use the owning handle's
+    /// `status()`, `latest()`, or `window()` methods to inspect retained state.
+    pub async fn recv(
+        &mut self,
+    ) -> std::result::Result<TopicObservationUpdate, TopicObservationUpdateClosed> {
+        match self.receiver.recv().await {
+            Ok(update) => Ok(update),
+            Err(broadcast::error::RecvError::Lagged(dropped)) => Ok(lagged_update(dropped)),
+            Err(broadcast::error::RecvError::Closed) => Err(TopicObservationUpdateClosed),
+        }
+    }
+
+    /// Return the next live update if one is immediately available.
+    ///
+    /// Receivers observe updates sent after they subscribed; old updates are not
+    /// replayed. `Ok(None)` means no update is currently queued.
+    /// `Err(TopicObservationUpdateClosed)` means the live update stream ended and
+    /// no future updates can arrive.
+    pub fn try_recv(
+        &mut self,
+    ) -> std::result::Result<Option<TopicObservationUpdate>, TopicObservationUpdateClosed> {
+        match self.receiver.try_recv() {
+            Ok(update) => Ok(Some(update)),
+            Err(broadcast::error::TryRecvError::Lagged(dropped)) => {
+                Ok(Some(lagged_update(dropped)))
+            }
+            Err(broadcast::error::TryRecvError::Empty) => Ok(None),
+            Err(broadcast::error::TryRecvError::Closed) => Err(TopicObservationUpdateClosed),
+        }
+    }
+}
+
+fn lagged_update(dropped: u64) -> TopicObservationUpdate {
+    TopicObservationUpdate::Lagged { dropped }
+}
+
+/// Configuration shared by observations spawned from a [`TopicObserver`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TopicObserverOptions {
+    target_identity: TargetIdentity,
+    schema_discovery_timeout: Duration,
+    retry_delay: Duration,
+}
+
+impl Default for TopicObserverOptions {
+    fn default() -> Self {
+        Self {
+            target_identity: TargetIdentity::new("/").expect("root namespace is valid"),
+            schema_discovery_timeout: Duration::from_secs(5),
+            retry_delay: Duration::from_secs(1),
+        }
+    }
+}
+
+impl TopicObserverOptions {
+    /// Create options that resolve relative topics against `namespace`.
+    pub fn with_namespace(namespace: impl Into<String>) -> Result<Self> {
+        let mut options = Self::default();
+        options.set_namespace(namespace)?;
+        Ok(options)
+    }
+
+    /// Return the default target identity used by spawned observations.
+    pub fn target_identity(&self) -> &TargetIdentity {
+        &self.target_identity
+    }
+
+    /// Set the default namespace used to resolve relative topic references.
+    pub fn set_namespace(&mut self, namespace: impl Into<String>) -> Result<&mut Self> {
+        self.target_identity.set_namespace(namespace)?;
+        Ok(self)
+    }
+
+    /// Set the default node name used to resolve private topic references.
+    pub fn set_node_name(&mut self, node_name: impl Into<String>) -> Result<&mut Self> {
+        self.target_identity.set_node_name(node_name)?;
+        Ok(self)
+    }
+
+    /// Set the delay used after failed cache builds before retrying.
+    pub fn set_retry_delay(&mut self, retry_delay: Duration) -> &mut Self {
+        self.retry_delay = retry_delay;
+        self
+    }
+
+    /// Set how long dynamic observations wait while discovering schema metadata.
+    pub fn set_schema_discovery_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.schema_discovery_timeout = timeout;
+        self
+    }
+}
+
+/// Factory for topic observations that can retarget existing observation handles.
+#[derive(Clone)]
+pub struct TopicObserver {
+    inner: Arc<TopicObserverInner>,
+}
+
+struct TopicObserverInner {
+    node: Arc<Node>,
+    options: Mutex<TopicObserverOptions>,
+    target_sender: watch::Sender<TargetIdentity>,
+}
+
+struct ObservationTaskContext {
+    observer: Weak<TopicObserverInner>,
+    node: Arc<Node>,
+    schema_discovery_timeout: Duration,
+    retry_delay: Duration,
+    target_receiver: watch::Receiver<TargetIdentity>,
+    graph_changes: ros_z::graph::GraphChangeSubscription,
+}
+
+impl TopicObserver {
+    /// Create an observer using `node` for underlying debug subscriptions.
+    pub fn new(node: Arc<Node>, options: TopicObserverOptions) -> Self {
+        let (target_sender, _) = watch::channel(options.target_identity().clone());
+        Self {
+            inner: Arc::new(TopicObserverInner {
+                node,
+                options: Mutex::new(options),
+                target_sender,
+            }),
+        }
+    }
+
+    /// Change the namespace inherited by observations that have not overridden it.
+    pub fn set_namespace(&self, namespace: impl Into<String>) -> Result<()> {
+        let mut options = self.inner.options.lock();
+        options.set_namespace(namespace)?;
+        self.inner
+            .target_sender
+            .send_replace(options.target_identity().clone());
+        Ok(())
+    }
+
+    /// Change the node name inherited by observations that have not overridden it.
+    pub fn set_node_name(&self, node_name: impl Into<String>) -> Result<()> {
+        let mut options = self.inner.options.lock();
+        options.set_node_name(node_name)?;
+        self.inner
+            .target_sender
+            .send_replace(options.target_identity().clone());
+        Ok(())
+    }
+
+    /// Start building a typed topic observation.
+    pub fn observe_typed<T>(&self, topic: impl Into<String>) -> Result<TopicObservationBuilder<T>> {
+        Ok(TopicObservationBuilder::new(
+            self.clone(),
+            TopicReference::new(topic.into())?,
+        ))
+    }
+
+    /// Start building a dynamic topic observation that can render retained data as JSON.
+    pub fn observe_dynamic(
+        &self,
+        topic: impl Into<String>,
+    ) -> Result<DynamicTopicObservationBuilder> {
+        Ok(DynamicTopicObservationBuilder::new(
+            self.clone(),
+            TopicReference::new(topic.into())?,
+        ))
+    }
+
+    fn task_context(&self) -> ObservationTaskContext {
+        let options = self.inner.options.lock().clone();
+        ObservationTaskContext {
+            observer: Arc::downgrade(&self.inner),
+            node: Arc::clone(&self.inner.node),
+            schema_discovery_timeout: options.schema_discovery_timeout,
+            retry_delay: options.retry_delay,
+            target_receiver: self.inner.target_sender.subscribe(),
+            graph_changes: self.inner.node.graph().subscribe_changes(),
+        }
+    }
+}
+
+/// Builder for a typed topic observation.
+pub struct TopicObservationBuilder<T> {
+    observer: TopicObserver,
+    topic: TopicReference,
+    retention: RetentionPolicy,
+    _value: PhantomData<T>,
+}
+
+impl<T> TopicObservationBuilder<T> {
+    fn new(observer: TopicObserver, topic: TopicReference) -> Self {
+        Self {
+            observer,
+            topic,
+            retention: RetentionPolicy::LatestOnly,
+            _value: PhantomData,
+        }
+    }
+
+    /// Set how much data the observation retains.
+    pub fn retention(mut self, retention: RetentionPolicy) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    /// Return the topic reference requested for this observation.
+    pub fn topic(&self) -> &str {
+        self.topic.as_str()
+    }
+
+    /// Return the configured retention policy.
+    pub fn retention_policy(&self) -> RetentionPolicy {
+        self.retention
+    }
+}
+
+impl<T> TopicObservationBuilder<T>
+where
+    T: Message + Send + Sync + 'static,
+    T::Codec: Send + Sync,
+{
+    /// Spawn the background task and return the live observation handle.
+    pub fn spawn(self) -> TopicObservation<T> {
+        let (desired_sender, desired_receiver) = watch::channel(DesiredObservation {
+            topic: self.topic,
+            namespace: None,
+            node_name: None,
+            retention: self.retention,
+            reconnect_revision: 0,
+        });
+        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+        let state = Arc::new(Mutex::new(TopicObservationState {
+            status: TopicObservationStatus::Building,
+            display_cache: None,
+            display_factory: None,
+            updates: Some(updates),
+        }));
+        let task = self.observer.task_context();
+        tokio::spawn(run_typed_observation::<T>(
+            task,
+            desired_receiver,
+            Arc::downgrade(&state),
+        ));
+        TopicObservation {
+            state,
+            controls: TopicObservationControls { desired_sender },
+        }
+    }
+}
+
+impl TopicObservationBuilder<DynamicPayload> {
+    fn spawn_dynamic(self) -> TopicObservation<DynamicPayload> {
+        let (desired_sender, desired_receiver) = watch::channel(DesiredObservation {
+            topic: self.topic,
+            namespace: None,
+            node_name: None,
+            retention: self.retention,
+            reconnect_revision: 0,
+        });
+        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+        let state = Arc::new(Mutex::new(TopicObservationState {
+            status: TopicObservationStatus::Building,
+            display_cache: None,
+            display_factory: None,
+            updates: Some(updates),
+        }));
+        let task = self.observer.task_context();
+        tokio::spawn(run_dynamic_observation(
+            task,
+            desired_receiver,
+            Arc::downgrade(&state),
+        ));
+        TopicObservation {
+            state,
+            controls: TopicObservationControls { desired_sender },
+        }
+    }
+}
+
+/// Builder for a dynamic topic observation.
+pub struct DynamicTopicObservationBuilder {
+    inner: TopicObservationBuilder<DynamicPayload>,
+}
+
+impl DynamicTopicObservationBuilder {
+    fn new(observer: TopicObserver, topic: TopicReference) -> Self {
+        Self {
+            inner: TopicObservationBuilder::new(observer, topic),
+        }
+    }
+
+    /// Set how much data the observation retains.
+    pub fn retention(mut self, retention: RetentionPolicy) -> Self {
+        self.inner = self.inner.retention(retention);
+        self
+    }
+
+    /// Return the topic reference requested for this observation.
+    pub fn topic(&self) -> &str {
+        self.inner.topic()
+    }
+
+    /// Return the configured retention policy.
+    pub fn retention_policy(&self) -> RetentionPolicy {
+        self.inner.retention_policy()
+    }
+
+    /// Spawn the background task and return the live dynamic observation handle.
+    pub fn spawn(self) -> DynamicTopicObservation {
+        DynamicTopicObservation {
+            inner: self.inner.spawn_dynamic(),
+        }
+    }
+}
+
+/// Handle for reading and retargeting an observed topic.
+pub struct TopicObservation<T> {
+    state: Arc<Mutex<TopicObservationState<T>>>,
+    controls: TopicObservationControls,
+}
+
+impl<T> TopicObservation<T> {
+    #[cfg(test)]
+    fn new(desired: DesiredObservation) -> Self {
+        let (desired_sender, _) = watch::channel(desired);
+        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+
+        Self {
+            state: Arc::new(Mutex::new(TopicObservationState {
+                status: TopicObservationStatus::Building,
+                display_cache: None,
+                display_factory: None,
+                updates: Some(updates),
+            })),
+            controls: TopicObservationControls { desired_sender },
+        }
+    }
+
+    /// Change the topic reference for future rebuilds.
+    pub fn set_topic(&self, topic: impl Into<String>) -> Result<()> {
+        let topic = TopicReference::new(topic.into())?;
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.topic = topic;
+        });
+        Ok(())
+    }
+
+    /// Override the namespace used to resolve this observation's relative topic.
+    pub fn set_namespace(&self, namespace: impl Into<String>) -> Result<()> {
+        let namespace = TargetIdentity::new(namespace.into())?
+            .namespace()
+            .to_string();
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.namespace = Some(namespace);
+        });
+        Ok(())
+    }
+
+    /// Return this observation to inheriting namespace changes from its observer.
+    pub fn inherit_namespace(&self) {
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.namespace = None;
+        });
+    }
+
+    /// Override the node name used to resolve this observation's private topic.
+    pub fn set_node_name(&self, node_name: impl Into<String>) -> Result<()> {
+        let node_name = node_name.into();
+        TargetIdentity::new("/")?.with_node_name(node_name.clone())?;
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.node_name = Some(node_name);
+        });
+        Ok(())
+    }
+
+    /// Return this observation to inheriting node-name changes from its observer.
+    pub fn inherit_node_name(&self) {
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.node_name = None;
+        });
+    }
+
+    /// Change the retention policy used on the next rebuild.
+    pub fn set_retention(&self, retention: RetentionPolicy) {
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.retention = retention;
+        });
+    }
+
+    /// Force the observation to rebuild its underlying cache.
+    pub fn reconnect(&self) {
+        self.controls.desired_sender.send_modify(|desired| {
+            desired.reconnect_revision = desired.reconnect_revision.saturating_add(1);
+        });
+    }
+
+    /// Return the current observation lifecycle status.
+    pub fn status(&self) -> TopicObservationStatus {
+        self.state.lock().status.clone()
+    }
+
+    /// Return the latest retained sample, if one has arrived.
+    pub fn latest(&self) -> Option<Arc<crate::SampleRecord<T>>> {
+        self.state.lock().display_cache.as_ref()?.latest()
+    }
+
+    /// Return retained samples whose source time falls inside `[start, end]`.
+    ///
+    /// Observations with [`RetentionPolicy::LatestOnly`] return an empty window.
+    pub fn window(&self, start: Time, end: Time) -> Vec<Arc<crate::SampleRecord<T>>> {
+        self.state
+            .lock()
+            .display_cache
+            .as_ref()
+            .map_or_else(Vec::new, |cache| cache.window(start, end))
+    }
+
+    /// Subscribe to future status and data update notifications.
+    ///
+    /// The receiver is a live stream and does not replay updates that happened
+    /// before subscription. When the observation closes, the update stream ends;
+    /// call [`Self::status`] to inspect the terminal status and [`Self::latest`]
+    /// or [`Self::window`] to inspect retained data.
+    pub fn subscribe_updates(
+        &self,
+    ) -> std::result::Result<TopicObservationUpdateReceiver, TopicObservationUpdateClosed> {
+        let state = self.state.lock();
+        if matches!(state.status, TopicObservationStatus::Closed) || state.updates.is_none() {
+            return Err(TopicObservationUpdateClosed);
+        }
+        let updates = state
+            .updates
+            .as_ref()
+            .expect("open observations keep an update sender")
+            .subscribe();
+        Ok(TopicObservationUpdateReceiver::new(updates))
+    }
+}
+
+/// Handle for reading and retargeting an observed dynamic topic.
+pub struct DynamicTopicObservation {
+    inner: TopicObservation<DynamicPayload>,
+}
+
+impl DynamicTopicObservation {
+    /// Render the latest retained dynamic payload as JSON.
+    pub fn latest_json(&self) -> Option<serde_json::Value> {
+        self.latest_json_record().map(|record| record.value)
+    }
+
+    /// Render the latest retained dynamic payload as JSON with sample metadata.
+    pub fn latest_json_record(&self) -> Option<crate::JsonSampleRecord> {
+        self.inner.latest().map(dynamic_record_to_json)
+    }
+
+    /// Render retained dynamic payloads in `[start, end]` as JSON records.
+    pub fn window_json(&self, start: Time, end: Time) -> Vec<crate::JsonSampleRecord> {
+        self.inner
+            .window(start, end)
+            .into_iter()
+            .map(dynamic_record_to_json)
+            .collect()
+    }
+
+    /// Return the current observation lifecycle status.
+    pub fn status(&self) -> TopicObservationStatus {
+        self.inner.status()
+    }
+
+    /// Return the latest retained dynamic sample, if one has arrived.
+    pub fn latest(&self) -> Option<Arc<crate::SampleRecord<DynamicPayload>>> {
+        self.inner.latest()
+    }
+
+    /// Return retained dynamic samples whose source time falls inside `[start, end]`.
+    pub fn window(&self, start: Time, end: Time) -> Vec<Arc<crate::SampleRecord<DynamicPayload>>> {
+        self.inner.window(start, end)
+    }
+
+    /// Change the topic reference for future rebuilds.
+    pub fn set_topic(&self, topic: impl Into<String>) -> Result<()> {
+        self.inner.set_topic(topic)
+    }
+
+    /// Override the namespace used to resolve this observation's relative topic.
+    pub fn set_namespace(&self, namespace: impl Into<String>) -> Result<()> {
+        self.inner.set_namespace(namespace)
+    }
+
+    /// Return this observation to inheriting namespace changes from its observer.
+    pub fn inherit_namespace(&self) {
+        self.inner.inherit_namespace();
+    }
+
+    /// Override the node name used to resolve this observation's private topic.
+    pub fn set_node_name(&self, node_name: impl Into<String>) -> Result<()> {
+        self.inner.set_node_name(node_name)
+    }
+
+    /// Return this observation to inheriting node-name changes from its observer.
+    pub fn inherit_node_name(&self) {
+        self.inner.inherit_node_name();
+    }
+
+    /// Change the retention policy used on the next rebuild.
+    pub fn set_retention(&self, retention: RetentionPolicy) {
+        self.inner.set_retention(retention);
+    }
+
+    /// Force the observation to rebuild its underlying cache.
+    pub fn reconnect(&self) {
+        self.inner.reconnect();
+    }
+
+    /// Subscribe to future status and data update notifications.
+    pub fn subscribe_updates(
+        &self,
+    ) -> std::result::Result<TopicObservationUpdateReceiver, TopicObservationUpdateClosed> {
+        self.inner.subscribe_updates()
+    }
+}
+
+fn dynamic_record_to_json(
+    record: Arc<crate::SampleRecord<DynamicPayload>>,
+) -> crate::JsonSampleRecord {
+    crate::JsonSampleRecord {
+        source_time: record.source_time,
+        transport_time: record.transport_time,
+        publication_id: record.publication_id,
+        metadata: Arc::clone(&record.metadata),
+        value: crate::dynamic_payload_to_json(&record.value, crate::JsonRenderPolicy::default()),
+    }
+}
+
+struct TopicObservationState<T> {
+    status: TopicObservationStatus,
+    display_cache: Option<CachedSubscription<T>>,
+    // Dropping a factory closes the subscriptions it built; retain it with the display cache.
+    display_factory: Option<Arc<CachedSubscriptionFactory>>,
+    updates: Option<broadcast::Sender<TopicObservationUpdate>>,
+}
+
+struct TopicObservationControls {
+    desired_sender: watch::Sender<DesiredObservation>,
+}
+
+#[derive(Clone)]
+struct DesiredObservation {
+    topic: TopicReference,
+    namespace: Option<String>,
+    node_name: Option<String>,
+    retention: RetentionPolicy,
+    reconnect_revision: u64,
+}
+
+impl DesiredObservation {
+    #[cfg(test)]
+    fn new(topic: TopicReference, retention: RetentionPolicy) -> Self {
+        Self {
+            topic,
+            namespace: None,
+            node_name: None,
+            retention,
+            reconnect_revision: 0,
+        }
+    }
+}
+
+struct BuiltTypedCache<T> {
+    cache: CachedSubscription<T>,
+    factory: Arc<CachedSubscriptionFactory>,
+}
+
+fn effective_identity(
+    observer_identity: &TargetIdentity,
+    desired: &DesiredObservation,
+) -> Result<TargetIdentity> {
+    let mut identity = TargetIdentity::new(
+        desired
+            .namespace
+            .as_deref()
+            .unwrap_or_else(|| observer_identity.namespace()),
+    )?;
+    if let Some(node_name) = desired
+        .node_name
+        .as_deref()
+        .or_else(|| observer_identity.node_name())
+    {
+        identity.set_node_name(node_name)?;
+    }
+    Ok(identity)
+}
+
+async fn build_typed_cache<T>(
+    node: Arc<Node>,
+    schema_discovery_timeout: Duration,
+    identity: TargetIdentity,
+    desired: DesiredObservation,
+) -> Result<BuiltTypedCache<T>>
+where
+    T: Message + Send + Sync + 'static,
+    T::Codec: Send + Sync,
+{
+    let mut options = CachedSubscriptionOptions::with_target_namespace(identity.namespace())?;
+    if let Some(node_name) = identity.node_name() {
+        options.set_target_node_name(node_name)?;
+    }
+    options.set_schema_discovery_timeout(schema_discovery_timeout);
+
+    let factory = Arc::new(CachedSubscriptionFactory::new(node, options));
+    let cache = factory
+        .subscribe_typed::<T>(desired.topic.as_str())?
+        .retention(desired.retention)
+        .build()
+        .await?;
+    Ok(BuiltTypedCache { cache, factory })
+}
+
+async fn build_dynamic_cache(
+    node: Arc<Node>,
+    schema_discovery_timeout: Duration,
+    identity: TargetIdentity,
+    desired: DesiredObservation,
+) -> Result<BuiltTypedCache<DynamicPayload>> {
+    let mut options = CachedSubscriptionOptions::with_target_namespace(identity.namespace())?;
+    if let Some(node_name) = identity.node_name() {
+        options.set_target_node_name(node_name)?;
+    }
+    options.set_schema_discovery_timeout(schema_discovery_timeout);
+
+    let factory = Arc::new(CachedSubscriptionFactory::new(node, options));
+    let cache = factory
+        .subscribe_dynamic(desired.topic.as_str())?
+        .retention(desired.retention)
+        .build()
+        .await?;
+    Ok(BuiltTypedCache { cache, factory })
+}
+
+enum BuildWait<T> {
+    Completed(Result<BuiltTypedCache<T>>),
+    RebuildRequested,
+    Closed,
+}
+
+async fn wait_for_build<T, F>(
+    build: F,
+    desired_receiver: &mut watch::Receiver<DesiredObservation>,
+    target_receiver: &mut watch::Receiver<TargetIdentity>,
+) -> BuildWait<T>
+where
+    F: Future<Output = Result<BuiltTypedCache<T>>>,
+{
+    tokio::select! {
+        result = build => BuildWait::Completed(result),
+        result = desired_receiver.changed() => {
+            if result.is_ok() {
+                BuildWait::RebuildRequested
+            } else {
+                BuildWait::Closed
+            }
+        }
+        result = target_receiver.changed() => {
+            if result.is_ok() {
+                BuildWait::RebuildRequested
+            } else {
+                BuildWait::Closed
+            }
+        }
+    }
+}
+
+async fn run_typed_observation<T>(
+    mut task: ObservationTaskContext,
+    mut desired_receiver: watch::Receiver<DesiredObservation>,
+    state: Weak<Mutex<TopicObservationState<T>>>,
+) where
+    T: Message + Send + Sync + 'static,
+    T::Codec: Send + Sync,
+{
+    loop {
+        if task.observer.upgrade().is_none() {
+            close_observation(&state);
+            return;
+        }
+        task.graph_changes.mark_seen();
+        let desired = desired_receiver.borrow_and_update().clone();
+        let observer_identity = task.target_receiver.borrow_and_update().clone();
+        let replacing_existing_cache = previous_cache(&state).is_some();
+
+        if !set_rebuild_status(&state) {
+            return;
+        }
+
+        let identity = match resolve_build_identity(&observer_identity, &desired) {
+            Ok(identity) => identity,
+            Err(Error::MissingTargetNodeName { .. }) => {
+                if !set_blocked_status(
+                    &state,
+                    TopicObservationBlockReason::MissingTargetNodeName {
+                        topic: desired.topic.as_str().to_string(),
+                    },
+                ) {
+                    return;
+                }
+                if !wait_for_blocked_signal(&mut desired_receiver, &mut task.target_receiver).await
+                {
+                    close_observation(&state);
+                    return;
+                }
+                continue;
+            }
+            Err(error) => {
+                if !set_retrying_status(&state, error.to_string()) {
+                    return;
+                }
+                if !wait_for_retry_signal(
+                    task.retry_delay,
+                    &mut desired_receiver,
+                    &mut task.target_receiver,
+                    &mut task.graph_changes,
+                )
+                .await
+                {
+                    close_observation(&state);
+                    return;
+                }
+                continue;
+            }
+        };
+
+        let build = build_typed_cache::<T>(
+            Arc::clone(&task.node),
+            task.schema_discovery_timeout,
+            identity,
+            desired,
+        );
+        match wait_for_build(build, &mut desired_receiver, &mut task.target_receiver).await {
+            BuildWait::Completed(Ok(built_cache)) => {
+                let cache = built_cache.cache.clone();
+                if !install_typed_cache(&state, built_cache) {
+                    return;
+                }
+                task.graph_changes.mark_seen();
+                let Ok(mut cache_updates) = cache.subscribe_updates() else {
+                    continue;
+                };
+
+                if !wait_for_observing_rebuild(
+                    &state,
+                    &mut desired_receiver,
+                    &mut task.target_receiver,
+                    &mut task.graph_changes,
+                    replacing_existing_cache,
+                    &mut cache_updates,
+                )
+                .await
+                {
+                    close_observation(&state);
+                    return;
+                }
+            }
+            BuildWait::Completed(Err(error)) => {
+                if !set_retrying_status(&state, error.to_string()) {
+                    return;
+                }
+                if !wait_for_retry_signal(
+                    task.retry_delay,
+                    &mut desired_receiver,
+                    &mut task.target_receiver,
+                    &mut task.graph_changes,
+                )
+                .await
+                {
+                    close_observation(&state);
+                    return;
+                }
+            }
+            BuildWait::RebuildRequested => continue,
+            BuildWait::Closed => {
+                close_observation(&state);
+                return;
+            }
+        }
+    }
+}
+
+async fn run_dynamic_observation(
+    mut task: ObservationTaskContext,
+    mut desired_receiver: watch::Receiver<DesiredObservation>,
+    state: Weak<Mutex<TopicObservationState<DynamicPayload>>>,
+) {
+    loop {
+        if task.observer.upgrade().is_none() {
+            close_observation(&state);
+            return;
+        }
+        task.graph_changes.mark_seen();
+        let desired = desired_receiver.borrow_and_update().clone();
+        let observer_identity = task.target_receiver.borrow_and_update().clone();
+        let replacing_existing_cache = previous_cache(&state).is_some();
+
+        if !set_rebuild_status(&state) {
+            return;
+        }
+
+        let identity = match resolve_build_identity(&observer_identity, &desired) {
+            Ok(identity) => identity,
+            Err(Error::MissingTargetNodeName { .. }) => {
+                if !set_blocked_status(
+                    &state,
+                    TopicObservationBlockReason::MissingTargetNodeName {
+                        topic: desired.topic.as_str().to_string(),
+                    },
+                ) {
+                    return;
+                }
+                if !wait_for_blocked_signal(&mut desired_receiver, &mut task.target_receiver).await
+                {
+                    close_observation(&state);
+                    return;
+                }
+                continue;
+            }
+            Err(error) => {
+                if !set_retrying_status(&state, error.to_string()) {
+                    return;
+                }
+                if !wait_for_retry_signal(
+                    task.retry_delay,
+                    &mut desired_receiver,
+                    &mut task.target_receiver,
+                    &mut task.graph_changes,
+                )
+                .await
+                {
+                    close_observation(&state);
+                    return;
+                }
+                continue;
+            }
+        };
+
+        let build = build_dynamic_cache(
+            Arc::clone(&task.node),
+            task.schema_discovery_timeout,
+            identity,
+            desired,
+        );
+        match wait_for_build(build, &mut desired_receiver, &mut task.target_receiver).await {
+            BuildWait::Completed(Ok(built_cache)) => {
+                let cache = built_cache.cache.clone();
+                if !install_typed_cache(&state, built_cache) {
+                    return;
+                }
+                task.graph_changes.mark_seen();
+                let Ok(mut cache_updates) = cache.subscribe_updates() else {
+                    continue;
+                };
+
+                if !wait_for_observing_rebuild(
+                    &state,
+                    &mut desired_receiver,
+                    &mut task.target_receiver,
+                    &mut task.graph_changes,
+                    replacing_existing_cache,
+                    &mut cache_updates,
+                )
+                .await
+                {
+                    close_observation(&state);
+                    return;
+                }
+            }
+            BuildWait::Completed(Err(error)) => {
+                if !set_retrying_status(&state, error.to_string()) {
+                    return;
+                }
+                if !wait_for_retry_signal(
+                    task.retry_delay,
+                    &mut desired_receiver,
+                    &mut task.target_receiver,
+                    &mut task.graph_changes,
+                )
+                .await
+                {
+                    close_observation(&state);
+                    return;
+                }
+            }
+            BuildWait::RebuildRequested => continue,
+            BuildWait::Closed => {
+                close_observation(&state);
+                return;
+            }
+        }
+    }
+}
+
+fn resolve_build_identity(
+    observer_identity: &TargetIdentity,
+    desired: &DesiredObservation,
+) -> Result<TargetIdentity> {
+    let identity = effective_identity(observer_identity, desired)?;
+    desired.topic.resolve(&identity)?;
+    Ok(identity)
+}
+
+async fn wait_for_blocked_signal(
+    desired_receiver: &mut watch::Receiver<DesiredObservation>,
+    target_receiver: &mut watch::Receiver<TargetIdentity>,
+) -> bool {
+    tokio::select! {
+        result = desired_receiver.changed() => result.is_ok(),
+        result = target_receiver.changed() => result.is_ok(),
+    }
+}
+
+async fn wait_for_retry_signal(
+    retry_delay: Duration,
+    desired_receiver: &mut watch::Receiver<DesiredObservation>,
+    target_receiver: &mut watch::Receiver<TargetIdentity>,
+    graph_changes: &mut ros_z::graph::GraphChangeSubscription,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(retry_delay) => true,
+        result = desired_receiver.changed() => result.is_ok(),
+        result = target_receiver.changed() => result.is_ok(),
+        revision = graph_changes.changed() => revision.is_some(),
+    }
+}
+
+async fn wait_for_observing_rebuild<T>(
+    state: &Weak<Mutex<TopicObservationState<T>>>,
+    desired_receiver: &mut watch::Receiver<DesiredObservation>,
+    target_receiver: &mut watch::Receiver<TargetIdentity>,
+    graph_changes: &mut ros_z::graph::GraphChangeSubscription,
+    mut suppress_next_graph_change: bool,
+    cache_updates: &mut CachedSubscriptionUpdateReceiver,
+) -> bool {
+    loop {
+        let rebuild = tokio::select! {
+            result = desired_receiver.changed() => return result.is_ok(),
+            result = target_receiver.changed() => return result.is_ok(),
+            revision = graph_changes.changed() => {
+                if revision.is_none() {
+                    return false;
+                }
+                !std::mem::take(&mut suppress_next_graph_change)
+            }
+            update = cache_updates.recv() => {
+                match update {
+                    Ok(CachedSubscriptionUpdate::DataChanged) => {
+                        send_observation_update(
+                            state,
+                            TopicObservationUpdate::DataChanged,
+                        );
+                        !refresh_observing_status(state)
+                    }
+                    Ok(CachedSubscriptionUpdate::StatusChanged(_)) => {
+                        !refresh_observing_status(state)
+                    }
+                    Ok(CachedSubscriptionUpdate::Lagged { dropped }) => {
+                        send_observation_update(
+                            state,
+                            TopicObservationUpdate::Lagged { dropped },
+                        );
+                        !refresh_observing_status(state)
+                    }
+                    Err(_) => true,
+                }
+            }
+        };
+
+        if rebuild {
+            return true;
+        }
+    }
+}
+
+fn previous_cache<T>(
+    state: &Weak<Mutex<TopicObservationState<T>>>,
+) -> Option<CachedSubscriptionStatusSnapshot> {
+    state.upgrade().and_then(|state| {
+        state
+            .lock()
+            .display_cache
+            .as_ref()
+            .map(CachedSubscription::status)
+    })
+}
+
+fn set_rebuild_status<T>(state: &Weak<Mutex<TopicObservationState<T>>>) -> bool {
+    let status = match previous_cache(state) {
+        Some(previous_cache) => TopicObservationStatus::Rebuilding { previous_cache },
+        None => TopicObservationStatus::Building,
+    };
+    set_observation_status(state, status)
+}
+
+fn set_retrying_status<T>(state: &Weak<Mutex<TopicObservationState<T>>>, error: String) -> bool {
+    let previous_cache = previous_cache(state);
+    set_observation_status(
+        state,
+        TopicObservationStatus::Retrying {
+            previous_cache,
+            error,
+        },
+    )
+}
+
+fn set_blocked_status<T>(
+    state: &Weak<Mutex<TopicObservationState<T>>>,
+    reason: TopicObservationBlockReason,
+) -> bool {
+    let previous_cache = previous_cache(state);
+    set_observation_status(
+        state,
+        TopicObservationStatus::Blocked {
+            previous_cache,
+            reason,
+        },
+    )
+}
+
+fn install_typed_cache<T>(
+    state: &Weak<Mutex<TopicObservationState<T>>>,
+    built_cache: BuiltTypedCache<T>,
+) -> bool {
+    let status = TopicObservationStatus::Observing {
+        cache: built_cache.cache.status(),
+    };
+    let Some(state) = state.upgrade() else {
+        return false;
+    };
+    let updates = {
+        let mut state = state.lock();
+        if state.updates.is_none() {
+            return false;
+        }
+        let status_changed = state.status != status;
+        state.display_factory = Some(built_cache.factory);
+        state.display_cache = Some(built_cache.cache);
+        state.status = status.clone();
+        status_changed.then(|| state.updates.clone()).flatten()
+    };
+    if let Some(updates) = updates {
+        let _ = updates.send(TopicObservationUpdate::StatusChanged(status));
+    }
+    true
+}
+
+fn refresh_observing_status<T>(state: &Weak<Mutex<TopicObservationState<T>>>) -> bool {
+    let Some(state) = state.upgrade() else {
+        return false;
+    };
+    let status = {
+        let state = state.lock();
+        let Some(cache) = &state.display_cache else {
+            return false;
+        };
+        TopicObservationStatus::Observing {
+            cache: cache.status(),
+        }
+    };
+    set_observation_status(&Arc::downgrade(&state), status)
+}
+
+fn set_observation_status<T>(
+    state: &Weak<Mutex<TopicObservationState<T>>>,
+    status: TopicObservationStatus,
+) -> bool {
+    let Some(state) = state.upgrade() else {
+        return false;
+    };
+    let updates = {
+        let mut state = state.lock();
+        if state.status == status {
+            return state.updates.is_some();
+        }
+        state.status = status.clone();
+        state.updates.clone()
+    };
+    let Some(updates) = updates else {
+        return false;
+    };
+    let _ = updates.send(TopicObservationUpdate::StatusChanged(status));
+    true
+}
+
+fn close_observation<T>(state: &Weak<Mutex<TopicObservationState<T>>>) {
+    let Some(state) = state.upgrade() else {
+        return;
+    };
+    let display_factory = {
+        let mut state = state.lock();
+        state.status = TopicObservationStatus::Closed;
+        state.updates.take();
+        state.display_factory.take()
+    };
+    drop(display_factory);
+}
+
+fn send_observation_update<T>(
+    state: &Weak<Mutex<TopicObservationState<T>>>,
+    update: TopicObservationUpdate,
+) -> bool {
+    let Some(state) = state.upgrade() else {
+        return false;
+    };
+    let updates = state.lock().updates.clone();
+    let Some(updates) = updates else {
+        return false;
+    };
+    let _ = updates.send(update);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use tokio::sync::{broadcast, oneshot};
+
+    use super::{
+        DesiredObservation, TopicObservation, TopicObservationBlockReason, TopicObservationStatus,
+        TopicObservationUpdate, TopicObservationUpdateClosed, TopicObservationUpdateReceiver,
+    };
+    use crate::{RetentionPolicy, TargetIdentity, TopicReference};
+
+    #[test]
+    fn building_status_has_no_cache() {
+        let status = TopicObservationStatus::Building;
+
+        assert!(matches!(status, TopicObservationStatus::Building));
+    }
+
+    #[test]
+    fn missing_target_node_block_reason_carries_topic() {
+        let reason = TopicObservationBlockReason::MissingTargetNodeName {
+            topic: "~trace".to_string(),
+        };
+
+        assert!(matches!(
+            reason,
+            TopicObservationBlockReason::MissingTargetNodeName { topic } if topic == "~trace"
+        ));
+    }
+
+    #[test]
+    fn observation_inherits_observer_target_identity_by_default() {
+        let observer_identity = TargetIdentity::new("/42")
+            .unwrap()
+            .with_node_name("behavior")
+            .unwrap();
+        let desired = DesiredObservation {
+            topic: TopicReference::new("~trace").unwrap(),
+            namespace: None,
+            node_name: None,
+            retention: RetentionPolicy::LatestOnly,
+            reconnect_revision: 0,
+        };
+
+        let effective = super::effective_identity(&observer_identity, &desired).unwrap();
+
+        assert_eq!(effective.namespace(), "/42");
+        assert_eq!(effective.node_name(), Some("behavior"));
+    }
+
+    #[test]
+    fn observation_target_identity_overrides_observer_defaults() {
+        let observer_identity = TargetIdentity::new("/42")
+            .unwrap()
+            .with_node_name("behavior")
+            .unwrap();
+        let desired = DesiredObservation {
+            topic: TopicReference::new("~trace").unwrap(),
+            namespace: Some("/99".to_string()),
+            node_name: Some("vision".to_string()),
+            retention: RetentionPolicy::LatestOnly,
+            reconnect_revision: 0,
+        };
+
+        let effective = super::effective_identity(&observer_identity, &desired).unwrap();
+
+        assert_eq!(effective.namespace(), "/99");
+        assert_eq!(effective.node_name(), Some("vision"));
+    }
+
+    #[test]
+    fn observation_update_receiver_reports_lagged() {
+        let (sender, receiver) = broadcast::channel(1);
+        let mut receiver = TopicObservationUpdateReceiver::new(receiver);
+        sender.send(TopicObservationUpdate::DataChanged).unwrap();
+        sender.send(TopicObservationUpdate::DataChanged).unwrap();
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(Some(TopicObservationUpdate::Lagged { dropped: 1 }))
+        ));
+    }
+
+    #[test]
+    fn observation_update_receiver_reports_closed() {
+        let (sender, receiver) = broadcast::channel(1);
+        let mut receiver = TopicObservationUpdateReceiver::new(receiver);
+        drop(sender);
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(TopicObservationUpdateClosed)
+        ));
+    }
+
+    #[test]
+    fn subscribe_updates_reports_closed_observation() {
+        let observation = TopicObservation::<String>::new(DesiredObservation::new(
+            TopicReference::new("status").unwrap(),
+            RetentionPolicy::LatestOnly,
+        ));
+        observation.state.lock().status = TopicObservationStatus::Closed;
+
+        assert!(matches!(
+            observation.subscribe_updates(),
+            Err(TopicObservationUpdateClosed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_last_observation_handle_stops_background_task() {
+        let (exited_sender, exited_receiver) = oneshot::channel();
+        let observation = test_observation_with_exit_signal::<String>(exited_sender);
+
+        drop(observation);
+
+        tokio::time::timeout(Duration::from_secs(1), exited_receiver)
+            .await
+            .expect("observation task should exit")
+            .expect("exit signal should send");
+    }
+
+    fn test_observation_with_exit_signal<T: Send + Sync + 'static>(
+        exited_sender: oneshot::Sender<()>,
+    ) -> TopicObservation<T> {
+        let observation = TopicObservation::new(DesiredObservation::new(
+            TopicReference::new("status").unwrap(),
+            RetentionPolicy::LatestOnly,
+        ));
+        let state = Arc::downgrade(&observation.state);
+
+        tokio::spawn(async move {
+            loop {
+                if state.upgrade().is_none() {
+                    let _ = exited_sender.send(());
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+
+        observation
+    }
+}

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -211,7 +211,7 @@ struct TopicObserverInner {
 }
 
 struct ObservationTaskContext {
-    observer: Weak<TopicObserverInner>,
+    _observer: Arc<TopicObserverInner>,
     node: Arc<Node>,
     schema_discovery_timeout: Duration,
     retry_delay: Duration,
@@ -274,7 +274,7 @@ impl TopicObserver {
     fn task_context(&self) -> ObservationTaskContext {
         let options = self.inner.options.lock().clone();
         ObservationTaskContext {
-            observer: Arc::downgrade(&self.inner),
+            _observer: Arc::clone(&self.inner),
             node: Arc::clone(&self.inner.node),
             schema_discovery_timeout: options.schema_discovery_timeout,
             retry_delay: options.retry_delay,
@@ -784,10 +784,6 @@ async fn run_typed_observation<T>(
     T::Codec: Send + Sync,
 {
     loop {
-        if task.observer.upgrade().is_none() {
-            close_observation(&state);
-            return;
-        }
         task.graph_changes.mark_seen();
         let desired = desired_receiver.borrow_and_update().clone();
         let observer_identity = task.target_receiver.borrow_and_update().clone();
@@ -896,10 +892,6 @@ async fn run_dynamic_observation(
     state: Weak<Mutex<TopicObservationState<DynamicPayload>>>,
 ) {
     loop {
-        if task.observer.upgrade().is_none() {
-            close_observation(&state);
-            return;
-        }
         task.graph_changes.mark_seen();
         let desired = desired_receiver.borrow_and_update().clone();
         let observer_identity = task.target_receiver.borrow_and_update().clone();

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -913,6 +913,8 @@ async fn run_typed_observation<T>(
                     return;
                 }
                 task.graph_changes.mark_seen();
+                let graph_fingerprint =
+                    topic_graph_fingerprint(task.node.as_ref(), target.resolved_topic.as_str());
                 let Ok(mut cache_updates) = cache.subscribe_updates() else {
                     continue;
                 };
@@ -922,7 +924,7 @@ async fn run_typed_observation<T>(
                     (
                         task.node.as_ref(),
                         target.resolved_topic.as_str(),
-                        target.graph_fingerprint,
+                        graph_fingerprint,
                     ),
                     &mut desired_receiver,
                     &mut task.target_receiver,
@@ -1030,6 +1032,8 @@ async fn run_dynamic_observation(
                     return;
                 }
                 task.graph_changes.mark_seen();
+                let graph_fingerprint =
+                    topic_graph_fingerprint(task.node.as_ref(), target.resolved_topic.as_str());
                 let Ok(mut cache_updates) = cache.subscribe_updates() else {
                     continue;
                 };
@@ -1039,7 +1043,7 @@ async fn run_dynamic_observation(
                     (
                         task.node.as_ref(),
                         target.resolved_topic.as_str(),
-                        target.graph_fingerprint,
+                        graph_fingerprint,
                     ),
                     &mut desired_receiver,
                     &mut task.target_receiver,

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -20,9 +20,10 @@ const UPDATE_BUFFER_CAPACITY: usize = 256;
 /// Lifecycle state for a topic observation.
 ///
 /// Observations rebuild their underlying cached subscription when the requested
-/// topic or target identity changes. Status snapshots retain the previous cache
-/// metadata while rebuilding or retrying so callers can keep displaying useful
-/// state.
+/// topic, target identity, retention policy, explicit reconnect revision, or
+/// relevant graph state changes. Status snapshots retain frozen previous cache
+/// metadata while rebuilding, retrying, or blocked so callers can keep displaying
+/// the last readable data without keeping the old subscription live.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TopicObservationStatus {
@@ -39,6 +40,8 @@ pub enum TopicObservationStatus {
         previous_cache: CachedSubscriptionStatusSnapshot,
     },
     /// The observation failed to build and is waiting for a retry signal.
+    ///
+    /// The previous cache, when present, is frozen and no longer receives data.
     Retrying {
         /// Last active cache status, if the observation had one before retrying.
         previous_cache: Option<CachedSubscriptionStatusSnapshot>,
@@ -46,6 +49,8 @@ pub enum TopicObservationStatus {
         error: String,
     },
     /// The request cannot currently be resolved without additional target identity.
+    ///
+    /// The previous cache, when present, is frozen and no longer receives data.
     Blocked {
         /// Last active cache status, if the observation had one before blocking.
         previous_cache: Option<CachedSubscriptionStatusSnapshot>,
@@ -198,7 +203,10 @@ impl TopicObserverOptions {
     }
 }
 
-/// Factory for topic observations that can retarget existing observation handles.
+/// Factory for topic observations that can retarget inherited observation state.
+///
+/// Dropping a `TopicObserver` handle does not close observations that were already
+/// spawned from it. Drop the observation handles to stop their background tasks.
 #[derive(Clone)]
 pub struct TopicObserver {
     inner: Arc<TopicObserverInner>,
@@ -911,9 +919,11 @@ async fn run_typed_observation<T>(
 
                 if !wait_for_observing_rebuild(
                     &state,
-                    task.node.as_ref(),
-                    target.resolved_topic.as_str(),
-                    target.graph_fingerprint,
+                    (
+                        task.node.as_ref(),
+                        target.resolved_topic.as_str(),
+                        target.graph_fingerprint,
+                    ),
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
@@ -1026,9 +1036,11 @@ async fn run_dynamic_observation(
 
                 if !wait_for_observing_rebuild(
                     &state,
-                    task.node.as_ref(),
-                    target.resolved_topic.as_str(),
-                    target.graph_fingerprint,
+                    (
+                        task.node.as_ref(),
+                        target.resolved_topic.as_str(),
+                        target.graph_fingerprint,
+                    ),
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
@@ -1114,10 +1126,10 @@ async fn wait_for_retry_signal(
                 if revision.is_none() {
                     return false;
                 }
-                if let Some((node, resolved_topic, fingerprint)) = &mut graph_filter {
-                    if topic_graph_fingerprint_changed(node, resolved_topic, fingerprint) {
-                        return true;
-                    }
+                if let Some((node, resolved_topic, fingerprint)) = &mut graph_filter
+                    && topic_graph_fingerprint_changed(node, resolved_topic, fingerprint)
+                {
+                    return true;
                 }
             }
         }
@@ -1126,14 +1138,13 @@ async fn wait_for_retry_signal(
 
 async fn wait_for_observing_rebuild<T>(
     state: &Weak<Mutex<TopicObservationState<T>>>,
-    node: &Node,
-    resolved_topic: &str,
-    mut graph_fingerprint: TopicGraphFingerprint,
+    graph_filter: (&Node, &str, TopicGraphFingerprint),
     desired_receiver: &mut watch::Receiver<DesiredObservation>,
     target_receiver: &mut watch::Receiver<TargetIdentity>,
     graph_changes: &mut ros_z::graph::GraphChangeSubscription,
     cache_updates: &mut CachedSubscriptionUpdateReceiver,
 ) -> bool {
+    let (node, resolved_topic, mut graph_fingerprint) = graph_filter;
     loop {
         let rebuild = tokio::select! {
             result = desired_receiver.changed() => return result.is_ok(),

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -1095,6 +1095,24 @@ fn previous_cache<T>(
     })
 }
 
+fn freeze_display_cache<T>(state: &Weak<Mutex<TopicObservationState<T>>>) -> bool {
+    let Some(state) = state.upgrade() else {
+        return false;
+    };
+    let (cache, factory) = {
+        let mut state = state.lock();
+        if state.updates.is_none() {
+            return false;
+        }
+        (state.display_cache.clone(), state.display_factory.take())
+    };
+    drop(factory);
+    if let Some(cache) = cache {
+        cache.close_retaining_samples();
+    }
+    true
+}
+
 fn set_rebuild_status<T>(state: &Weak<Mutex<TopicObservationState<T>>>) -> bool {
     let status = match previous_cache(state) {
         Some(previous_cache) => TopicObservationStatus::Rebuilding { previous_cache },
@@ -1105,6 +1123,9 @@ fn set_rebuild_status<T>(state: &Weak<Mutex<TopicObservationState<T>>>) -> bool 
 
 fn set_retrying_status<T>(state: &Weak<Mutex<TopicObservationState<T>>>, error: String) -> bool {
     let previous_cache = previous_cache(state);
+    if !freeze_display_cache(state) {
+        return false;
+    }
     set_observation_status(
         state,
         TopicObservationStatus::Retrying {
@@ -1119,6 +1140,9 @@ fn set_blocked_status<T>(
     reason: TopicObservationBlockReason,
 ) -> bool {
     let previous_cache = previous_cache(state);
+    if !freeze_display_cache(state) {
+        return false;
+    }
     set_observation_status(
         state,
         TopicObservationStatus::Blocked {

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -12,7 +12,7 @@ use tokio::sync::{broadcast, watch};
 use crate::{
     CachedSubscription, CachedSubscriptionFactory, CachedSubscriptionOptions,
     CachedSubscriptionStatusSnapshot, CachedSubscriptionUpdate, CachedSubscriptionUpdateReceiver,
-    Error, Result, RetentionPolicy, TargetIdentity, TopicReference,
+    Error, JsonRenderPolicy, Result, RetentionPolicy, TargetIdentity, TopicReference,
 };
 
 const UPDATE_BUFFER_CAPACITY: usize = 256;
@@ -385,18 +385,26 @@ impl TopicObservationBuilder<DynamicPayload> {
 /// Builder for a dynamic topic observation.
 pub struct DynamicTopicObservationBuilder {
     inner: TopicObservationBuilder<DynamicPayload>,
+    json_render_policy: JsonRenderPolicy,
 }
 
 impl DynamicTopicObservationBuilder {
     fn new(observer: TopicObserver, topic: TopicReference) -> Self {
         Self {
             inner: TopicObservationBuilder::new(observer, topic),
+            json_render_policy: JsonRenderPolicy::default(),
         }
     }
 
     /// Set how much data the observation retains.
     pub fn retention(mut self, retention: RetentionPolicy) -> Self {
         self.inner = self.inner.retention(retention);
+        self
+    }
+
+    /// Set how retained dynamic payloads are rendered as JSON.
+    pub fn json_render_policy(mut self, policy: JsonRenderPolicy) -> Self {
+        self.json_render_policy = policy;
         self
     }
 
@@ -414,6 +422,7 @@ impl DynamicTopicObservationBuilder {
     pub fn spawn(self) -> DynamicTopicObservation {
         DynamicTopicObservation {
             inner: self.inner.spawn_dynamic(),
+            json_render_policy: self.json_render_policy,
         }
     }
 }
@@ -545,6 +554,7 @@ impl<T> TopicObservation<T> {
 /// Handle for reading and retargeting an observed dynamic topic.
 pub struct DynamicTopicObservation {
     inner: TopicObservation<DynamicPayload>,
+    json_render_policy: JsonRenderPolicy,
 }
 
 impl DynamicTopicObservation {
@@ -555,15 +565,25 @@ impl DynamicTopicObservation {
 
     /// Render the latest retained dynamic payload as JSON with sample metadata.
     pub fn latest_json_record(&self) -> Option<crate::JsonSampleRecord> {
-        self.inner.latest().map(dynamic_record_to_json)
+        self.inner
+            .latest()
+            .map(|record| dynamic_record_to_json(record, self.json_render_policy))
+    }
+
+    /// Render retained dynamic payloads in `[start, end]` as JSON values.
+    pub fn window_json(&self, start: Time, end: Time) -> Vec<serde_json::Value> {
+        self.window_json_records(start, end)
+            .into_iter()
+            .map(|record| record.value)
+            .collect()
     }
 
     /// Render retained dynamic payloads in `[start, end]` as JSON records.
-    pub fn window_json(&self, start: Time, end: Time) -> Vec<crate::JsonSampleRecord> {
+    pub fn window_json_records(&self, start: Time, end: Time) -> Vec<crate::JsonSampleRecord> {
         self.inner
             .window(start, end)
             .into_iter()
-            .map(dynamic_record_to_json)
+            .map(|record| dynamic_record_to_json(record, self.json_render_policy))
             .collect()
     }
 
@@ -627,13 +647,14 @@ impl DynamicTopicObservation {
 
 fn dynamic_record_to_json(
     record: Arc<crate::SampleRecord<DynamicPayload>>,
+    policy: JsonRenderPolicy,
 ) -> crate::JsonSampleRecord {
     crate::JsonSampleRecord {
         source_time: record.source_time,
         transport_time: record.transport_time,
         publication_id: record.publication_id,
         metadata: Arc::clone(&record.metadata),
-        value: crate::dynamic_payload_to_json(&record.value, crate::JsonRenderPolicy::default()),
+        value: crate::dynamic_payload_to_json(&record.value, policy),
     }
 }
 

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -676,6 +676,47 @@ struct BuiltTypedCache<T> {
     factory: Arc<CachedSubscriptionFactory>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TopicGraphFingerprint {
+    publisher_types: Vec<(String, String)>,
+}
+
+struct ResolvedObservationTarget {
+    identity: TargetIdentity,
+    resolved_topic: String,
+    graph_fingerprint: TopicGraphFingerprint,
+}
+
+fn topic_graph_fingerprint(node: &Node, resolved_topic: &str) -> TopicGraphFingerprint {
+    let mut publisher_types = node
+        .graph()
+        .view()
+        .publishers_on(resolved_topic)
+        .into_iter()
+        .map(|publisher| {
+            (
+                publisher.type_info.name,
+                publisher.type_info.hash.to_hash_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    publisher_types.sort();
+    TopicGraphFingerprint { publisher_types }
+}
+
+fn topic_graph_fingerprint_changed(
+    node: &Node,
+    resolved_topic: &str,
+    current: &mut TopicGraphFingerprint,
+) -> bool {
+    let next = topic_graph_fingerprint(node, resolved_topic);
+    if next == *current {
+        return false;
+    }
+    *current = next;
+    true
+}
+
 fn effective_identity(
     observer_identity: &TargetIdentity,
     desired: &DesiredObservation,
@@ -787,14 +828,13 @@ async fn run_typed_observation<T>(
         task.graph_changes.mark_seen();
         let desired = desired_receiver.borrow_and_update().clone();
         let observer_identity = task.target_receiver.borrow_and_update().clone();
-        let replacing_existing_cache = previous_cache(&state).is_some();
 
         if !set_rebuild_status(&state) {
             return;
         }
 
-        let identity = match resolve_build_identity(&observer_identity, &desired) {
-            Ok(identity) => identity,
+        let target = match resolve_build_target(&task.node, &observer_identity, &desired) {
+            Ok(target) => target,
             Err(Error::MissingTargetNodeName { .. }) => {
                 if !set_blocked_status(
                     &state,
@@ -820,6 +860,7 @@ async fn run_typed_observation<T>(
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
+                    None,
                 )
                 .await
                 {
@@ -833,7 +874,7 @@ async fn run_typed_observation<T>(
         let build = build_typed_cache::<T>(
             Arc::clone(&task.node),
             task.schema_discovery_timeout,
-            identity,
+            target.identity,
             desired,
         );
         match wait_for_build(build, &mut desired_receiver, &mut task.target_receiver).await {
@@ -849,10 +890,12 @@ async fn run_typed_observation<T>(
 
                 if !wait_for_observing_rebuild(
                     &state,
+                    task.node.as_ref(),
+                    target.resolved_topic.as_str(),
+                    target.graph_fingerprint,
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
-                    replacing_existing_cache,
                     &mut cache_updates,
                 )
                 .await
@@ -870,6 +913,11 @@ async fn run_typed_observation<T>(
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
+                    Some((
+                        task.node.as_ref(),
+                        target.resolved_topic.as_str(),
+                        target.graph_fingerprint,
+                    )),
                 )
                 .await
                 {
@@ -895,14 +943,13 @@ async fn run_dynamic_observation(
         task.graph_changes.mark_seen();
         let desired = desired_receiver.borrow_and_update().clone();
         let observer_identity = task.target_receiver.borrow_and_update().clone();
-        let replacing_existing_cache = previous_cache(&state).is_some();
 
         if !set_rebuild_status(&state) {
             return;
         }
 
-        let identity = match resolve_build_identity(&observer_identity, &desired) {
-            Ok(identity) => identity,
+        let target = match resolve_build_target(&task.node, &observer_identity, &desired) {
+            Ok(target) => target,
             Err(Error::MissingTargetNodeName { .. }) => {
                 if !set_blocked_status(
                     &state,
@@ -928,6 +975,7 @@ async fn run_dynamic_observation(
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
+                    None,
                 )
                 .await
                 {
@@ -941,7 +989,7 @@ async fn run_dynamic_observation(
         let build = build_dynamic_cache(
             Arc::clone(&task.node),
             task.schema_discovery_timeout,
-            identity,
+            target.identity,
             desired,
         );
         match wait_for_build(build, &mut desired_receiver, &mut task.target_receiver).await {
@@ -957,10 +1005,12 @@ async fn run_dynamic_observation(
 
                 if !wait_for_observing_rebuild(
                     &state,
+                    task.node.as_ref(),
+                    target.resolved_topic.as_str(),
+                    target.graph_fingerprint,
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
-                    replacing_existing_cache,
                     &mut cache_updates,
                 )
                 .await
@@ -978,6 +1028,11 @@ async fn run_dynamic_observation(
                     &mut desired_receiver,
                     &mut task.target_receiver,
                     &mut task.graph_changes,
+                    Some((
+                        task.node.as_ref(),
+                        target.resolved_topic.as_str(),
+                        target.graph_fingerprint,
+                    )),
                 )
                 .await
                 {
@@ -994,13 +1049,19 @@ async fn run_dynamic_observation(
     }
 }
 
-fn resolve_build_identity(
+fn resolve_build_target(
+    node: &Node,
     observer_identity: &TargetIdentity,
     desired: &DesiredObservation,
-) -> Result<TargetIdentity> {
+) -> Result<ResolvedObservationTarget> {
     let identity = effective_identity(observer_identity, desired)?;
-    desired.topic.resolve(&identity)?;
-    Ok(identity)
+    let resolved_topic = desired.topic.resolve(&identity)?;
+    let graph_fingerprint = topic_graph_fingerprint(node, &resolved_topic);
+    Ok(ResolvedObservationTarget {
+        identity,
+        resolved_topic,
+        graph_fingerprint,
+    })
 }
 
 async fn wait_for_blocked_signal(
@@ -1018,21 +1079,38 @@ async fn wait_for_retry_signal(
     desired_receiver: &mut watch::Receiver<DesiredObservation>,
     target_receiver: &mut watch::Receiver<TargetIdentity>,
     graph_changes: &mut ros_z::graph::GraphChangeSubscription,
+    graph_filter: Option<(&Node, &str, TopicGraphFingerprint)>,
 ) -> bool {
-    tokio::select! {
-        _ = tokio::time::sleep(retry_delay) => true,
-        result = desired_receiver.changed() => result.is_ok(),
-        result = target_receiver.changed() => result.is_ok(),
-        revision = graph_changes.changed() => revision.is_some(),
+    let mut graph_filter = graph_filter;
+    let retry_sleep = tokio::time::sleep(retry_delay);
+    tokio::pin!(retry_sleep);
+    loop {
+        tokio::select! {
+            _ = &mut retry_sleep => return true,
+            result = desired_receiver.changed() => return result.is_ok(),
+            result = target_receiver.changed() => return result.is_ok(),
+            revision = graph_changes.changed() => {
+                if revision.is_none() {
+                    return false;
+                }
+                if let Some((node, resolved_topic, fingerprint)) = &mut graph_filter {
+                    if topic_graph_fingerprint_changed(node, resolved_topic, fingerprint) {
+                        return true;
+                    }
+                }
+            }
+        }
     }
 }
 
 async fn wait_for_observing_rebuild<T>(
     state: &Weak<Mutex<TopicObservationState<T>>>,
+    node: &Node,
+    resolved_topic: &str,
+    mut graph_fingerprint: TopicGraphFingerprint,
     desired_receiver: &mut watch::Receiver<DesiredObservation>,
     target_receiver: &mut watch::Receiver<TargetIdentity>,
     graph_changes: &mut ros_z::graph::GraphChangeSubscription,
-    mut suppress_next_graph_change: bool,
     cache_updates: &mut CachedSubscriptionUpdateReceiver,
 ) -> bool {
     loop {
@@ -1043,7 +1121,7 @@ async fn wait_for_observing_rebuild<T>(
                 if revision.is_none() {
                     return false;
                 }
-                !std::mem::take(&mut suppress_next_graph_change)
+                topic_graph_fingerprint_changed(node, resolved_topic, &mut graph_fingerprint)
             }
             update = cache_updates.recv() => {
                 match update {

--- a/crates/ros-z-debug/src/sample.rs
+++ b/crates/ros-z-debug/src/sample.rs
@@ -6,8 +6,8 @@ use ros_z::{TypeInfo, time::Time};
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct SampleMetadata {
-    /// Topic selector originally requested by the caller.
-    pub requested_topic: crate::TopicSelector,
+    /// Topic reference originally requested by the caller.
+    pub topic_reference: crate::TopicReference,
     /// Absolute topic name used for the underlying subscription.
     pub resolved_topic: String,
     /// Type metadata discovered or declared for this subscription.
@@ -28,4 +28,14 @@ pub struct SampleRecord<V> {
     pub publication_id: ros_z::pubsub::PublicationId,
     /// Metadata shared by all samples received through the same subscription.
     pub metadata: Arc<SampleMetadata>,
+}
+
+/// A retained dynamic subscription sample projected to JSON with original metadata preserved.
+#[derive(Debug, Clone)]
+pub struct JsonSampleRecord {
+    pub source_time: ros_z::time::Time,
+    pub transport_time: Option<ros_z::time::Time>,
+    pub publication_id: ros_z::pubsub::PublicationId,
+    pub metadata: Arc<SampleMetadata>,
+    pub value: serde_json::Value,
 }

--- a/crates/ros-z-debug/src/status.rs
+++ b/crates/ros-z-debug/src/status.rs
@@ -3,7 +3,7 @@ use ros_z::TypeInfo;
 /// Current lifecycle state for a debug subscription.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum SubscriptionStatus {
+pub enum CachedSubscriptionStatus {
     /// The subscription has been created and is waiting for its first sample.
     WaitingForFirstSample,
     /// At least one sample has been received and retained.
@@ -16,7 +16,7 @@ pub enum SubscriptionStatus {
     Closed,
 }
 
-impl SubscriptionStatus {
+impl CachedSubscriptionStatus {
     /// Create a protocol error status with a diagnostic message.
     pub fn protocol_error(message: impl Into<String>) -> Self {
         Self::ProtocolError {
@@ -41,17 +41,17 @@ impl SubscriptionStatus {
 }
 
 /// Point-in-time subscription status and resolved metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct SubscriptionStatusSnapshot {
-    status: SubscriptionStatus,
+pub struct CachedSubscriptionStatusSnapshot {
+    status: CachedSubscriptionStatus,
     resolved_topic: Option<String>,
     type_info: Option<TypeInfo>,
 }
 
-impl SubscriptionStatusSnapshot {
+impl CachedSubscriptionStatusSnapshot {
     #[cfg(test)]
-    pub(crate) fn new(status: SubscriptionStatus) -> Self {
+    pub(crate) fn new(status: CachedSubscriptionStatus) -> Self {
         Self {
             status,
             resolved_topic: None,
@@ -60,7 +60,7 @@ impl SubscriptionStatusSnapshot {
     }
 
     pub(crate) fn with_metadata(
-        status: SubscriptionStatus,
+        status: CachedSubscriptionStatus,
         resolved_topic: String,
         type_info: TypeInfo,
     ) -> Self {
@@ -72,7 +72,7 @@ impl SubscriptionStatusSnapshot {
     }
 
     /// Return the lifecycle status at the time this snapshot was taken.
-    pub fn status(&self) -> &SubscriptionStatus {
+    pub fn status(&self) -> &CachedSubscriptionStatus {
         &self.status
     }
 
@@ -91,20 +91,20 @@ impl SubscriptionStatusSnapshot {
         self.type_info.as_ref()
     }
 
-    pub(crate) fn set_status(&mut self, status: SubscriptionStatus) {
+    pub(crate) fn set_status(&mut self, status: CachedSubscriptionStatus) {
         self.status = status;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SubscriptionStatus, SubscriptionStatusSnapshot};
+    use super::{CachedSubscriptionStatus, CachedSubscriptionStatusSnapshot};
 
     #[test]
     fn error_status_carries_message_in_variant() {
-        let snapshot = SubscriptionStatusSnapshot::new(SubscriptionStatus::decode_error(
-            "failed to decode sample",
-        ));
+        let snapshot = CachedSubscriptionStatusSnapshot::new(
+            CachedSubscriptionStatus::decode_error("failed to decode sample"),
+        );
 
         assert_eq!(snapshot.message(), Some("failed to decode sample"));
         assert_eq!(snapshot.resolved_topic(), None);

--- a/crates/ros-z-debug/src/topic.rs
+++ b/crates/ros-z-debug/src/topic.rs
@@ -4,14 +4,20 @@ use crate::{Error, Result};
 
 const TARGET_NODE_PLACEHOLDER: &str = "debug_target";
 
-/// Validated topic selector used by debug subscriptions.
+/// Validated topic reference used by debug subscriptions.
 ///
-/// Relative selectors resolve against a target namespace. Absolute selectors
-/// are used as-is through `ros-z` topic qualification. Private `~` selectors are
-/// rejected because the debug manager has target namespace context, not target
-/// node context.
+/// Relative references resolve against a target namespace. Absolute references
+/// are used as-is through `ros-z` topic qualification. Private `~` references
+/// resolve against the target namespace and target node name.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TopicSelector(String);
+pub struct TopicReference(String);
+
+/// Identity of the ROS node namespace and optional node name being inspected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TargetIdentity {
+    namespace: String,
+    node_name: Option<String>,
+}
 
 /// Topic name projected for display in a UI or debug tool.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,33 +42,79 @@ pub enum ProjectedTopicScope {
 /// Projects absolute or relative topic names for display under an active namespace.
 pub struct TopicProjection;
 
-impl TopicSelector {
-    /// Validate and store a topic selector.
-    pub fn new(selector: impl Into<String>) -> Result<Self> {
-        let selector = selector.into();
-
-        if selector.starts_with('~') {
-            return Err(Error::UnsupportedPrivateTopicSelector { selector });
-        }
-
-        resolve_topic_name(&selector, "/")?;
-
-        Ok(Self(selector))
+impl TargetIdentity {
+    /// Create a target identity from a ROS namespace.
+    pub fn new(namespace: impl Into<String>) -> Result<Self> {
+        let namespace = namespace.into();
+        Ok(Self {
+            namespace: normalize_target_namespace(&namespace)?,
+            node_name: None,
+        })
     }
 
-    /// Return the original selector string.
+    /// Create an updated identity with a validated target node name.
+    pub fn with_node_name(mut self, node_name: impl Into<String>) -> Result<Self> {
+        self.set_node_name(node_name)?;
+        Ok(self)
+    }
+
+    /// Namespace of the target node.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// Name of the target node, when known.
+    pub fn node_name(&self) -> Option<&str> {
+        self.node_name.as_deref()
+    }
+
+    /// Update the target namespace after validation.
+    pub fn set_namespace(&mut self, namespace: impl Into<String>) -> Result<&mut Self> {
+        let namespace = namespace.into();
+        let namespace = normalize_target_namespace(&namespace)?;
+        if let Some(node_name) = self.node_name.as_deref() {
+            validate_node_name(&namespace, node_name)?;
+        }
+        self.namespace = namespace;
+        Ok(self)
+    }
+
+    /// Update the target node name after validation.
+    pub fn set_node_name(&mut self, node_name: impl Into<String>) -> Result<&mut Self> {
+        let node_name = node_name.into();
+        validate_node_name(&self.namespace, &node_name)?;
+        self.node_name = Some(node_name);
+        Ok(self)
+    }
+}
+
+impl TopicReference {
+    /// Validate and store a topic reference.
+    pub fn new(topic: impl Into<String>) -> Result<Self> {
+        let topic = topic.into();
+        validate_topic_reference(&topic)?;
+
+        Ok(Self(topic))
+    }
+
+    /// Return the original topic reference string.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
-    /// Return whether this selector is absolute.
+    /// Return whether this reference is absolute.
     pub fn is_absolute(&self) -> bool {
         self.0.starts_with('/')
     }
 
-    /// Resolve this selector against `target_namespace`.
-    pub fn resolve(&self, target_namespace: &str) -> Result<String> {
-        resolve_topic_name(&self.0, target_namespace)
+    /// Return whether this reference is private to a target node.
+    pub fn is_private(&self) -> bool {
+        self.0.starts_with('~')
+    }
+
+    /// Resolve this reference against `target`.
+    pub fn resolve(&self, target: &TargetIdentity) -> Result<String> {
+        resolve_topic_name(&self.0, target)
     }
 }
 
@@ -79,12 +131,14 @@ impl TopicProjection {
     where
         Topic: AsRef<str>,
     {
-        let active_namespace = normalize_target_namespace(active_namespace)?;
+        let active_identity = TargetIdentity::new(active_namespace)?;
         topics
             .into_iter()
             .map(|topic| {
-                let resolved_topic = resolve_topic_name(topic.as_ref(), &active_namespace)?;
-                let (display_name, scope) = display_name(&active_namespace, &resolved_topic);
+                let topic = TopicReference::new(topic.as_ref())?;
+                let resolved_topic = topic.resolve(&active_identity)?;
+                let (display_name, scope) =
+                    display_name(active_identity.namespace(), &resolved_topic);
 
                 Ok(ProjectedTopic {
                     display_name,
@@ -96,25 +150,48 @@ impl TopicProjection {
     }
 }
 
-fn resolve_topic_name(selector: &str, target_namespace: &str) -> Result<String> {
-    if selector.starts_with('~') {
-        return Err(Error::UnsupportedPrivateTopicSelector {
-            selector: selector.to_string(),
-        });
+fn resolve_topic_name(topic: &str, target: &TargetIdentity) -> Result<String> {
+    if let Some(private_topic) = topic.strip_prefix('~') {
+        let node_name = target
+            .node_name()
+            .ok_or_else(|| Error::MissingTargetNodeName {
+                topic: topic.to_string(),
+            })?;
+        let private_topic = private_topic.trim_start_matches('/');
+        let topic = if private_topic.is_empty() {
+            node_name.to_string()
+        } else {
+            format!("{node_name}/{private_topic}")
+        };
+        return qualify_topic_name(&topic, target.namespace(), TARGET_NODE_PLACEHOLDER).map_err(
+            |source| Error::InvalidTopicReference {
+                topic: topic.to_string(),
+                source,
+            },
+        );
     }
 
-    let namespace = if selector.starts_with('/') {
-        "/".to_string()
+    let target = if topic.starts_with('/') {
+        TargetIdentity::new("/")?
     } else {
-        normalize_target_namespace(target_namespace)?
+        target.clone()
     };
 
-    qualify_topic_name(selector, &namespace, TARGET_NODE_PLACEHOLDER).map_err(|error| {
-        Error::InvalidTopicSelector {
-            selector: selector.to_string(),
-            source: error,
+    qualify_topic_name(topic, target.namespace(), TARGET_NODE_PLACEHOLDER).map_err(|source| {
+        Error::InvalidTopicReference {
+            topic: topic.to_string(),
+            source,
         }
     })
+}
+
+fn validate_topic_reference(topic: &str) -> Result<()> {
+    qualify_topic_name(topic, "/", TARGET_NODE_PLACEHOLDER)
+        .map(|_| ())
+        .map_err(|source| Error::InvalidTopicReference {
+            topic: topic.to_string(),
+            source,
+        })
 }
 
 pub(crate) fn normalize_target_namespace(target_namespace: &str) -> Result<String> {
@@ -134,6 +211,15 @@ fn validate_target_namespace(target_namespace: &str, normalized_namespace: &str)
         target_namespace: target_namespace.to_string(),
         source: error,
     })
+}
+
+fn validate_node_name(namespace: &str, node_name: &str) -> Result<()> {
+    qualify_topic_name("ros_z_debug_node_probe", namespace, node_name)
+        .map(|_| ())
+        .map_err(|source| Error::InvalidTargetNodeName {
+            target_node_name: node_name.to_string(),
+            source,
+        })
 }
 
 fn normalize_namespace(namespace: &str) -> String {
@@ -169,75 +255,139 @@ fn display_name(active_namespace: &str, resolved_topic: &str) -> (String, Projec
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error as _;
-
-    use super::{ProjectedTopicScope, TopicProjection, TopicSelector};
+    use super::{ProjectedTopicScope, TargetIdentity, TopicProjection, TopicReference};
     use crate::Error;
 
     #[test]
-    fn relative_selector_resolves_under_target_namespace() {
-        let selector = TopicSelector::new("my_data/foo").unwrap();
+    fn relative_topic_reference_resolves_nested_path_under_target_namespace() {
+        let topic = TopicReference::new("my_data/foo").unwrap();
+        let identity = TargetIdentity::new("alpha").unwrap();
 
-        assert_eq!(selector.resolve("alpha").unwrap(), "/alpha/my_data/foo");
+        assert_eq!(topic.resolve(&identity).unwrap(), "/alpha/my_data/foo");
     }
 
     #[test]
-    fn relative_selector_trims_trailing_slash() {
-        let selector = TopicSelector::new("foo/").unwrap();
+    fn relative_topic_reference_trims_trailing_slash() {
+        let topic = TopicReference::new("foo/").unwrap();
+        let identity = TargetIdentity::new("alpha").unwrap();
 
-        assert_eq!(selector.resolve("alpha").unwrap(), "/alpha/foo");
+        assert_eq!(topic.resolve(&identity).unwrap(), "/alpha/foo");
     }
 
     #[test]
     fn target_namespace_trims_trailing_slash() {
-        let selector = TopicSelector::new("foo").unwrap();
+        let topic = TopicReference::new("foo").unwrap();
+        let identity = TargetIdentity::new("/alpha/").unwrap();
 
-        assert_eq!(selector.resolve("/alpha/").unwrap(), "/alpha/foo");
+        assert_eq!(topic.resolve(&identity).unwrap(), "/alpha/foo");
     }
 
     #[test]
-    fn absolute_selector_ignores_namespace() {
-        let selector = TopicSelector::new("/diagnostics").unwrap();
+    fn absolute_topic_reference_ignores_namespace() {
+        let topic = TopicReference::new("/diagnostics").unwrap();
+        let identity = TargetIdentity::new("alpha").unwrap();
 
-        assert_eq!(selector.resolve("alpha").unwrap(), "/diagnostics");
+        assert_eq!(topic.resolve(&identity).unwrap(), "/diagnostics");
     }
 
     #[test]
-    fn absolute_selector_does_not_validate_target_namespace() {
-        let selector = TopicSelector::new("/diagnostics").unwrap();
-
-        assert_eq!(selector.resolve("123invalid/").unwrap(), "/diagnostics");
-    }
-
-    #[test]
-    fn relative_selector_reports_invalid_target_namespace() {
-        let selector = TopicSelector::new("diagnostics").unwrap();
-
-        let error = selector.resolve("alpha%bad").unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("invalid target namespace 'alpha%bad'")
-        );
-    }
-
-    #[test]
-    fn private_selector_rejection_explains_missing_target_node() {
-        let error = TopicSelector::new("~private").unwrap_err();
+    fn target_identity_rejects_invalid_namespace() {
+        let error = TargetIdentity::new("alpha%bad").unwrap_err();
 
         assert!(matches!(
             error,
-            Error::UnsupportedPrivateTopicSelector { ref selector } if selector == "~private"
+            Error::InvalidTargetNamespace { ref target_namespace, .. }
+                if target_namespace == "alpha%bad"
         ));
     }
 
     #[test]
-    fn invalid_relative_selector_is_rejected_during_construction() {
-        let error = TopicSelector::new("foo%bar").unwrap_err();
+    fn relative_topic_reference_resolves_under_target_namespace() {
+        let topic = TopicReference::new("ball_position").unwrap();
+        let identity = TargetIdentity::new("/42").unwrap();
 
-        assert!(error.source().is_some());
-        assert!(error.to_string().contains("invalid component 'foo%bar'"));
+        assert_eq!(topic.resolve(&identity).unwrap(), "/42/ball_position");
+    }
+
+    #[test]
+    fn absolute_topic_reference_ignores_target_identity() {
+        let topic = TopicReference::new("/diagnostics").unwrap();
+        let identity = TargetIdentity::new("/42").unwrap();
+
+        assert_eq!(topic.resolve(&identity).unwrap(), "/diagnostics");
+    }
+
+    #[test]
+    fn private_topic_reference_resolves_with_target_node_name() {
+        let topic = TopicReference::new("~trace").unwrap();
+        let identity = TargetIdentity::new("/42")
+            .unwrap()
+            .with_node_name("behavior_node")
+            .unwrap();
+
+        assert_eq!(topic.resolve(&identity).unwrap(), "/42/behavior_node/trace");
+    }
+
+    #[test]
+    fn private_topic_reference_requires_target_node_name() {
+        let topic = TopicReference::new("~trace").unwrap();
+        let identity = TargetIdentity::new("/42").unwrap();
+
+        let error = topic.resolve(&identity).unwrap_err();
+
+        assert!(matches!(error, Error::MissingTargetNodeName { .. }));
+    }
+
+    #[test]
+    fn target_identity_set_namespace_leaves_previous_state_unchanged_on_error() {
+        let mut identity = TargetIdentity::new("/alpha").unwrap();
+
+        let error = identity.set_namespace("alpha%bad").unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidTargetNamespace { ref target_namespace, .. }
+                if target_namespace == "alpha%bad"
+        ));
+        assert_eq!(identity.namespace(), "/alpha");
+    }
+
+    #[test]
+    fn target_identity_set_node_name_leaves_previous_state_unchanged_on_error() {
+        let mut identity = TargetIdentity::new("/42")
+            .unwrap()
+            .with_node_name("behavior_node")
+            .unwrap();
+
+        let error = identity.set_node_name("bad%node").unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidTargetNodeName { ref target_node_name, .. }
+                if target_node_name == "bad%node"
+        ));
+        assert_eq!(identity.node_name(), Some("behavior_node"));
+    }
+
+    #[test]
+    fn private_topic_reference_is_accepted_during_construction() {
+        let topic = TopicReference::new("~private").unwrap();
+
+        assert_eq!(topic.as_str(), "~private");
+        assert!(topic.is_private());
+    }
+
+    #[test]
+    fn invalid_relative_topic_reference_is_rejected_during_construction() {
+        let error = TopicReference::new("foo%bar").unwrap_err();
+
+        match error {
+            Error::InvalidTopicReference { topic, source } => {
+                assert_eq!(topic, "foo%bar");
+                assert!(source.to_string().contains("invalid component 'foo%bar'"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
     }
 
     #[test]
@@ -279,6 +429,12 @@ mod tests {
     fn projection_rejects_invalid_relative_topics_using_ros_z_validation() {
         let error = TopicProjection::project("alpha", ["foo%bar"]).unwrap_err();
 
-        assert!(error.to_string().contains("invalid component 'foo%bar'"));
+        match error {
+            Error::InvalidTopicReference { topic, source } => {
+                assert_eq!(topic, "foo%bar");
+                assert!(source.to_string().contains("invalid component 'foo%bar'"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
     }
 }

--- a/crates/ros-z-debug/tests/integration.rs
+++ b/crates/ros-z-debug/tests/integration.rs
@@ -1,19 +1,19 @@
 use std::{sync::Arc, time::Duration};
 
 use ros_z::prelude::*;
-use ros_z_debug::{ManagerOptions, RetentionPolicy, SubscriptionManager};
+use ros_z_debug::{CachedSubscriptionFactory, CachedSubscriptionOptions, RetentionPolicy};
 
 #[allow(dead_code)]
 fn typed_subscription_builder_can_be_named<'a, T>(
-    builder: ros_z_debug::TypedSubscriptionBuilder<'a, T>,
-) -> ros_z_debug::TypedSubscriptionBuilder<'a, T> {
+    builder: ros_z_debug::CachedTypedSubscriptionBuilder<'a, T>,
+) -> ros_z_debug::CachedTypedSubscriptionBuilder<'a, T> {
     builder
 }
 
 #[allow(dead_code)]
 fn dynamic_subscription_builder_can_be_named<'a>(
-    builder: ros_z_debug::DynamicSubscriptionBuilder<'a>,
-) -> ros_z_debug::DynamicSubscriptionBuilder<'a> {
+    builder: ros_z_debug::CachedDynamicSubscriptionBuilder<'a>,
+) -> ros_z_debug::CachedDynamicSubscriptionBuilder<'a> {
     builder
 }
 
@@ -60,9 +60,11 @@ async fn typed_subscription_receives_latest_sample() {
         .build()
         .await
         .expect("publisher");
-    let manager = SubscriptionManager::new(subscriber_node, ManagerOptions::default());
-    let handle = manager
+    let factory =
+        CachedSubscriptionFactory::new(subscriber_node, CachedSubscriptionOptions::default());
+    let handle = factory
         .subscribe_typed::<String>("debug_text")
+        .expect("subscription builder")
         .retention(RetentionPolicy::LatestOnly)
         .build()
         .await
@@ -136,10 +138,12 @@ async fn typed_subscription_resolves_relative_topic_against_target_namespace() {
         .build()
         .await
         .expect("publisher");
-    let options = ManagerOptions::with_target_namespace("/alpha").expect("valid target namespace");
-    let manager = SubscriptionManager::new(subscriber_node, options);
-    let handle = manager
+    let options =
+        CachedSubscriptionOptions::with_target_namespace("/alpha").expect("valid target namespace");
+    let factory = CachedSubscriptionFactory::new(subscriber_node, options);
+    let handle = factory
         .subscribe_typed::<String>("debug_text")
+        .expect("subscription builder")
         .retention(RetentionPolicy::LatestOnly)
         .build()
         .await
@@ -199,9 +203,11 @@ async fn dynamic_subscription_renders_json_view() {
         .build()
         .await
         .expect("dynamic publisher");
-    let manager = SubscriptionManager::new(subscriber_node, ManagerOptions::default());
-    let json = manager
+    let factory =
+        CachedSubscriptionFactory::new(subscriber_node, CachedSubscriptionOptions::default());
+    let json = factory
         .subscribe_dynamic("debug_dynamic")
+        .expect("subscription builder")
         .retention(RetentionPolicy::LatestOnly)
         .build_json(Default::default())
         .await

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -305,8 +305,8 @@ async fn dynamic_observation_freezes_previous_cache_while_retrying_after_retarge
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn dropping_observer_closes_live_observation_while_handle_remains() -> ros_z_debug::Result<()>
-{
+async fn dropping_observer_does_not_close_live_observation_while_handle_remains()
+-> ros_z_debug::Result<()> {
     let context = ContextBuilder::default().build().await?;
     let publisher_node = context.create_node("observer_drop_pub").build().await?;
     let observer_node = Arc::new(
@@ -329,33 +329,24 @@ async fn dropping_observer_closes_live_observation_while_handle_remains() -> ros
         .spawn();
 
     publish_until_latest_value(&publisher, &observation, "alive").await?;
-    let mut updates = observation.subscribe_updates().unwrap();
-
     drop(observer);
+    publish_until_latest_value(&publisher, &observation, "still_alive").await?;
 
-    tokio::time::timeout(std::time::Duration::from_secs(1), async {
-        loop {
-            if matches!(observation.status(), TopicObservationStatus::Closed)
-                && updates.try_recv().is_err()
-            {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("dropping observer should close observation promptly");
-
+    assert!(matches!(
+        observation.status(),
+        TopicObservationStatus::Observing { .. }
+    ));
     assert_eq!(
         observation.latest().map(|record| record.value.clone()),
-        Some("alive".to_string())
+        Some("still_alive".to_string())
     );
 
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn dropping_observer_cancels_in_flight_dynamic_schema_discovery() -> ros_z_debug::Result<()> {
+async fn dropping_observation_cancels_in_flight_dynamic_schema_discovery() -> ros_z_debug::Result<()>
+{
     let context = ContextBuilder::default().build().await?;
     let observer_node = Arc::new(context.create_node("dynamic_drop_observer").build().await?);
     let observer = TopicObserver::new(observer_node, {
@@ -367,21 +358,20 @@ async fn dropping_observer_cancels_in_flight_dynamic_schema_discovery() -> ros_z
     let observation = observer.observe_dynamic("never_appears")?.spawn();
     let mut updates = observation.subscribe_updates().unwrap();
 
-    drop(observer);
+    drop(observation);
 
     tokio::time::timeout(std::time::Duration::from_millis(500), async {
         loop {
-            if matches!(observation.status(), TopicObservationStatus::Closed)
-                && updates.try_recv().is_err()
-            {
+            if updates.try_recv().is_err() {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     })
     .await
-    .expect("observer drop should cancel schema discovery without waiting for timeout");
+    .expect("observation drop should cancel schema discovery without waiting for timeout");
 
+    drop(observer);
     Ok(())
 }
 

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -421,7 +421,7 @@ async fn dropping_last_observation_handle_closes_real_spawned_loop() -> ros_z_de
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn observing_observation_rebuilds_on_graph_revision() -> ros_z_debug::Result<()> {
+async fn observing_observation_ignores_unrelated_graph_revision() -> ros_z_debug::Result<()> {
     let context = ContextBuilder::default().build().await?;
     let publisher_node = context.create_node("graph_rebuild_pub").build().await?;
     let observer_node = Arc::new(
@@ -451,6 +451,64 @@ async fn observing_observation_rebuilds_on_graph_revision() -> ros_z_debug::Resu
         .build()
         .await?;
 
+    let no_rebuild = tokio::time::timeout(std::time::Duration::from_millis(200), async {
+        loop {
+            if matches!(
+                updates.recv().await,
+                Ok(TopicObservationUpdate::StatusChanged(
+                    TopicObservationStatus::Rebuilding { .. }
+                ))
+            ) {
+                break;
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        no_rebuild.is_err(),
+        "unrelated graph revisions should not rebuild the observation"
+    );
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observing_observation_rebuilds_on_relevant_publisher_graph_change()
+-> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context
+        .create_node("relevant_graph_rebuild_pub")
+        .build()
+        .await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("relevant_graph_rebuild_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<String>("/42/relevant_graph_rebuild")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(
+        Arc::clone(&observer_node),
+        TopicObserverOptions::with_namespace("/42")?,
+    );
+    let observation = observer
+        .observe_typed::<String>("relevant_graph_rebuild")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    publish_until_latest_value(&publisher, &observation, "before_graph_change").await?;
+    let mut updates = observation.subscribe_updates().unwrap();
+
+    let _second_publisher = publisher_node
+        .publisher::<String>("/42/relevant_graph_rebuild")?
+        .build()
+        .await?;
+
     tokio::time::timeout(std::time::Duration::from_secs(1), async {
         loop {
             if matches!(
@@ -464,7 +522,7 @@ async fn observing_observation_rebuilds_on_graph_revision() -> ros_z_debug::Resu
         }
     })
     .await
-    .expect("observing graph revision should wake a rebuild");
+    .expect("relevant publisher graph change should wake a rebuild");
 
     drop(observer);
     Ok(())

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -2,14 +2,20 @@ use std::sync::Arc;
 
 use ros_z::{prelude::*, time::Time};
 use ros_z_debug::{
-    RetentionPolicy, TopicObservationBlockReason, TopicObservationStatus, TopicObservationUpdate,
-    TopicObserver, TopicObserverOptions,
+    JsonRenderPolicy, NonFiniteFloatRenderPolicy, RetentionPolicy, TopicObservationBlockReason,
+    TopicObservationStatus, TopicObservationUpdate, TopicObserver, TopicObserverOptions,
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ros_z::Message)]
 #[message(name = "test_msgs::TwixDebugValue")]
 struct TwixDebugValue {
     value: i32,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ros_z::Message)]
+#[message(name = "test_msgs::FloatDebugValue")]
+struct FloatDebugValue {
+    value: f64,
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -120,7 +126,7 @@ async fn dynamic_json_observation_exposes_time_window_records() -> ros_z_debug::
         loop {
             publisher.publish(&TwixDebugValue { value: 1 }).await?;
             publisher.publish(&TwixDebugValue { value: 2 }).await?;
-            let records = observation.window_json(Time::zero(), Time::from_nanos(i64::MAX));
+            let records = observation.window_json_records(Time::zero(), Time::from_nanos(i64::MAX));
             if records.len() >= 2 {
                 assert!(
                     records
@@ -140,6 +146,94 @@ async fn dynamic_json_observation_exposes_time_window_records() -> ros_z_debug::
     })
     .await
     .expect("dynamic observation should expose timestamped window records")?;
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_json_observation_exposes_value_only_window_json() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context
+        .create_node("dynamic_value_window_pub")
+        .build()
+        .await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_value_window_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/value_window")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(observer_node, TopicObserverOptions::with_namespace("/42")?);
+    let observation = observer
+        .observe_dynamic("value_window")?
+        .retention(RetentionPolicy::time_window(
+            std::time::Duration::from_secs(10),
+        )?)
+        .spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 3 }).await?;
+            publisher.publish(&TwixDebugValue { value: 4 }).await?;
+            let values = observation.window_json(Time::zero(), Time::from_nanos(i64::MAX));
+            if values.len() >= 2 {
+                assert!(values.contains(&serde_json::json!({ "value": 3 })));
+                assert!(values.contains(&serde_json::json!({ "value": 4 })));
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should expose value-only window JSON")?;
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_json_observation_uses_configured_render_policy() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("dynamic_policy_pub").build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_policy_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<FloatDebugValue>("/42/policy_value")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(observer_node, TopicObserverOptions::with_namespace("/42")?);
+    let observation = observer
+        .observe_dynamic("policy_value")?
+        .json_render_policy(JsonRenderPolicy {
+            non_finite_float: NonFiniteFloatRenderPolicy::Null,
+            ..JsonRenderPolicy::default()
+        })
+        .spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher
+                .publish(&FloatDebugValue { value: f64::NAN })
+                .await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": null })) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should use configured JSON render policy")?;
 
     drop(observer);
     Ok(())

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use ros_z::{prelude::*, time::Time};
 use ros_z_debug::{
     JsonRenderPolicy, NonFiniteFloatRenderPolicy, RetentionPolicy, TopicObservationBlockReason,
-    TopicObservationStatus, TopicObservationUpdate, TopicObserver, TopicObserverOptions,
+    TopicObservationStatus, TopicObservationUpdate, TopicObservationUpdateReceiver, TopicObserver,
+    TopicObserverOptions,
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ros_z::Message)]
@@ -545,24 +546,101 @@ async fn observing_observation_ignores_unrelated_graph_revision() -> ros_z_debug
         .build()
         .await?;
 
-    let no_rebuild = tokio::time::timeout(std::time::Duration::from_millis(200), async {
-        loop {
-            if matches!(
-                updates.recv().await,
-                Ok(TopicObservationUpdate::StatusChanged(
-                    TopicObservationStatus::Rebuilding { .. }
-                ))
-            ) {
-                break;
-            }
-        }
-    })
+    wait_for_publisher_count_without_rebuilding(
+        &observer_node,
+        "/42/unrelated_graph_change",
+        1,
+        &mut updates,
+    )
     .await;
 
-    assert!(
-        no_rebuild.is_err(),
-        "unrelated graph revisions should not rebuild the observation"
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_observation_keeps_fresh_graph_baseline_after_late_initial_publisher()
+-> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context
+        .create_node("dynamic_late_baseline_pub")
+        .build()
+        .await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_late_baseline_observer")
+            .build()
+            .await?,
     );
+    let observer = TopicObserver::new(Arc::clone(&observer_node), {
+        let mut options = TopicObserverOptions::with_namespace("/42")?;
+        options.set_retry_delay(std::time::Duration::from_secs(30));
+        options.set_schema_discovery_timeout(std::time::Duration::from_secs(2));
+        options
+    });
+    let observation = observer
+        .observe_dynamic("late_baseline")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if matches!(observation.status(), TopicObservationStatus::Building)
+                && observer_node
+                    .graph()
+                    .view()
+                    .publisher_count_on("/42/late_baseline")
+                    == 0
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("dynamic observation should enter schema discovery before the publisher exists");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let schema = dynamic_int_value_schema("test_msgs::LateBaselineValue");
+    let type_info = ros_z::TypeInfo::new(
+        "test_msgs::LateBaselineValue",
+        ros_z_schema::compute_hash(schema.as_ref()).expect("schema hash"),
+    );
+    let publisher = publisher_node
+        .dynamic_publisher("/42/late_baseline", type_info, Arc::clone(&schema))?
+        .build()
+        .await?;
+    let mut message =
+        ros_z::dynamic::DynamicStruct::default_for_schema(&schema).expect("default dynamic struct");
+    message.set("value", 31).expect("set value field");
+    let payload = ros_z::dynamic::DynamicPayload::from_struct(message).expect("dynamic payload");
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&payload).await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": 31 })) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should finish initial schema discovery")?;
+    let mut updates = observation.subscribe_updates().unwrap();
+
+    let _unrelated = publisher_node
+        .publisher::<String>("/42/dynamic_late_baseline_unrelated")?
+        .build()
+        .await?;
+
+    wait_for_publisher_count_without_rebuilding(
+        &observer_node,
+        "/42/dynamic_late_baseline_unrelated",
+        1,
+        &mut updates,
+    )
+    .await;
 
     drop(observer);
     Ok(())
@@ -757,6 +835,98 @@ async fn publish_until_latest_value(
     })
     .await
     .expect("observation should receive expected value")
+}
+
+fn dynamic_int_value_schema(type_name: &str) -> ros_z::dynamic::Schema {
+    use ros_z_schema::{
+        FieldDef, PrimitiveTypeDef, SchemaBundle, StructDef, TypeDef, TypeDefinition,
+        TypeDefinitions, TypeName,
+    };
+
+    let name = TypeName::new(type_name).expect("valid dynamic type name");
+    Arc::new(SchemaBundle {
+        root: TypeDef::Named(name.clone()),
+        definitions: TypeDefinitions::from([(
+            name,
+            TypeDefinition::Struct(StructDef {
+                fields: vec![FieldDef::new(
+                    "value",
+                    TypeDef::Primitive(PrimitiveTypeDef::I32),
+                )],
+            }),
+        )]),
+    })
+}
+
+async fn wait_for_publisher_count_without_rebuilding(
+    node: &Arc<ros_z::node::Node>,
+    topic: &str,
+    expected: usize,
+    updates: &mut TopicObservationUpdateReceiver,
+) {
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            drain_non_rebuilding_updates(updates);
+            if node.graph().view().publisher_count_on(topic) == expected {
+                drain_non_rebuilding_updates(updates);
+                break;
+            }
+
+            tokio::select! {
+                update = updates.recv() => {
+                    assert_non_rebuilding_update(update.expect("observation update stream should remain open"));
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+            }
+        }
+    })
+    .await
+    .expect("graph should observe publisher without rebuilding");
+
+    assert_no_rebuilding_update_for(std::time::Duration::from_millis(200), updates).await;
+}
+
+async fn assert_no_rebuilding_update_for(
+    duration: std::time::Duration,
+    updates: &mut TopicObservationUpdateReceiver,
+) {
+    let no_rebuild = tokio::time::timeout(duration, async {
+        loop {
+            assert_non_rebuilding_update(
+                updates
+                    .recv()
+                    .await
+                    .expect("observation update stream should remain open"),
+            );
+        }
+    })
+    .await;
+
+    assert!(
+        no_rebuild.is_err(),
+        "unrelated graph revisions should not rebuild the observation"
+    );
+}
+
+fn drain_non_rebuilding_updates(updates: &mut TopicObservationUpdateReceiver) {
+    while let Some(update) = updates
+        .try_recv()
+        .expect("observation update stream should remain open")
+    {
+        assert_non_rebuilding_update(update);
+    }
+}
+
+fn assert_non_rebuilding_update(update: TopicObservationUpdate) {
+    match update {
+        TopicObservationUpdate::StatusChanged(TopicObservationStatus::Rebuilding { .. }) => {
+            panic!("unrelated graph revisions should not rebuild the observation");
+        }
+        TopicObservationUpdate::Lagged { dropped } => {
+            panic!("missed {dropped} observation updates while checking for rebuild");
+        }
+        _ => {}
+    }
 }
 
 async fn wait_for_dynamic_retrying(observation: &ros_z_debug::DynamicTopicObservation) {

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -220,7 +220,87 @@ async fn private_topic_resolves_delivers_and_preserves_previous_cache_when_later
     .await
     .expect("blocked private observation should preserve previous cache");
 
+    for _ in 0..5 {
+        publisher.publish(&TwixDebugValue { value: 22 }).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        observation.latest_json(),
+        Some(serde_json::json!({ "value": 21 })),
+        "blocked observation should keep a frozen previous cache"
+    );
+
     drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_observation_freezes_previous_cache_while_retrying_after_retarget()
+-> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context
+        .create_node("dynamic_retry_freeze_pub")
+        .build()
+        .await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_retry_freeze_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/retry_freeze_value")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(observer_node, {
+        let mut options = TopicObserverOptions::with_namespace("/42")?;
+        options.set_retry_delay(std::time::Duration::from_secs(30));
+        options.set_schema_discovery_timeout(std::time::Duration::from_millis(100));
+        options
+    });
+    let observation = observer.observe_dynamic("retry_freeze_value")?.spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 1 }).await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": 1 })) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should receive initial value")?;
+
+    observation.set_topic("retry_freeze_missing")?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if matches!(
+                observation.status(),
+                TopicObservationStatus::Retrying { .. }
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("retargeting to a missing dynamic topic should enter retrying");
+
+    for _ in 0..5 {
+        publisher.publish(&TwixDebugValue { value: 2 }).await?;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        observation.latest_json(),
+        Some(serde_json::json!({ "value": 1 })),
+        "retrying observation should keep a frozen previous cache"
+    );
+
     Ok(())
 }
 

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -1,0 +1,563 @@
+use std::sync::Arc;
+
+use ros_z::{prelude::*, time::Time};
+use ros_z_debug::{
+    RetentionPolicy, TopicObservationBlockReason, TopicObservationStatus, TopicObservationUpdate,
+    TopicObserver, TopicObserverOptions,
+};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ros_z::Message)]
+#[message(name = "test_msgs::TwixDebugValue")]
+struct TwixDebugValue {
+    value: i32,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_observation_rebuilds_when_inherited_namespace_changes() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("typed_retarget_pub").build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("typed_retarget_observer")
+            .build()
+            .await?,
+    );
+    let alpha = publisher_node
+        .publisher::<String>("/alpha/state")?
+        .build()
+        .await?;
+    let beta = publisher_node
+        .publisher::<String>("/beta/state")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(
+        observer_node,
+        TopicObserverOptions::with_namespace("/alpha")?,
+    );
+    let observation = observer
+        .observe_typed::<String>("state")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    publish_until_latest_value(&alpha, &observation, "alpha").await?;
+
+    observer.set_namespace("/beta")?;
+    publish_until_latest_value(&beta, &observation, "beta").await?;
+
+    assert!(matches!(
+        observation.status(),
+        TopicObservationStatus::Observing { .. }
+    ));
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_json_observation_exposes_latest_value() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("dynamic_latest_pub").build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_latest_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/debug_value")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(observer_node, TopicObserverOptions::with_namespace("/42")?);
+    let observation = observer
+        .observe_dynamic("debug_value")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 7 }).await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": 7 })) {
+                let record = observation
+                    .latest_json_record()
+                    .expect("latest JSON record should be available");
+                assert_eq!(record.value, serde_json::json!({ "value": 7 }));
+                assert_eq!(record.metadata.resolved_topic, "/42/debug_value");
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should expose latest JSON")?;
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_json_observation_exposes_time_window_records() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("dynamic_window_pub").build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_window_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/window_value")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(observer_node, TopicObserverOptions::with_namespace("/42")?);
+    let observation = observer
+        .observe_dynamic("window_value")?
+        .retention(RetentionPolicy::time_window(
+            std::time::Duration::from_secs(10),
+        )?)
+        .spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 1 }).await?;
+            publisher.publish(&TwixDebugValue { value: 2 }).await?;
+            let records = observation.window_json(Time::zero(), Time::from_nanos(i64::MAX));
+            if records.len() >= 2 {
+                assert!(
+                    records
+                        .iter()
+                        .any(|record| record.value == serde_json::json!({ "value": 1 }))
+                );
+                assert!(
+                    records
+                        .iter()
+                        .any(|record| record.value == serde_json::json!({ "value": 2 }))
+                );
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should expose timestamped window records")?;
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn private_topic_resolves_delivers_and_preserves_previous_cache_when_later_blocked()
+-> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("private_topic_pub").build().await?;
+    let observer_node = Arc::new(context.create_node("private_observer").build().await?);
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/behavior_node/trace")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(observer_node, TopicObserverOptions::with_namespace("/42")?);
+    let observation = observer.observe_dynamic("~trace")?.spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if matches!(
+                observation.status(),
+                TopicObservationStatus::Blocked {
+                    reason: TopicObservationBlockReason::MissingTargetNodeName { .. },
+                    ..
+                }
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("private observation should report missing node name");
+
+    observation.set_node_name("behavior_node")?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 21 }).await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": 21 })) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("private observation should receive resolved topic data")?;
+
+    let record = observation
+        .latest_json_record()
+        .expect("private observation should retain latest JSON record");
+    assert_eq!(record.metadata.resolved_topic, "/42/behavior_node/trace");
+
+    observation.inherit_node_name();
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if let TopicObservationStatus::Blocked {
+                previous_cache: Some(previous_cache),
+                reason: TopicObservationBlockReason::MissingTargetNodeName { .. },
+            } = observation.status()
+            {
+                assert_eq!(
+                    previous_cache.resolved_topic(),
+                    Some("/42/behavior_node/trace")
+                );
+                assert_eq!(
+                    observation.latest_json(),
+                    Some(serde_json::json!({ "value": 21 }))
+                );
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("blocked private observation should preserve previous cache");
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_observer_closes_live_observation_while_handle_remains() -> ros_z_debug::Result<()>
+{
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("observer_drop_pub").build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("observer_drop_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<String>("/42/observer_drop")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(
+        Arc::clone(&observer_node),
+        TopicObserverOptions::with_namespace("/42")?,
+    );
+    let observation = observer
+        .observe_typed::<String>("observer_drop")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    publish_until_latest_value(&publisher, &observation, "alive").await?;
+    let mut updates = observation.subscribe_updates().unwrap();
+
+    drop(observer);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if matches!(observation.status(), TopicObservationStatus::Closed)
+                && updates.try_recv().is_err()
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("dropping observer should close observation promptly");
+
+    assert_eq!(
+        observation.latest().map(|record| record.value.clone()),
+        Some("alive".to_string())
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_observer_cancels_in_flight_dynamic_schema_discovery() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let observer_node = Arc::new(context.create_node("dynamic_drop_observer").build().await?);
+    let observer = TopicObserver::new(observer_node, {
+        let mut options = TopicObserverOptions::with_namespace("/42")?;
+        options.set_retry_delay(std::time::Duration::from_secs(30));
+        options.set_schema_discovery_timeout(std::time::Duration::from_secs(30));
+        options
+    });
+    let observation = observer.observe_dynamic("never_appears")?.spawn();
+    let mut updates = observation.subscribe_updates().unwrap();
+
+    drop(observer);
+
+    tokio::time::timeout(std::time::Duration::from_millis(500), async {
+        loop {
+            if matches!(observation.status(), TopicObservationStatus::Closed)
+                && updates.try_recv().is_err()
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("observer drop should cancel schema discovery without waiting for timeout");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_last_observation_handle_closes_real_spawned_loop() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("drop_handle_pub").build().await?;
+    let observer_node = Arc::new(context.create_node("drop_handle_observer").build().await?);
+    let publisher = publisher_node
+        .publisher::<String>("/42/drop_handle")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(
+        Arc::clone(&observer_node),
+        TopicObserverOptions::with_namespace("/42")?,
+    );
+    let observation = observer
+        .observe_typed::<String>("drop_handle")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    publish_until_latest_value(&publisher, &observation, "before_drop").await?;
+    wait_for_subscription_count(&observer_node, "/42/drop_handle", 1).await;
+
+    let mut updates = observation.subscribe_updates().unwrap();
+    drop(observation);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if updates.try_recv().is_err()
+                && observer_node
+                    .graph()
+                    .view()
+                    .subscription_count_on("/42/drop_handle")
+                    == 0
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("dropping last observation handle should close spawned subscription");
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observing_observation_rebuilds_on_graph_revision() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let publisher_node = context.create_node("graph_rebuild_pub").build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("graph_rebuild_observer")
+            .build()
+            .await?,
+    );
+    let publisher = publisher_node
+        .publisher::<String>("/42/graph_rebuild")?
+        .build()
+        .await?;
+    let observer = TopicObserver::new(
+        Arc::clone(&observer_node),
+        TopicObserverOptions::with_namespace("/42")?,
+    );
+    let observation = observer
+        .observe_typed::<String>("graph_rebuild")?
+        .retention(RetentionPolicy::LatestOnly)
+        .spawn();
+
+    publish_until_latest_value(&publisher, &observation, "before_graph_change").await?;
+    let mut updates = observation.subscribe_updates().unwrap();
+
+    let _unrelated = publisher_node
+        .publisher::<String>("/42/unrelated_graph_change")?
+        .build()
+        .await?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if matches!(
+                updates.recv().await,
+                Ok(TopicObservationUpdate::StatusChanged(
+                    TopicObservationStatus::Rebuilding { .. }
+                ))
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("observing graph revision should wake a rebuild");
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_observation_retries_until_schema_publisher_appears() -> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_retry_observer")
+            .build()
+            .await?,
+    );
+    let observer = TopicObserver::new(observer_node, {
+        let mut options = TopicObserverOptions::with_namespace("/42")?;
+        options.set_retry_delay(std::time::Duration::from_millis(25));
+        options.set_schema_discovery_timeout(std::time::Duration::from_millis(100));
+        options
+    });
+    let observation = observer.observe_dynamic("late_value")?.spawn();
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if matches!(
+                observation.status(),
+                TopicObservationStatus::Retrying { .. }
+            ) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("observation should retry before publisher exists");
+
+    let publisher_node = context.create_node("dynamic_retry_pub").build().await?;
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/late_value")?
+        .build()
+        .await?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 9 }).await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": 9 })) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("dynamic observation should recover after publisher appears")?;
+
+    drop(observer);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_observation_graph_change_wakes_retry_before_retry_delay() -> ros_z_debug::Result<()>
+{
+    let context = ContextBuilder::default().build().await?;
+    let observer_node = Arc::new(
+        context
+            .create_node("dynamic_graph_wakeup_observer")
+            .build()
+            .await?,
+    );
+    let observer = TopicObserver::new(observer_node, {
+        let mut options = TopicObserverOptions::with_namespace("/42")?;
+        options.set_retry_delay(std::time::Duration::from_secs(30));
+        options.set_schema_discovery_timeout(std::time::Duration::from_millis(500));
+        options
+    });
+    let observation = observer.observe_dynamic("graph_wakeup_value")?.spawn();
+
+    let early_retry = tokio::time::timeout(
+        std::time::Duration::from_millis(150),
+        wait_for_dynamic_retrying(&observation),
+    )
+    .await;
+    assert!(
+        early_retry.is_err(),
+        "dynamic schema discovery should wait before retrying when no publisher exists"
+    );
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        wait_for_dynamic_retrying(&observation),
+    )
+    .await
+    .expect("observation should retry after schema discovery fails");
+
+    let publisher_node = context
+        .create_node("dynamic_graph_wakeup_pub")
+        .build()
+        .await?;
+    let publisher = publisher_node
+        .publisher::<TwixDebugValue>("/42/graph_wakeup_value")?
+        .build()
+        .await?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&TwixDebugValue { value: 17 }).await?;
+            if observation.latest_json() == Some(serde_json::json!({ "value": 17 })) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("graph change should wake retry before retry delay")?;
+
+    drop(observer);
+    Ok(())
+}
+
+async fn publish_until_latest_value(
+    publisher: &ros_z::pubsub::Publisher<String>,
+    observation: &ros_z_debug::TopicObservation<String>,
+    expected: &str,
+) -> ros_z_debug::Result<()> {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            publisher.publish(&expected.to_string()).await?;
+            if observation
+                .latest()
+                .is_some_and(|record| record.value == expected)
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Ok::<_, ros_z_debug::Error>(())
+    })
+    .await
+    .expect("observation should receive expected value")
+}
+
+async fn wait_for_dynamic_retrying(observation: &ros_z_debug::DynamicTopicObservation) {
+    loop {
+        if matches!(
+            observation.status(),
+            TopicObservationStatus::Retrying { .. }
+        ) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_subscription_count(node: &Arc<ros_z::node::Node>, topic: &str, expected: usize) {
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if node.graph().view().subscription_count_on(topic) == expected {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("graph should observe subscription count");
+}

--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, atomic::AtomicUsize},
-    time::Duration,
-};
+use std::sync::{Arc, atomic::AtomicUsize};
 
 use tracing::{debug, warn};
 use zenoh::{Session, Wait};
@@ -11,7 +8,7 @@ use crate::{
     config::{SessionConfigBuilder, session_config},
     entity::normalize_node_namespace,
     error::ConfigError,
-    graph::{Graph, GraphOptions},
+    graph::Graph,
     node::NodeBuilder,
     shm::{DEFAULT_SHM_POOL_SIZE, ShmConfig, ShmProviderBuilder},
     time::Clock,
@@ -50,7 +47,6 @@ pub struct ContextBuilder {
     shm_config: Option<Arc<ShmConfig>>,
     clock: Option<Clock>,
     runtime_parameter_inputs: RuntimeParameterInputs,
-    graph_options: GraphOptions,
 }
 
 impl ContextBuilder {
@@ -222,16 +218,6 @@ impl ContextBuilder {
     /// Inject a pre-configured clock.
     pub fn with_clock(mut self, clock: Clock) -> Self {
         self.clock = Some(clock);
-        self
-    }
-
-    pub fn with_graph_initial_query_timeout(mut self, timeout: Duration) -> Self {
-        self.graph_options.initial_liveliness_query_timeout = Some(timeout);
-        self
-    }
-
-    pub fn without_graph_initial_query(mut self) -> Self {
-        self.graph_options.initial_liveliness_query_timeout = None;
         self
     }
 
@@ -489,7 +475,7 @@ impl ContextBuilder {
             }
         }
 
-        let graph = Arc::new(Graph::new_with_options(&session, builder.graph_options).await?);
+        let graph = Arc::new(Graph::new(&session).await?);
 
         Ok(Context {
             session,

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::time::Duration;
 
 use itertools::Itertools;
+use tokio::time::Instant;
 
 use crate::{
     dynamic::{DynamicError, Schema},
@@ -93,6 +94,25 @@ fn collect_topic_schema_candidates(
     collect_topic_schema_candidates_from_publishers(&publishers, qualified_topic)
 }
 
+fn schema_query_timeout(deadline: Instant) -> Option<Duration> {
+    let timeout = deadline.saturating_duration_since(Instant::now());
+    if timeout.is_zero() {
+        return None;
+    }
+    Some(timeout)
+}
+
+fn schema_query_timeout_error(
+    qualified_topic: &str,
+    last_error: Option<&DynamicError>,
+) -> DynamicError {
+    let mut message = format!("Timed out while discovering schema for topic: {qualified_topic}");
+    if let Some(error) = last_error {
+        message.push_str(&format!("; last candidate error: {error}"));
+    }
+    DynamicError::SchemaNotFound(message)
+}
+
 pub(crate) struct SchemaDiscovery<'a> {
     node: &'a Node,
     timeout: Duration,
@@ -107,14 +127,18 @@ impl<'a> SchemaDiscovery<'a> {
         &self,
         topic: &str,
     ) -> Result<DiscoveredTopicSchema, DynamicError> {
+        let deadline = Instant::now() + self.timeout;
         let qualified_topic = qualify_topic_name(topic, self.node.namespace(), self.node.name())
             .map_err(|error| {
                 DynamicError::SchemaNotFound(format!("Failed to qualify topic: {error}"))
             })?;
-        let candidates =
-            collect_topic_schema_candidates(self.node.graph().as_ref(), &qualified_topic)?;
+        let candidates = self
+            .wait_for_topic_schema_candidates(&qualified_topic, deadline)
+            .await?;
 
-        let (root_name, schema, schema_hash) = self.try_schema_service(&candidates[..]).await?;
+        let (root_name, schema, schema_hash) = self
+            .try_schema_service(&qualified_topic, &candidates[..], deadline)
+            .await?;
 
         Ok(DiscoveredTopicSchema {
             qualified_topic,
@@ -124,16 +148,55 @@ impl<'a> SchemaDiscovery<'a> {
         })
     }
 
+    async fn wait_for_topic_schema_candidates(
+        &self,
+        qualified_topic: &str,
+        deadline: Instant,
+    ) -> Result<Vec<TopicSchemaCandidate>, DynamicError> {
+        let graph = self.node.graph();
+        if tokio::time::timeout_at(
+            deadline,
+            graph.wait_until(|view| view.has_publishers_on(qualified_topic)),
+        )
+        .await
+        .is_err()
+        {
+            return Err(schema_query_timeout_error(qualified_topic, None));
+        }
+
+        collect_topic_schema_candidates(graph.as_ref(), qualified_topic)
+    }
+
     async fn try_schema_service(
         &self,
+        qualified_topic: &str,
         candidates: &[TopicSchemaCandidate],
+        deadline: Instant,
     ) -> Result<(String, Schema, SchemaHash), DynamicError> {
         let mut last_error = None;
 
         for candidate in candidates {
-            match super::schema_query::query_schema(self.node, candidate, self.timeout).await {
-                Ok(result) => return Ok(result),
-                Err(error) => last_error = Some(error),
+            let Some(timeout) = schema_query_timeout(deadline) else {
+                return Err(schema_query_timeout_error(
+                    qualified_topic,
+                    last_error.as_ref(),
+                ));
+            };
+
+            match tokio::time::timeout_at(
+                deadline,
+                super::schema_query::query_schema(self.node, candidate, timeout),
+            )
+            .await
+            {
+                Ok(Ok(result)) => return Ok(result),
+                Ok(Err(error)) => last_error = Some(error),
+                Err(_) => {
+                    return Err(schema_query_timeout_error(
+                        qualified_topic,
+                        last_error.as_ref(),
+                    ));
+                }
             }
         }
 
@@ -145,8 +208,21 @@ impl<'a> SchemaDiscovery<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
+    use crate::context::ContextBuilder;
     use crate::entity::{EndpointKind, NodeEntity, SchemaHash, TypeInfo};
+
+    fn unique_node_name(prefix: &str) -> String {
+        format!(
+            "{prefix}_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after Unix epoch")
+                .as_nanos()
+        )
+    }
 
     fn publisher(type_name: &str) -> EndpointEntity {
         EndpointEntity {
@@ -187,6 +263,75 @@ mod tests {
             type_info: TypeInfo::new(type_name, hash),
             qos: Default::default(),
         }
+    }
+
+    #[test]
+    fn schema_query_timeout_returns_none_for_elapsed_deadline() {
+        let deadline = Instant::now() - Duration::from_millis(1);
+
+        assert_eq!(schema_query_timeout(deadline), None);
+    }
+
+    #[test]
+    fn schema_query_timeout_returns_remaining_duration_for_future_deadline() {
+        let timeout = schema_query_timeout(Instant::now() + Duration::from_secs(1))
+            .expect("future deadline should leave time for one schema query");
+
+        assert!(timeout > Duration::ZERO);
+        assert!(timeout <= Duration::from_secs(1));
+    }
+
+    #[test]
+    fn schema_query_timeout_error_reports_timeout_without_candidate_error() {
+        let error = schema_query_timeout_error("/chatter", None);
+
+        let DynamicError::SchemaNotFound(message) = error else {
+            panic!("expected schema not found timeout, got {error:?}");
+        };
+        assert!(message.contains("Timed out"));
+        assert!(message.contains("/chatter"));
+    }
+
+    #[test]
+    fn schema_query_timeout_error_keeps_candidate_error_as_context() {
+        let error = schema_query_timeout_error(
+            "/chatter",
+            Some(&DynamicError::SerializationError(
+                "candidate failed".to_string(),
+            )),
+        );
+
+        let DynamicError::SchemaNotFound(message) = error else {
+            panic!("expected timeout schema not found, got {error:?}");
+        };
+        assert!(message.contains("Timed out"));
+        assert!(message.contains("/chatter"));
+        assert!(message.contains("candidate failed"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn schema_candidate_wait_reports_timeout_when_no_publishers_arrive() {
+        let context = ContextBuilder::default()
+            .build()
+            .await
+            .expect("test context should build");
+        let node = context
+            .create_node(unique_node_name("schema_candidate_timeout"))
+            .build()
+            .await
+            .expect("test node should build");
+        let discovery = SchemaDiscovery::new(&node, Duration::from_millis(1));
+
+        let error = discovery
+            .wait_for_topic_schema_candidates("/missing_schema_timeout", Instant::now())
+            .await
+            .expect_err("elapsed publisher wait should report timeout");
+
+        let DynamicError::SchemaNotFound(message) = error else {
+            panic!("expected timeout schema not found, got {error:?}");
+        };
+        assert!(message.contains("Timed out"));
+        assert!(message.contains("/missing_schema_timeout"));
     }
 
     #[test]

--- a/crates/ros-z/src/graph.rs
+++ b/crates/ros-z/src/graph.rs
@@ -1,43 +1,42 @@
-use parking_lot::Mutex;
-use std::{sync::Arc, time::Duration};
-use tokio::sync::Notify;
-
 mod discovery;
 mod query;
 mod snapshot;
 mod state;
 
 use discovery::install_liveliness;
-pub use query::{GraphView, QosIncompatibility};
+pub use query::{GraphChangeSubscription, GraphView, QosIncompatibility};
 pub use snapshot::{GraphSnapshot, NodeSnapshot, ServiceSnapshot, TopicSnapshot};
-use state::GraphData;
+use state::GraphStore;
 
 use crate::Result;
 use crate::entity::{ADMIN_SPACE, Entity};
 use zenoh::{Session, pubsub::Subscriber, session::ZenohId};
 
-#[derive(Debug, Clone)]
-pub struct GraphOptions {
-    pub initial_liveliness_query_timeout: Option<Duration>,
-}
+/// Opaque token identifying a local graph state revision.
+///
+/// Values support equality and monotonic recency comparisons within one [`Graph`]. Ordering is
+/// intentionally exposed for revisions from the same graph instance or snapshot/subscription
+/// stream. Do not compare revisions from independently created graphs.
+///
+/// A changed revision means consumers should resync from [`Graph::view`] or [`Graph::snapshot`].
+/// Do not treat revisions as stable event counts or as proof that the distributed graph is
+/// complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(transparent)]
+pub struct GraphRevision(u64);
 
-impl Default for GraphOptions {
-    fn default() -> Self {
-        Self {
-            initial_liveliness_query_timeout: Some(Duration::from_secs(3)),
-        }
+impl GraphRevision {
+    /// Baseline revision before any observed effective graph changes.
+    pub const INITIAL: Self = Self(0);
+
+    pub(super) fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
     }
 }
 
 pub struct Graph {
-    data: Arc<Mutex<GraphData>>,
+    pub(crate) store: GraphStore,
     pub zid: ZenohId,
-    /// Notified whenever an entity appears or disappears in the graph.
-    ///
-    /// Publishers use this to implement `wait_for_subscribers`: they register
-    /// a `notified()` future before sampling the graph, then `await` it so no
-    /// arrival is missed between the sample and the wait.
-    pub(crate) change_notify: Arc<Notify>,
     _subscriber: Subscriber<()>,
 }
 
@@ -51,30 +50,38 @@ impl std::fmt::Debug for Graph {
 
 impl Graph {
     /// Create a new Graph using the native ros-z liveliness protocol.
+    ///
+    /// The graph is a live local observation of Zenoh liveliness. This returns after the
+    /// liveliness subscription has been declared; historical liveliness samples may still arrive
+    /// later and advance the graph revision.
     pub async fn new(session: &Session) -> Result<Self> {
-        Self::new_with_options(session, GraphOptions::default()).await
-    }
-
-    pub async fn new_with_options(session: &Session, options: GraphOptions) -> Result<Self> {
         let liveliness_pattern = format!("{}/**", ADMIN_SPACE);
         let zid = session.zid();
-        let graph_data = Arc::new(Mutex::new(GraphData::new()));
-        let change_notify = Arc::new(Notify::new());
-        let sub = install_liveliness(
-            session,
-            &liveliness_pattern,
-            &options,
-            graph_data.clone(),
-            change_notify.clone(),
-        )
-        .await?;
+        let store = GraphStore::new();
+        let sub = install_liveliness(session, &liveliness_pattern, store.clone()).await?;
 
         Ok(Self {
             _subscriber: sub,
-            data: graph_data,
-            change_notify,
+            store,
             zid,
         })
+    }
+
+    /// Return the current local graph change revision.
+    ///
+    /// The initial revision is `0`. Zenoh liveliness history and live events are reported through
+    /// the same revision stream. A revision change is a resync signal, not a graph-completeness
+    /// guarantee.
+    pub fn revision(&self) -> GraphRevision {
+        self.store.revision()
+    }
+
+    /// Subscribe to effective local graph changes.
+    ///
+    /// Subscriptions start from the current revision and keep only the latest revision. Treat each
+    /// observed change as a signal to inspect [`Graph::view`] again.
+    pub fn subscribe_changes(&self) -> GraphChangeSubscription {
+        GraphChangeSubscription::new(self.store.subscribe_changes())
     }
 
     /// Check if an entity belongs to the current session
@@ -90,24 +97,24 @@ impl Graph {
     /// immediately visible in graph queries without waiting for Zenoh liveliness propagation
     pub fn add_local_entity(&self, entity: Entity) -> Result<()> {
         let key_expr = entity.liveliness_key_expr()?;
-        self.data.lock().insert(key_expr, entity);
-        self.change_notify.notify_waiters();
+        self.store.insert(key_expr, entity);
         Ok(())
     }
 
     /// Remove a local entity from the graph
     pub fn remove_local_entity(&self, entity: &Entity) -> Result<()> {
         let key_expr = entity.liveliness_key_expr()?;
-        if self.data.lock().remove(&key_expr) {
-            self.change_notify.notify_waiters();
-        }
+        self.store.remove(&key_expr);
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::Arc,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
 
     use crate::{
         Error, Result,
@@ -127,24 +134,28 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn local_entity_add_notifies_graph_waiters() -> Result<()> {
+    async fn graph_wait_until_returns_immediately_when_predicate_is_true() -> Result<()> {
         let session = zenoh::open(zenoh::Config::default())
             .await
             .map_err(|source| Error::zenoh("open Zenoh session", source))?;
         let graph = Graph::new(&session).await?;
         let entity = Entity::Node(NodeEntity::new(
             session.zid(),
-            51,
-            unique_node_name("local_add_notify"),
+            55,
+            unique_node_name("wait_until_immediate"),
             String::new(),
         ));
-
-        let notified = graph.change_notify.notified();
+        let expected = entity.clone();
         graph.add_local_entity(entity)?;
 
-        tokio::time::timeout(Duration::from_millis(100), notified)
-            .await
-            .expect("local add should notify graph waiters");
+        let observed = tokio::time::timeout(
+            Duration::from_millis(100),
+            graph.wait_until(|view| view.entities().any(|candidate| candidate == &expected)),
+        )
+        .await
+        .expect("wait_until should return immediately for a true predicate");
+
+        assert!(observed);
         session
             .close()
             .await
@@ -153,25 +164,175 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn local_entity_remove_notifies_graph_waiters() -> Result<()> {
+    async fn graph_wait_until_observes_later_graph_revision() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Arc::new(Graph::new(&session).await?);
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
+            56,
+            unique_node_name("wait_until_later"),
+            String::new(),
+        ));
+        let expected = entity.clone();
+
+        let waiter = tokio::spawn({
+            let graph = Arc::clone(&graph);
+            async move {
+                graph
+                    .wait_until(|view| view.entities().any(|candidate| candidate == &expected))
+                    .await
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        graph.add_local_entity(entity)?;
+
+        let observed = tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .expect("wait_until should observe the graph revision")
+            .expect("wait_until task should not panic");
+
+        assert!(observed);
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn graph_change_subscription_current_does_not_block_revision_publication() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Arc::new(Graph::new(&session).await?);
+        let changes = graph.subscribe_changes();
+        let _held_revision = changes.current();
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
+            54,
+            unique_node_name("copied_revision_publish"),
+            String::new(),
+        ));
+
+        let update = tokio::task::spawn_blocking({
+            let graph = Arc::clone(&graph);
+            move || graph.add_local_entity(entity)
+        });
+
+        tokio::time::timeout(Duration::from_millis(100), update)
+            .await
+            .expect("copied public revisions must not block graph updates")
+            .expect("graph update task should not panic")?;
+
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn local_entity_add_and_remove_advance_graph_revision() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Graph::new(&session).await?;
+        let mut changes = graph.subscribe_changes();
+        let initial_revision: GraphRevision = graph.revision();
+        assert_eq!(initial_revision, GraphRevision::INITIAL);
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
+            51,
+            unique_node_name("local_update_revision"),
+            String::new(),
+        ));
+
+        graph.add_local_entity(entity.clone())?;
+
+        let add_revision = tokio::time::timeout(Duration::from_millis(100), changes.changed())
+            .await
+            .expect("local add should publish a graph revision")
+            .expect("graph revision sender should stay alive");
+        assert_ne!(add_revision, initial_revision);
+        assert_eq!(graph.revision(), add_revision);
+
+        graph.remove_local_entity(&entity)?;
+
+        let remove_revision = tokio::time::timeout(Duration::from_millis(100), changes.changed())
+            .await
+            .expect("local remove should publish a graph revision")
+            .expect("graph revision sender should stay alive");
+        assert_ne!(remove_revision, add_revision);
+        assert_eq!(graph.revision(), remove_revision);
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn snapshot_captures_current_graph_revision() -> Result<()> {
         let session = zenoh::open(zenoh::Config::default())
             .await
             .map_err(|source| Error::zenoh("open Zenoh session", source))?;
         let graph = Graph::new(&session).await?;
         let entity = Entity::Node(NodeEntity::new(
             session.zid(),
+            53,
+            unique_node_name("snapshot_revision"),
+            String::new(),
+        ));
+
+        let initial_snapshot = graph.snapshot();
+        assert_eq!(initial_snapshot.revision, GraphRevision::INITIAL);
+        let initial_snapshot_json =
+            serde_json::to_value(initial_snapshot).expect("graph snapshot should serialize");
+        assert_eq!(initial_snapshot_json["revision"], serde_json::json!(0));
+
+        graph.add_local_entity(entity)?;
+
+        assert_eq!(graph.snapshot().revision, graph.revision());
+        session
+            .close()
+            .await
+            .map_err(|source| Error::zenoh("close Zenoh session", source))?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unchanged_local_readd_does_not_advance_graph_revision() -> Result<()> {
+        let session = zenoh::open(zenoh::Config::default())
+            .await
+            .map_err(|source| Error::zenoh("open Zenoh session", source))?;
+        let graph = Graph::new(&session).await?;
+        let mut changes = graph.subscribe_changes();
+        let entity = Entity::Node(NodeEntity::new(
+            session.zid(),
             52,
-            unique_node_name("local_remove_notify"),
+            unique_node_name("local_readd_revision"),
             String::new(),
         ));
 
         graph.add_local_entity(entity.clone())?;
-        let notified = graph.change_notify.notified();
-        graph.remove_local_entity(&entity)?;
-
-        tokio::time::timeout(Duration::from_millis(100), notified)
+        tokio::time::timeout(Duration::from_millis(100), changes.changed())
             .await
-            .expect("local remove should notify graph waiters");
+            .expect("first local add should publish a graph revision")
+            .expect("graph revision sender should stay alive");
+        let revision_after_first_add = graph.revision();
+
+        graph.add_local_entity(entity)?;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), changes.changed())
+                .await
+                .is_err(),
+            "unchanged local re-add must not publish a graph revision"
+        );
+        assert_eq!(graph.revision(), revision_after_first_add);
         session
             .close()
             .await

--- a/crates/ros-z/src/graph/discovery.rs
+++ b/crates/ros-z/src/graph/discovery.rs
@@ -1,95 +1,50 @@
-use parking_lot::Mutex;
-use std::sync::Arc;
-use tokio::sync::Notify;
 use tracing::{debug, warn};
 use zenoh::{Session, pubsub::Subscriber, sample::SampleKind};
 
 use crate::{Result, entity::LivelinessKE};
 
-use super::{GraphOptions, state::GraphData};
+use super::state::GraphStore;
 use ros_z_protocol::format::parse_liveliness;
 
 pub(super) async fn install_liveliness(
     session: &Session,
     pattern: &str,
-    options: &GraphOptions,
-    graph_data: Arc<Mutex<GraphData>>,
-    change_notify: Arc<Notify>,
+    graph_store: GraphStore,
 ) -> Result<Subscriber<()>> {
     debug!(pattern = %pattern, "declaring graph liveliness subscriber");
     let sub = session
         .liveliness()
         .declare_subscriber(pattern)
         .history(true)
-        .callback({
-            let graph_data = graph_data.clone();
-            move |sample| {
-                let key_expr = LivelinessKE(sample.key_expr().to_owned());
-                let sample_kind = sample.kind();
-                debug!(
-                    liveliness_key = %key_expr.0,
-                    kind = ?sample_kind,
-                    "received graph liveliness token"
-                );
+        .callback(move |sample| {
+            let key_expr = LivelinessKE(sample.key_expr().to_owned());
+            let sample_kind = sample.kind();
+            debug!(
+                liveliness_key = %key_expr.0,
+                kind = ?sample_kind,
+                "received graph liveliness token"
+            );
 
-                let changed = match sample_kind {
-                    SampleKind::Put => match parse_liveliness(&key_expr) {
-                        Ok(entity) => {
-                            graph_data.lock().insert(key_expr, entity);
-                            true
-                        }
-                        Err(error) => {
-                            warn!(
-                                liveliness_key = %key_expr.0,
-                                error = ?error,
-                                "failed to parse liveliness key; ignoring remote entity"
-                            );
-                            false
-                        }
-                    },
-                    SampleKind::Delete => graph_data.lock().remove(&key_expr),
-                };
-
-                if changed {
-                    change_notify.notify_waiters();
-                }
-            }
-        })
-        .await
-        .map_err(|source| crate::Error::zenoh("declare graph liveliness subscriber", source))?;
-
-    if let Some(timeout) = options.initial_liveliness_query_timeout {
-        let replies = session
-            .liveliness()
-            .get(pattern)
-            .timeout(timeout)
-            .await
-            .map_err(|source| crate::Error::zenoh("query initial graph liveliness", source))?;
-        let mut reply_count = 0;
-        while let Ok(reply) = replies.recv_async().await {
-            reply_count += 1;
-            if let Ok(sample) = reply.into_result() {
-                let key_expr = LivelinessKE(sample.key_expr().to_owned());
-                debug!(
-                    liveliness_key = %key_expr.0,
-                    "received initial graph liveliness token"
-                );
-                match parse_liveliness(&key_expr) {
+            match sample_kind {
+                SampleKind::Put => match parse_liveliness(&key_expr) {
                     Ok(entity) => {
-                        graph_data.lock().insert(key_expr, entity);
+                        graph_store.insert(key_expr, entity);
                     }
                     Err(error) => {
                         warn!(
                             liveliness_key = %key_expr.0,
                             error = ?error,
-                            "failed to parse initial liveliness key; ignoring remote entity"
+                            "failed to parse liveliness key; ignoring remote entity"
                         );
                     }
+                },
+                SampleKind::Delete => {
+                    graph_store.remove(&key_expr);
                 }
             }
-        }
-        debug!(reply_count, "initial graph liveliness query completed");
-    }
+        })
+        .await
+        .map_err(|source| crate::Error::zenoh("declare graph liveliness subscriber", source))?;
 
     Ok(sub)
 }

--- a/crates/ros-z/src/graph/query.rs
+++ b/crates/ros-z/src/graph/query.rs
@@ -5,7 +5,7 @@ use parking_lot::MutexGuard;
 use crate::entity::{EndpointEntity, EndpointKind, Entity, NodeEntity, NodeKey};
 use crate::qos::{QosCompatibility, QosProfile};
 
-use super::{Graph, state::GraphData};
+use super::{Graph, GraphRevision, state::GraphState};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QosIncompatibility {
@@ -19,7 +19,44 @@ pub struct QosIncompatibility {
 ///
 /// Do not hold a `GraphView` across `.await` points or while calling other `Graph` methods.
 pub struct GraphView<'a> {
-    data: MutexGuard<'a, GraphData>,
+    state: MutexGuard<'a, GraphState>,
+}
+
+/// Subscription to effective local graph changes.
+///
+/// The subscription stores only the latest graph revision. Treat each observed revision as a signal
+/// to resync from [`Graph::view`] or [`Graph::snapshot`]; revisions do not carry per-change payloads
+/// and do not prove that the distributed graph is complete.
+pub struct GraphChangeSubscription {
+    changes: tokio::sync::watch::Receiver<GraphRevision>,
+}
+
+impl GraphChangeSubscription {
+    pub(super) fn new(changes: tokio::sync::watch::Receiver<GraphRevision>) -> Self {
+        Self { changes }
+    }
+
+    /// Return the currently observed graph revision without marking it as seen.
+    pub fn current(&self) -> GraphRevision {
+        *self.changes.borrow()
+    }
+
+    /// Mark the current revision as seen and return it.
+    ///
+    /// Call this before evaluating a graph predicate when implementing a wait loop. That arms the
+    /// subscription so a later [`Self::changed`] call waits for changes after the sampled graph
+    /// state instead of returning an already-observed revision.
+    pub fn mark_seen(&mut self) -> GraphRevision {
+        *self.changes.borrow_and_update()
+    }
+
+    /// Wait for a later graph revision.
+    ///
+    /// Returns `None` when the graph change sender has closed.
+    pub async fn changed(&mut self) -> Option<GraphRevision> {
+        self.changes.changed().await.ok()?;
+        Some(*self.changes.borrow_and_update())
+    }
 }
 
 impl Graph {
@@ -29,14 +66,42 @@ impl Graph {
     /// methods; those operations may need the same lock.
     pub fn view(&self) -> GraphView<'_> {
         GraphView {
-            data: self.data.lock(),
+            state: self.store.state(),
+        }
+    }
+
+    pub(crate) async fn wait_until<F>(&self, mut predicate: F) -> bool
+    where
+        F: for<'view> FnMut(GraphView<'view>) -> bool,
+    {
+        let mut changes = self.subscribe_changes();
+        loop {
+            changes.mark_seen();
+            let satisfied = {
+                let view = self.view();
+                predicate(view)
+            };
+            if satisfied {
+                return true;
+            }
+
+            if changes.changed().await.is_none() {
+                return false;
+            }
         }
     }
 }
 
 impl GraphView<'_> {
+    /// Return the graph revision for this locked view.
+    ///
+    /// This revision belongs to the same graph state as the entities read through this view.
+    pub fn revision(&self) -> GraphRevision {
+        self.state.revision()
+    }
+
     pub fn entities(&self) -> impl Iterator<Item = &Entity> + '_ {
-        self.data.entities()
+        self.state.entities()
     }
 
     pub fn nodes(&self) -> impl Iterator<Item = &NodeEntity> + '_ {
@@ -59,6 +124,22 @@ impl GraphView<'_> {
 
     pub fn subscriptions_on(&self, topic: impl AsRef<str>) -> Vec<EndpointEntity> {
         self.endpoints_named(EndpointKind::Subscription, topic)
+    }
+
+    pub fn publisher_count_on(&self, topic: impl AsRef<str>) -> usize {
+        self.endpoint_count_named(EndpointKind::Publisher, topic)
+    }
+
+    pub fn subscription_count_on(&self, topic: impl AsRef<str>) -> usize {
+        self.endpoint_count_named(EndpointKind::Subscription, topic)
+    }
+
+    pub fn has_publishers_on(&self, topic: impl AsRef<str>) -> bool {
+        self.has_endpoint_named(EndpointKind::Publisher, topic)
+    }
+
+    pub fn has_subscriptions_on(&self, topic: impl AsRef<str>) -> bool {
+        self.has_endpoint_named(EndpointKind::Subscription, topic)
     }
 
     pub fn services_named(&self, service_name: impl AsRef<str>) -> Vec<EndpointEntity> {
@@ -117,6 +198,19 @@ impl GraphView<'_> {
             .filter(|endpoint| endpoint.kind == kind && endpoint.topic == name)
             .cloned()
             .collect()
+    }
+
+    fn endpoint_count_named(&self, kind: EndpointKind, name: impl AsRef<str>) -> usize {
+        let name = name.as_ref();
+        self.endpoints()
+            .filter(|endpoint| endpoint.kind == kind && endpoint.topic == name)
+            .count()
+    }
+
+    fn has_endpoint_named(&self, kind: EndpointKind, name: impl AsRef<str>) -> bool {
+        let name = name.as_ref();
+        self.endpoints()
+            .any(|endpoint| endpoint.kind == kind && endpoint.topic == name)
     }
 
     fn names_and_types_for(
@@ -312,5 +406,21 @@ mod tests {
             .await
             .map_err(|source| Error::zenoh("close Zenoh session", source))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn graph_change_subscription_changed_returns_none_after_sender_closes() {
+        let (sender, receiver) = tokio::sync::watch::channel(GraphRevision::INITIAL);
+        let mut changes = GraphChangeSubscription::new(receiver);
+        changes.mark_seen();
+
+        drop(sender);
+
+        assert_eq!(changes.changed().await, None);
     }
 }

--- a/crates/ros-z/src/graph/snapshot.rs
+++ b/crates/ros-z/src/graph/snapshot.rs
@@ -4,11 +4,16 @@ use serde::Serialize;
 
 use crate::entity::EndpointKind;
 
-use super::Graph;
+use super::{Graph, GraphRevision};
 
-/// A serializable snapshot of the native ros-z graph state
+/// A serializable point-in-time observation of the local native ros-z graph state.
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphSnapshot {
+    /// Revision of the local graph state used to produce this snapshot.
+    ///
+    /// This is a monotonic local progress token. It does not mean the distributed graph is complete
+    /// or settled.
+    pub revision: GraphRevision,
     pub timestamp: SystemTime,
     pub topics: Vec<TopicSnapshot>,
     pub nodes: Vec<NodeSnapshot>,
@@ -38,13 +43,14 @@ pub struct ServiceSnapshot {
 }
 
 impl Graph {
-    /// Create a serializable snapshot of the current graph state
+    /// Create a serializable point-in-time observation of the current local graph state.
     ///
-    /// This captures topics, nodes, and services with their metadata,
-    /// suitable for JSON serialization or other export formats.
+    /// This captures topics, nodes, services, and the local revision used to produce the snapshot.
+    /// The snapshot does not imply that the distributed graph is complete or settled.
     pub fn snapshot(&self) -> GraphSnapshot {
-        let (topics, nodes, services) = {
+        let (revision, topics, nodes, services) = {
             let view = self.view();
+            let revision = view.revision();
             let topics: Vec<TopicSnapshot> = view
                 .topic_names_and_types()
                 .into_iter()
@@ -82,10 +88,11 @@ impl Graph {
                 .map(|(name, type_name)| ServiceSnapshot { name, type_name })
                 .collect();
 
-            (topics, nodes, services)
+            (revision, topics, nodes, services)
         };
 
         GraphSnapshot {
+            revision,
             timestamp: SystemTime::now(),
             topics,
             nodes,

--- a/crates/ros-z/src/graph/state.rs
+++ b/crates/ros-z/src/graph/state.rs
@@ -1,9 +1,90 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
+use std::sync::Arc;
 
+use parking_lot::{Mutex, MutexGuard};
+use tokio::sync::watch;
+
+use super::GraphRevision;
 use crate::entity::{Entity, LivelinessKE};
 
 pub(super) struct GraphData {
     entities: HashMap<LivelinessKE, Entity>,
+}
+
+pub(super) struct GraphState {
+    data: GraphData,
+    revision: GraphRevision,
+}
+
+impl GraphState {
+    pub(super) fn revision(&self) -> GraphRevision {
+        self.revision
+    }
+
+    pub(super) fn entities(&self) -> impl Iterator<Item = &Entity> + '_ {
+        self.data.entities()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GraphStore {
+    state: Arc<Mutex<GraphState>>,
+    revision_tx: watch::Sender<GraphRevision>,
+}
+
+impl GraphStore {
+    pub(super) fn new() -> Self {
+        let (revision_tx, _) = watch::channel(GraphRevision::INITIAL);
+        Self {
+            state: Arc::new(Mutex::new(GraphState {
+                data: GraphData::new(),
+                revision: GraphRevision::INITIAL,
+            })),
+            revision_tx,
+        }
+    }
+
+    pub(super) fn revision(&self) -> GraphRevision {
+        self.state.lock().revision()
+    }
+
+    pub(super) fn subscribe_changes(&self) -> watch::Receiver<GraphRevision> {
+        self.revision_tx.subscribe()
+    }
+
+    pub(super) fn state(&self) -> MutexGuard<'_, GraphState> {
+        self.state.lock()
+    }
+
+    pub(super) fn insert(&self, key_expr: LivelinessKE, entity: Entity) -> bool {
+        self.apply_effective_change(|data| data.insert(key_expr, entity))
+    }
+
+    pub(super) fn remove(&self, key_expr: &LivelinessKE) -> bool {
+        self.apply_effective_change(|data| data.remove(key_expr))
+    }
+
+    fn apply_effective_change(&self, update: impl FnOnce(&mut GraphData) -> bool) -> bool {
+        let revision = {
+            let mut state = self.state.lock();
+            if !update(&mut state.data) {
+                return false;
+            }
+
+            let revision = state.revision.next();
+            state.revision = revision;
+            revision
+        };
+
+        self.revision_tx.send_if_modified(|current| {
+            if *current >= revision {
+                return false;
+            }
+            *current = revision;
+            true
+        });
+        true
+    }
 }
 
 impl GraphData {
@@ -13,8 +94,18 @@ impl GraphData {
         }
     }
 
-    pub(super) fn insert(&mut self, key_expr: LivelinessKE, entity: Entity) {
-        self.entities.insert(key_expr, entity);
+    pub(super) fn insert(&mut self, key_expr: LivelinessKE, entity: Entity) -> bool {
+        match self.entities.entry(key_expr) {
+            Entry::Vacant(entry) => {
+                entry.insert(entity);
+                true
+            }
+            Entry::Occupied(mut entry) if entry.get() != &entity => {
+                entry.insert(entity);
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
     }
 
     pub(super) fn remove(&mut self, key_expr: &LivelinessKE) -> bool {
@@ -54,36 +145,36 @@ mod tests {
     }
 
     #[test]
-    fn insert_stores_one_entity_by_liveliness_key() {
+    fn insert_reports_change_for_new_entity() {
         let mut data = GraphData::new();
         let entity = Entity::Node(node("inserted_node"));
         let key = key_for(&entity);
 
-        data.insert(key, entity.clone());
+        assert!(data.insert(key, entity.clone()));
         assert_eq!(data.entities().collect::<Vec<_>>(), vec![&entity]);
     }
 
     #[test]
-    fn duplicate_insert_upserts_without_duplicating() {
+    fn duplicate_insert_reports_no_change() {
         let mut data = GraphData::new();
         let entity = Entity::Node(node("duplicate_node"));
         let key = key_for(&entity);
 
-        data.insert(key.clone(), entity.clone());
-        data.insert(key, entity);
+        assert!(data.insert(key.clone(), entity.clone()));
+        assert!(!data.insert(key, entity));
         assert_eq!(data.entities().count(), 1);
     }
 
     #[test]
-    fn replacing_same_key_updates_existing_entity() {
+    fn replacing_same_key_reports_change() {
         let mut data = GraphData::new();
         let node = node("replace_node");
         let old = Entity::Endpoint(publisher(&node, 2, "/old_topic"));
         let new = Entity::Endpoint(publisher(&node, 3, "/new_topic"));
         let key = key_for(&old);
 
-        data.insert(key.clone(), old);
-        data.insert(key, new.clone());
+        assert!(data.insert(key.clone(), old));
+        assert!(data.insert(key, new.clone()));
         assert_eq!(data.entities().collect::<Vec<_>>(), vec![&new]);
     }
 
@@ -115,5 +206,27 @@ mod tests {
 
         assert!(!data.remove(&key));
         assert_eq!(data.entities().count(), 0);
+    }
+
+    #[test]
+    fn store_insert_and_remove_advance_revision_only_for_effective_changes() {
+        let store = GraphStore::new();
+        let entity = Entity::Node(node("store_revision_node"));
+        let key = key_for(&entity);
+
+        assert_eq!(store.revision(), GraphRevision::INITIAL);
+        assert!(store.insert(key.clone(), entity.clone()));
+        let insert_revision = store.revision();
+        assert!(insert_revision > GraphRevision::INITIAL);
+
+        assert!(!store.insert(key.clone(), entity.clone()));
+        assert_eq!(store.revision(), insert_revision);
+
+        assert!(store.remove(&key));
+        let remove_revision = store.revision();
+        assert!(remove_revision > insert_revision);
+
+        assert!(!store.remove(&key));
+        assert_eq!(store.revision(), remove_revision);
     }
 }

--- a/crates/ros-z/src/node.rs
+++ b/crates/ros-z/src/node.rs
@@ -623,10 +623,15 @@ impl Node {
             .dynamic_schema(schema))
     }
 
-    /// Discover the schema that publishers currently expose on a topic.
+    /// Discover the schema exposed by publishers on a topic.
     ///
     /// The topic name is qualified according to the same ros-z graph-name rules as the
     /// regular publisher and subscriber builder APIs.
+    ///
+    /// Discovery waits up to `discovery_timeout` for a matching publisher to appear in
+    /// the graph. Once publishers are available, the remaining timeout budget is used
+    /// to query their schema services. If no matching publisher appears before the
+    /// timeout expires, this returns [`DynamicError::SchemaNotFound`].
     pub async fn discover_topic_schema(
         &self,
         topic: &str,
@@ -639,10 +644,13 @@ impl Node {
 
     /// Create a dynamic subscriber with automatic schema discovery.
     ///
-    /// This method queries publishers on the topic for their schema service
-    /// and returns a preconfigured subscriber builder using the discovered
-    /// schema. This is useful when you don't know the message type at compile
-    /// time.
+    /// This method waits for publishers on the topic, queries their schema services,
+    /// and returns a preconfigured subscriber builder using the discovered schema.
+    /// This is useful when you don't know the message type at compile time.
+    ///
+    /// The `discovery_timeout` covers both waiting for a matching publisher and
+    /// querying schema services. If no matching publisher appears before the timeout
+    /// expires, this returns [`DynamicError::SchemaNotFound`].
     ///
     /// The topic name will be qualified as a ros-z graph name:
     /// - Absolute topics (starting with '/') are used as-is

--- a/crates/ros-z/src/pubsub/publisher.rs
+++ b/crates/ros-z/src/pubsub/publisher.rs
@@ -398,7 +398,7 @@ where
 {
     /// Return the number of matched subscribers currently visible in the graph.
     pub fn subscriber_count(&self) -> usize {
-        self.graph.view().subscriptions_on(&self.entity.topic).len()
+        self.graph.view().subscription_count_on(&self.entity.topic)
     }
 
     /// Return whether at least one subscriber is currently matched.
@@ -423,30 +423,15 @@ where
     /// assert!(publisher.wait_for_subscribers(1, Duration::from_secs(5)).await);
     /// ```
     pub async fn wait_for_subscribers(&self, count: usize, timeout: Duration) -> bool {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            // Arm the notification *before* reading the count to avoid a TOCTOU
-            // race where a subscriber arrives between the count check and the await.
-            let notified = self.graph.change_notify.notified();
-            tokio::pin!(notified);
+        let topic = self.entity.topic.as_str();
+        let wait = self
+            .graph
+            .wait_until(move |view| view.subscription_count_on(topic) >= count);
 
-            let n = self.graph.view().subscriptions_on(&self.entity.topic).len();
-            if n >= count {
-                return true;
-            }
-
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return false;
-            }
-
-            // Sleep until either a graph change fires or the deadline passes.
-            if tokio::time::timeout(remaining, &mut notified)
-                .await
-                .is_err()
-            {
-                // Timeout — do one final check in case a late notification was missed.
-                return self.graph.view().subscriptions_on(&self.entity.topic).len() >= count;
+        match tokio::time::timeout(timeout, wait).await {
+            Ok(true) => true,
+            Ok(false) | Err(_) => {
+                self.graph.view().subscription_count_on(&self.entity.topic) >= count
             }
         }
     }

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -642,11 +642,12 @@ pub(crate) fn spawn_transient_local_replay_task(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut seen = initial_seen;
+        let mut changes = graph.subscribe_changes();
         loop {
             if coordinator.is_cancelled() {
                 return;
             }
-            let notified = graph.change_notify.notified();
+            changes.mark_seen();
             let discovered = begin_unseen_late_publishers(
                 &mut seen,
                 &coordinator,
@@ -672,7 +673,9 @@ pub(crate) fn spawn_transient_local_replay_task(
                 }
                 coordinator.finish_late_replay(publisher_global_id);
             }
-            notified.await;
+            if changes.changed().await.is_none() {
+                return;
+            }
         }
     })
 }

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -408,27 +408,14 @@ where
     /// assert!(subscriber.wait_for_publishers(1, Duration::from_secs(5)).await);
     /// ```
     pub async fn wait_for_publishers(&self, count: usize, timeout: Duration) -> bool {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            let notified = self.graph.change_notify.notified();
-            tokio::pin!(notified);
+        let topic = self.entity.topic.as_str();
+        let wait = self
+            .graph
+            .wait_until(move |view| view.publisher_count_on(topic) >= count);
 
-            let n = self.graph.view().publishers_on(&self.entity.topic).len();
-            if n >= count {
-                return true;
-            }
-
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return false;
-            }
-
-            if tokio::time::timeout(remaining, &mut notified)
-                .await
-                .is_err()
-            {
-                return self.graph.view().publishers_on(&self.entity.topic).len() >= count;
-            }
+        match tokio::time::timeout(timeout, wait).await {
+            Ok(true) => true,
+            Ok(false) | Err(_) => self.graph.view().publisher_count_on(&self.entity.topic) >= count,
         }
     }
 }
@@ -440,7 +427,7 @@ where
 {
     /// Return the number of matched publishers currently visible in the graph.
     pub fn publisher_count(&self) -> usize {
-        self.graph.view().publishers_on(&self.entity.topic).len()
+        self.graph.view().publisher_count_on(&self.entity.topic)
     }
 
     /// Return whether at least one publisher is currently matched.

--- a/crates/ros-z/tests/graph.rs
+++ b/crates/ros-z/tests/graph.rs
@@ -7,17 +7,18 @@
 //! - Node discovery and information
 //! - Service availability checking
 
-use std::{num::NonZeroUsize, time::Duration};
+use std::{net::TcpListener, num::NonZeroUsize, time::Duration};
 
 use ros_z::{
     Message, ServiceTypeInfo,
     context::ContextBuilder,
     entity::{EndpointEntity, EndpointKind, Entity, NodeEntity, NodeKey, SchemaHash, TypeInfo},
-    graph::GraphView,
+    graph::{GraphChangeSubscription, GraphRevision, GraphView},
     message::Service,
     qos::{QosCompatibility, QosDurability, QosHistory, QosProfile, QosReliability},
 };
 use serde::{Deserialize, Serialize};
+use zenoh::config::WhatAmI;
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -84,6 +85,140 @@ fn unique_node_name(prefix: &str) -> String {
     )
 }
 
+fn unique_listen_endpoint() -> Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    Ok(format!("tcp/127.0.0.1:{port}"))
+}
+
+fn isolated_peer_config(
+    listen_endpoint: Option<&str>,
+    connect_endpoints: &[&str],
+) -> Result<zenoh::Config> {
+    let mut config = zenoh::Config::default();
+    config
+        .set_mode(Some(WhatAmI::Peer))
+        .map_err(|mode| format!("failed to set Zenoh mode to peer: {mode:?}"))?;
+    let listen_endpoints = listen_endpoint
+        .map(|endpoint| format!("[\"{endpoint}\"]"))
+        .unwrap_or_else(|| "[\"tcp/127.0.0.1:0\"]".to_string());
+    let connect_endpoints = if connect_endpoints.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "[{}]",
+            connect_endpoints
+                .iter()
+                .map(|endpoint| format!("\"{endpoint}\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    };
+    config.insert_json5("listen/endpoints", &listen_endpoints)?;
+    config.insert_json5("connect/endpoints", &connect_endpoints)?;
+    config.insert_json5("scouting/multicast/enabled", "false")?;
+    Ok(config)
+}
+
+async fn try_open_isolated_graph_sessions() -> Result<(zenoh::Session, zenoh::Session)> {
+    let graph_endpoint = unique_listen_endpoint()?;
+    let graph_session = zenoh::open(isolated_peer_config(Some(&graph_endpoint), &[])?).await?;
+    let remote_session = zenoh::open(isolated_peer_config(None, &[&graph_endpoint])?).await?;
+    Ok((graph_session, remote_session))
+}
+
+async fn open_isolated_graph_sessions() -> Result<(zenoh::Session, zenoh::Session)> {
+    let mut last_error = None;
+    for _ in 0..8 {
+        match try_open_isolated_graph_sessions().await {
+            Ok(sessions) => return Ok(sessions),
+            Err(error) => last_error = Some(error),
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    Err(last_error.unwrap_or_else(|| "failed to open isolated graph sessions".into()))
+}
+
+fn remote_node_entity(session: &zenoh::Session, id: usize, prefix: &str) -> Entity {
+    Entity::Node(NodeEntity::new(
+        session.zid(),
+        id,
+        unique_node_name(prefix),
+        String::new(),
+    ))
+}
+
+async fn declare_liveliness_token(
+    session: &zenoh::Session,
+    entity: &Entity,
+) -> Result<zenoh::liveliness::LivelinessToken> {
+    let liveliness_key_expr = entity.liveliness_key_expr()?;
+    session
+        .liveliness()
+        .declare_token(liveliness_key_expr.0)
+        .await
+}
+
+async fn wait_for_liveliness_token(
+    session: &zenoh::Session,
+    entity: &Entity,
+    timeout: Duration,
+) -> Result<()> {
+    let liveliness_key_expr = entity.liveliness_key_expr()?;
+    let started_at = std::time::Instant::now();
+    loop {
+        if started_at.elapsed() >= timeout {
+            return Err(format!(
+                "timed out waiting for liveliness token {}",
+                liveliness_key_expr.as_str()
+            )
+            .into());
+        }
+        let query_timeout = timeout
+            .saturating_sub(started_at.elapsed())
+            .min(Duration::from_millis(50));
+        let replies = session
+            .liveliness()
+            .get(liveliness_key_expr.as_str())
+            .timeout(query_timeout)
+            .await?;
+        while let Ok(reply) = replies.recv_async().await {
+            if let Ok(sample) = reply.into_result()
+                && sample.key_expr().as_str() == liveliness_key_expr.as_str()
+            {
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn wait_for_graph_revision_change(
+    changes: &mut GraphChangeSubscription,
+    previous_revision: GraphRevision,
+    timeout: Duration,
+) -> Result<GraphRevision> {
+    let revision = changes.mark_seen();
+    if revision != previous_revision {
+        return Ok(revision);
+    }
+
+    tokio::time::timeout(timeout, async {
+        loop {
+            let revision = changes
+                .changed()
+                .await
+                .ok_or("graph change subscription closed")?;
+            if revision != previous_revision {
+                return Ok(revision);
+            }
+        }
+    })
+    .await
+    .map_err(|_| {
+        format!("timed out waiting for graph revision change from {previous_revision:?}")
+    })?
+}
+
 async fn wait_for_count(
     node: &ros_z::node::Node,
     name: &str,
@@ -132,11 +267,11 @@ async fn wait_for_count_matching(
 }
 
 fn publisher_count(view: &GraphView<'_>, topic: &str) -> usize {
-    view.publishers_on(topic).len()
+    view.publisher_count_on(topic)
 }
 
 fn subscriber_count(view: &GraphView<'_>, topic: &str) -> usize {
-    view.subscriptions_on(topic).len()
+    view.subscription_count_on(topic)
 }
 
 fn service_count(view: &GraphView<'_>, service: &str) -> usize {
@@ -265,7 +400,9 @@ mod tests {
         graph.add_local_entity(Entity::Endpoint(service_endpoint.clone()))?;
         graph.add_local_entity(Entity::Endpoint(client_endpoint.clone()))?;
 
+        let graph_revision = graph.revision();
         let view: ros_z::graph::GraphView<'_> = graph.view();
+        assert_eq!(view.revision(), graph_revision);
         assert!(
             view.entities()
                 .any(|candidate| candidate == &Entity::Node(node.clone()))
@@ -278,6 +415,14 @@ mod tests {
         assert!(view.endpoints().any(|candidate| candidate == &publisher));
         assert_eq!(view.publishers_on(&topic), vec![publisher.clone()]);
         assert_eq!(view.subscriptions_on(&topic), vec![subscription]);
+        assert_eq!(view.publisher_count_on(&topic), 1);
+        assert_eq!(view.subscription_count_on(&topic), 1);
+        assert!(view.has_publishers_on(&topic));
+        assert!(view.has_subscriptions_on(&topic));
+        assert_eq!(view.publisher_count_on("/missing_topic"), 0);
+        assert_eq!(view.subscription_count_on("/missing_topic"), 0);
+        assert!(!view.has_publishers_on("/missing_topic"));
+        assert!(!view.has_subscriptions_on("/missing_topic"));
         assert_eq!(
             view.services_named(&service),
             vec![service_endpoint.clone()]
@@ -469,15 +614,6 @@ mod tests {
 
         assert!(graph.view().node_exists(&node_key));
         session.close().await?;
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn context_can_skip_initial_graph_liveliness_query() -> Result<()> {
-        let _ctx = ContextBuilder::default()
-            .without_graph_initial_query()
-            .build()
-            .await?;
         Ok(())
     }
 
@@ -1085,6 +1221,75 @@ mod tests {
         assert!(!pubs.is_empty(), "Expected to find publishers");
         assert!(!subs.is_empty(), "Expected to find subscribers");
 
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graph_change_subscription_reports_historical_liveliness_put_as_revision() -> Result<()>
+    {
+        let (graph_session, remote_session) = open_isolated_graph_sessions().await?;
+        let entity = remote_node_entity(&remote_session, 91, "graph_revision_history_remote");
+        let _token = declare_liveliness_token(&remote_session, &entity).await?;
+        wait_for_liveliness_token(&graph_session, &entity, Duration::from_secs(2)).await?;
+
+        let graph = ros_z::graph::Graph::new(&graph_session).await?;
+        let mut changes = graph.subscribe_changes();
+
+        let history_revision = wait_for_graph_revision_change(
+            &mut changes,
+            GraphRevision::INITIAL,
+            Duration::from_secs(2),
+        )
+        .await?;
+
+        assert_ne!(history_revision, GraphRevision::INITIAL);
+        assert!(
+            graph
+                .view()
+                .entities()
+                .any(|candidate| candidate == &entity)
+        );
+
+        graph_session.close().await?;
+        remote_session.close().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graph_change_subscription_reports_live_remote_put_and_delete() -> Result<()> {
+        let (graph_session, remote_session) = open_isolated_graph_sessions().await?;
+        let graph = ros_z::graph::Graph::new(&graph_session).await?;
+        let mut changes = graph.subscribe_changes();
+        let initial_revision = graph.revision();
+        let entity = remote_node_entity(&remote_session, 92, "graph_revision_live_put_delete");
+
+        let token = declare_liveliness_token(&remote_session, &entity).await?;
+
+        let put_revision =
+            wait_for_graph_revision_change(&mut changes, initial_revision, Duration::from_secs(2))
+                .await?;
+        assert_ne!(put_revision, initial_revision);
+        assert!(
+            graph
+                .view()
+                .entities()
+                .any(|candidate| candidate == &entity)
+        );
+
+        drop(token);
+        let delete_revision =
+            wait_for_graph_revision_change(&mut changes, put_revision, Duration::from_secs(2))
+                .await?;
+        assert_ne!(delete_revision, put_revision);
+        assert!(
+            !graph
+                .view()
+                .entities()
+                .any(|candidate| candidate == &entity)
+        );
+
+        graph_session.close().await?;
+        remote_session.close().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Closed in favor of #2653, which uses `schmidma:ros-z-topic-observer` as the PR head instead of an upstream `HULKs` branch.