### PR TITLE
Bump os_version to 1.6.2.2

### DIFF
--- a/hulk.toml
+++ b/hulk.toml
@@ -1,2 +1,2 @@
-os_version = "v1.6.1.1-release-01967-2026-04-27"
+os_version = "v1.6.2.2-release.global-02145-2026-06-03"
 sdk_version = "1.2.0"


### PR DESCRIPTION
## Why? What?

Bumps the os version to the latest version 1.6.2.2.
