### PR TITLE
New gamecontroller messages

### DIFF
--- a/crates/hsl_network_messages/headers/RoboCupGameControlData.hpp
+++ b/crates/hsl_network_messages/headers/RoboCupGameControlData.hpp
@@ -7,7 +7,7 @@
 #define GAMECONTROLLER_RETURN_PORT 3939
 
 #define GAMECONTROLLER_STRUCT_HEADER  "RGme"
-#define GAMECONTROLLER_STRUCT_VERSION 19
+#define GAMECONTROLLER_STRUCT_VERSION 20
 
 #define MAX_NUM_PLAYERS 20
 
@@ -26,10 +26,10 @@
 #define COMPETITION_TYPE_MIDDLE 1
 #define COMPETITION_TYPE_LARGE  2
 
-#define GAME_PHASE_NORMAL       0
-#define GAME_PHASE_PENALTYSHOOT 1
-#define GAME_PHASE_EXTRATIME    2
-#define GAME_PHASE_TIMEOUT      3
+#define GAME_PHASE_NORMAL            0
+#define GAME_PHASE_PENALTY_SHOOT_OUT 1
+#define GAME_PHASE_EXTRA_TIME        2
+#define GAME_PHASE_TIMEOUT           3
 
 #define STATE_INITIAL  0
 #define STATE_READY    1
@@ -50,29 +50,30 @@
 #define PENALTY_NONE                          0
 #define PENALTY_ILLEGAL_POSITIONING           1
 #define PENALTY_MOTION_IN_SET                 2
-#define PENALTY_LOCAL_GAME_STUCK              3
-#define PENALTY_INCAPABLE_ROBOT               4
-#define PENALTY_PICK_UP                       5
-#define PENALTY_BALL_HOLDING                  6
-#define PENALTY_LEAVING_THE_FIELD             7
-#define PENALTY_PLAYING_WITH_ARMS_HANDS       8
-#define PENALTY_PUSHING                       9
-#define PENALTY_SENT_OFF                      10
-#define PENALTY_SUBSTITUTE                    11
+#define PENALTY_MOTION_IN_STOP                3
+#define PENALTY_LOCAL_GAME_STUCK              4
+#define PENALTY_INCAPABLE_ROBOT               5
+#define PENALTY_PICK_UP                       6
+#define PENALTY_BALL_HOLDING                  7
+#define PENALTY_LEAVING_THE_FIELD             8
+#define PENALTY_PLAYING_WITH_ARMS_HANDS       9
+#define PENALTY_PUSHING                       10
+#define PENALTY_CAUTIONED                     11
+#define PENALTY_SENT_OFF                      12
+#define PENALTY_SUBSTITUTE                    13
 
 struct RobotInfo
 {
-  uint8_t penalty;             // penalty state of the player
+  uint8_t penalty;             // penalty state of the player (PENALTY_NONE, etc)
   uint8_t secsTillUnpenalised; // estimate of time till unpenalised
-  uint8_t warnings;            // number of warnings
   uint8_t cautions;            // number of cautions (yellow cards)
 };
 
 struct TeamInfo
 {
   uint8_t teamNumber;                        // unique team number
-  uint8_t fieldPlayerColour;                 // colour of the field players
-  uint8_t goalkeeperColour;                  // colour of the goalkeeper
+  uint8_t fieldPlayerColour;                 // colour of the field players (TEAM_BLUE, etc)
+  uint8_t goalkeeperColour;                  // colour of the goalkeeper (TEAM_BLUE, etc)
   uint8_t goalkeeper;                        // player number of the goalkeeper (0-MAX_NUM_PLAYERS)
   uint8_t score;                             // team's score
   uint8_t penaltyShot;                       // penalty shot counter
@@ -89,9 +90,9 @@ struct RoboCupGameControlData
   uint8_t playersPerTeam;   // the number of players on a team
   uint8_t competitionType;  // type of the competition (COMPETITION_TYPE_SMALL, etc)
   uint8_t stopped;          // 1 = play is currently stopped, 0 otherwise
-  uint8_t gamePhase;        // phase of the game (GAME_PHASE_NORMAL, GAME_PHASE_PENALTYSHOOT, etc)
-  uint8_t state;            // state of the game (STATE_READY, STATE_PLAYING, etc)
-  uint8_t setPlay;          // active set play (SET_PLAY_NONE, SET_PLAY_GOAL_KICK, etc)
+  uint8_t gamePhase;        // phase of the game (GAME_PHASE_NORMAL, etc)
+  uint8_t state;            // state of the game (STATE_INITIAL, etc)
+  uint8_t setPlay;          // active set play (SET_PLAY_NONE, etc)
   uint8_t firstHalf;        // 1 = game in first half, 0 otherwise
   uint8_t kickingTeam;      // the team number of the next team to kick-off, free kick etc, or KICKING_TEAM_NONE
   int16_t secsRemaining;    // estimate of number of seconds remaining in the half

--- a/crates/hsl_network_messages/src/game_controller_state_message.rs
+++ b/crates/hsl_network_messages/src/game_controller_state_message.rs
@@ -15,16 +15,17 @@ use crate::{
     HULKS_TEAM_NUMBER, NONE_TEAM_NUMBER, PlayerNumber,
     bindings::{
         COMPETITION_TYPE_LARGE, COMPETITION_TYPE_MIDDLE, COMPETITION_TYPE_SMALL,
-        GAME_PHASE_EXTRATIME, GAME_PHASE_NORMAL, GAME_PHASE_PENALTYSHOOT, GAME_PHASE_TIMEOUT,
+        GAME_PHASE_EXTRA_TIME, GAME_PHASE_NORMAL, GAME_PHASE_PENALTY_SHOOT_OUT, GAME_PHASE_TIMEOUT,
         GAMECONTROLLER_STRUCT_HEADER, GAMECONTROLLER_STRUCT_VERSION, MAX_NUM_PLAYERS,
-        PENALTY_BALL_HOLDING, PENALTY_ILLEGAL_POSITIONING, PENALTY_INCAPABLE_ROBOT,
-        PENALTY_LEAVING_THE_FIELD, PENALTY_LOCAL_GAME_STUCK, PENALTY_MOTION_IN_SET, PENALTY_NONE,
-        PENALTY_PICK_UP, PENALTY_PLAYING_WITH_ARMS_HANDS, PENALTY_PUSHING, PENALTY_SENT_OFF,
-        PENALTY_SUBSTITUTE, RoboCupGameControlData, RobotInfo, SET_PLAY_CORNER_KICK,
-        SET_PLAY_DIRECT_FREE_KICK, SET_PLAY_GOAL_KICK, SET_PLAY_INDIRECT_FREE_KICK, SET_PLAY_NONE,
-        SET_PLAY_PENALTY_KICK, SET_PLAY_THROW_IN, STATE_FINISHED, STATE_INITIAL, STATE_PLAYING,
-        STATE_READY, STATE_SET, TEAM_BLACK, TEAM_BLUE, TEAM_BROWN, TEAM_GRAY, TEAM_GREEN,
-        TEAM_ORANGE, TEAM_PURPLE, TEAM_RED, TEAM_WHITE, TEAM_YELLOW,
+        PENALTY_BALL_HOLDING, PENALTY_CAUTIONED, PENALTY_ILLEGAL_POSITIONING,
+        PENALTY_INCAPABLE_ROBOT, PENALTY_LEAVING_THE_FIELD, PENALTY_LOCAL_GAME_STUCK,
+        PENALTY_MOTION_IN_SET, PENALTY_MOTION_IN_STOP, PENALTY_NONE, PENALTY_PICK_UP,
+        PENALTY_PLAYING_WITH_ARMS_HANDS, PENALTY_PUSHING, PENALTY_SENT_OFF, PENALTY_SUBSTITUTE,
+        RoboCupGameControlData, RobotInfo, SET_PLAY_CORNER_KICK, SET_PLAY_DIRECT_FREE_KICK,
+        SET_PLAY_GOAL_KICK, SET_PLAY_INDIRECT_FREE_KICK, SET_PLAY_NONE, SET_PLAY_PENALTY_KICK,
+        SET_PLAY_THROW_IN, STATE_FINISHED, STATE_INITIAL, STATE_PLAYING, STATE_READY, STATE_SET,
+        TEAM_BLACK, TEAM_BLUE, TEAM_BROWN, TEAM_GRAY, TEAM_GREEN, TEAM_ORANGE, TEAM_PURPLE,
+        TEAM_RED, TEAM_WHITE, TEAM_YELLOW,
     },
 };
 
@@ -265,8 +266,8 @@ impl GamePhase {
         };
         match game_phase {
             GAME_PHASE_NORMAL => Ok(GamePhase::Normal),
-            GAME_PHASE_PENALTYSHOOT => Ok(GamePhase::PenaltyShootout { kicking_team: team }),
-            GAME_PHASE_EXTRATIME => Ok(GamePhase::Extratime),
+            GAME_PHASE_PENALTY_SHOOT_OUT => Ok(GamePhase::PenaltyShootout { kicking_team: team }),
+            GAME_PHASE_EXTRA_TIME => Ok(GamePhase::Extratime),
             GAME_PHASE_TIMEOUT => Ok(GamePhase::Timeout),
             _ => bail!("unexpected game phase"),
         }
@@ -468,7 +469,6 @@ pub enum PenaltyShoot {
 #[derive(Clone, Debug, Deserialize, Serialize, Message)]
 pub struct Player {
     pub penalty: Option<Penalty>,
-    pub warning: u8,
     pub caution: u8,
 }
 
@@ -479,7 +479,6 @@ impl TryFrom<RobotInfo> for Player {
         let remaining = Duration::from_secs(player.secsTillUnpenalised.into());
         Ok(Self {
             penalty: Penalty::try_from(remaining, player.penalty)?,
-            warning: player.warnings,
             caution: player.cautions,
         })
     }
@@ -500,6 +499,7 @@ impl TryFrom<RobotInfo> for Player {
 pub enum Penalty {
     IllegalPosition { remaining: Duration },
     MotionInSet { remaining: Duration },
+    MotionInStop { remaining: Duration },
     LocalGameStuck { remaining: Duration },
     IncapableRobot { remaining: Duration },
     PickUp { remaining: Duration },
@@ -507,6 +507,7 @@ pub enum Penalty {
     LeavingTheField { remaining: Duration },
     PlayingWithArmsHands { remaining: Duration },
     Pushing { remaining: Duration },
+    Cautioned { remaining: Duration },
     SentOff { remaining: Duration },
     Substitute { remaining: Duration },
 }
@@ -517,6 +518,7 @@ impl Penalty {
             PENALTY_NONE => Ok(None),
             PENALTY_ILLEGAL_POSITIONING => Ok(Some(Penalty::IllegalPosition { remaining })),
             PENALTY_MOTION_IN_SET => Ok(Some(Penalty::MotionInSet { remaining })),
+            PENALTY_MOTION_IN_STOP => Ok(Some(Penalty::MotionInStop { remaining })),
             PENALTY_LOCAL_GAME_STUCK => Ok(Some(Penalty::LocalGameStuck { remaining })),
             PENALTY_INCAPABLE_ROBOT => Ok(Some(Penalty::IncapableRobot { remaining })),
             PENALTY_PICK_UP => Ok(Some(Penalty::PickUp { remaining })),
@@ -526,6 +528,7 @@ impl Penalty {
                 Ok(Some(Penalty::PlayingWithArmsHands { remaining }))
             }
             PENALTY_PUSHING => Ok(Some(Penalty::Pushing { remaining })),
+            PENALTY_CAUTIONED => Ok(Some(Penalty::Cautioned { remaining })),
             PENALTY_SENT_OFF => Ok(Some(Penalty::SentOff { remaining })),
             PENALTY_SUBSTITUTE => Ok(Some(Penalty::Substitute { remaining })),
             _ => bail!("unexpected penalty type"),


### PR DESCRIPTION
## Why? What?

Adds new gamecontroler penaltys 

- Fixes #2674

## How to Test

Set Wifi on the robot and start  a gamecontroller in the same wifi.  The robot should connect to it and react to it
- and also test the new penaltys 
       - motion in stop
       - caution