### PR TITLE
Add ros-z MCAP topic recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ site/
 
 deploy.toml
 logs
+rosz-recording-*.mcap
 
 notes*
 .worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9438,7 +9438,10 @@ dependencies = [
  "clap_complete",
  "color-eyre",
  "humantime",
+ "libc",
+ "mcap",
  "ros-z",
+ "ros-z-recording",
  "serde",
  "serde_json",
  "tempfile",
@@ -9478,6 +9481,23 @@ dependencies = [
  "serde",
  "sha2",
  "thiserror 2.0.18",
+ "zenoh",
+]
+
+[[package]]
+name = "ros-z-recording"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "hex",
+ "mcap",
+ "ros-z",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "zenoh",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ members = [
   "crates/ros-z-debug",
   "crates/ros-z-derive",
   "crates/ros-z-protocol",
+  "crates/ros-z-recording",
   "crates/ros-z-schema",
   "crates/ros-z-streams",
   "crates/ros2",
@@ -322,6 +323,7 @@ ros-z-cdr = { path = "crates/ros-z-cdr" }
 ros-z-debug = { path = "crates/ros-z-debug" }
 ros-z-derive = { path = "crates/ros-z-derive" }
 ros-z-protocol = { path = "crates/ros-z-protocol" }
+ros-z-recording = { path = "crates/ros-z-recording" }
 ros-z-schema = { path = "crates/ros-z-schema" }
 ros-z-streams = { path = "crates/ros-z-streams" }
 ros2 = { path = "crates/ros2" }

--- a/crates/ros-z-cli/Cargo.toml
+++ b/crates/ros-z-cli/Cargo.toml
@@ -16,6 +16,7 @@ clap_complete = { workspace = true }
 color-eyre = { workspace = true }
 humantime = { workspace = true }
 ros-z = { workspace = true }
+ros-z-recording = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = [
@@ -27,4 +28,6 @@ tokio = { workspace = true, features = [
 zenoh = { workspace = true }
 
 [dev-dependencies]
+libc = { workspace = true }
+mcap = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/ros-z-cli/src/app/context.rs
+++ b/crates/ros-z-cli/src/app/context.rs
@@ -16,13 +16,34 @@ const GRAPH_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const GRAPH_SETTLE_QUIET_WINDOW: Duration = Duration::from_millis(500);
 const GRAPH_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeIdentity {
+    pub namespace: String,
+    pub name: String,
+}
+
+impl NodeIdentity {
+    pub fn new(namespace: String, name: String) -> Self {
+        Self { namespace, name }
+    }
+}
+
+impl Default for NodeIdentity {
+    fn default() -> Self {
+        Self {
+            namespace: "/".to_string(),
+            name: "rosz".to_string(),
+        }
+    }
+}
+
 pub struct AppContext {
     context: Context,
     node: Arc<Node>,
 }
 
 impl AppContext {
-    pub async fn new(router: &str) -> Result<Self> {
+    pub async fn new(router: &str, identity: NodeIdentity) -> Result<Self> {
         let context = ContextBuilder::default()
             .with_mode("client")
             .with_connect_endpoints([router])
@@ -31,7 +52,8 @@ impl AppContext {
             .wrap_err("failed to build ros-z context")?;
         let node = Arc::new(
             context
-                .create_node("rosz")
+                .create_node(identity.name)
+                .with_namespace(identity.namespace)
                 .build()
                 .await
                 .wrap_err("failed to build rosz node")?,

--- a/crates/ros-z-cli/src/app/mod.rs
+++ b/crates/ros-z-cli/src/app/mod.rs
@@ -1,3 +1,3 @@
 pub mod context;
 
-pub use context::AppContext;
+pub use context::{AppContext, NodeIdentity};

--- a/crates/ros-z-cli/src/cli.rs
+++ b/crates/ros-z-cli/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::{num::NonZeroUsize, path::PathBuf, time::Duration};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
@@ -54,6 +54,14 @@ pub struct Cli {
     /// Zenoh router address
     #[arg(long, default_value = "tcp/127.0.0.1:7447", global = true)]
     pub router: String,
+
+    /// Namespace for the rosz node used by online commands
+    #[arg(long, default_value = "/", global = true)]
+    pub namespace: String,
+
+    /// Node name for the rosz node used by online commands
+    #[arg(long, default_value = "rosz", global = true)]
+    pub node_name: String,
 
     /// Emit JSON output when supported
     #[arg(long, global = true)]
@@ -137,6 +145,16 @@ pub enum OnlineCommand {
     },
     /// Estimate topic message frequency
     Hz(HzArgs),
+    /// Record topics into an MCAP file
+    Record {
+        /// Output MCAP path. Defaults to a timestamped file in the current directory.
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Topic names to record, using normal ros-z qualification rules
+        #[arg(required = true)]
+        topics: Vec<String>,
+    },
     /// Show metadata for a topic, service, or node
     Info {
         #[arg(value_enum)]
@@ -353,12 +371,74 @@ mod tests {
     }
 
     #[test]
+    fn parses_default_online_node_identity() {
+        let cli = Cli::parse_from(["rosz", "list", "topics"]);
+
+        assert_eq!(cli.namespace, "/");
+        assert_eq!(cli.node_name, "rosz");
+    }
+
+    #[test]
+    fn parses_global_online_node_identity_flags_after_subcommand() {
+        let cli = Cli::parse_from([
+            "rosz",
+            "record",
+            "relative_topic",
+            "--namespace",
+            "/tools",
+            "--node-name",
+            "recorder",
+        ]);
+
+        assert_eq!(cli.namespace, "/tools");
+        assert_eq!(cli.node_name, "recorder");
+        match cli.command {
+            Command::Online(OnlineCommand::Record { topics, .. }) => {
+                assert_eq!(topics, ["relative_topic"]);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_help_describes_qualified_topic_names() {
+        let error = Cli::try_parse_from(["rosz", "record", "--help"])
+            .expect_err("record help should exit before parsing a command");
+
+        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+        let help = error.to_string();
+        assert!(help.contains("Topic names to record"));
+        assert!(help.contains("normal ros-z qualification rules"));
+        assert!(!help.contains("Exact topic names"));
+    }
+
+    #[test]
     fn parses_doctor_command_with_default_settle_timeout() {
         let cli = Cli::parse_from(["rosz", "doctor"]);
 
         match cli.command {
             Command::Online(OnlineCommand::Doctor { settle_timeout }) => {
                 assert_eq!(settle_timeout, Duration::from_secs(2));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_record_command_with_output_and_topics() {
+        let cli = Cli::parse_from([
+            "rosz",
+            "record",
+            "--output",
+            "capture.mcap",
+            "/alpha",
+            "/beta",
+        ]);
+
+        match cli.command {
+            Command::Online(OnlineCommand::Record { output, topics }) => {
+                assert_eq!(output, Some(std::path::PathBuf::from("capture.mcap")));
+                assert_eq!(topics, ["/alpha", "/beta"]);
             }
             other => panic!("unexpected command: {other:?}"),
         }
@@ -395,6 +475,14 @@ mod tests {
             .expect_err("unitless settle timeout should be rejected");
 
         assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn record_command_requires_at_least_one_topic() {
+        let error = Cli::try_parse_from(["rosz", "record", "--output", "capture.mcap"])
+            .expect_err("record command must require a topic");
+
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/crates/ros-z-cli/src/commands/mod.rs
+++ b/crates/ros-z-cli/src/commands/mod.rs
@@ -5,5 +5,6 @@ pub mod hz;
 pub mod info;
 pub mod list;
 pub mod parameter;
+pub mod record;
 pub mod schema;
 pub mod watch;

--- a/crates/ros-z-cli/src/commands/record.rs
+++ b/crates/ros-z-cli/src/commands/record.rs
@@ -1,0 +1,116 @@
+use std::io;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use color_eyre::eyre::{Result, WrapErr};
+use ros_z_recording::{RecordingConfig, RecordingError, RecordingSession, RecordingSummary};
+
+use crate::{app::AppContext, render::text};
+
+pub(crate) fn config_from_args(
+    output: Option<PathBuf>,
+    topics: Vec<String>,
+) -> ros_z_recording::Result<RecordingConfig> {
+    let output_path =
+        output.unwrap_or_else(|| RecordingConfig::default_output_path(SystemTime::now()));
+    let config = RecordingConfig::new(output_path, topics)?;
+    if config.output_path().exists() {
+        return Err(RecordingError::OutputAlreadyExists {
+            path: config.output_path().to_path_buf(),
+        });
+    }
+
+    Ok(config)
+}
+
+pub async fn run(app: &AppContext, config: RecordingConfig) -> Result<()> {
+    app.wait_for_graph_settle().await;
+    let session = RecordingSession::start(app.node(), config)
+        .await
+        .wrap_err("failed to start recording")?;
+    text::print_record_start(session.output_path());
+
+    let mut session = session;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result.wrap_err("failed to wait for Ctrl-C")?;
+        }
+        () = session.wait_for_failure() => {}
+    }
+    finish_stop_result(session.stop().await, &mut io::stdout())
+        .wrap_err("failed to stop recording")?;
+    Ok(())
+}
+
+fn finish_stop_result(
+    result: ros_z_recording::Result<RecordingSummary>,
+    output: &mut impl io::Write,
+) -> Result<()> {
+    match result {
+        Ok(summary) => {
+            text::write_record_summary(output, &summary)?;
+            Ok(())
+        }
+        Err(RecordingError::RecordingStoppedAfterReceiveError { source, summary }) => {
+            text::write_record_summary(output, &summary)?;
+            Err(RecordingError::RecordingStoppedAfterReceiveError { source, summary }.into())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::UNIX_EPOCH;
+
+    use ros_z_recording::RecordingError;
+    use ros_z_recording::{RecordingSummary, TopicSummary};
+
+    use super::*;
+
+    #[test]
+    fn config_from_args_rejects_existing_output_path() {
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+
+        let error = config_from_args(Some(file.path().to_path_buf()), vec!["/alpha".to_string()])
+            .expect_err("existing output path must fail");
+
+        assert!(matches!(
+            error,
+            RecordingError::OutputAlreadyExists { path } if path == file.path()
+        ));
+    }
+
+    #[test]
+    fn finish_stop_result_prints_summary_before_returning_receive_error() {
+        let summary = RecordingSummary {
+            output_path: PathBuf::from("recording.mcap"),
+            start_time: UNIX_EPOCH,
+            end_time: UNIX_EPOCH,
+            topics: vec![TopicSummary {
+                topic: "/alpha".to_string(),
+                type_name: "test_msgs::Alpha".to_string(),
+                schema_hash: "RZHS02_alpha".to_string(),
+                messages: 2,
+                bytes: 10,
+            }],
+        };
+        let error = RecordingError::RecordingStoppedAfterReceiveError {
+            source: Box::new(RecordingError::EmptyTopicSelection),
+            summary: Box::new(summary),
+        };
+        let mut output = Vec::new();
+
+        let returned = finish_stop_result(Err(error), &mut output)
+            .expect_err("receive error should still be returned");
+        let output = String::from_utf8(output).expect("summary should be UTF-8");
+
+        assert!(output.contains("Recording finished"));
+        assert!(output.contains("Messages: 2"));
+        assert!(output.contains("/alpha  messages=2 bytes=10"));
+        assert!(!output.contains("Drops:"));
+        assert!(!output.contains("drops="));
+        assert!(returned.to_string().contains("receive error"));
+    }
+}

--- a/crates/ros-z-cli/src/lib.rs
+++ b/crates/ros-z-cli/src/lib.rs
@@ -11,10 +11,10 @@ mod support;
 use std::process::ExitCode;
 
 use clap::CommandFactory;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, bail};
 
 use crate::{
-    app::AppContext,
+    app::{AppContext, NodeIdentity},
     cli::{Cli, Command, OnlineCommand},
     render::OutputMode,
 };
@@ -23,6 +23,8 @@ use crate::{
 pub async fn run(cli: Cli) -> Result<ExitCode> {
     let Cli {
         router,
+        namespace,
+        node_name,
         json,
         command,
     } = cli;
@@ -35,59 +37,116 @@ pub async fn run(cli: Cli) -> Result<ExitCode> {
         }
         Command::Online(command) => {
             let output_mode = OutputMode::from_json_flag(json);
-            run_online_command(router, output_mode, command).await
+            let identity = NodeIdentity::new(namespace, node_name);
+            run_online_command(router, identity, output_mode, command).await
         }
     }
 }
 
 async fn run_online_command(
     router: String,
+    identity: NodeIdentity,
     output_mode: OutputMode,
     command: OnlineCommand,
 ) -> Result<ExitCode> {
-    let app = AppContext::new(&router).await?;
-    let mut exit_code = ExitCode::SUCCESS;
-
-    let result = match command {
-        OnlineCommand::List { target } => commands::list::run(&app, output_mode, target).await,
-        OnlineCommand::Watch => commands::watch::run(&app, output_mode).await,
-        OnlineCommand::Graph => commands::graph::run(&app, output_mode).await,
-        OnlineCommand::Doctor { settle_timeout } => {
-            match commands::doctor::run(&app, output_mode, settle_timeout).await {
-                Ok(has_errors) => {
-                    if has_errors {
-                        exit_code = ExitCode::from(1);
-                    }
-                    Ok(())
-                }
-                Err(error) => Err(error),
+    match command {
+        OnlineCommand::Record { output, topics } => {
+            if output_mode == OutputMode::Json {
+                bail!("record does not support --json output in V1");
             }
+            let config = commands::record::config_from_args(output, topics)?;
+            let app = AppContext::new(&router, identity.clone()).await?;
+            let result = commands::record::run(&app, config).await;
+            finish_online_command(app, result, ExitCode::SUCCESS)
         }
-        OnlineCommand::Schema {
-            type_name,
-            node,
-            schema_hash,
-        } => commands::schema::run(&app, output_mode, &node, &type_name, &schema_hash).await,
-        OnlineCommand::Parameter { command } => {
-            commands::parameter::run(&app, output_mode, command).await
+        command => {
+            let app = AppContext::new(&router, identity.clone()).await?;
+            let mut exit_code = ExitCode::SUCCESS;
+            let result = match command {
+                OnlineCommand::List { target } => {
+                    commands::list::run(&app, output_mode, target).await
+                }
+                OnlineCommand::Watch => commands::watch::run(&app, output_mode).await,
+                OnlineCommand::Graph => commands::graph::run(&app, output_mode).await,
+                OnlineCommand::Doctor { settle_timeout } => {
+                    match commands::doctor::run(&app, output_mode, settle_timeout).await {
+                        Ok(has_errors) => {
+                            if has_errors {
+                                exit_code = ExitCode::from(1);
+                            }
+                            Ok(())
+                        }
+                        Err(error) => Err(error),
+                    }
+                }
+                OnlineCommand::Schema {
+                    type_name,
+                    node,
+                    schema_hash,
+                } => {
+                    commands::schema::run(&app, output_mode, &node, &type_name, &schema_hash).await
+                }
+                OnlineCommand::Parameter { command } => {
+                    commands::parameter::run(&app, output_mode, command).await
+                }
+                OnlineCommand::Echo {
+                    topic,
+                    count,
+                    timeout,
+                } => commands::echo::run(&app, output_mode, &topic, count, timeout).await,
+                OnlineCommand::Hz(args) => {
+                    commands::hz::run(&app, output_mode, &args.topic, args.window, args.limit())
+                        .await
+                }
+                OnlineCommand::Info { target, name } => {
+                    commands::info::run(&app, output_mode, target, &name).await
+                }
+                OnlineCommand::Record { .. } => {
+                    unreachable!("record command is preflighted before AppContext")
+                }
+            };
+            finish_online_command(app, result, exit_code)
         }
-        OnlineCommand::Echo {
-            topic,
-            count,
-            timeout,
-        } => commands::echo::run(&app, output_mode, &topic, count, timeout).await,
-        OnlineCommand::Hz(args) => {
-            commands::hz::run(&app, output_mode, &args.topic, args.window, args.limit()).await
-        }
-        OnlineCommand::Info { target, name } => {
-            commands::info::run(&app, output_mode, target, &name).await
-        }
-    };
+    }
+}
+
+fn finish_online_command(
+    app: AppContext,
+    result: Result<()>,
+    exit_code: ExitCode,
+) -> Result<ExitCode> {
     let shutdown_result = app.shutdown();
 
     match (result, shutdown_result) {
         (Ok(()), Ok(())) => Ok(exit_code),
         (Err(error), _) => Err(error),
         (Ok(()), Err(error)) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn record_rejects_json_output_before_graph_setup() {
+        let error = run_online_command(
+            "tcp/127.0.0.1:1".to_string(),
+            NodeIdentity::default(),
+            OutputMode::Json,
+            OnlineCommand::Record {
+                output: Some(PathBuf::from("recording.mcap")),
+                topics: vec!["/alpha".to_string()],
+            },
+        )
+        .await
+        .expect_err("record should reject --json before connecting to the router");
+
+        let message = format!("{error:#}");
+
+        assert!(message.contains("record"));
+        assert!(message.contains("--json"));
     }
 }

--- a/crates/ros-z-cli/src/render/text.rs
+++ b/crates/ros-z-cli/src/render/text.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Write};
+use std::path::Path;
 
 use ros_z::graph::GraphSnapshot;
+use ros_z_recording::{RecordingSummary, format_system_time_utc};
 
 use crate::{
     model::{
@@ -451,6 +453,39 @@ fn print_named_type_section(label: &str, entries: &[NamedType]) {
     }
 }
 
+pub fn print_record_start(output_path: &Path) {
+    println!("Recording to {}", output_path.display());
+    println!("Press Ctrl-C to stop recording.");
+}
+
+pub(crate) fn write_record_summary(
+    mut writer: impl Write,
+    summary: &RecordingSummary,
+) -> io::Result<()> {
+    writeln!(writer, "Recording finished")?;
+    writeln!(writer, "Output: {}", summary.output_path.display())?;
+    writeln!(
+        writer,
+        "Start: {}",
+        format_system_time_utc(summary.start_time)
+    )?;
+    writeln!(writer, "End: {}", format_system_time_utc(summary.end_time))?;
+    writeln!(writer, "Duration: {:.3}s", summary.duration().as_secs_f64())?;
+    writeln!(writer, "Topics: {}", summary.topic_count())?;
+    writeln!(writer, "Messages: {}", summary.total_messages())?;
+    writeln!(writer, "Bytes: {}", summary.total_bytes())?;
+    writeln!(writer)?;
+    writeln!(writer, "Per-topic counts")?;
+    for topic in &summary.topics {
+        writeln!(
+            writer,
+            "{}  messages={} bytes={}",
+            topic.topic, topic.messages, topic.bytes
+        )?;
+    }
+    Ok(())
+}
+
 fn column_width<'a>(values: impl Iterator<Item = &'a str>) -> usize {
     values.map(str::len).max().unwrap_or(0)
 }
@@ -543,7 +578,12 @@ mod tests {
         SchemaEnumVariantFieldView, SchemaFieldKindView, SchemaRootView, SchemaView,
     };
 
-    use super::write_schema;
+    use std::path::PathBuf;
+    use std::time::UNIX_EPOCH;
+
+    use ros_z_recording::{RecordingSummary, TopicSummary};
+
+    use super::{write_record_summary, write_schema};
 
     #[test]
     fn renders_root_schema_details() {
@@ -571,5 +611,31 @@ mod tests {
         assert!(output.contains("Root type: enum custom_msgs::Mode"));
         assert!(output.contains("Root variants: Idle, Manual"));
         assert!(output.contains("Root variant Manual.speed_limit  type=uint32"));
+    }
+
+    #[test]
+    fn writes_record_summary_to_supplied_writer() {
+        let summary = RecordingSummary {
+            output_path: PathBuf::from("recording.mcap"),
+            start_time: UNIX_EPOCH,
+            end_time: UNIX_EPOCH,
+            topics: vec![TopicSummary {
+                topic: "/alpha".to_string(),
+                type_name: "test_msgs::Alpha".to_string(),
+                schema_hash: "RZHS02_alpha".to_string(),
+                messages: 2,
+                bytes: 10,
+            }],
+        };
+        let mut output = Vec::new();
+
+        write_record_summary(&mut output, &summary).expect("summary writes");
+        let output = String::from_utf8(output).expect("summary should be UTF-8");
+
+        assert!(output.contains("Recording finished"));
+        assert!(output.contains("Messages: 2"));
+        assert!(output.contains("/alpha  messages=2 bytes=10"));
+        assert!(!output.contains("Drops:"));
+        assert!(!output.contains("drops="));
     }
 }

--- a/crates/ros-z-cli/tests/e2e.rs
+++ b/crates/ros-z-cli/tests/e2e.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::{OsStr, OsString},
     path::{Path, PathBuf},
-    process::{Command, ExitStatus, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -14,7 +14,7 @@ use ros_z::{
     Message, ServiceTypeInfo,
     context::{Context, ContextBuilder},
     entity::TypeInfo,
-    message::Service,
+    message::{Service, WireEncoder},
     node::Node,
     parameter::{NodeParameters, NodeParametersExt},
     pubsub::Publisher,
@@ -32,6 +32,7 @@ type TestResult<T = ()> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(15);
 const EVENTUALLY_TIMEOUT: Duration = Duration::from_secs(8);
 const EVENTUALLY_POLL: Duration = Duration::from_millis(100);
+const POST_SUBSCRIPTION_PUBLISHES: usize = 3;
 
 #[derive(Debug, Clone, SerdeEnc, SerdeDec, PartialEq, ros_z::Message)]
 #[message(name = "test_cli::Telemetry")]
@@ -39,6 +40,14 @@ struct Telemetry {
     label: String,
     sequence: u32,
     temperatures: Vec<f32>,
+}
+
+fn fixture_telemetry() -> Telemetry {
+    Telemetry {
+        label: "robot-7".to_string(),
+        sequence: 7,
+        temperatures: vec![20.0, 20.5],
+    }
 }
 
 #[derive(Debug, Clone, SerdeEnc, SerdeDec, PartialEq, ros_z::Message)]
@@ -318,6 +327,17 @@ fn path_str(path: &Path) -> &str {
     path.to_str().expect("test path must be UTF-8")
 }
 
+fn wait_for_file(path: &Path) {
+    let started = Instant::now();
+    while started.elapsed() < EVENTUALLY_TIMEOUT {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(EVENTUALLY_POLL);
+    }
+    panic!("file did not appear: {}", path.display());
+}
+
 fn write_parameter_file(layer: &Path, parameter_key: &str, contents: &str) {
     std::fs::create_dir_all(layer).expect("create parameter layer");
     std::fs::write(layer.join(format!("{parameter_key}.json5")), contents)
@@ -440,6 +460,32 @@ impl RoszCommand {
         output.assert_success();
         output
     }
+
+    fn command<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.args
+            .extend(args.into_iter().map(|arg| arg.as_ref().to_os_string()));
+        self
+    }
+
+    fn spawn(self) -> RoszChild {
+        let binary = env!("CARGO_BIN_EXE_rosz");
+        let child = Command::new(binary)
+            .args(&self.args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|error| panic!("failed to spawn rosz {:?}: {error}", self.args));
+
+        RoszChild {
+            args: self.args,
+            child: Some(child),
+        }
+    }
 }
 
 struct CommandOutput {
@@ -471,6 +517,80 @@ impl CommandOutput {
             self.stdout,
             self.stderr
         );
+    }
+}
+
+struct RoszChild {
+    args: Vec<OsString>,
+    child: Option<Child>,
+}
+
+impl RoszChild {
+    fn interrupt_and_wait(mut self) -> CommandOutput {
+        let mut child = self
+            .child
+            .take()
+            .unwrap_or_else(|| panic!("rosz child already collected\nargs: {:?}", self.args));
+
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(child.id() as i32, libc::SIGINT);
+        }
+
+        let started = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let output = child.wait_with_output().unwrap_or_else(|error| {
+                        panic!("failed to collect rosz {:?}: {error}", self.args)
+                    });
+                    let args = std::mem::take(&mut self.args);
+                    return CommandOutput {
+                        args,
+                        status: output.status,
+                        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                    };
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("failed to poll rosz {:?}: {error}", self.args);
+                }
+            }
+
+            if started.elapsed() >= COMMAND_TIMEOUT {
+                let _ = child.kill();
+                let output = child.wait_with_output().unwrap_or_else(|error| {
+                    panic!("failed to collect timed out rosz {:?}: {error}", self.args)
+                });
+                panic!(
+                    "rosz did not stop after SIGINT\nargs: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    self.args,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+impl Drop for RoszChild {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let _ = child.wait();
+                }
+                Ok(None) | Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+            }
+        }
     }
 }
 
@@ -513,6 +633,7 @@ struct PublishingFixture {
     topic: String,
     node_fqn: String,
     publisher: Arc<Publisher<Telemetry>>,
+    published_count: Arc<AtomicUsize>,
     publish_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     _node: Node,
     _context: Context,
@@ -548,6 +669,7 @@ impl PublishingFixture {
             topic: topic.to_string(),
             node_fqn: "/cli_e2e/schema_fixture".to_string(),
             publisher: Arc::new(publisher),
+            published_count: Arc::new(AtomicUsize::new(0)),
             publish_task: Mutex::new(None),
             _node: node,
             _context: context,
@@ -556,17 +678,15 @@ impl PublishingFixture {
 
     fn start_publishing(&self) {
         let publisher = self.publisher.clone();
+        let published_count = self.published_count.clone();
         let handle = tokio::spawn(async move {
-            let message = Telemetry {
-                label: "robot-7".to_string(),
-                sequence: 7,
-                temperatures: vec![20.0, 20.5],
-            };
+            let message = fixture_telemetry();
 
             loop {
                 if publisher.publish(&message).await.is_err() {
                     break;
                 }
+                published_count.fetch_add(1, Ordering::Relaxed);
                 tokio::time::sleep(Duration::from_millis(50)).await;
             }
         });
@@ -579,6 +699,27 @@ impl PublishingFixture {
         {
             previous.abort();
         }
+    }
+
+    fn published_count(&self) -> usize {
+        self.published_count.load(Ordering::Relaxed)
+    }
+
+    async fn wait_for_publishes_after(&self, previous: usize, additional: usize) {
+        let target = previous.saturating_add(additional);
+        let started = Instant::now();
+        while started.elapsed() < EVENTUALLY_TIMEOUT {
+            if self.published_count() >= target {
+                return;
+            }
+            tokio::time::sleep(EVENTUALLY_POLL).await;
+        }
+
+        panic!(
+            "fixture published {} messages on {} after recorder subscribed, expected at least {additional}",
+            self.published_count().saturating_sub(previous),
+            self.topic
+        );
     }
 }
 
@@ -1109,6 +1250,229 @@ async fn schema_resolves_string_publisher_schema() -> TestResult {
         schema["fields"]
             .as_array()
             .is_some_and(|fields| fields.is_empty())
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn record_writes_mcap_for_fixture_topic() -> TestResult {
+    let env = TestEnv::new();
+    let fixture = PublishingFixture::new(&env, "/cli_e2e/record_telemetry").await?;
+    fixture.start_publishing();
+
+    eventually_json(&env, &["list", "topics"], |topics| {
+        json_array_contains_field(topics, "name", &fixture.topic)
+    });
+
+    let output_path = env.temp_path("recording.mcap");
+    let child = env
+        .rosz()
+        .command([
+            "record",
+            "--output",
+            path_str(&output_path),
+            fixture.topic.as_str(),
+        ])
+        .spawn();
+    wait_for_file(&output_path);
+    assert!(
+        fixture
+            .publisher
+            .wait_for_subscribers(1, EVENTUALLY_TIMEOUT)
+            .await,
+        "recorder did not subscribe to {}",
+        fixture.topic
+    );
+    let published_before = fixture.published_count();
+    fixture
+        .wait_for_publishes_after(published_before, POST_SUBSCRIPTION_PUBLISHES)
+        .await;
+    let output = child.interrupt_and_wait();
+    output.assert_success();
+
+    let bytes = std::fs::read(&output_path)?;
+    let summary = mcap::Summary::read(&bytes)?.expect("recording should contain summary");
+    let metadata_index = summary
+        .metadata_indexes
+        .iter()
+        .find(|metadata| metadata.name == "ros-z")
+        .expect("ros-z metadata should be present");
+    let metadata = mcap::read::metadata(&bytes, metadata_index)?;
+    let resolved_topics = metadata
+        .metadata
+        .get("resolved_topics")
+        .expect("resolved topics metadata");
+    assert!(!resolved_topics.contains("publishers"));
+    assert!(resolved_topics.contains("message_encoding"));
+    assert!(resolved_topics.contains("schema_encoding"));
+
+    let messages = mcap::MessageStream::new(&bytes)?.collect::<Result<Vec<_>, _>>()?;
+    assert!(
+        !messages.is_empty(),
+        "recording should contain at least one message"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| message.channel.topic == fixture.topic)
+    );
+    assert!(
+        messages.iter().all(|message| {
+            message.channel.message_encoding == ros_z_recording::MESSAGE_ENCODING
+        })
+    );
+    assert!(messages.iter().all(|message| {
+        message
+            .channel
+            .schema
+            .as_ref()
+            .is_some_and(|schema| schema.encoding == ros_z_recording::SCHEMA_ENCODING)
+    }));
+
+    let expected_message = fixture_telemetry();
+    let expected_wire_bytes =
+        <<Telemetry as Message>::Codec as WireEncoder>::serialize(&expected_message)?;
+    assert!(
+        messages
+            .iter()
+            .all(|message| { message.data.as_ref() == expected_wire_bytes.as_slice() })
+    );
+
+    let total_messages = messages.len() as u64;
+    let total_bytes = messages
+        .iter()
+        .map(|message| message.data.len() as u64)
+        .sum::<u64>();
+    let per_topic_summary = format!(
+        "{}  messages={} bytes={}",
+        fixture.topic, total_messages, total_bytes
+    );
+
+    for expected in [
+        "Recording finished",
+        "Output:",
+        "Start:",
+        "End:",
+        "Duration:",
+        "Topics:",
+        "Messages:",
+        "Bytes:",
+        "Per-topic counts",
+        path_str(&output_path),
+        "Topics: 1",
+        &format!("Messages: {total_messages}"),
+        &format!("Bytes: {total_bytes}"),
+        &per_topic_summary,
+    ] {
+        assert!(
+            output.stdout.contains(expected),
+            "record summary stdout did not contain {expected:?}\nstdout:\n{}",
+            output.stdout
+        );
+    }
+    assert!(!output.stdout.contains("Drops:"));
+    assert!(!output.stdout.contains("drops="));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn record_uses_namespace_for_relative_topic() -> TestResult {
+    let env = TestEnv::new();
+    let context = env.create_context().await?;
+    let node = context
+        .create_node("relative_record_fixture")
+        .with_namespace("/cli_e2e/record_ns")
+        .build()
+        .await?;
+    let topic = "/cli_e2e/record_ns/relative_telemetry";
+    let publisher = node.publisher::<Telemetry>(topic).build().await?;
+    publisher.publish(&fixture_telemetry()).await?;
+
+    eventually_json(&env, &["list", "topics"], |topics| {
+        json_array_contains_field(topics, "name", topic)
+    });
+
+    let output_path = env.temp_path("relative-recording.mcap");
+    let child = env
+        .rosz()
+        .command([
+            "record",
+            "relative_telemetry",
+            "--namespace",
+            "/cli_e2e/record_ns",
+            "--output",
+            path_str(&output_path),
+        ])
+        .spawn();
+    wait_for_file(&output_path);
+    assert!(publisher.wait_for_subscribers(1, EVENTUALLY_TIMEOUT).await);
+    for _ in 0..POST_SUBSCRIPTION_PUBLISHES {
+        publisher.publish(&fixture_telemetry()).await?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let output = child.interrupt_and_wait();
+    output.assert_success();
+
+    let bytes = std::fs::read(&output_path)?;
+    let messages = mcap::MessageStream::new(&bytes)?.collect::<Result<Vec<_>, _>>()?;
+    assert!(!messages.is_empty());
+    assert!(
+        messages
+            .iter()
+            .all(|message| message.channel.topic == topic)
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn record_uses_namespace_and_node_name_for_private_topic() -> TestResult {
+    let env = TestEnv::new();
+    let topic = "/cli_e2e/private_recorder/private_telemetry";
+    let fixture = PublishingFixture::new(&env, topic).await?;
+    fixture.start_publishing();
+
+    eventually_json(&env, &["list", "topics"], |topics| {
+        json_array_contains_field(topics, "name", topic)
+    });
+
+    let output_path = env.temp_path("private-recording.mcap");
+    let child = env
+        .rosz()
+        .command([
+            "record",
+            "~private_telemetry",
+            "--namespace",
+            "/cli_e2e",
+            "--node-name",
+            "private_recorder",
+            "--output",
+            path_str(&output_path),
+        ])
+        .spawn();
+    wait_for_file(&output_path);
+    assert!(
+        fixture
+            .publisher
+            .wait_for_subscribers(1, EVENTUALLY_TIMEOUT)
+            .await
+    );
+    let published_before = fixture.published_count();
+    fixture
+        .wait_for_publishes_after(published_before, POST_SUBSCRIPTION_PUBLISHES)
+        .await;
+    let output = child.interrupt_and_wait();
+    output.assert_success();
+
+    let bytes = std::fs::read(&output_path)?;
+    let messages = mcap::MessageStream::new(&bytes)?.collect::<Result<Vec<_>, _>>()?;
+    assert!(!messages.is_empty());
+    assert!(
+        messages
+            .iter()
+            .all(|message| message.channel.topic == topic)
     );
 
     Ok(())

--- a/crates/ros-z-recording/Cargo.toml
+++ b/crates/ros-z-recording/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ros-z-recording"
+version.workspace = true
+edition.workspace = true
+description = "MCAP recording backend for ros-z"
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+chrono = { workspace = true }
+hex = { workspace = true }
+mcap = { workspace = true }
+ros-z = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tracing = { workspace = true }
+zenoh = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ros-z-recording/src/config.rs
+++ b/crates/ros-z-recording/src/config.rs
@@ -1,0 +1,124 @@
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+
+use crate::{RecordingError, Result};
+
+const DEFAULT_WRITER_QUEUE_CAPACITY: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct RecordingConfig {
+    output_path: PathBuf,
+    topics: Vec<String>,
+    writer_queue_capacity: NonZeroUsize,
+}
+
+impl RecordingConfig {
+    pub fn new(output_path: PathBuf, topics: Vec<String>) -> Result<Self> {
+        Self::with_writer_queue_capacity(output_path, topics, default_writer_queue_capacity())
+    }
+
+    pub fn output_path(&self) -> &Path {
+        &self.output_path
+    }
+
+    pub fn topics(&self) -> &[String] {
+        &self.topics
+    }
+
+    pub(crate) fn with_writer_queue_capacity(
+        output_path: PathBuf,
+        topics: Vec<String>,
+        writer_queue_capacity: NonZeroUsize,
+    ) -> Result<Self> {
+        if topics.is_empty() {
+            return Err(RecordingError::EmptyTopicSelection);
+        }
+
+        Ok(Self {
+            output_path,
+            topics,
+            writer_queue_capacity,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn writer_queue_capacity(&self) -> NonZeroUsize {
+        self.writer_queue_capacity
+    }
+
+    pub(crate) fn into_parts(self) -> (PathBuf, Vec<String>, NonZeroUsize) {
+        (self.output_path, self.topics, self.writer_queue_capacity)
+    }
+
+    pub fn default_output_path(now: SystemTime) -> PathBuf {
+        let timestamp: DateTime<Utc> = now.into();
+        PathBuf::from(format!(
+            "rosz-recording-{}.mcap",
+            timestamp.format("%Y-%m-%dT%H-%M-%SZ")
+        ))
+    }
+}
+
+fn default_writer_queue_capacity() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_WRITER_QUEUE_CAPACITY)
+        .expect("default writer queue capacity must be non-zero")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::path::PathBuf;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use super::{DEFAULT_WRITER_QUEUE_CAPACITY, RecordingConfig};
+    use crate::RecordingError;
+
+    #[test]
+    fn recording_config_rejects_empty_topics() {
+        let error = RecordingConfig::new(PathBuf::from("out.mcap"), Vec::new())
+            .expect_err("empty topic list must fail");
+
+        assert!(matches!(error, RecordingError::EmptyTopicSelection));
+    }
+
+    #[test]
+    fn recording_config_stores_exact_topics_and_default_queue_capacity() {
+        let config = RecordingConfig::new(
+            PathBuf::from("out.mcap"),
+            vec!["/alpha".to_string(), "/beta".to_string()],
+        )
+        .expect("valid config");
+
+        assert_eq!(config.output_path(), PathBuf::from("out.mcap"));
+        assert_eq!(config.topics(), ["/alpha", "/beta"]);
+        assert_eq!(
+            config.writer_queue_capacity().get(),
+            DEFAULT_WRITER_QUEUE_CAPACITY
+        );
+    }
+
+    #[test]
+    fn recording_config_keeps_writer_queue_capacity_crate_private_and_non_zero() {
+        let config = RecordingConfig::with_writer_queue_capacity(
+            PathBuf::from("out.mcap"),
+            vec!["/alpha".to_string()],
+            NonZeroUsize::new(1).expect("non-zero test capacity"),
+        )
+        .expect("valid config");
+
+        assert_eq!(config.writer_queue_capacity().get(), 1);
+    }
+
+    #[test]
+    fn default_output_path_uses_filename_safe_utc_timestamp() {
+        let path = RecordingConfig::default_output_path(UNIX_EPOCH + Duration::from_secs(3661));
+
+        assert_eq!(
+            path,
+            PathBuf::from("rosz-recording-1970-01-01T01-01-01Z.mcap")
+        );
+    }
+}

--- a/crates/ros-z-recording/src/error.rs
+++ b/crates/ros-z-recording/src/error.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, RecordingError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordingError {
+    #[error("at least one topic must be requested")]
+    EmptyTopicSelection,
+
+    #[error("output path already exists: {}", path.display())]
+    OutputAlreadyExists { path: PathBuf },
+
+    #[error("failed to create output file: {}", path.display())]
+    OutputCreate {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to serialize recorder metadata")]
+    MetadataSerialize(#[source] serde_json::Error),
+
+    #[error("sample is missing ros-z attachment metadata")]
+    MissingSampleAttachment,
+
+    #[error("failed to decode ros-z sample attachment")]
+    SampleAttachmentDecode(#[source] zenoh::Error),
+
+    #[error("sample sequence {sequence} for topic {topic} cannot be represented in MCAP")]
+    SequenceOutOfRange { topic: String, sequence: i64 },
+
+    #[error("failed to subscribe to topic {topic}")]
+    Subscribe {
+        topic: String,
+        #[source]
+        source: ros_z::Error,
+    },
+
+    #[error("recording receive task failed for topic {topic}")]
+    ReceiveTask {
+        topic: String,
+        #[source]
+        source: Box<RecordingError>,
+    },
+
+    #[error("failed to receive sample for topic {topic}")]
+    Receive {
+        topic: String,
+        #[source]
+        source: ros_z::Error,
+    },
+
+    #[error("recording finalized after a receive error")]
+    RecordingStoppedAfterReceiveError {
+        #[source]
+        source: Box<RecordingError>,
+        summary: Box<crate::RecordingSummary>,
+    },
+
+    #[error("recording receive failed ({receive}) and finalization failed ({finalize})")]
+    ReceiveAndFinalize {
+        #[source]
+        receive: Box<RecordingError>,
+        finalize: Box<RecordingError>,
+    },
+
+    #[error("recording task join failed")]
+    Join(#[source] tokio::task::JoinError),
+
+    #[error("failed to serialize topic schema for {topic}")]
+    SchemaSerialize {
+        topic: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("failed to write MCAP data")]
+    Mcap(#[source] mcap::McapError),
+
+    #[error("sample topic index {topic_index} is out of range for {topic_count} writer topics")]
+    InvalidTopicIndex {
+        topic_index: usize,
+        topic_count: usize,
+    },
+
+    #[error("failed to discover schema for requested topic {topic}")]
+    SchemaDiscovery {
+        topic: String,
+        #[source]
+        source: ros_z::dynamic::DynamicError,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+    use std::path::PathBuf;
+
+    use super::RecordingError;
+
+    #[test]
+    fn receive_and_finalize_display_keeps_both_errors_and_exposes_source() {
+        let error = RecordingError::ReceiveAndFinalize {
+            receive: Box::new(RecordingError::OutputAlreadyExists {
+                path: PathBuf::from("receive.mcap"),
+            }),
+            finalize: Box::new(RecordingError::OutputAlreadyExists {
+                path: PathBuf::from("finalize.mcap"),
+            }),
+        };
+
+        let message = error.to_string();
+
+        assert!(
+            message.contains("receive.mcap"),
+            "combined error should include receive failure: {message}"
+        );
+        assert!(
+            message.contains("finalize.mcap"),
+            "combined error should include finalize failure: {message}"
+        );
+        assert!(
+            error.source().is_some(),
+            "combined error should expose at least the receive error as source"
+        );
+    }
+}

--- a/crates/ros-z-recording/src/lib.rs
+++ b/crates/ros-z-recording/src/lib.rs
@@ -1,0 +1,20 @@
+//! MCAP recording backend for live ros-z topics.
+//!
+//! The crate records raw ros-z sample payloads together with the discovered
+//! ros-z schema metadata needed to interpret them later. Topic names use normal
+//! ros-z qualification rules through the node passed to [`RecordingSession`].
+
+mod config;
+mod error;
+mod metadata;
+mod runtime;
+mod sample;
+mod summary;
+mod topic;
+mod writer;
+
+pub use config::RecordingConfig;
+pub use error::{RecordingError, Result};
+pub use metadata::{MESSAGE_ENCODING, METADATA_SCHEMA_VERSION, RECORDER_NAME, SCHEMA_ENCODING};
+pub use runtime::RecordingSession;
+pub use summary::{RecordingSummary, TopicSummary, format_system_time_utc};

--- a/crates/ros-z-recording/src/metadata.rs
+++ b/crates/ros-z-recording/src/metadata.rs
@@ -1,0 +1,64 @@
+use std::collections::BTreeMap;
+
+use crate::{RecordingError, Result};
+
+pub const RECORDER_NAME: &str = "ros-z-recording";
+pub const METADATA_SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_ENCODING: &str = "ros-z.schema.v1";
+pub const MESSAGE_ENCODING: &str = "ros-z.cdr";
+
+pub fn recording_metadata(
+    requested_topics: &[String],
+    resolved_topics_json: &str,
+    timestamp_semantics_json: &str,
+) -> BTreeMap<String, String> {
+    let requested_topics = serde_json::to_string(requested_topics)
+        .expect("serializing Vec<String> for MCAP metadata cannot fail");
+
+    BTreeMap::from([
+        ("recorder".to_string(), RECORDER_NAME.to_string()),
+        (
+            "recorder_version".to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+        ),
+        (
+            "metadata_schema_version".to_string(),
+            METADATA_SCHEMA_VERSION.to_string(),
+        ),
+        ("schema_encoding".to_string(), SCHEMA_ENCODING.to_string()),
+        ("message_encoding".to_string(), MESSAGE_ENCODING.to_string()),
+        ("requested_topics".to_string(), requested_topics),
+        (
+            "resolved_topics".to_string(),
+            resolved_topics_json.to_string(),
+        ),
+        (
+            "timestamp_semantics".to_string(),
+            timestamp_semantics_json.to_string(),
+        ),
+    ])
+}
+
+pub fn serialize_metadata_value<T: serde::Serialize>(value: &T) -> Result<String> {
+    serde_json::to_string(value).map_err(RecordingError::MetadataSerialize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MESSAGE_ENCODING, RECORDER_NAME, SCHEMA_ENCODING, recording_metadata};
+
+    #[test]
+    fn metadata_identifies_ros_z_recording_and_encodings_without_publisher_provenance() {
+        let metadata = recording_metadata(
+            &["chatter".to_string()],
+            r#"[{"requested_topic":"chatter","topic":"/tools/chatter","type_name":"std_msgs::String","schema_hash":"RZHS02_hash","schema_encoding":"ros-z.schema.v1","message_encoding":"ros-z.cdr"}]"#,
+            r#"{"log_time":"transport"}"#,
+        );
+
+        assert_eq!(metadata["recorder"], RECORDER_NAME);
+        assert_eq!(metadata["schema_encoding"], SCHEMA_ENCODING);
+        assert_eq!(metadata["message_encoding"], MESSAGE_ENCODING);
+        assert_eq!(metadata["requested_topics"], r#"["chatter"]"#);
+        assert!(!metadata["resolved_topics"].contains("publishers"));
+    }
+}

--- a/crates/ros-z-recording/src/runtime.rs
+++ b/crates/ros-z-recording/src/runtime.rs
@@ -1,0 +1,558 @@
+use std::fs::OpenOptions;
+use std::io::BufWriter;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use ros_z::node::Node;
+use tokio::sync::{mpsc, watch};
+
+use crate::sample::QueuedSample;
+use crate::summary::{RecordingSummary, TopicSummary};
+use crate::topic::{ResolvedTopic, resolve_topics};
+use crate::writer::{McapWriterSink, WriterTopicSummary};
+use crate::{RecordingConfig, RecordingError, Result};
+
+pub struct RecordingSession {
+    output_path: PathBuf,
+    start_time: SystemTime,
+    topics: Vec<ResolvedTopic>,
+    stop: watch::Sender<bool>,
+    failure_rx: mpsc::Receiver<()>,
+    receive_tasks: Vec<(String, tokio::task::JoinHandle<Result<()>>)>,
+    writer_task: tokio::task::JoinHandle<Result<Vec<WriterTopicSummary>>>,
+}
+
+impl RecordingSession {
+    pub async fn start(node: Arc<Node>, config: RecordingConfig) -> Result<Self> {
+        let (output_path, requested_topics, writer_queue_capacity) = config.into_parts();
+
+        if requested_topics.is_empty() {
+            return Err(RecordingError::EmptyTopicSelection);
+        }
+
+        if output_path.exists() {
+            return Err(RecordingError::OutputAlreadyExists { path: output_path });
+        }
+
+        let topics = resolve_topics(Arc::clone(&node), &requested_topics).await?;
+
+        let mut subscribers = Vec::with_capacity(topics.len());
+        for (topic_index, topic) in topics.iter().enumerate() {
+            let subscriber = node
+                .dynamic_subscriber(
+                    topic.topic(),
+                    topic.type_info().clone(),
+                    Arc::clone(topic.schema()),
+                )
+                .raw()
+                .build()
+                .await
+                .map_err(|source| RecordingError::Subscribe {
+                    topic: topic.topic().to_string(),
+                    source,
+                })?;
+            subscribers.push((topic_index, topic.topic().to_string(), subscriber));
+        }
+
+        let output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&output_path)
+            .map_err(|source| RecordingError::OutputCreate {
+                path: output_path.clone(),
+                source,
+            })?;
+        let mut startup_output_guard = StartupOutputGuard::new(output_path.clone());
+        let mut sink = McapWriterSink::new(BufWriter::new(output), &topics, &requested_topics)?;
+        let (sample_tx, mut sample_rx) = mpsc::channel::<QueuedSample>(writer_queue_capacity.get());
+        let (stop_tx, stop_rx) = watch::channel(false);
+        let (failure_tx, failure_rx) = mpsc::channel::<()>(1);
+        let writer_task = spawn_writer_task(failure_tx.clone(), move || {
+            while let Some(sample) = sample_rx.blocking_recv() {
+                sink.write_sample(&sample)?;
+            }
+            sink.finish()
+        });
+
+        let mut receive_tasks = Vec::with_capacity(topics.len());
+        for (topic_index, task_topic, mut subscriber) in subscribers {
+            let receive_topic = task_topic.clone();
+            let sender = sample_tx.clone();
+            let mut stop_rx = stop_rx.clone();
+            let stop_sender = stop_tx.clone();
+            let failure_sender = failure_tx.clone();
+            let handle = tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        changed = stop_rx.changed() => {
+                            if changed.is_err() || *stop_rx.borrow() {
+                                return Ok(());
+                            }
+                        }
+                        sample = subscriber.recv() => {
+                            let sample = match sample {
+                                Ok(sample) => sample,
+                                Err(source) => {
+                                    let _ = failure_sender.try_send(());
+                                    let _ = stop_sender.send(true);
+                                    return Err(RecordingError::Receive {
+                                        topic: receive_topic.clone(),
+                                        source,
+                                    });
+                                }
+                            };
+                            match enqueue_sample(
+                                topic_index,
+                                &receive_topic,
+                                sample,
+                                &sender,
+                                SystemTime::now(),
+                                writer_queue_capacity.get(),
+                            ) {
+                                EnqueueOutcome::Sent | EnqueueOutcome::DroppedFull => {}
+                                EnqueueOutcome::Closed => return Ok(()),
+                            }
+                        }
+                    }
+                }
+            });
+            receive_tasks.push((task_topic, handle));
+        }
+        drop(sample_tx);
+        drop(failure_tx);
+        startup_output_guard.disarm();
+
+        Ok(Self {
+            output_path,
+            start_time: SystemTime::now(),
+            topics,
+            stop: stop_tx,
+            failure_rx,
+            receive_tasks,
+            writer_task,
+        })
+    }
+
+    pub fn output_path(&self) -> &std::path::Path {
+        &self.output_path
+    }
+
+    pub async fn wait_for_failure(&mut self) {
+        let _ = self.failure_rx.recv().await;
+    }
+
+    pub async fn stop(self) -> Result<RecordingSummary> {
+        let _ = self.stop.send(true);
+        let mut receive_error = None;
+        for (topic, task) in self.receive_tasks {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(source)) => {
+                    if receive_error.is_none() {
+                        receive_error = Some(RecordingError::ReceiveTask {
+                            topic,
+                            source: Box::new(source),
+                        });
+                    }
+                }
+                Err(source) => {
+                    if receive_error.is_none() {
+                        receive_error = Some(RecordingError::ReceiveTask {
+                            topic,
+                            source: Box::new(RecordingError::Join(source)),
+                        });
+                    }
+                }
+            }
+        }
+
+        let writer_counts = match self.writer_task.await {
+            Ok(Ok(counts)) => counts,
+            Ok(Err(finalize)) => {
+                if let Some(receive) = receive_error {
+                    return Err(RecordingError::ReceiveAndFinalize {
+                        receive: Box::new(receive),
+                        finalize: Box::new(finalize),
+                    });
+                }
+                return Err(finalize);
+            }
+            Err(source) => {
+                let finalize = RecordingError::Join(source);
+                if let Some(receive) = receive_error {
+                    return Err(RecordingError::ReceiveAndFinalize {
+                        receive: Box::new(receive),
+                        finalize: Box::new(finalize),
+                    });
+                }
+                return Err(finalize);
+            }
+        };
+        let end_time = SystemTime::now();
+        let topic_summaries = self
+            .topics
+            .iter()
+            .map(|topic| topic_summary(topic.topic(), topic.type_name(), topic.schema_hash()))
+            .collect();
+
+        let summary = build_summary(
+            self.output_path,
+            self.start_time,
+            end_time,
+            topic_summaries,
+            writer_counts,
+        );
+
+        if let Some(source) = receive_error {
+            return Err(RecordingError::RecordingStoppedAfterReceiveError {
+                source: Box::new(source),
+                summary: Box::new(summary),
+            });
+        }
+
+        Ok(summary)
+    }
+}
+
+struct StartupOutputGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl StartupOutputGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for StartupOutputGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn spawn_writer_task(
+    failure_sender: mpsc::Sender<()>,
+    write: impl FnOnce() -> Result<Vec<WriterTopicSummary>> + Send + 'static,
+) -> tokio::task::JoinHandle<Result<Vec<WriterTopicSummary>>> {
+    tokio::task::spawn_blocking(move || {
+        let result = write();
+        if result.is_err() {
+            let _ = failure_sender.try_send(());
+        }
+        result
+    })
+}
+
+enum EnqueueOutcome {
+    Sent,
+    DroppedFull,
+    Closed,
+}
+
+fn enqueue_sample(
+    topic_index: usize,
+    topic: &str,
+    sample: zenoh::sample::Sample,
+    sender: &mpsc::Sender<QueuedSample>,
+    receive_time: SystemTime,
+    writer_queue_capacity: usize,
+) -> EnqueueOutcome {
+    let permit = match sender.try_reserve() {
+        Ok(permit) => permit,
+        Err(mpsc::error::TrySendError::Full(())) => {
+            tracing::warn!(
+                topic,
+                writer_queue_capacity,
+                "recording writer queue full; dropped sample"
+            );
+            return EnqueueOutcome::DroppedFull;
+        }
+        Err(mpsc::error::TrySendError::Closed(())) => return EnqueueOutcome::Closed,
+    };
+
+    permit.send(QueuedSample {
+        topic_index,
+        sample,
+        receive_time,
+    });
+    EnqueueOutcome::Sent
+}
+
+pub(crate) fn topic_summary(topic: &str, type_name: &str, schema_hash: &str) -> TopicSummary {
+    TopicSummary {
+        topic: topic.to_string(),
+        type_name: type_name.to_string(),
+        schema_hash: schema_hash.to_string(),
+        messages: 0,
+        bytes: 0,
+    }
+}
+
+pub(crate) fn build_summary(
+    output_path: PathBuf,
+    start_time: SystemTime,
+    end_time: SystemTime,
+    mut topics: Vec<TopicSummary>,
+    writer_counts: Vec<WriterTopicSummary>,
+) -> RecordingSummary {
+    for (topic, counts) in topics.iter_mut().zip(writer_counts) {
+        topic.messages = counts.messages;
+        topic.bytes = counts.bytes;
+    }
+
+    RecordingSummary {
+        output_path,
+        start_time,
+        end_time,
+        topics,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use ros_z::EndpointGlobalId;
+    use ros_z::attachment::Attachment;
+    use tokio::sync::{mpsc, oneshot, watch};
+    use tokio::time::timeout;
+
+    use crate::runtime::{
+        EnqueueOutcome, RecordingSession, StartupOutputGuard, build_summary, enqueue_sample,
+        spawn_writer_task, topic_summary,
+    };
+    use crate::sample::QueuedSample;
+    use crate::summary::TopicSummary;
+    use crate::writer::WriterTopicSummary;
+    use crate::{RecordingConfig, RecordingError};
+
+    #[test]
+    fn empty_topic_selection_is_rejected_before_runtime_start() {
+        let temp = tempfile::tempdir().expect("tempdir creates");
+
+        match RecordingConfig::new(temp.path().join("empty-topics.mcap"), Vec::new()) {
+            Err(RecordingError::EmptyTopicSelection) => {}
+            Err(error) => panic!("expected EmptyTopicSelection, got {error:?}"),
+            Ok(_) => panic!("empty topic selection must fail before starting a session"),
+        }
+    }
+
+    #[test]
+    fn startup_output_guard_removes_armed_file_on_drop() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("startup-failure.mcap");
+        std::fs::write(&path, b"partial").expect("create partial output");
+
+        {
+            let _guard = StartupOutputGuard::new(path.clone());
+        }
+
+        assert!(
+            !path.exists(),
+            "armed startup guard should remove created file"
+        );
+    }
+
+    #[test]
+    fn startup_output_guard_keeps_disarmed_file_on_drop() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("started.mcap");
+        std::fs::write(&path, b"partial").expect("create partial output");
+
+        {
+            let mut guard = StartupOutputGuard::new(path.clone());
+            guard.disarm();
+        }
+
+        assert!(
+            path.exists(),
+            "disarmed startup guard should keep recording file"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_sample_drops_full_queue_without_converting_payload() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender
+            .try_send(QueuedSample {
+                topic_index: 0,
+                sample: sample_without_attachment("queued"),
+                receive_time: UNIX_EPOCH,
+            })
+            .expect("fill queue");
+        let sample = sample_without_attachment("would be invalid if converted");
+
+        let outcome = enqueue_sample(0, "/demo", sample, &sender, UNIX_EPOCH, 1);
+
+        assert!(matches!(outcome, EnqueueOutcome::DroppedFull));
+        assert_eq!(
+            receiver
+                .recv()
+                .await
+                .expect("queued sample remains")
+                .topic_index,
+            0
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_failure_wakes_when_writer_task_fails() {
+        let (stop_tx, _stop_rx) = watch::channel(false);
+        let (failure_tx, failure_rx) = mpsc::channel(1);
+        let writer_task =
+            spawn_writer_task(failure_tx, || Err(RecordingError::EmptyTopicSelection));
+        let mut session = RecordingSession {
+            output_path: PathBuf::from("writer-error.mcap"),
+            start_time: UNIX_EPOCH,
+            topics: Vec::new(),
+            stop: stop_tx,
+            failure_rx,
+            receive_tasks: Vec::new(),
+            writer_task,
+        };
+
+        timeout(Duration::from_secs(1), session.wait_for_failure())
+            .await
+            .expect("writer failure should notify waiters");
+
+        let error = session
+            .stop()
+            .await
+            .expect_err("writer failure should return");
+        assert!(matches!(error, RecordingError::EmptyTopicSelection));
+    }
+
+    #[tokio::test]
+    async fn stop_joins_remaining_receivers_and_finalizes_writer_after_receive_join_error() {
+        let (stop_tx, _stop_rx) = watch::channel(false);
+        let (_failure_tx, failure_rx) = mpsc::channel(1);
+        let (second_receive_release_tx, second_receive_release_rx) = oneshot::channel();
+        let (writer_release_tx, writer_release_rx) = oneshot::channel();
+        let (writer_finalized_tx, writer_finalized_rx) = oneshot::channel();
+        let panicking_receive_task = tokio::spawn(async move {
+            panic!("receive task join failure");
+            #[allow(unreachable_code)]
+            Ok::<(), RecordingError>(())
+        });
+        let blocked_receive_task = tokio::spawn(async move {
+            let _ = second_receive_release_rx.await;
+            Ok::<(), RecordingError>(())
+        });
+        let writer_task = tokio::spawn(async move {
+            let _ = writer_release_rx.await;
+            let _ = writer_finalized_tx.send(());
+            Ok::<Vec<WriterTopicSummary>, RecordingError>(Vec::new())
+        });
+        let session = RecordingSession {
+            output_path: PathBuf::from("join-error.mcap"),
+            start_time: UNIX_EPOCH,
+            topics: Vec::new(),
+            stop: stop_tx,
+            failure_rx,
+            receive_tasks: vec![
+                ("/panics".to_string(), panicking_receive_task),
+                ("/blocked".to_string(), blocked_receive_task),
+            ],
+            writer_task,
+        };
+        let mut stop_task = tokio::spawn(session.stop());
+
+        assert!(
+            timeout(Duration::from_millis(50), &mut stop_task)
+                .await
+                .is_err(),
+            "stop returned before joining all receive tasks"
+        );
+
+        second_receive_release_tx
+            .send(())
+            .expect("blocked receive task should still be pending");
+        assert!(
+            timeout(Duration::from_millis(50), &mut stop_task)
+                .await
+                .is_err(),
+            "stop returned before awaiting writer finalization"
+        );
+
+        writer_release_tx
+            .send(())
+            .expect("writer task should still be pending");
+        let result = timeout(Duration::from_secs(1), stop_task)
+            .await
+            .expect("stop should finish after writer finalizes")
+            .expect("stop task should not panic");
+        writer_finalized_rx
+            .await
+            .expect("writer finalization should be observed");
+
+        let Err(RecordingError::RecordingStoppedAfterReceiveError { source, .. }) = result else {
+            panic!("expected receive task join failure after finalization, got {result:?}");
+        };
+        match *source {
+            RecordingError::ReceiveTask { topic, source } => {
+                assert_eq!(topic, "/panics");
+                assert!(matches!(*source, RecordingError::Join(_)));
+            }
+            error => panic!("expected ReceiveTask source, got {error:?}"),
+        }
+    }
+
+    #[test]
+    fn build_summary_combines_writer_counts() {
+        let topics = vec![topic_summary("/demo", "test_msgs::Demo", "RZHS02_demo")];
+        let summary = build_summary(
+            PathBuf::from("demo.mcap"),
+            UNIX_EPOCH,
+            UNIX_EPOCH + Duration::from_secs(2),
+            topics,
+            vec![WriterTopicSummary {
+                messages: 4,
+                bytes: 20,
+            }],
+        );
+
+        assert_eq!(summary.output_path, PathBuf::from("demo.mcap"));
+        assert_eq!(summary.duration(), Duration::from_secs(2));
+        assert_eq!(summary.topics[0].messages, 4);
+        assert_eq!(summary.topics[0].bytes, 20);
+    }
+
+    #[test]
+    fn topic_summary_initializes_counts_from_resolved_metadata() {
+        let summary: TopicSummary = topic_summary("/demo", "test_msgs::Demo", "RZHS02_demo");
+
+        assert_eq!(summary.topic, "/demo");
+        assert_eq!(summary.type_name, "test_msgs::Demo");
+        assert_eq!(summary.schema_hash, "RZHS02_demo");
+        assert_eq!(summary.messages, 0);
+        assert_eq!(summary.bytes, 0);
+    }
+
+    fn sample_without_attachment(payload: &str) -> zenoh::sample::Sample {
+        let key_expr = "test/key".parse::<zenoh::key_expr::KeyExpr>().unwrap();
+        zenoh::sample::SampleBuilder::put(key_expr, payload).into()
+    }
+
+    #[allow(dead_code)]
+    fn sample_with_attachment(sequence: i64, payload: &str) -> zenoh::sample::Sample {
+        let key_expr = "test/key".parse::<zenoh::key_expr::KeyExpr>().unwrap();
+        let attachment = Attachment::with_source_time(
+            sequence,
+            EndpointGlobalId::from([7; 16]),
+            ros_z::time::Time::from_nanos(123_456),
+        );
+        zenoh::sample::SampleBuilder::put(key_expr, payload)
+            .attachment(attachment)
+            .into()
+    }
+}

--- a/crates/ros-z-recording/src/sample.rs
+++ b/crates/ros-z-recording/src/sample.rs
@@ -1,0 +1,140 @@
+use std::time::SystemTime;
+
+use mcap::records::system_time_to_nanos;
+use ros_z::attachment::Attachment;
+use zenoh::sample::Sample;
+
+use crate::{RecordingError, Result};
+
+#[derive(Debug)]
+pub(crate) struct QueuedSample {
+    pub topic_index: usize,
+    pub sample: Sample,
+    pub receive_time: SystemTime,
+}
+
+#[derive(Debug)]
+pub(crate) struct McapSampleHeader {
+    pub sequence: u32,
+    pub log_time: u64,
+    pub publish_time: u64,
+}
+
+pub(crate) fn sample_to_mcap_header(
+    topic: &str,
+    sample: &Sample,
+    receive_time: SystemTime,
+) -> Result<McapSampleHeader> {
+    let attachment = sample
+        .attachment()
+        .ok_or(RecordingError::MissingSampleAttachment)
+        .and_then(|raw| {
+            Attachment::try_from(raw).map_err(RecordingError::SampleAttachmentDecode)
+        })?;
+    let sequence = u32::try_from(attachment.sequence_number).map_err(|_| {
+        RecordingError::SequenceOutOfRange {
+            topic: topic.to_string(),
+            sequence: attachment.sequence_number,
+        }
+    })?;
+    let log_time = sample
+        .timestamp()
+        .map(|timestamp| system_time_to_nanos(&timestamp.get_time().to_system_time()))
+        .unwrap_or_else(|| system_time_to_nanos(&receive_time));
+
+    Ok(McapSampleHeader {
+        sequence,
+        log_time,
+        publish_time: u64::try_from(attachment.source_time().as_nanos()).unwrap_or(0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use ros_z::EndpointGlobalId;
+    use ros_z::attachment::Attachment;
+    use zenoh::sample::Sample;
+
+    use super::sample_to_mcap_header;
+    use crate::RecordingError;
+
+    fn sample_with_attachment(sequence: i64, payload: &str) -> Sample {
+        let key_expr = "test/key".parse::<zenoh::key_expr::KeyExpr>().unwrap();
+        let attachment = Attachment::with_source_time(
+            sequence,
+            EndpointGlobalId::from([7; 16]),
+            ros_z::time::Time::from_nanos(123_456),
+        );
+        zenoh::sample::SampleBuilder::put(key_expr, payload)
+            .attachment(attachment)
+            .into()
+    }
+
+    fn sample_without_attachment(payload: &str) -> Sample {
+        let key_expr = "test/key".parse::<zenoh::key_expr::KeyExpr>().unwrap();
+        zenoh::sample::SampleBuilder::put(key_expr, payload).into()
+    }
+
+    #[test]
+    fn converts_raw_sample_metadata_to_mcap_message() {
+        let sample = sample_with_attachment(42, "payload");
+
+        let header = sample_to_mcap_header("/demo", &sample, UNIX_EPOCH + Duration::from_secs(10))
+            .expect("sample converts");
+
+        assert_eq!(header.sequence, 42);
+        assert_eq!(header.publish_time, 123_456);
+        assert_eq!(header.log_time, 10_000_000_000);
+        assert_eq!(sample.payload().to_bytes().as_ref(), b"payload");
+    }
+
+    #[test]
+    fn rejects_sample_without_ros_z_attachment() {
+        let error =
+            sample_to_mcap_header("/demo", &sample_without_attachment("payload"), UNIX_EPOCH)
+                .expect_err("missing attachment must fail");
+
+        assert!(matches!(error, RecordingError::MissingSampleAttachment));
+    }
+
+    #[test]
+    fn rejects_negative_sequence() {
+        let error =
+            sample_to_mcap_header("/demo", &sample_with_attachment(-1, "payload"), UNIX_EPOCH)
+                .expect_err("negative sequence must fail");
+
+        assert!(matches!(
+            error,
+            RecordingError::SequenceOutOfRange { topic, sequence }
+                if topic == "/demo" && sequence == -1
+        ));
+    }
+
+    #[test]
+    fn rejects_overflowing_sequence() {
+        let overflowing_sequence = i64::from(u32::MAX) + 1;
+        let error = sample_to_mcap_header(
+            "/demo",
+            &sample_with_attachment(overflowing_sequence, "payload"),
+            UNIX_EPOCH,
+        )
+        .expect_err("overflowing sequence must fail");
+
+        assert!(matches!(
+            error,
+            RecordingError::SequenceOutOfRange { topic, sequence }
+                if topic == "/demo" && sequence == overflowing_sequence
+        ));
+    }
+
+    #[test]
+    fn accepts_sequence_zero() {
+        let header =
+            sample_to_mcap_header("/demo", &sample_with_attachment(0, "payload"), UNIX_EPOCH)
+                .expect("sequence zero is valid");
+
+        assert_eq!(header.sequence, 0);
+    }
+}

--- a/crates/ros-z-recording/src/summary.rs
+++ b/crates/ros-z-recording/src/summary.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use chrono::{DateTime, Utc};
+
+/// Summary returned after a recording session has stopped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingSummary {
+    pub output_path: PathBuf,
+    pub start_time: SystemTime,
+    pub end_time: SystemTime,
+    pub topics: Vec<TopicSummary>,
+}
+
+/// Per-topic message and byte counts for one recording session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopicSummary {
+    pub topic: String,
+    pub type_name: String,
+    pub schema_hash: String,
+    pub messages: u64,
+    pub bytes: u64,
+}
+
+impl RecordingSummary {
+    pub fn duration(&self) -> Duration {
+        self.end_time
+            .duration_since(self.start_time)
+            .unwrap_or(Duration::ZERO)
+    }
+
+    pub fn topic_count(&self) -> usize {
+        self.topics.len()
+    }
+
+    pub fn total_messages(&self) -> u64 {
+        self.topics.iter().map(|topic| topic.messages).sum()
+    }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.topics.iter().map(|topic| topic.bytes).sum()
+    }
+}
+
+pub fn format_system_time_utc(time: SystemTime) -> String {
+    let timestamp: DateTime<Utc> = time.into();
+    timestamp.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use super::{RecordingSummary, TopicSummary, format_system_time_utc};
+
+    #[test]
+    fn summary_totals_messages_and_bytes_by_topic() {
+        let summary = RecordingSummary {
+            output_path: PathBuf::from("recording.mcap"),
+            start_time: UNIX_EPOCH,
+            end_time: UNIX_EPOCH + Duration::from_secs(3),
+            topics: vec![
+                TopicSummary {
+                    topic: "/alpha".to_string(),
+                    type_name: "test_msgs::Alpha".to_string(),
+                    schema_hash: "RZHS02_alpha".to_string(),
+                    messages: 2,
+                    bytes: 10,
+                },
+                TopicSummary {
+                    topic: "/beta".to_string(),
+                    type_name: "test_msgs::Beta".to_string(),
+                    schema_hash: "RZHS02_beta".to_string(),
+                    messages: 3,
+                    bytes: 90,
+                },
+            ],
+        };
+
+        assert_eq!(summary.duration(), Duration::from_secs(3));
+        assert_eq!(summary.topic_count(), 2);
+        assert_eq!(summary.total_messages(), 5);
+        assert_eq!(summary.total_bytes(), 100);
+    }
+
+    #[test]
+    fn formats_system_time_as_utc_without_spaces() {
+        let text = format_system_time_utc(UNIX_EPOCH + Duration::from_secs(3661));
+
+        assert_eq!(text, "1970-01-01T01:01:01Z");
+    }
+}

--- a/crates/ros-z-recording/src/topic.rs
+++ b/crates/ros-z-recording/src/topic.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use ros_z::dynamic::{DiscoveredTopicSchema, Schema};
+use ros_z::entity::TypeInfo;
+use ros_z::node::Node;
+
+use crate::{RecordingError, Result};
+
+const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedTopic {
+    requested_topic: String,
+    topic: String,
+    type_info: TypeInfo,
+    schema_hash: String,
+    schema: Schema,
+}
+
+impl ResolvedTopic {
+    pub(crate) fn from_discovery(
+        requested_topic: String,
+        discovered: DiscoveredTopicSchema,
+    ) -> Self {
+        let type_info = discovered.type_info();
+        Self {
+            requested_topic,
+            topic: discovered.qualified_topic,
+            schema_hash: discovered.schema_hash.to_hash_string(),
+            type_info,
+            schema: discovered.schema,
+        }
+    }
+
+    pub(crate) fn requested_topic(&self) -> &str {
+        &self.requested_topic
+    }
+
+    pub(crate) fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    pub(crate) fn type_info(&self) -> &TypeInfo {
+        &self.type_info
+    }
+
+    pub(crate) fn type_name(&self) -> &str {
+        &self.type_info.name
+    }
+
+    pub(crate) fn schema_hash(&self) -> &str {
+        &self.schema_hash
+    }
+
+    pub(crate) fn schema(&self) -> &Schema {
+        &self.schema
+    }
+}
+
+pub(crate) async fn resolve_topics(
+    node: Arc<Node>,
+    topics: &[String],
+) -> Result<Vec<ResolvedTopic>> {
+    let mut resolved = Vec::with_capacity(topics.len());
+    for topic in topics {
+        let discovered = node
+            .discover_topic_schema(topic, DISCOVERY_TIMEOUT)
+            .await
+            .map_err(|source| RecordingError::SchemaDiscovery {
+                topic: topic.clone(),
+                source,
+            })?;
+        resolved.push(ResolvedTopic::from_discovery(topic.clone(), discovered));
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ros_z::Message;
+
+    use super::ResolvedTopic;
+
+    #[test]
+    fn resolved_topic_preserves_requested_and_qualified_topic() {
+        let discovered = ros_z::dynamic::DiscoveredTopicSchema {
+            qualified_topic: "/tools/chatter".to_string(),
+            root_name: String::type_name(),
+            schema: Arc::new(String::schema()),
+            schema_hash: String::schema_hash(),
+        };
+
+        let topic = ResolvedTopic::from_discovery("chatter".to_string(), discovered);
+
+        assert_eq!(topic.requested_topic(), "chatter");
+        assert_eq!(topic.topic(), "/tools/chatter");
+        assert_eq!(topic.type_name(), String::type_name());
+        assert_eq!(topic.schema_hash(), String::schema_hash().to_hash_string());
+    }
+}

--- a/crates/ros-z-recording/src/writer.rs
+++ b/crates/ros-z-recording/src/writer.rs
@@ -1,0 +1,252 @@
+use std::collections::BTreeMap;
+use std::io::{Seek, Write};
+
+use mcap::Writer;
+use mcap::records::MessageHeader;
+use mcap::write::Metadata;
+use serde::Serialize;
+
+use crate::metadata::{recording_metadata, serialize_metadata_value};
+use crate::sample::{QueuedSample, sample_to_mcap_header};
+use crate::topic::ResolvedTopic;
+use crate::{MESSAGE_ENCODING, RecordingError, Result, SCHEMA_ENCODING};
+
+pub struct McapWriterSink<W: Write + Seek> {
+    writer: Writer<W>,
+    channel_ids: Vec<u16>,
+    topics: Vec<String>,
+    topic_counts: Vec<WriterTopicSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriterTopicSummary {
+    pub messages: u64,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ResolvedTopicMetadata<'a> {
+    requested_topic: &'a str,
+    topic: &'a str,
+    type_name: &'a str,
+    schema_hash: &'a str,
+    schema_encoding: &'static str,
+    message_encoding: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct TimestampSemantics {
+    log_time: &'static str,
+    publish_time: &'static str,
+}
+
+impl<W: Write + Seek> McapWriterSink<W> {
+    pub fn new(writer: W, topics: &[ResolvedTopic], requested_topics: &[String]) -> Result<Self> {
+        let mut writer = Writer::new(writer).map_err(RecordingError::Mcap)?;
+        let mut channel_ids = Vec::with_capacity(topics.len());
+
+        for topic in topics {
+            let schema_data = serde_json::to_vec(topic.schema().as_ref()).map_err(|source| {
+                RecordingError::SchemaSerialize {
+                    topic: topic.topic().to_string(),
+                    source,
+                }
+            })?;
+            let schema_id = writer
+                .add_schema(topic.type_name(), SCHEMA_ENCODING, &schema_data)
+                .map_err(RecordingError::Mcap)?;
+            let channel_id = writer
+                .add_channel(schema_id, topic.topic(), MESSAGE_ENCODING, &BTreeMap::new())
+                .map_err(RecordingError::Mcap)?;
+            channel_ids.push(channel_id);
+        }
+
+        let resolved_topics = topics
+            .iter()
+            .map(|topic| ResolvedTopicMetadata {
+                requested_topic: topic.requested_topic(),
+                topic: topic.topic(),
+                type_name: topic.type_name(),
+                schema_hash: topic.schema_hash(),
+                schema_encoding: SCHEMA_ENCODING,
+                message_encoding: MESSAGE_ENCODING,
+            })
+            .collect::<Vec<_>>();
+        let resolved_topics_json = serialize_metadata_value(&resolved_topics)?;
+        let timestamp_semantics_json = serialize_metadata_value(&TimestampSemantics {
+            log_time: "Zenoh transport timestamp when present, otherwise recorder wall-clock receive time",
+            publish_time: "ros-z source timestamp from sample attachment",
+        })?;
+        writer
+            .write_metadata(&Metadata {
+                name: "ros-z".to_string(),
+                metadata: recording_metadata(
+                    requested_topics,
+                    &resolved_topics_json,
+                    &timestamp_semantics_json,
+                ),
+            })
+            .map_err(RecordingError::Mcap)?;
+
+        Ok(Self {
+            writer,
+            channel_ids,
+            topics: topics
+                .iter()
+                .map(|topic| topic.topic().to_string())
+                .collect(),
+            topic_counts: vec![
+                WriterTopicSummary {
+                    messages: 0,
+                    bytes: 0,
+                };
+                topics.len()
+            ],
+        })
+    }
+
+    pub fn write_sample(&mut self, sample: &QueuedSample) -> Result<()> {
+        let topic_count = self.channel_ids.len();
+        let channel_id = self.channel_ids.get(sample.topic_index).copied().ok_or(
+            RecordingError::InvalidTopicIndex {
+                topic_index: sample.topic_index,
+                topic_count,
+            },
+        )?;
+        let topic =
+            self.topics
+                .get(sample.topic_index)
+                .ok_or(RecordingError::InvalidTopicIndex {
+                    topic_index: sample.topic_index,
+                    topic_count,
+                })?;
+        let counts = self.topic_counts.get_mut(sample.topic_index).ok_or(
+            RecordingError::InvalidTopicIndex {
+                topic_index: sample.topic_index,
+                topic_count,
+            },
+        )?;
+        let header = sample_to_mcap_header(topic, &sample.sample, sample.receive_time)?;
+        let payload = sample.sample.payload().to_bytes();
+        self.writer
+            .write_to_known_channel(
+                &MessageHeader {
+                    channel_id,
+                    sequence: header.sequence,
+                    log_time: header.log_time,
+                    publish_time: header.publish_time,
+                },
+                payload.as_ref(),
+            )
+            .map_err(RecordingError::Mcap)?;
+        counts.messages += 1;
+        counts.bytes += payload.as_ref().len() as u64;
+        Ok(())
+    }
+
+    pub fn finish(mut self) -> Result<Vec<WriterTopicSummary>> {
+        self.writer.finish().map_err(RecordingError::Mcap)?;
+        Ok(self.topic_counts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ros_z::Message;
+
+    use super::McapWriterSink;
+    use crate::RecordingError;
+    use crate::sample::QueuedSample;
+    use crate::topic::ResolvedTopic;
+
+    fn resolved_topic(topic: &str) -> ResolvedTopic {
+        ResolvedTopic::from_discovery(
+            topic.to_string(),
+            ros_z::dynamic::DiscoveredTopicSchema {
+                qualified_topic: topic.to_string(),
+                root_name: String::type_name(),
+                schema: Arc::new(String::schema()),
+                schema_hash: String::schema_hash(),
+            },
+        )
+    }
+
+    fn queued_sample(topic_index: usize, sequence: i64, payload: &str) -> QueuedSample {
+        let key_expr = "test/key".parse::<zenoh::key_expr::KeyExpr>().unwrap();
+        let attachment = ros_z::attachment::Attachment::with_source_time(
+            sequence,
+            ros_z::EndpointGlobalId::from([7; 16]),
+            ros_z::time::Time::from_nanos(123_456),
+        );
+        QueuedSample {
+            topic_index,
+            sample: zenoh::sample::SampleBuilder::put(key_expr, payload)
+                .attachment(attachment)
+                .into(),
+            receive_time: std::time::UNIX_EPOCH,
+        }
+    }
+
+    #[test]
+    fn writes_schema_channel_metadata_and_message() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::NamedTempFile::new()?;
+        let file = std::fs::File::create(temp.path())?;
+        let topics = vec![resolved_topic("/demo")];
+        let mut sink = McapWriterSink::new(file, &topics, &["/demo".to_string()])?;
+
+        sink.write_sample(&queued_sample(0, 7, "hello"))
+            .expect("sample writes");
+        let counts = sink.finish()?;
+
+        assert_eq!(counts[0].messages, 1);
+        assert_eq!(counts[0].bytes, 5);
+
+        let bytes = std::fs::read(temp.path())?;
+        let messages = mcap::MessageStream::new(&bytes)
+            .expect("valid mcap")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("messages read");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].channel.topic, "/demo");
+        assert_eq!(
+            messages[0].channel.message_encoding,
+            crate::MESSAGE_ENCODING
+        );
+        assert_eq!(
+            messages[0]
+                .channel
+                .schema
+                .as_ref()
+                .expect("schema")
+                .encoding,
+            crate::SCHEMA_ENCODING
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_sample_with_out_of_range_topic_index() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::NamedTempFile::new()?;
+        let file = std::fs::File::create(temp.path())?;
+        let topics = vec![resolved_topic("/demo")];
+        let mut sink = McapWriterSink::new(file, &topics, &["/demo".to_string()])?;
+
+        let error = sink
+            .write_sample(&queued_sample(1, 7, "hello"))
+            .expect_err("out-of-range topic index must fail");
+
+        assert!(matches!(
+            error,
+            RecordingError::InvalidTopicIndex {
+                topic_index: 1,
+                topic_count: 1,
+            }
+        ));
+        let counts = sink.finish()?;
+        assert_eq!(counts[0].messages, 0);
+        assert_eq!(counts[0].bytes, 0);
+        Ok(())
+    }
+}

--- a/crates/ros-z/README.md
+++ b/crates/ros-z/README.md
@@ -19,8 +19,9 @@ C/C++ runtime dependencies.
 - `ros-z-schema`: schema and type-shape support for generated and dynamic data.
 - `ros-z-derive`: `#[derive(Message)]` support for typed messages.
 - `ros-z-streams`: future queues and maps for timestamped sensor-fusion streams.
-- `ros-z-cli`: graph, schema, topic, and parameter inspection commands.
+- `ros-z-cli`: graph, schema, topic, parameter inspection, and MCAP recording commands.
 - `ros-z-debug`: read-only debug subscriptions with retained samples and JSON views.
+- `ros-z-recording`: `rosz record` records qualified live ros-z topics into MCAP with ros-z schema and raw payload data.
 
 ## Quick Start
 

--- a/docs/tooling/recording_and_replay.md
+++ b/docs/tooling/recording_and_replay.md
@@ -19,6 +19,36 @@ Be careful enabling vision cyclers because this will result in a lot of data bei
 
 Data is only recorded during `PrimaryState::Ready`, `PrimaryState::Set`, and `PrimaryState::Play`.
 
+## MCAP topic recording with `rosz`
+
+Use `rosz record [--output <path>] <topic>...` to record live `ros-z`
+topics into an MCAP file:
+
+```bash
+rosz --namespace /robot --node-name recorder record --output capture.mcap telemetry '~/debug'
+```
+
+Topic names use the normal ros-z qualification rules. Absolute topics are used
+as-is, relative topics are resolved in the recorder node namespace, and private
+topics starting with `~` are resolved under the recorder node name. Use the
+global `--namespace` and `--node-name` flags to control that identity.
+
+The MVP writes raw ros-z sample payloads with `ros-z.cdr` message encoding and
+stores the discovered ros-z schema with `ros-z.schema.v1` schema encoding. If
+`--output` is omitted, `rosz` writes a timestamped file in the current directory
+named `rosz-recording-<timestamp>.mcap`. Existing output files are rejected.
+
+Recording starts after all requested topics have discoverable publishers and
+schemas. Stop recording with Ctrl-C; `rosz` finalizes the MCAP file and prints a
+text summary with output path, duration, total messages, bytes, and per-topic
+message and byte counts.
+
+V1 does not include JSON output for `record`, publisher provenance metadata,
+prefix filters, partial mode, overwrite flags, duration or message limits,
+sampling, robot-side recording services, `pepsi` integration, inspect/replay
+commands, Foxglove-specific compatibility work, or ROS 2 MCAP compatibility
+work.
+
 ## Replay(er)
 
 Assuming you already recorded some data on a robot, you can now use the "replayer" tool to replay the recorded data.


### PR DESCRIPTION
## Summary
- add a reusable `ros-z-recording` crate for MVP MCAP topic recording
- add `rosz record [--output <path>] <topic>...` with text summaries, existing-output preflight, and configurable CLI node identity
- verify recorded MCAP contents end to end, including raw payload bytes, ros-z encodings, and qualified topic resolution

## Motivation
This gives developers a local ros-z topic recorder without adding robot-side services, replay support, or broader recording workflow changes.

## Implementation
The recording backend resolves requested topics at startup with normal ros-z topic qualification rules, writes raw Zenoh sample payloads to MCAP with `ros-z.schema.v1` schemas and `ros-z.cdr` messages, and finalizes on Ctrl-C or internal recording failure. The MVP keeps publisher provenance, drop counts, replay, and JSON record output out of scope. The CLI rejects `--json record` before graph setup.

## Verification
- `cargo nextest run -p ros-z-recording -p ros-z-cli`
- `cargo test --doc -p ros-z-recording -p ros-z-cli`
- `cargo clippy -p ros-z-recording -p ros-z-cli --all-targets --locked -- -D warnings`
- `git diff --check ddf687a4393935f18781a57ea7cfa001cfd2c557..HEAD`
