### PR TITLE
3v3 speedup

### DIFF
--- a/crates/bevyhavior_simulator/src/auto_referee.rs
+++ b/crates/bevyhavior_simulator/src/auto_referee.rs
@@ -425,7 +425,23 @@ pub fn run_auto_referee(
         rule.apply(&mut context);
     }
 
+    sync_remaining_time_in_half(&mut context);
+
     auto_referee.rules = rules;
+}
+
+fn sync_remaining_time_in_half(context: &mut AutoRefereeContext<'_>) {
+    context
+        .game_state
+        .game_controller_state
+        .remaining_time_in_half = context
+        .auto_referee
+        .halftime_started_at
+        .and_then(|started_at| context.now.duration_since(started_at).ok())
+        .map_or(context.config.halftime_duration, |elapsed| {
+            context.config.halftime_duration.saturating_sub(elapsed)
+        });
+    context.game_state.sync_filtered_game_controller_state();
 }
 
 fn apply_referee_command(command: SimulatorRefereeCommand, context: &mut AutoRefereeContext<'_>) {

--- a/crates/bevyhavior_simulator/src/bin/three_vs_three_until_goal_or_half.rs
+++ b/crates/bevyhavior_simulator/src/bin/three_vs_three_until_goal_or_half.rs
@@ -60,7 +60,7 @@ fn update(
         .now
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("simulator time should not move backwards");
-    if hulks_score > 1 || opponent_score > 1 {
+    if hulks_score > 0 || opponent_score > 0 {
         println!(
             "result=goal elapsed={:.2} hulks_score={hulks_score} opponent_score={opponent_score}",
             elapsed.as_secs_f32()


### PR DESCRIPTION
## Why? What?

3v3 scenario currently takes about a minute of wall time to simulate because they bounce the ball back and fourth a lot.
- remaining time in half was incorrectly set, causing robots to send messages at max speed
- once message budget runs out, only robots which see the ball participate in driving game forward
- few robots participating = more bouncing ball back and fourth.
- Instead of first goal, simulation ran until one team has at least two goals.

This PR stops scenario after first goal and implements remaining time in half tracking.

Based on #2669 

## How to Test

`cargo run --bin three_vs_three_until_goal_or_half`