### PR TITLE
avoid crash when alsa device busy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6671,6 +6671,7 @@ name = "microphone_recorder"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "log",
  "microphones",
  "ros-z",
  "serde",

--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -136,7 +136,7 @@ async fn spawn_all(ctx: Arc<Context>) -> Result<RunningStack> {
     join_set.spawn(low_state_bridge::run_boxed(ctx.clone()));
     join_set.spawn(message_filter::run_boxed(ctx.clone()));
     join_set.spawn(message_handler::run_boxed(ctx.clone()));
-    // join_set.spawn(microphone_recorder::run_boxed(ctx.clone()));
+    join_set.spawn(microphone_recorder::run_boxed(ctx.clone()));
     join_set.spawn(motor_commands_collector::run_boxed(ctx.clone()));
     join_set.spawn(obstacle_filter::run_boxed(ctx.clone()));
     join_set.spawn(odometer_bridge::run_boxed(ctx.clone()));

--- a/crates/nodes/microphone_recorder/Cargo.toml
+++ b/crates/nodes/microphone_recorder/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 
 [dependencies]
 color-eyre = { workspace = true }
+log = { workspace = true }
 microphones = { workspace = true }
 ros-z = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nodes/microphone_recorder/src/lib.rs
+++ b/crates/nodes/microphone_recorder/src/lib.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::{boxed::Box, future::Future, pin::Pin};
 
 use color_eyre::Result;
+use log::warn;
 
 use microphones::{parameters::Parameters as MicrophonesParameters, reader::Microphones};
 use ros_z::{context::Context, parameter::NodeParametersExt};
@@ -23,7 +24,13 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let parameters_snapshot = parameters.snapshot();
     let parameters = parameters_snapshot.typed();
-    let mut microphones = Microphones::new(parameters.clone())?;
+    let mut microphones = match Microphones::new(parameters.clone()) {
+        Ok(microphones) => microphones,
+        Err(error) => {
+            warn!("failed to create microphones: {error:#?}");
+            return Ok(());
+        }
+    };
 
     loop {
         let samples = microphones.retrying_read()?;


### PR DESCRIPTION
## Why? What?

re-enable microphone crate and avoid crash when alsa device busy, logs the error and not use the microphone

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

Test with changing the hardware_device_name or when robot crashes again. 
