### PR TITLE
feat(twix): route through hidden Zenoh router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11181,6 +11181,7 @@ dependencies = [
  "tracing-subscriber",
  "types",
  "uuid",
+ "zenoh",
 ]
 
 [[package]]

--- a/crates/ros-z/src/context.rs
+++ b/crates/ros-z/src/context.rs
@@ -401,7 +401,7 @@ impl ContextBuilder {
     ))]
     pub async fn build(self) -> Result<Context> {
         // Priority order:
-        // 1. Custom Zenoh config passed via with_zenoh_config()
+        // 1. Custom Zenoh config passed via with_zenoh_config() or with_router_endpoint()
         // 2. Config file passed via with_config_file()
         // 3. ZENOH_SESSION_CONFIG_URI environment variable
         // 4. Default ros-z session config (connects to router at tcp/localhost:7447)
@@ -411,7 +411,6 @@ impl ContextBuilder {
             self.config_file.is_some()
         );
 
-        // Apply environment variable overrides first
         let builder = self.apply_env_overrides()?;
         debug!(
             "[CTX] Applied {} env overrides",

--- a/docs/tooling/twix.md
+++ b/docs/tooling/twix.md
@@ -10,11 +10,15 @@ Run it from the repository with:
 
 The positional namespace is optional. If provided, it must be an absolute ROS-Z namespace such as `/42`; bare values such as `42` are invalid. If omitted, Twix uses the last stored namespace and then falls back to `/`.
 
-To connect through a specific Zenoh router endpoint at startup, pass `--router`:
+Twix starts a private in-process Zenoh router for each Twix process and connects its ROS-Z session through that router. By default, that private router has no direct upstream Zenoh endpoints configured.
+
+To connect the private router to one or more direct upstream Zenoh routers for the current run, repeat `--router`:
 
 ```bash
-./twix /42 --router tcp/127.0.0.1:7447
+./twix /42 --router tcp/robot-a:7447 --router tcp/robot-b:7447
 ```
+
+The top bar shows local backend health. Hover the status to see the private local router endpoint and best-effort direct upstream-link status for each configured endpoint. The symbols mean `✓` for a matched direct link, `×` for a disconnected literal endpoint, and `?` when Twix cannot confidently map the endpoint to an active direct link. These diagnostics are not transitive Zenoh network reachability checks.
 
 If an old saved layout fails to load, or if you want to reset the current panel setup, start Twix with `--clear`.
 

--- a/tools/twix/Cargo.toml
+++ b/tools/twix/Cargo.toml
@@ -32,3 +32,4 @@ toml = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 types = { workspace = true }
 uuid = { workspace = true }
+zenoh = { workspace = true }

--- a/tools/twix/src/backend.rs
+++ b/tools/twix/src/backend.rs
@@ -1,56 +1,87 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    net::IpAddr,
+    sync::{Arc, Mutex},
+};
 
-use color_eyre::{Result, eyre::Context as _};
+use color_eyre::{
+    Result,
+    eyre::{Context as _, eyre},
+};
 use ros_z::{context::ContextBuilder, prelude::*};
 use ros_z_debug::{TopicObserver, TopicObserverOptions};
-use tokio::runtime::Handle;
+use serde_json::json;
+use tokio::{
+    runtime::Handle,
+    task::JoinHandle,
+    time::{self, Duration},
+};
 use uuid::Uuid;
 
-pub struct RobotBackend {
-    runtime_handle: Handle,
+use crate::zenoh_router::HiddenZenohRouter;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendStatus {
+    pub local_router_endpoint: String,
+    pub direct_upstream_links: Vec<DirectUpstreamLinkStatus>,
+}
+
+impl BackendStatus {
+    fn new(local_router_endpoint: String, upstream_endpoints: &[String]) -> Self {
+        Self {
+            local_router_endpoint,
+            direct_upstream_links: upstream_endpoints
+                .iter()
+                .map(|endpoint| DirectUpstreamLinkStatus {
+                    endpoint: endpoint.clone(),
+                    state: DirectUpstreamLinkState::Unknown,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectUpstreamLinkStatus {
+    pub endpoint: String,
+    pub state: DirectUpstreamLinkState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectUpstreamLinkState {
+    Connected,
+    Disconnected,
+    Unknown,
+}
+
+struct RobotBackendLive {
+    upstream_status_task: JoinHandle<()>,
+    _router: HiddenZenohRouter,
     context: Arc<Context>,
     _node: Arc<Node>,
     observer: TopicObserver,
+}
+
+pub struct RobotBackend {
+    runtime_handle: Handle,
+    live: RobotBackendLive,
+    status: Arc<Mutex<BackendStatus>>,
     namespace: Mutex<String>,
 }
 
 impl RobotBackend {
     pub async fn new(
         runtime_handle: Handle,
-        router: Option<String>,
+        router_endpoints: Vec<String>,
         namespace: String,
     ) -> Result<Self> {
-        let mut builder = ContextBuilder::default();
-        if let Some(router) = router {
-            builder = builder
-                .with_router_endpoint(router)
-                .wrap_err("failed to configure ROS-Z router endpoint")?;
-        }
-
-        let context = Arc::new(
-            builder
-                .build()
-                .await
-                .wrap_err("failed to build ROS-Z context")?,
-        );
-        let node_name = twix_node_name();
-        let node = Arc::new(
-            context
-                .create_node(node_name)
-                .with_namespace("/_twix")
-                .build()
-                .await
-                .wrap_err("failed to create Twix ROS-Z node")?,
-        );
         let options = TopicObserverOptions::with_namespace(namespace.clone())
             .wrap_err("failed to configure initial Twix namespace")?;
-        let observer = TopicObserver::new(Arc::clone(&node), options);
+        let (live, status) = RobotBackendLive::start(router_endpoints, options).await?;
 
         Ok(Self {
             runtime_handle,
-            context,
-            _node: node,
-            observer,
+            live,
+            status,
             namespace: Mutex::new(namespace),
         })
     }
@@ -60,11 +91,18 @@ impl RobotBackend {
     }
 
     pub fn observer(&self) -> &TopicObserver {
-        &self.observer
+        &self.live.observer
     }
 
     pub fn graph(&self) -> &ros_z::graph::Graph {
-        self.context.graph().as_ref()
+        self.live.context.graph().as_ref()
+    }
+
+    pub fn status(&self) -> BackendStatus {
+        self.status
+            .lock()
+            .expect("backend status mutex should not be poisoned")
+            .clone()
     }
 
     pub fn namespace(&self) -> String {
@@ -75,7 +113,10 @@ impl RobotBackend {
     }
 
     pub fn set_namespace(&self, namespace: String) -> Result<()> {
-        self.observer
+        TopicObserverOptions::with_namespace(namespace.clone())
+            .wrap_err("failed to validate Twix target namespace")?;
+        self.live
+            .observer
             .set_namespace(namespace.clone())
             .wrap_err("failed to set Twix target namespace")?;
         *self
@@ -86,8 +127,146 @@ impl RobotBackend {
     }
 }
 
-impl Drop for RobotBackend {
+impl RobotBackendLive {
+    async fn start(
+        router_endpoints: Vec<String>,
+        options: TopicObserverOptions,
+    ) -> Result<(Self, Arc<Mutex<BackendStatus>>)> {
+        let router = HiddenZenohRouter::start(&router_endpoints).await?;
+        let local_endpoint = router.local_endpoint().to_string();
+        let status = Arc::new(Mutex::new(BackendStatus::new(
+            local_endpoint.clone(),
+            &router_endpoints,
+        )));
+
+        let context = Arc::new(
+            ContextBuilder::default()
+                .with_router_endpoint(local_endpoint.clone())
+                .wrap_err("failed to configure Twix ROS-Z context through hidden Zenoh router")?
+                .with_json("connect/timeout_ms", json!(0))
+                .with_json("connect/exit_on_failure", json!(false))
+                .build()
+                .await
+                .wrap_err("failed to build ROS-Z context through hidden Zenoh router")?,
+        );
+
+        if context
+            .session()
+            .info()
+            .routers_zid()
+            .await
+            .next()
+            .is_none()
+        {
+            return Err(eyre!("Twix session does not see hidden Zenoh router"));
+        }
+
+        let node_name = twix_node_name();
+        let node = Arc::new(
+            context
+                .create_node(node_name)
+                .with_namespace("/_twix")
+                .build()
+                .await
+                .wrap_err("failed to create Twix ROS-Z node")?,
+        );
+        let observer = TopicObserver::new(Arc::clone(&node), options);
+        let upstream_status_task =
+            spawn_upstream_status_task(router.session(), router_endpoints, Arc::clone(&status));
+
+        Ok((
+            Self {
+                upstream_status_task,
+                _router: router,
+                context,
+                _node: node,
+                observer,
+            },
+            status,
+        ))
+    }
+}
+
+fn spawn_upstream_status_task(
+    router_session: zenoh::Session,
+    upstream_endpoints: Vec<String>,
+    status: Arc<Mutex<BackendStatus>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            refresh_upstream_status(&router_session, &upstream_endpoints, &status).await;
+            time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+}
+
+async fn refresh_upstream_status(
+    router_session: &zenoh::Session,
+    upstream_endpoints: &[String],
+    status: &Arc<Mutex<BackendStatus>>,
+) {
+    let link_destinations: Vec<String> = router_session
+        .info()
+        .links()
+        .await
+        .map(|link| link.dst().to_string())
+        .collect();
+    let direct_upstream_links =
+        direct_upstream_link_statuses(upstream_endpoints, &link_destinations);
+
+    status
+        .lock()
+        .expect("backend status mutex should not be poisoned")
+        .direct_upstream_links = direct_upstream_links;
+}
+
+fn direct_upstream_link_statuses(
+    upstream_endpoints: &[String],
+    link_destinations: &[String],
+) -> Vec<DirectUpstreamLinkStatus> {
+    upstream_endpoints
+        .iter()
+        .map(|endpoint| DirectUpstreamLinkStatus {
+            endpoint: endpoint.clone(),
+            state: direct_upstream_link_state(endpoint, link_destinations),
+        })
+        .collect()
+}
+
+fn direct_upstream_link_state(
+    endpoint: &str,
+    link_destinations: &[String],
+) -> DirectUpstreamLinkState {
+    if link_destinations
+        .iter()
+        .any(|destination| destination == endpoint)
+    {
+        DirectUpstreamLinkState::Connected
+    } else if endpoint_has_literal_tcp_host(endpoint) {
+        DirectUpstreamLinkState::Disconnected
+    } else {
+        DirectUpstreamLinkState::Unknown
+    }
+}
+
+fn endpoint_has_literal_tcp_host(endpoint: &str) -> bool {
+    let Some(address) = endpoint.strip_prefix("tcp/") else {
+        return false;
+    };
+    let Some((host, port)) = address.rsplit_once(':') else {
+        return false;
+    };
+    if port.parse::<u16>().is_err() {
+        return false;
+    }
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    host.parse::<IpAddr>().is_ok()
+}
+
+impl Drop for RobotBackendLive {
     fn drop(&mut self) {
+        self.upstream_status_task.abort();
+
         if let Err(error) = self.context.shutdown() {
             log::error!("failed to shut down ROS-Z context: {error:#}");
         }
@@ -118,5 +297,148 @@ fn sanitize_node_component(value: &str) -> String {
         "unknown-host".to_string()
     } else {
         sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::TcpListener, time::Duration};
+
+    use super::{
+        BackendStatus, DirectUpstreamLinkState, DirectUpstreamLinkStatus, RobotBackend,
+        direct_upstream_link_statuses,
+    };
+
+    #[test]
+    fn direct_upstream_link_statuses_marks_exact_match_connected() {
+        let upstream_endpoints = vec!["tcp/127.0.0.1:7447".to_string()];
+        let link_destinations = vec!["tcp/127.0.0.1:7447".to_string()];
+
+        assert_eq!(
+            direct_upstream_link_statuses(&upstream_endpoints, &link_destinations),
+            vec![DirectUpstreamLinkStatus {
+                endpoint: "tcp/127.0.0.1:7447".to_string(),
+                state: DirectUpstreamLinkState::Connected,
+            }],
+        );
+    }
+
+    #[test]
+    fn direct_upstream_link_statuses_marks_literal_tcp_miss_disconnected() {
+        let upstream_endpoints = vec!["tcp/192.168.1.20:7447".to_string()];
+        let link_destinations = Vec::new();
+
+        assert_eq!(
+            direct_upstream_link_statuses(&upstream_endpoints, &link_destinations),
+            vec![DirectUpstreamLinkStatus {
+                endpoint: "tcp/192.168.1.20:7447".to_string(),
+                state: DirectUpstreamLinkState::Disconnected,
+            }],
+        );
+    }
+
+    #[test]
+    fn direct_upstream_link_statuses_marks_hostname_miss_unknown() {
+        let upstream_endpoints = vec!["tcp/robot-a:7447".to_string()];
+        let link_destinations = vec!["tcp/192.168.1.20:7447".to_string()];
+
+        assert_eq!(
+            direct_upstream_link_statuses(&upstream_endpoints, &link_destinations),
+            vec![DirectUpstreamLinkStatus {
+                endpoint: "tcp/robot-a:7447".to_string(),
+                state: DirectUpstreamLinkState::Unknown,
+            }],
+        );
+    }
+
+    #[test]
+    fn direct_upstream_link_statuses_marks_ipv6_literal_miss_disconnected() {
+        let upstream_endpoints = vec!["tcp/[::1]:7447".to_string()];
+        let link_destinations = Vec::new();
+
+        assert_eq!(
+            direct_upstream_link_statuses(&upstream_endpoints, &link_destinations),
+            vec![DirectUpstreamLinkStatus {
+                endpoint: "tcp/[::1]:7447".to_string(),
+                state: DirectUpstreamLinkState::Disconnected,
+            }],
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backend_starts_with_empty_direct_upstream_links() {
+        let backend = tokio::time::timeout(
+            Duration::from_secs(5),
+            RobotBackend::new(
+                tokio::runtime::Handle::current(),
+                Vec::new(),
+                "/".to_string(),
+            ),
+        )
+        .await
+        .expect("backend startup should not block without direct upstream links")
+        .expect("backend should build");
+
+        let status = backend.status();
+
+        assert!(status.local_router_endpoint.starts_with("tcp/127.0.0.1:"));
+        assert_eq!(
+            status,
+            BackendStatus {
+                local_router_endpoint: status.local_router_endpoint.clone(),
+                direct_upstream_links: Vec::new(),
+            }
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backend_starts_healthy_when_upstream_router_is_unavailable() {
+        let unavailable_endpoint = {
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .expect("loopback listener should bind an ephemeral port");
+            let endpoint = format!(
+                "tcp/{}",
+                listener
+                    .local_addr()
+                    .expect("loopback listener should have a local address")
+            );
+            drop(listener);
+            endpoint
+        };
+        let upstream_endpoints = vec![unavailable_endpoint.clone()];
+
+        let backend = tokio::time::timeout(
+            Duration::from_secs(5),
+            RobotBackend::new(
+                tokio::runtime::Handle::current(),
+                upstream_endpoints.clone(),
+                "/".to_string(),
+            ),
+        )
+        .await
+        .expect("backend startup should not block on an unavailable upstream router")
+        .expect("backend should build even when an upstream router is unavailable");
+        let status = backend.status();
+
+        assert!(status.local_router_endpoint.starts_with("tcp/127.0.0.1:"));
+        assert_eq!(status.direct_upstream_links.len(), 1);
+        let upstream_link: &DirectUpstreamLinkStatus = &status.direct_upstream_links[0];
+        assert_eq!(upstream_link.endpoint, unavailable_endpoint);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backend_returns_error_when_hidden_router_configuration_is_invalid() {
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            RobotBackend::new(
+                tokio::runtime::Handle::current(),
+                vec!["not a Zenoh endpoint".to_string()],
+                "/".to_string(),
+            ),
+        )
+        .await
+        .expect("backend startup should not time out");
+
+        assert!(result.is_err());
     }
 }

--- a/tools/twix/src/main.rs
+++ b/tools/twix/src/main.rs
@@ -12,7 +12,9 @@ use configuration::{
 };
 use eframe::{
     App, CreationContext, Frame, NativeOptions, Storage,
-    egui::{CentralPanel, Context, CornerRadius, Id, Layout, StrokeKind, TopBottomPanel, Ui},
+    egui::{
+        CentralPanel, Color32, Context, CornerRadius, Id, Layout, StrokeKind, TopBottomPanel, Ui,
+    },
     emath::Align,
     run_native,
 };
@@ -28,7 +30,7 @@ use serde_json::{Value, from_str, to_string};
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 use visuals::Visuals;
 
-use crate::backend::RobotBackend;
+use crate::backend::{BackendStatus, DirectUpstreamLinkState, RobotBackend};
 
 mod backend;
 mod configuration;
@@ -39,6 +41,7 @@ mod repaint;
 mod selectable_panel_macro;
 mod status;
 mod visuals;
+mod zenoh_router;
 
 impl_selectable_panel!(TextPanel, ImagePanel);
 
@@ -60,14 +63,51 @@ fn default_dock_state(backend: &Arc<RobotBackend>, egui_context: &Context) -> Do
     ))])
 }
 
+fn render_backend_status(ui: &mut Ui, backend: &RobotBackend) {
+    let status = backend.status();
+
+    ui.colored_label(Color32::GREEN, "Backend: healthy")
+        .on_hover_text(format_backend_status_hover_text(&status));
+}
+
+fn format_backend_status_hover_text(status: &BackendStatus) -> String {
+    let mut lines = vec![
+        format!("Local router: {}", status.local_router_endpoint),
+        String::new(),
+        "Direct upstream links:".to_string(),
+    ];
+
+    if status.direct_upstream_links.is_empty() {
+        lines.push("none configured".to_string());
+    } else {
+        lines.extend(status.direct_upstream_links.iter().map(|upstream| {
+            format!(
+                "{} {}",
+                direct_upstream_link_symbol(upstream.state),
+                upstream.endpoint
+            )
+        }));
+    }
+
+    lines.join("\n")
+}
+
+fn direct_upstream_link_symbol(state: DirectUpstreamLinkState) -> &'static str {
+    match state {
+        DirectUpstreamLinkState::Connected => "✓",
+        DirectUpstreamLinkState::Disconnected => "×",
+        DirectUpstreamLinkState::Unknown => "?",
+    }
+}
+
 #[derive(Debug, Clone, clap::Parser)]
 struct Arguments {
     /// Target ROS-Z namespace, for example /42.
     namespace: Option<String>,
 
-    /// Router endpoint passed to ROS-Z, for example tcp/127.0.0.1:7447.
-    #[arg(long)]
-    router: Option<String>,
+    /// Direct upstream Zenoh router endpoint for Twix's private router. Can be repeated.
+    #[arg(long, value_name = "ENDPOINT")]
+    router: Vec<String>,
 
     /// Alternative repository root for local Twix version checks.
     #[arg(long)]
@@ -323,6 +363,9 @@ impl App for TwixApp {
                         log::error!("failed to set namespace: {error:#}");
                         self.namespace_editor = self.backend.namespace();
                     }
+
+                    ui.separator();
+                    render_backend_status(ui, &self.backend);
 
                     if self.active_tab_index() != Some(self.last_focused_tab) {
                         self.last_focused_tab =
@@ -669,14 +712,88 @@ fn main() -> eframe::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
+    use clap::Parser as _;
     use color_eyre::eyre::eyre;
     use eframe::egui::Context;
     use egui_dock::TabViewer as _;
     use uuid::Uuid;
 
-    use super::{RobotBackend, Tab, TabViewer};
+    use crate::backend::{
+        BackendStatus, DirectUpstreamLinkState, DirectUpstreamLinkStatus, RobotBackend,
+    };
+
+    use super::{Arguments, Tab, TabViewer, format_backend_status_hover_text};
+
+    #[test]
+    fn backend_status_hover_text_formats_empty_direct_upstream_links() {
+        let status = BackendStatus {
+            local_router_endpoint: "tcp/127.0.0.1:12345".to_string(),
+            direct_upstream_links: Vec::new(),
+        };
+
+        assert_eq!(
+            format_backend_status_hover_text(&status),
+            "Local router: tcp/127.0.0.1:12345\n\nDirect upstream links:\nnone configured",
+        );
+    }
+
+    #[test]
+    fn backend_status_hover_text_formats_direct_upstream_symbols() {
+        let status = BackendStatus {
+            local_router_endpoint: "tcp/127.0.0.1:12345".to_string(),
+            direct_upstream_links: vec![
+                DirectUpstreamLinkStatus {
+                    endpoint: "tcp/127.0.0.1:7447".to_string(),
+                    state: DirectUpstreamLinkState::Connected,
+                },
+                DirectUpstreamLinkStatus {
+                    endpoint: "tcp/robot-a:7447".to_string(),
+                    state: DirectUpstreamLinkState::Unknown,
+                },
+                DirectUpstreamLinkStatus {
+                    endpoint: "tcp/192.168.1.20:7447".to_string(),
+                    state: DirectUpstreamLinkState::Disconnected,
+                },
+            ],
+        };
+
+        assert_eq!(
+            format_backend_status_hover_text(&status),
+            "Local router: tcp/127.0.0.1:12345\n\nDirect upstream links:\n✓ tcp/127.0.0.1:7447\n? tcp/robot-a:7447\n× tcp/192.168.1.20:7447",
+        );
+    }
+
+    #[test]
+    fn parses_repeated_router_flags() {
+        let arguments = Arguments::try_parse_from([
+            "twix",
+            "/42",
+            "--router",
+            "tcp/robot-a:7447",
+            "--router",
+            "tcp/robot-b:7447",
+        ])
+        .expect("repeated router flags should parse");
+
+        assert_eq!(arguments.namespace.as_deref(), Some("/42"));
+        assert_eq!(
+            arguments.router,
+            vec![
+                "tcp/robot-a:7447".to_string(),
+                "tcp/robot-b:7447".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn router_defaults_to_empty_list() {
+        let arguments = Arguments::try_parse_from(["twix", "/42"])
+            .expect("arguments without router should parse");
+
+        assert!(arguments.router.is_empty());
+    }
 
     #[test]
     fn duplicate_title_tabs_have_distinct_dock_ids() {
@@ -684,15 +801,18 @@ mod tests {
             .enable_all()
             .build()
             .expect("runtime should build");
-        let backend = Arc::new(
-            runtime
-                .block_on(RobotBackend::new(
-                    runtime.handle().clone(),
-                    None,
-                    "/".to_string(),
-                ))
-                .expect("backend should build"),
-        );
+        let backend = {
+            let _runtime_guard = runtime.enter();
+            Arc::new(
+                runtime
+                    .block_on(tokio::time::timeout(
+                        Duration::from_secs(5),
+                        RobotBackend::new(runtime.handle().clone(), Vec::new(), "/".to_string()),
+                    ))
+                    .expect("backend startup should not time out")
+                    .expect("backend should build"),
+            )
+        };
         let mut viewer = TabViewer {
             nodes_to_add_tabs_to: Vec::new(),
             backend,

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -548,15 +548,18 @@ mod tests {
             .enable_all()
             .build()
             .expect("runtime should build");
-        let backend = Arc::new(
-            runtime
-                .block_on(RobotBackend::new(
-                    runtime.handle().clone(),
-                    None,
-                    "/".to_string(),
-                ))
-                .expect("backend should build"),
-        );
+        let backend = {
+            let _runtime_guard = runtime.enter();
+            Arc::new(
+                runtime
+                    .block_on(tokio::time::timeout(
+                        Duration::from_secs(5),
+                        RobotBackend::new(runtime.handle().clone(), Vec::new(), "/".to_string()),
+                    ))
+                    .expect("backend startup should not time out")
+                    .expect("backend should build"),
+            )
+        };
 
         let panel = ImagePanel::new(PanelCreationContext {
             backend,

--- a/tools/twix/src/panels/text.rs
+++ b/tools/twix/src/panels/text.rs
@@ -321,7 +321,7 @@ fn format_publication_id(publication_id: PublicationId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use eframe::egui::Context;
     use ros_z::{EndpointGlobalId, pubsub::Received, time::Time};
@@ -403,15 +403,18 @@ mod tests {
             .enable_all()
             .build()
             .expect("runtime should build");
-        let backend = Arc::new(
-            runtime
-                .block_on(RobotBackend::new(
-                    runtime.handle().clone(),
-                    None,
-                    "/".to_string(),
-                ))
-                .expect("backend should build"),
-        );
+        let backend = {
+            let _runtime_guard = runtime.enter();
+            Arc::new(
+                runtime
+                    .block_on(tokio::time::timeout(
+                        Duration::from_secs(5),
+                        RobotBackend::new(runtime.handle().clone(), Vec::new(), "/".to_string()),
+                    ))
+                    .expect("backend startup should not time out")
+                    .expect("backend should build"),
+            )
+        };
         let saved = json!({
             "topic": "/output/text",
             "pretty": true,

--- a/tools/twix/src/zenoh_router.rs
+++ b/tools/twix/src/zenoh_router.rs
@@ -1,0 +1,205 @@
+use std::{future::Future, net::TcpListener};
+
+use color_eyre::{Result, eyre::Context as _};
+use ros_z::config::RouterConfigBuilder;
+use serde_json::json;
+use zenoh::{Session, Wait};
+
+const HIDDEN_ZENOH_ROUTER_START_ATTEMPTS: usize = 16;
+
+pub struct HiddenZenohRouter {
+    session: Session,
+    local_endpoint: String,
+}
+
+impl HiddenZenohRouter {
+    pub async fn start(upstream_endpoints: &[String]) -> Result<Self> {
+        let (session, local_endpoint) = open_hidden_router_with(
+            upstream_endpoints,
+            allocate_loopback_endpoint,
+            |config, _endpoint| async move {
+                zenoh::open(config)
+                    .await
+                    .map_err(|error| color_eyre::eyre::eyre!(error))
+                    .wrap_err("failed to open hidden Zenoh router")
+            },
+        )
+        .await?;
+
+        Ok(Self {
+            session,
+            local_endpoint,
+        })
+    }
+
+    pub fn local_endpoint(&self) -> &str {
+        &self.local_endpoint
+    }
+
+    pub fn session(&self) -> Session {
+        self.session.clone()
+    }
+}
+
+async fn open_hidden_router_with<AllocateEndpoint, Open, OpenFuture, Opened>(
+    upstream_endpoints: &[String],
+    mut allocate_endpoint: AllocateEndpoint,
+    mut open: Open,
+) -> Result<(Opened, String)>
+where
+    AllocateEndpoint: FnMut() -> Result<String, std::io::Error>,
+    Open: FnMut(zenoh::Config, String) -> OpenFuture,
+    OpenFuture: Future<Output = Result<Opened>>,
+{
+    for attempt in 1..=HIDDEN_ZENOH_ROUTER_START_ATTEMPTS {
+        let local_endpoint = match allocate_endpoint() {
+            Ok(endpoint) => endpoint,
+            Err(error) if attempt < HIDDEN_ZENOH_ROUTER_START_ATTEMPTS => {
+                log::debug!("failed to allocate hidden Zenoh router endpoint; retrying: {error:#}");
+                continue;
+            }
+            Err(error) => {
+                return Err(error).wrap_err("failed to allocate hidden Zenoh router endpoint");
+            }
+        };
+
+        let config = build_hidden_router_config(&local_endpoint, upstream_endpoints)?;
+
+        match open(config, local_endpoint.clone()).await {
+            Ok(opened) => return Ok((opened, local_endpoint)),
+            Err(error) if attempt < HIDDEN_ZENOH_ROUTER_START_ATTEMPTS => {
+                log::debug!(
+                    "failed to open hidden Zenoh router on {local_endpoint}; retrying with a new endpoint: {error:#}"
+                );
+            }
+            Err(error) => {
+                return Err(error).wrap_err_with(|| {
+                    format!("failed to open hidden Zenoh router after {attempt} attempts")
+                });
+            }
+        }
+    }
+
+    unreachable!("hidden Zenoh router start attempts loop must return")
+}
+
+fn build_hidden_router_config(
+    local_endpoint: &str,
+    upstream_endpoints: &[String],
+) -> Result<zenoh::Config> {
+    RouterConfigBuilder::new()
+        .with_listen_endpoint(local_endpoint)
+        .with_override(
+            "connect/endpoints",
+            json!(upstream_endpoints),
+            "Twix hidden router upstream endpoints",
+        )
+        .with_override(
+            "connect/timeout_ms",
+            json!(0),
+            "Do not block Twix startup on upstream endpoints",
+        )
+        .with_override(
+            "connect/exit_on_failure",
+            json!(false),
+            "Keep Twix running when upstream endpoints are unavailable",
+        )
+        .build_config()
+        .map_err(|error| color_eyre::eyre::eyre!(error))
+        .wrap_err("failed to build hidden Zenoh router config")
+}
+
+impl Drop for HiddenZenohRouter {
+    fn drop(&mut self) {
+        if let Err(error) = self.session.close().wait() {
+            log::error!("failed to close hidden Zenoh router: {error:#}");
+        }
+    }
+}
+
+fn allocate_loopback_endpoint() -> Result<String, std::io::Error> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(format!("tcp/127.0.0.1:{port}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Error, ErrorKind},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use super::{HiddenZenohRouter, open_hidden_router_with};
+    use tokio::time::timeout;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hidden_router_retries_with_a_new_endpoint_when_open_finds_the_port_claimed() {
+        let allocated_endpoints = [
+            "tcp/127.0.0.1:18001".to_string(),
+            "tcp/127.0.0.1:18002".to_string(),
+        ];
+        let next_endpoint = Arc::new(Mutex::new(0));
+        let attempted_endpoints = Arc::new(Mutex::new(Vec::new()));
+
+        let (_, local_endpoint) = timeout(
+            Duration::from_secs(5),
+            open_hidden_router_with(
+                &[],
+                || {
+                    let mut next_endpoint = next_endpoint.lock().unwrap();
+                    let endpoint = allocated_endpoints[*next_endpoint].clone();
+                    *next_endpoint += 1;
+                    Ok(endpoint)
+                },
+                |_, endpoint| {
+                    let attempted_endpoints = attempted_endpoints.clone();
+                    async move {
+                        attempted_endpoints.lock().unwrap().push(endpoint.clone());
+
+                        if endpoint.ends_with(":18001") {
+                            Err(Error::new(ErrorKind::AddrInUse, "address already in use").into())
+                        } else {
+                            Ok(())
+                        }
+                    }
+                },
+            ),
+        )
+        .await
+        .expect("hidden router retry timed out")
+        .expect("hidden router should retry with a fresh endpoint");
+
+        assert_eq!(local_endpoint, "tcp/127.0.0.1:18002");
+        assert_eq!(
+            attempted_endpoints.lock().unwrap().as_slice(),
+            ["tcp/127.0.0.1:18001", "tcp/127.0.0.1:18002"]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hidden_router_uses_private_loopback_endpoint() {
+        let router = timeout(Duration::from_secs(5), HiddenZenohRouter::start(&[]))
+            .await
+            .expect("hidden router start timed out")
+            .expect("hidden router should start");
+
+        assert!(router.local_endpoint().starts_with("tcp/127.0.0.1:"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hidden_routers_can_coexist() {
+        let first = timeout(Duration::from_secs(5), HiddenZenohRouter::start(&[]))
+            .await
+            .expect("first hidden router start timed out")
+            .expect("first hidden router should start");
+        let second = timeout(Duration::from_secs(5), HiddenZenohRouter::start(&[]))
+            .await
+            .expect("second hidden router start timed out")
+            .expect("second hidden router should start");
+
+        assert_ne!(first.local_endpoint(), second.local_endpoint());
+    }
+}


### PR DESCRIPTION
## Summary
- route Twix through a private in-process Zenoh router on a per-process loopback endpoint
- fail Twix startup when the hidden local backend cannot be created
- allow repeated `--router` direct upstream endpoints while defaulting to no upstream endpoints
- show local backend health with best-effort direct upstream-link diagnostics
- keep `ZENOH_CONFIG_OVERRIDE` as the low-level Zenoh override mechanism while removing Twix's env-override test workaround

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p twix`
- `cargo check -p ros-z`
- `cargo nextest run -p twix` (33 tests)