### PR TITLE
Add no message behavior

### DIFF
--- a/crates/bevyhavior_simulator/src/behavior_runtime.rs
+++ b/crates/bevyhavior_simulator/src/behavior_runtime.rs
@@ -120,7 +120,7 @@ impl SimulatorRobotBehavior {
         game_controller_address: Option<SocketAddr>,
     ) -> Vec<OutgoingMessage> {
         self.blackboard.world_state = world_state;
-        self.blackboard.parameters.hsl_network = hsl_network_parameters;
+        self.blackboard.hsl_network_parameters = hsl_network_parameters;
 
         let mut outgoing_messages = Vec::new();
         if let Some(message) = self
@@ -180,6 +180,7 @@ fn create_behavior_blackboard(parameters: BehaviorParameters) -> BehaviorBlackbo
         body_motion: None,
         head_motion: None,
         voronoi_map: None,
+        hsl_network_parameters: HslNetworkParameters::default(),
     }
 }
 

--- a/crates/bevyhavior_simulator/src/behavior_tree_simulator.rs
+++ b/crates/bevyhavior_simulator/src/behavior_tree_simulator.rs
@@ -34,8 +34,7 @@ pub use crate::communication::{
 };
 pub use crate::config::{
     DEFAULT_TICK_DURATION, SimulationConfig, default_behavior_parameters,
-    default_hsl_network_parameters,
-    default_walking_parameters,
+    default_hsl_network_parameters, default_walking_parameters,
 };
 pub use crate::game_controller::SimulatorGameState;
 pub use crate::invariant_checks::{
@@ -450,7 +449,7 @@ mod tests {
     use linear_algebra::{Isometry2, point, vector};
     use types::{
         field_dimensions::Side, motion_command::MotionCommand, primary_state::PrimaryState,
-    };    
+    };
     #[test]
     fn plugin_initializes_live_message_budget_from_simulation_config() {
         let mut app = App::new();

--- a/crates/bevyhavior_simulator/src/behavior_tree_simulator.rs
+++ b/crates/bevyhavior_simulator/src/behavior_tree_simulator.rs
@@ -34,6 +34,7 @@ pub use crate::communication::{
 };
 pub use crate::config::{
     DEFAULT_TICK_DURATION, SimulationConfig, default_behavior_parameters,
+    default_hsl_network_parameters,
     default_walking_parameters,
 };
 pub use crate::game_controller::SimulatorGameState;
@@ -111,7 +112,8 @@ impl Default for BehaviorTreeSimulatorPlugin {
             config: SimulationConfig::default(),
             auto_referee_config: AutoRefereeConfig::default(),
             field_dimensions: FieldDimensions::SPL_2025,
-            hsl_network_parameters: HslNetworkParameters::default(),
+            hsl_network_parameters: default_hsl_network_parameters()
+                .expect("failed to load default HSL network parameters"),
             tick_duration: DEFAULT_TICK_DURATION,
             enable_default_ball_physics: true,
             enable_default_kinematics: true,
@@ -448,8 +450,7 @@ mod tests {
     use linear_algebra::{Isometry2, point, vector};
     use types::{
         field_dimensions::Side, motion_command::MotionCommand, primary_state::PrimaryState,
-    };
-
+    };    
     #[test]
     fn plugin_initializes_live_message_budget_from_simulation_config() {
         let mut app = App::new();

--- a/crates/bevyhavior_simulator/src/config.rs
+++ b/crates/bevyhavior_simulator/src/config.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, time::Duration};
 
 use color_eyre::{Result, eyre::Context};
 use serde::Deserialize;
-use types::parameters::{BehaviorParameters, RLWalkingParameters};
+use types::parameters::{BehaviorParameters, HslNetworkParameters, RLWalkingParameters};
 
 pub const DEFAULT_TICK_DURATION: Duration = Duration::from_millis(10);
 
@@ -60,6 +60,19 @@ pub fn default_behavior_parameters() -> Result<BehaviorParameters> {
         "../../../etc/parameters/ros_z/base/behavior_node.json5"
     ))
     .wrap_err("failed to parse behavior parameters")
+}
+
+#[derive(Deserialize)]
+struct GlobalParametersFile {
+    hsl_network: HslNetworkParameters,
+}
+
+pub fn default_hsl_network_parameters() -> Result<HslNetworkParameters> {
+    let file: GlobalParametersFile = json5::from_str(include_str!(
+        "../../../etc/parameters/ros_z/base/global.json5"
+    ))
+    .wrap_err("failed to parse global parameters")?;
+    Ok(file.hsl_network)
 }
 
 #[derive(Deserialize)]

--- a/crates/control/src/free_kick_signal_filter.rs
+++ b/crates/control/src/free_kick_signal_filter.rs
@@ -59,7 +59,7 @@ pub struct CycleContext {
     message_grace_period:
         Parameter<Duration, "free_kick_signal_detection_filter.message_grace_period">,
     message_interval: Parameter<Duration, "free_kick_signal_detection_filter.message_interval">,
-    hsl_network_parameters: Parameter<HslNetworkParameters, "behavior.hsl_network">,
+    hsl_network_parameters: Parameter<HslNetworkParameters, "hsl_network">,
 
     free_kick_detection_times: AdditionalOutput<
         Players<Option<TimeTaggedKickingTeamDetections>>,

--- a/crates/control/src/ready_signal_detection_filter.rs
+++ b/crates/control/src/ready_signal_detection_filter.rs
@@ -56,7 +56,7 @@ pub struct CycleContext {
         Parameter<usize, "ready_signal_detection_filter.minimum_number_poses_before_message">,
     message_grace_period: Parameter<Duration, "ready_signal_detection_filter.message_grace_period">,
     message_interval: Parameter<Duration, "ready_signal_detection_filter.message_interval">,
-    hsl_network_parameters: Parameter<HslNetworkParameters, "behavior.hsl_network">,
+    hsl_network_parameters: Parameter<HslNetworkParameters, "hsl_network">,
 
     ready_signal_detection_times:
         AdditionalOutput<Players<Option<SystemTime>>, "player_referee_detection_times">,

--- a/crates/nodes/behavior_node/src/conditions.rs
+++ b/crates/nodes/behavior_node/src/conditions.rs
@@ -188,3 +188,17 @@ pub fn hulks_is_kicking_team(blackboard: &mut Blackboard) -> bool {
         })
     )
 }
+
+pub fn out_of_messages(blackboard: &mut Blackboard) -> bool {
+    blackboard
+        .world_state
+        .filtered_game_controller_state
+        .as_ref()
+        .map(|state| state.remaining_number_of_messages)
+        .is_none_or(|remaining_amount_of_messages| {
+            remaining_amount_of_messages
+                < blackboard
+                    .hsl_network_parameters
+                    .remaining_amount_of_messages_to_stop_sending
+        })
+}

--- a/crates/nodes/behavior_node/src/node.rs
+++ b/crates/nodes/behavior_node/src/node.rs
@@ -18,7 +18,7 @@ use types::{
     motion_command::{BodyMotion, HeadMotion, MotionCommand},
     motion_type::MotionType,
     obstacles::Obstacle,
-    parameters::BehaviorParameters,
+    parameters::{BehaviorParameters, HslNetworkParameters},
     path_obstacles::PathObstacle,
     players::Players,
     primary_state::PrimaryState,
@@ -42,6 +42,7 @@ pub struct LastBall {
 pub struct Blackboard {
     pub field_dimensions: FieldDimensions,
     pub parameters: BehaviorParameters,
+    pub hsl_network_parameters: HslNetworkParameters,
     pub world_state: WorldState,
 
     pub path_obstacles_output: Vec<PathObstacle>,
@@ -136,9 +137,17 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .cache(1)
         .build()
         .await?;
-
     let player_number_cache = node
         .subscriber::<PlayerNumber>("player_number")
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
+        .cache(1)
+        .build()
+        .await?;
+    let hsl_network_parameters_cache = node
+        .subscriber::<HslNetworkParameters>("hsl_network_parameters")
         .qos(QosProfile {
             durability: QosDurability::TransientLocal,
             ..Default::default()
@@ -253,6 +262,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             .map(|dimensions| *dimensions)
             .unwrap_or_default(),
         parameters: parameters.snapshot().typed().clone(),
+        hsl_network_parameters: hsl_network_parameters_cache
+            .get_latest()
+            .map(|params| params.as_ref().clone())
+            .unwrap_or_default(),
         world_state: WorldState::default(),
 
         path_obstacles_output: Vec::new(),
@@ -297,6 +310,12 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             .map(|n| *n)
             .unwrap_or_default();
         blackboard.parameters = parameters.snapshot().typed().clone();
+
+        let hsl_network_messages = hsl_network_parameters_cache
+            .get_latest()
+            .map(|params| params.as_ref().clone())
+            .unwrap_or_default();
+        blackboard.hsl_network_parameters = hsl_network_messages;
 
         let player_states = player_states_cache
             .get_latest()

--- a/crates/nodes/behavior_node/src/send_message.rs
+++ b/crates/nodes/behavior_node/src/send_message.rs
@@ -14,7 +14,7 @@ impl Blackboard {
     ) -> Option<OutgoingMessage> {
         let now = self.world_state.now;
 
-        if !self.is_return_message_cooldown_elapsed(now, &self.parameters.hsl_network) {
+        if !self.is_return_message_cooldown_elapsed(now, &self.hsl_network_parameters) {
             return None;
         }
         let address = game_controller_address?;
@@ -68,14 +68,13 @@ impl Blackboard {
             .as_ref()
             .map(|state| state.remaining_number_of_messages);
 
-        if !self.is_state_message_cooldown_elapsed(now, &self.parameters.hsl_network) {
+        if !self.is_state_message_cooldown_elapsed(now, &self.hsl_network_parameters) {
             return None;
         }
         if remaining_amount_of_messages.is_none_or(|remaining_amount_of_messages| {
             remaining_amount_of_messages
                 < self
-                    .parameters
-                    .hsl_network
+                    .hsl_network_parameters
                     .remaining_amount_of_messages_to_stop_sending
         }) {
             return None;

--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -8,6 +8,7 @@ use crate::{
     conditions::{
         has_ball_position, is_ball_interception_candidate, is_close_to_ball, is_closest_to_ball,
         is_fallen, is_goalkeeper, is_primary_state, is_remote_controlled, is_remote_kick_mode,
+        out_of_messages,
     },
     head::{look_at_ball_subtree, look_straight_ahead, search_for_lost_ball_subtree},
     kick::{intercept, kick, kick_power_subtree, kick_subtree, set_kick_target_in_front},
@@ -75,6 +76,7 @@ fn ready_subtree() -> Node<Blackboard> {
 
 fn playing_subtree() -> Node<Blackboard> {
     selection!(
+        sequence!(condition!(out_of_messages), subtree!(striker_subtree)),
         sequence!(condition!(is_goalkeeper), subtree!(goalkeeper_subtree)),
         sequence!(
             negation!(condition!(has_ball_position)),

--- a/crates/nodes/global_parameter_provider/src/lib.rs
+++ b/crates/nodes/global_parameter_provider/src/lib.rs
@@ -5,13 +5,14 @@ use hsl_network_messages::PlayerNumber;
 use serde::{Deserialize, Serialize};
 
 use ros_z::{prelude::*, qos::QosDurability};
-use types::field_dimensions::FieldDimensions;
+use types::{field_dimensions::FieldDimensions, parameters::HslNetworkParameters};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
 #[serde(deny_unknown_fields)]
 pub struct Parameters {
     pub player_number: PlayerNumber,
     pub field_dimensions: FieldDimensions,
+    pub hsl_network: HslNetworkParameters,
 }
 
 pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
@@ -41,13 +42,22 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
 
+    let hsl_network_pub = node
+        .publisher::<HslNetworkParameters>("hsl_network_parameters")
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
+        .build()
+        .await?;
+
     let parameters_snapshot = node_parameters.snapshot();
     let parameters = parameters_snapshot.typed();
     player_number_pub.publish(&parameters.player_number).await?;
     field_dimensions_pub
         .publish(&parameters.field_dimensions)
         .await?;
-
+    hsl_network_pub.publish(&parameters.hsl_network).await?;
     let mut parameters_receiver = node_parameters.subscribe();
     loop {
         let _ = parameters_receiver.changed().await;
@@ -58,5 +68,6 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         field_dimensions_pub
             .publish(&parameters.field_dimensions.clone())
             .await?;
+        hsl_network_pub.publish(&parameters.hsl_network).await?;
     }
 }

--- a/crates/nodes/player_state_receiver/src/lib.rs
+++ b/crates/nodes/player_state_receiver/src/lib.rs
@@ -5,8 +5,8 @@ use hsl_network_messages::HulkMessage;
 use ros_z::{prelude::*, qos::QosDurability};
 use types::{
     ball_position::BallPosition, filtered_game_controller_state::FilteredGameControllerState,
-    messages::IncomingMessage, players::Players, time_wrapper::TimeWrapper,
-    world_state::PlayerState,
+    messages::IncomingMessage, parameters::HslNetworkParameters, players::Players,
+    time_wrapper::TimeWrapper, world_state::PlayerState,
 };
 
 pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
@@ -23,6 +23,15 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .subscriber::<TimeWrapper<IncomingMessage>>("filtered_message")
         .build()
         .await?;
+    let hsl_network_parameters_cache = node
+        .subscriber::<HslNetworkParameters>("hsl_network_parameters")
+        .qos(QosProfile {
+            durability: QosDurability::TransientLocal,
+            ..Default::default()
+        })
+        .cache(1)
+        .build()
+        .await?;
     let player_states_pub = node
         .publisher::<Players<Option<TimeWrapper<PlayerState>>>>("player_states")
         .qos(QosProfile {
@@ -36,8 +45,14 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
     loop {
         tokio::select! {
             received_game_controller_state = filtered_game_controller_state_sub.recv() => {
+                let Some(hsl_network_parameters) = hsl_network_parameters_cache.get_latest() else {continue};
+
                 let game_controller_state = received_game_controller_state?;
-                clear_penalized_players(&mut player_states, &game_controller_state);
+                apply_game_controller_state(
+                    &mut player_states,
+                    &game_controller_state,
+                    &hsl_network_parameters,
+                );
                 player_states_pub.publish(&player_states).await?;
             }
             received_message = filtered_message_sub.recv() => {
@@ -45,6 +60,19 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                 player_states_pub.publish(&player_states).await?;
             }
         }
+    }
+}
+
+fn apply_game_controller_state(
+    player_states: &mut Players<Option<TimeWrapper<PlayerState>>>,
+    game_controller_state: &FilteredGameControllerState,
+    hsl_network_parameters: &HslNetworkParameters,
+) {
+    clear_penalized_players(player_states, game_controller_state);
+    if game_controller_state.remaining_number_of_messages
+        < hsl_network_parameters.remaining_amount_of_messages_to_stop_sending
+    {
+        clear_all_players(player_states);
     }
 }
 
@@ -80,6 +108,10 @@ fn clear_penalized_players(
             player_states[player_number] = None;
         }
     }
+}
+
+fn clear_all_players(player_states: &mut Players<Option<TimeWrapper<PlayerState>>>) {
+    *player_states = Players::new(None);
 }
 
 #[cfg(test)]
@@ -141,5 +173,26 @@ mod tests {
 
         assert!(states[PlayerNumber::Two].is_none());
         assert!(states[PlayerNumber::Three].is_some());
+    }
+
+    #[test]
+    fn all_players_are_cleared_below_remaining_message_threshold() {
+        let mut states = Players::new(Some(TimeWrapper {
+            time: Time::from_nanos(10),
+            inner: PlayerState::default(),
+        }));
+
+        let game_controller_state = FilteredGameControllerState {
+            remaining_number_of_messages: 2,
+            ..Default::default()
+        };
+        let hsl_network_parameters = HslNetworkParameters {
+            remaining_amount_of_messages_to_stop_sending: 3,
+            ..Default::default()
+        };
+
+        apply_game_controller_state(&mut states, &game_controller_state, &hsl_network_parameters);
+
+        assert!(states.iter().all(|(_, state)| state.is_none()));
     }
 }

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -96,7 +96,6 @@ pub struct BehaviorParameters {
     pub intercept_ball: InterceptBallParameters,
     pub substates: SubstatesParameters,
     pub voronoi: VoronoiParameters,
-    pub hsl_network: HslNetworkParameters,
     pub closest_to_ball_enter_duration: Duration,
     pub closest_to_ball_exit_duration: Duration,
 }

--- a/crates/world_state/src/behavior/node.rs
+++ b/crates/world_state/src/behavior/node.rs
@@ -10,6 +10,7 @@ use hardware::NetworkInterface;
 use hsl_network_messages::HulkMessage;
 use linear_algebra::{Point2, Pose2, Vector2};
 use serde::{Deserialize, Serialize};
+use types::parameters::HslNetworkParameters;
 use types::{
     behavior_tree::NodeTrace,
     field_dimensions::{FieldDimensions, Side},
@@ -115,6 +116,7 @@ pub struct CycleContext {
 
     field_dimensions: Parameter<FieldDimensions, "field_dimensions">,
     parameters: Parameter<BehaviorParameters, "behavior">,
+    hsl_network_parameters: Parameter<HslNetworkParameters, "hsl_network">,
     free_kick_obstacle_radius: Parameter<f32, "rule_obstacles.free_kick_obstacle_radius">,
 
     behavior_trace: AdditionalOutput<NodeTrace, "behavior.trace">,
@@ -232,13 +234,13 @@ impl Behavior {
         self.send_game_controller_return_message(
             context.world_state,
             context.game_controller_address,
-            &context.parameters.hsl_network,
+            context.hsl_network_parameters,
             context.hardware,
         )?;
 
         self.send_state_message(
             context.world_state,
-            &context.parameters.hsl_network,
+            context.hsl_network_parameters,
             context.remaining_amount_of_messages,
             &mut context.last_sent_message,
             context.hardware,

--- a/crates/world_state/src/player_states_receiver.rs
+++ b/crates/world_state/src/player_states_receiver.rs
@@ -38,7 +38,7 @@ pub struct CycleContext {
     network_message: PerceptionInput<Option<IncomingMessage>, "HslNetwork", "filtered_message?">,
 
     player_number: Parameter<PlayerNumber, "player_number">,
-    hsl_network_parameters: Parameter<HslNetworkParameters, "behavior.hsl_network">,
+    hsl_network_parameters: Parameter<HslNetworkParameters, "hsl_network">,
 
     hardware: HardwareInterface,
 }

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -539,25 +539,25 @@
       "padding": 0.5
     }
   },
-      "hsl_network": {
-      "game_controller_return_message_interval": {
-        "nanos": 0,
-        "secs": 1
-      },
-      "remaining_amount_of_messages_to_stop_sending": 20,
-      "silence_interval_between_messages": {
-        "nanos": 0,
-        "secs": 1
-      },
-      "hsl_striker_message_receive_timeout": {
-        "nanos": 0,
-        "secs": 3
-      },
-      "hsl_state_message_send_interval": {
-        "nanos": 0,
-        "secs": 2
-      }
+  "hsl_network": {
+    "game_controller_return_message_interval": {
+      "nanos": 0,
+      "secs": 1
     },
+    "remaining_amount_of_messages_to_stop_sending": 20,
+    "silence_interval_between_messages": {
+      "nanos": 0,
+      "secs": 1
+    },
+    "hsl_striker_message_receive_timeout": {
+      "nanos": 0,
+      "secs": 3
+    },
+    "hsl_state_message_send_interval": {
+      "nanos": 0,
+      "secs": 2
+    }
+  },
   "field_dimensions": {
     "ball_radius": 0.095,
     "length": 9.0,

--- a/etc/parameters/default.json
+++ b/etc/parameters/default.json
@@ -537,8 +537,9 @@
       "orientation_bias": 0.5,
       "grid_resolution": 0.2,
       "padding": 0.5
-    },
-    "hsl_network": {
+    }
+  },
+      "hsl_network": {
       "game_controller_return_message_interval": {
         "nanos": 0,
         "secs": 1
@@ -556,8 +557,7 @@
         "nanos": 0,
         "secs": 2
       }
-    }
-  },
+    },
   "field_dimensions": {
     "ball_radius": 0.095,
     "length": 9.0,

--- a/etc/parameters/ros_z/base/behavior_node.json5
+++ b/etc/parameters/ros_z/base/behavior_node.json5
@@ -142,23 +142,4 @@
     grid_resolution: 0.2,
     padding: 0.5,
   },
-  hsl_network: {
-    game_controller_return_message_interval: {
-      nanos: 0,
-      secs: 1,
-    },
-    remaining_amount_of_messages_to_stop_sending: 20,
-    silence_interval_between_messages: {
-      nanos: 0,
-      secs: 1,
-    },
-    hsl_striker_message_receive_timeout: {
-      nanos: 0,
-      secs: 3,
-    },
-    hsl_state_message_send_interval: {
-      nanos: 0,
-      secs: 2,
-    },
-  },
 }

--- a/etc/parameters/ros_z/base/global.json5
+++ b/etc/parameters/ros_z/base/global.json5
@@ -18,4 +18,23 @@
     corner_arc_radius: 0.0,
   },
   player_number: "Three",
+  hsl_network: {
+    game_controller_return_message_interval: {
+      nanos: 0,
+      secs: 1,
+    },
+    remaining_amount_of_messages_to_stop_sending: 20,
+    silence_interval_between_messages: {
+      nanos: 0,
+      secs: 1,
+    },
+    hsl_striker_message_receive_timeout: {
+      nanos: 0,
+      secs: 3,
+    },
+    hsl_state_message_send_interval: {
+      nanos: 0,
+      secs: 2,
+    },
+  },
 }


### PR DESCRIPTION
## Why? What?

removes stale inputs in player_state_filter when we dont have any messages anymore.
and adds a condition when we have no messages anymore to get striker

## How to Test

test if we are out off messages if the robot the goes into that part of the tree and if the player_state is None for every player.
