### PR TITLE
feat(twix): add topic completion

### DIFF
--- a/tools/twix/src/backend.rs
+++ b/tools/twix/src/backend.rs
@@ -2,14 +2,14 @@ use std::sync::{Arc, Mutex};
 
 use color_eyre::{Result, eyre::Context as _};
 use ros_z::{context::ContextBuilder, prelude::*};
-use ros_z_debug::{TopicObserver, TopicObserverOptions};
+use ros_z_debug::{TopicObserver, TopicObserverOptions, TopicProjection};
 use tokio::runtime::Handle;
 use uuid::Uuid;
 
 pub struct RobotBackend {
     runtime_handle: Handle,
     context: Arc<Context>,
-    _node: Arc<Node>,
+    node: Arc<Node>,
     observer: TopicObserver,
     namespace: Mutex<String>,
 }
@@ -49,7 +49,7 @@ impl RobotBackend {
         Ok(Self {
             runtime_handle,
             context,
-            _node: node,
+            node,
             observer,
             namespace: Mutex::new(namespace),
         })
@@ -61,6 +61,13 @@ impl RobotBackend {
 
     pub fn observer(&self) -> &TopicObserver {
         &self.observer
+    }
+
+    pub fn topic_completions(&self, type_name: Option<&str>) -> Vec<String> {
+        let namespace = self.namespace();
+        let topics = self.node.graph().view().topic_names_and_types();
+
+        topic_completions_from_graph(&namespace, topics, type_name)
     }
 
     pub fn namespace(&self) -> String {
@@ -90,6 +97,25 @@ impl Drop for RobotBackend {
     }
 }
 
+fn topic_completions_from_graph(
+    namespace: &str,
+    topics: impl IntoIterator<Item = (String, String)>,
+    type_name: Option<&str>,
+) -> Vec<String> {
+    let topics = topics
+        .into_iter()
+        .filter_map(|(topic, topic_type_name)| {
+            type_name
+                .is_none_or(|type_name| topic_type_name == type_name)
+                .then_some(topic)
+        })
+        .collect::<Vec<_>>();
+
+    TopicProjection::project(namespace, topics)
+        .map(|topics| topics.into_iter().map(|topic| topic.display_name).collect())
+        .unwrap_or_default()
+}
+
 fn twix_node_name() -> String {
     let host = std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown-host".to_string());
     let host = sanitize_node_component(&host);
@@ -114,5 +140,58 @@ fn sanitize_node_component(value: &str) -> String {
         "unknown-host".to_string()
     } else {
         sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::topic_completions_from_graph;
+
+    fn topic(name: &str, type_name: &str) -> (String, String) {
+        (name.to_string(), type_name.to_string())
+    }
+
+    #[test]
+    fn topic_completions_project_active_namespace_topics_relatively() {
+        let completions = topic_completions_from_graph(
+            "/42",
+            [topic("/42/outputs/ball", "debug_msgs::Ball")],
+            None,
+        );
+
+        assert_eq!(completions, ["outputs/ball"]);
+    }
+
+    #[test]
+    fn topic_completions_keep_outside_namespace_topics_absolute() {
+        let completions = topic_completions_from_graph(
+            "/42",
+            [topic("/diagnostics", "debug_msgs::Diagnostics")],
+            None,
+        );
+
+        assert_eq!(completions, ["/diagnostics"]);
+    }
+
+    #[test]
+    fn topic_completions_filter_by_type_name() {
+        let completions = topic_completions_from_graph(
+            "/42",
+            [
+                topic("/42/inputs/left_image", "image-type"),
+                topic("/42/outputs/ball", "debug-type"),
+            ],
+            Some("image-type"),
+        );
+
+        assert_eq!(completions, ["inputs/left_image"]);
+    }
+
+    #[test]
+    fn topic_completions_return_empty_when_projection_fails() {
+        let completions =
+            topic_completions_from_graph("/42", [topic("bad%topic", "debug-type")], None);
+
+        assert!(completions.is_empty());
     }
 }

--- a/tools/twix/src/panels/image.rs
+++ b/tools/twix/src/panels/image.rs
@@ -4,7 +4,7 @@ use color_eyre::{Report, eyre::Context as _};
 use eframe::egui::{ColorImage, Context, TextureHandle, TextureOptions, Ui, load::SizedTexture};
 use hulk_widgets::CompletionEdit;
 use image::RgbImage;
-use ros_z::{pubsub::PublicationId, time::Time};
+use ros_z::{Message, pubsub::PublicationId, time::Time};
 use ros_z_debug::{SampleRecord, TopicObservation, TopicObservationStatus};
 use ros2::sensor_msgs::image::Image as RosImage;
 use serde_json::{Value, json};
@@ -95,7 +95,10 @@ impl Panel for ImagePanel {
         ui.vertical(|ui| {
             ui.horizontal(|ui| {
                 ui.label("Topic");
-                let completions = Vec::<String>::new();
+                let image_topic_type_name = <TimeWrapper<RosImage> as Message>::type_name();
+                let completions = context
+                    .backend
+                    .topic_completions(Some(&image_topic_type_name));
                 let response = ui.add(CompletionEdit::new(
                     ui.id().with("image_topic"),
                     &completions,

--- a/tools/twix/src/panels/text.rs
+++ b/tools/twix/src/panels/text.rs
@@ -80,7 +80,7 @@ impl Panel for TextPanel {
         ui.vertical(|ui| {
             ui.horizontal(|ui| {
                 ui.label("Topic");
-                let completions = Vec::<String>::new();
+                let completions = context.backend.topic_completions(None);
                 let response = ui.add(CompletionEdit::new(
                     ui.id().with("topic"),
                     &completions,


### PR DESCRIPTION
## Summary
- feed the Text panel topic editor with ROS-Z graph topic completions
- filter Image panel topic completions to `TimeWrapper` topics
- project completion labels relative to the active Twix namespace

## Motivation
Topic panels already use `CompletionEdit`, but had no topic suggestions. This connects them to the ROS-Z graph so discovered topics can be selected directly.

## Implementation
- add a `RobotBackend::topic_completions` helper backed by `node.graph().view().topic_names_and_types()`
- reuse `ros_z_debug::TopicProjection` for namespace-relative display names
- keep Text panel suggestions unfiltered and Image panel suggestions type-filtered

## Verification
- `cargo fmt --check`
- `cargo check -p twix`
- `cargo nextest run -p twix`
- `git diff --check`