### PR TITLE
more messages

### DIFF
--- a/etc/parameters/ros_z/base/behavior_node.json5
+++ b/etc/parameters/ros_z/base/behavior_node.json5
@@ -157,8 +157,8 @@
       secs: 3,
     },
     hsl_state_message_send_interval: {
-      nanos: 0,
-      secs: 2,
+      nanos: 300000000,
+      secs: 0,
     },
   },
 }


### PR DESCRIPTION
## Why? What?

make message interval faster  6000 per halftime 2000 per robot,
2000 / 600s (Playtime) = 3.333 Hz or every 300000000ns

we have spare messages because we only sen in playing

## How to Test

test if we send messages in this interval