### PR TITLE
Add missing HSL networks

### DIFF
--- a/crates/argument_parsers/src/lib.rs
+++ b/crates/argument_parsers/src/lib.rs
@@ -36,6 +36,10 @@ pub const NETWORK_POSSIBLE_VALUES: &[&str] = &[
     "HSL_D",
     "HSL_E",
     "HSL_F",
+    "HSL_G",
+    "HSL_H",
+    "HSL_I",
+    "HSL_J",
     "HSL_HULKs",
 ];
 
@@ -48,6 +52,10 @@ pub fn parse_network(network: &str) -> Result<Network> {
         "HSL_D" => Ok(Network::HslD),
         "HSL_E" => Ok(Network::HslE),
         "HSL_F" => Ok(Network::HslF),
+        "HSL_G" => Ok(Network::HslG),
+        "HSL_H" => Ok(Network::HslH),
+        "HSL_I" => Ok(Network::HslI),
+        "HSL_J" => Ok(Network::HslJ),
         "HSL_HULKs" => Ok(Network::HslHulks),
         _ => bail!("unexpected network"),
     }

--- a/crates/robot/src/lib.rs
+++ b/crates/robot/src/lib.rs
@@ -526,6 +526,10 @@ pub enum Network {
     HslD,
     HslE,
     HslF,
+    HslG,
+    HslH,
+    HslI,
+    HslJ,
     HslHulks,
 }
 
@@ -539,13 +543,17 @@ impl Display for Network {
             Network::HslD => formatter.write_str("HSL_D"),
             Network::HslE => formatter.write_str("HSL_E"),
             Network::HslF => formatter.write_str("HSL_F"),
+            Network::HslG => formatter.write_str("HSL_G"),
+            Network::HslH => formatter.write_str("HSL_H"),
+            Network::HslI => formatter.write_str("HSL_I"),
+            Network::HslJ => formatter.write_str("HSL_J"),
             Network::HslHulks => formatter.write_str("HSL_HULKs"),
         }
     }
 }
 
 impl Network {
-    pub fn all() -> [Network; 7] {
+    pub fn all() -> [Network; 11] {
         [
             Network::HslA,
             Network::HslB,
@@ -553,6 +561,10 @@ impl Network {
             Network::HslD,
             Network::HslE,
             Network::HslF,
+            Network::HslG,
+            Network::HslH,
+            Network::HslI,
+            Network::HslJ,
             Network::HslHulks,
         ]
     }


### PR DESCRIPTION
## Why? What?

Adds RC26 wifi networks to pepsi.

## Ideas for Next Iterations (Not This PR)

- Accept any "HSL_*" network.

## How to Test

`pepsi wifi set HSL_J`