### PR TITLE
Add ROS-Z observation policy

### DIFF
--- a/crates/ros-z-debug/src/builder.rs
+++ b/crates/ros-z-debug/src/builder.rs
@@ -31,7 +31,7 @@ pub struct CachedSubscriptionBuilder {
     node: Arc<Node>,
     topic: TopicReference,
     target_identity: TargetIdentity,
-    retention: RetentionPolicy,
+    policy: ObservationPolicy,
     schema_discovery_timeout: Duration,
 }
 
@@ -42,15 +42,26 @@ impl CachedSubscriptionBuilder {
             node,
             topic: TopicReference::new(topic.into())?,
             target_identity: TargetIdentity::new("/").expect("root namespace is valid"),
-            retention: RetentionPolicy::LatestOnly,
+            policy: ObservationPolicy::default(),
             schema_discovery_timeout: Duration::from_secs(5),
         })
     }
 
     /// Configure how many samples the handle retains.
     pub fn retention(mut self, retention: RetentionPolicy) -> Self {
-        self.retention = retention;
+        self.policy = self.policy.with_retention(retention);
         self
+    }
+
+    /// Configure this cached subscription with a full observation policy.
+    pub fn policy(mut self, policy: ObservationPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Return the configured observation policy.
+    pub fn observation_policy(&self) -> ObservationPolicy {
+        self.policy
     }
 
     /// Configure the target identity used to resolve topic references.
@@ -90,7 +101,7 @@ impl CachedSubscriptionBuilder {
 
     /// Configured retention policy.
     pub fn retention_policy(&self) -> RetentionPolicy {
-        self.retention
+        self.policy.retention()
     }
 
     /// Build the typed subscription and spawn its receive task.
@@ -103,11 +114,21 @@ impl CachedSubscriptionBuilder {
             node,
             topic,
             target_identity,
-            retention,
+            policy,
             schema_discovery_timeout: _,
         } = self;
         let resolved_topic = topic.resolve(&target_identity)?;
-        let subscriber = node.subscriber::<T>(&resolved_topic).build().await?;
+        let mut subscriber_builder = node.subscriber::<T>(&resolved_topic);
+        if let Some(qos) = policy.subscriber_qos() {
+            subscriber_builder = subscriber_builder.qos(qos);
+        }
+        if let Some(queue_capacity) = policy.subscriber_queue_capacity() {
+            subscriber_builder = subscriber_builder.queue_capacity(queue_capacity);
+        }
+        let subscriber = subscriber_builder
+            .queue_overflow_reporting(policy.queue_overflow_reporting())
+            .build()
+            .await?;
         let type_info = subscriber.entity().type_info.clone();
         let metadata = Arc::new(SampleMetadata {
             topic_reference: topic,
@@ -120,8 +141,8 @@ impl CachedSubscriptionBuilder {
                 resolved_topic,
                 type_info,
             ),
-            retention,
-            ObservationPolicy::default().update_buffer_capacity(),
+            policy.retention(),
+            policy.update_buffer_capacity(),
             move |state, cancellation| {
                 receive_typed_loop(subscriber, state, cancellation, metadata)
             },
@@ -151,12 +172,20 @@ impl CachedSubscriptionBuilder {
             node,
             topic,
             target_identity,
-            retention,
+            policy,
             schema_discovery_timeout,
         } = self;
         let resolved_topic = topic.resolve(&target_identity)?;
-        let subscriber = node
-            .dynamic_subscriber_auto(&resolved_topic, schema_discovery_timeout)
+        let mut subscriber_builder =
+            node.dynamic_subscriber_auto(&resolved_topic, schema_discovery_timeout);
+        if let Some(qos) = policy.subscriber_qos() {
+            subscriber_builder = subscriber_builder.qos(qos);
+        }
+        if let Some(queue_capacity) = policy.subscriber_queue_capacity() {
+            subscriber_builder = subscriber_builder.queue_capacity(queue_capacity);
+        }
+        let subscriber = subscriber_builder
+            .queue_overflow_reporting(policy.queue_overflow_reporting())
             .build()
             .await?;
         let type_info = subscriber.entity().type_info.clone();
@@ -171,8 +200,8 @@ impl CachedSubscriptionBuilder {
                 resolved_topic,
                 type_info,
             ),
-            retention,
-            ObservationPolicy::default().update_buffer_capacity(),
+            policy.retention(),
+            policy.update_buffer_capacity(),
             move |state, cancellation| {
                 receive_dynamic_loop(subscriber, state, cancellation, metadata)
             },
@@ -289,8 +318,11 @@ fn classify_receive_error(error: &ros_z::Error, message: String) -> CachedSubscr
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_receive_error, receive_error_diagnostic};
-    use crate::{CachedSubscriptionStatus, SampleMetadata, TopicReference};
+    use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+
+    use ros_z::context::ContextBuilder;
+
+    use super::*;
 
     fn test_metadata() -> SampleMetadata {
         SampleMetadata {
@@ -335,5 +367,32 @@ mod tests {
         assert!(message.contains("/debug"));
         assert!(message.contains("test_msgs::DebugValue"));
         assert!(message.contains("failed to deserialize cdr payload"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cached_subscription_builder_policy_can_be_configured() -> Result<()> {
+        let context = ContextBuilder::default()
+            .disable_multicast_scouting()
+            .with_json("connect/endpoints", serde_json::json!([]))
+            .build()
+            .await?;
+        let node = Arc::new(context.create_node("policy_builder").build().await?);
+        let capacity = NonZeroUsize::new(64).unwrap();
+        let policy = ObservationPolicy::latest().with_subscriber_queue_capacity(capacity);
+
+        let builder = CachedSubscriptionBuilder::new(node, "debug_text")?.policy(policy);
+
+        assert_eq!(builder.observation_policy(), policy);
+
+        let builder = builder.retention(RetentionPolicy::time_window(Duration::from_secs(1))?);
+        assert!(matches!(
+            builder.observation_policy().retention(),
+            RetentionPolicy::TimeWindow(_)
+        ));
+        assert_eq!(
+            builder.observation_policy().subscriber_queue_capacity(),
+            Some(capacity)
+        );
+        Ok(())
     }
 }

--- a/crates/ros-z-debug/src/builder.rs
+++ b/crates/ros-z-debug/src/builder.rs
@@ -5,8 +5,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     CachedJsonSubscription, CachedSubscription, CachedSubscriptionStatus,
-    CachedSubscriptionStatusSnapshot, JsonRenderPolicy, Result, RetentionPolicy, SampleMetadata,
-    SampleRecord, TargetIdentity, TopicReference, cache::CachedSubscriptionState,
+    CachedSubscriptionStatusSnapshot, JsonRenderPolicy, ObservationPolicy, Result, RetentionPolicy,
+    SampleMetadata, SampleRecord, TargetIdentity, TopicReference, cache::CachedSubscriptionState,
 };
 
 /// Convenience methods for creating cached debug subscriptions from a `ros-z` node.
@@ -121,6 +121,7 @@ impl CachedSubscriptionBuilder {
                 type_info,
             ),
             retention,
+            ObservationPolicy::default().update_buffer_capacity(),
             move |state, cancellation| {
                 receive_typed_loop(subscriber, state, cancellation, metadata)
             },
@@ -171,6 +172,7 @@ impl CachedSubscriptionBuilder {
                 type_info,
             ),
             retention,
+            ObservationPolicy::default().update_buffer_capacity(),
             move |state, cancellation| {
                 receive_dynamic_loop(subscriber, state, cancellation, metadata)
             },

--- a/crates/ros-z-debug/src/cache.rs
+++ b/crates/ros-z-debug/src/cache.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use arc_swap::ArcSwapOption;
 use parking_lot::Mutex;
@@ -14,8 +14,6 @@ use crate::{
     history::TimeIndexedHistory,
     sample::{dynamic_record_json_value, dynamic_record_to_json_sample},
 };
-
-const UPDATE_BUFFER_CAPACITY: usize = 256;
 
 /// Handle for reading retained subscription state.
 ///
@@ -153,13 +151,14 @@ impl<V> CachedSubscriptionState<V> {
     pub(crate) fn new(
         status: CachedSubscriptionStatusSnapshot,
         retention: RetentionPolicy,
+        update_buffer_capacity: NonZeroUsize,
     ) -> Self {
         let history = match retention {
             RetentionPolicy::LatestOnly => None,
             RetentionPolicy::TimeWindow(_) => Some(Mutex::new(TimeIndexedHistory::new(retention))),
         };
 
-        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+        let (updates, _) = broadcast::channel(update_buffer_capacity.get());
 
         Self {
             latest: ArcSwapOption::empty(),
@@ -172,6 +171,7 @@ impl<V> CachedSubscriptionState<V> {
     pub(crate) fn spawn<F, Fut>(
         status: CachedSubscriptionStatusSnapshot,
         retention: RetentionPolicy,
+        update_buffer_capacity: NonZeroUsize,
         receive_loop: F,
     ) -> Arc<Self>
     where
@@ -179,7 +179,7 @@ impl<V> CachedSubscriptionState<V> {
         Fut: std::future::Future<Output = ()> + Send + 'static,
         V: Send + Sync + 'static,
     {
-        let state = Arc::new(Self::new(status, retention));
+        let state = Arc::new(Self::new(status, retention, update_buffer_capacity));
         let weak_state = Arc::downgrade(&state);
         let cancellation = state.cancellation_token();
 
@@ -299,7 +299,7 @@ impl<V> Drop for CachedSubscriptionState<V> {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
     use ros_z::{
         dynamic::{DynamicPayload, DynamicValue, PrimitiveTypeDef, SchemaBundle, TypeDef},
@@ -381,6 +381,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let record = sample_record(NonClonePayload(7));
 
@@ -396,6 +397,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+            NonZeroUsize::new(256).unwrap(),
         ));
         let first = sample_record_at(NonClonePayload(1), Time::from_nanos(1));
         let second = sample_record_at(NonClonePayload(2), Time::from_nanos(2));
@@ -416,6 +418,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+            NonZeroUsize::new(256).unwrap(),
         ));
         state.store_latest(sample_record_at(NonClonePayload(1), Time::from_nanos(1)));
 
@@ -431,6 +434,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let record = sample_record_at(NonClonePayload(3), Time::from_nanos(3));
 
@@ -450,6 +454,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -474,6 +479,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
 
@@ -488,6 +494,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -510,6 +517,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -540,6 +548,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
 
         state.store_latest(sample_record(NonClonePayload(1)));
@@ -555,6 +564,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -573,6 +583,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
 
@@ -589,6 +600,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let record = sample_record(NonClonePayload(11));
@@ -606,6 +618,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let first = sample_record_at(NonClonePayload(1), Time::from_nanos(1));
@@ -627,6 +640,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -645,6 +659,7 @@ mod tests {
         let state = CachedSubscriptionState::<NonClonePayload>::spawn(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
             move |_state, cancellation| async move {
                 cancellation.cancelled().await;
                 let _ = exited_sender.send(());
@@ -665,6 +680,7 @@ mod tests {
         let state = CachedSubscriptionState::<NonClonePayload>::spawn(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
             move |_state, cancellation| async move {
                 cancellation.cancelled().await;
                 let _ = exited_sender.send(());
@@ -686,6 +702,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -706,6 +723,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -729,6 +747,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = state.handle();
         let mut updates = handle.subscribe_updates().unwrap();
@@ -748,6 +767,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         state.store_latest(dynamic_record_at(42, Time::zero()));
         let handle = CachedJsonSubscription::new(state.handle(), JsonRenderPolicy::default());
@@ -760,6 +780,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let source = dynamic_record_at(42, Time::from_nanos(7));
         state.store_latest(Arc::clone(&source));
@@ -781,6 +802,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<DynamicPayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let handle = CachedJsonSubscription::new(state.handle(), JsonRenderPolicy::default());
         let mut updates = handle.subscribe_updates().unwrap();
@@ -804,6 +826,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+            NonZeroUsize::new(256).unwrap(),
         ));
         state.store_latest(dynamic_record_at(1, Time::from_nanos(1)));
         state.store_latest(dynamic_record_at(2, Time::from_nanos(2)));
@@ -820,6 +843,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::time_window(Duration::from_secs(10)).unwrap(),
+            NonZeroUsize::new(256).unwrap(),
         ));
         let first = dynamic_record_at(1, Time::from_nanos(1));
         let second = dynamic_record_at(2, Time::from_nanos(2));
@@ -843,6 +867,7 @@ mod tests {
         let state = Arc::new(CachedSubscriptionState::<NonClonePayload>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let cancellation = state.cancellation_token();
         let handle = state.handle();
@@ -863,6 +888,7 @@ mod tests {
                     CachedSubscriptionStatus::WaitingForFirstSample,
                 ),
                 RetentionPolicy::LatestOnly,
+                NonZeroUsize::new(256).unwrap(),
             ));
 
             state.handle().subscribe_updates().unwrap()

--- a/crates/ros-z-debug/src/lib.rs
+++ b/crates/ros-z-debug/src/lib.rs
@@ -55,6 +55,7 @@ mod error;
 mod event;
 mod history;
 mod observation;
+mod policy;
 mod retention;
 mod sample;
 mod status;
@@ -72,6 +73,7 @@ pub use observation::{
     TopicObservationUpdate, TopicObservationUpdateClosed, TopicObservationUpdateReceiver,
     TopicObserver, TopicObserverOptions,
 };
+pub use policy::ObservationPolicy;
 pub use retention::{DEFAULT_TIME_WINDOW_MAX_SAMPLES, RetentionPolicy, RetentionWindow};
 pub use ros_z::dynamic::{
     ByteRenderPolicy, DynamicJsonRenderPolicy as JsonRenderPolicy, NonFiniteFloatRenderPolicy,

--- a/crates/ros-z-debug/src/lib.rs
+++ b/crates/ros-z-debug/src/lib.rs
@@ -26,6 +26,31 @@
 //! # }
 //! ```
 //!
+//! A full [`ObservationPolicy`] exposes observer-side buffering knobs when the
+//! default retention shortcut is not enough:
+//!
+//! ```rust,ignore
+//! use std::{num::NonZeroUsize, sync::Arc};
+//!
+//! use ros_z::context::ContextBuilder;
+//! use ros_z_debug::{CachedSubscriptionNodeExt, ObservationPolicy};
+//!
+//! # async fn demo() -> ros_z_debug::Result<()> {
+//! let context = ContextBuilder::default().build().await?;
+//! let node = Arc::new(context.create_node("debug").build().await?);
+//! let cache = node
+//!     .cached_subscription("status")?
+//!     .policy(
+//!         ObservationPolicy::latest()
+//!             .with_subscriber_queue_capacity(NonZeroUsize::new(128).unwrap()),
+//!     )
+//!     .build_typed::<String>()
+//!     .await?;
+//! # let _ = cache;
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! `TopicObserver` spawns observations that keep running after the observer handle
 //! is dropped. Drop the returned observation handle to stop its background task.
 //!

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -1866,7 +1866,7 @@ fn send_observation_update<T>(
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
     use parking_lot::Mutex;
     use ros_z::{prelude::*, time::Time};
@@ -2241,6 +2241,7 @@ mod tests {
         let cache_state = Arc::new(CachedSubscriptionState::<String>::new(
             fresh_cache,
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let (observation_update_sender, observation_update_receiver) =
             broadcast::channel(super::UPDATE_BUFFER_CAPACITY);
@@ -2307,6 +2308,7 @@ mod tests {
         let cache_state = Arc::new(CachedSubscriptionState::<String>::new(
             stale_cache.clone(),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let cache = cache_state.handle();
         let (observation_update_sender, observation_update_receiver) =
@@ -2353,6 +2355,7 @@ mod tests {
         let cache_state = Arc::new(CachedSubscriptionState::<String>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         cache_state.store_latest(string_sample_record("ready before install"));
         let cache = cache_state.handle();
@@ -2400,6 +2403,7 @@ mod tests {
         let cache_state = Arc::new(CachedSubscriptionState::<String>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let cache = cache_state.handle();
         let built_cache = cache.clone();
@@ -2487,6 +2491,7 @@ mod tests {
         let cache_state = Arc::new(CachedSubscriptionState::<String>::new(
             CachedSubscriptionStatusSnapshot::new(CachedSubscriptionStatus::WaitingForFirstSample),
             RetentionPolicy::LatestOnly,
+            NonZeroUsize::new(256).unwrap(),
         ));
         let built_cache = cache_state.handle();
         let (observation_update_sender, _observation_update_receiver) =

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -19,17 +19,18 @@ use tokio::sync::{broadcast, watch};
 
 use crate::{
     CachedSubscription, CachedSubscriptionBuilder, CachedSubscriptionStatusSnapshot,
-    CachedSubscriptionUpdate, CachedSubscriptionUpdateReceiver, Error, JsonRenderPolicy, Result,
-    RetentionPolicy, TargetIdentity, TopicReference,
+    CachedSubscriptionUpdate, CachedSubscriptionUpdateReceiver, Error, JsonRenderPolicy,
+    ObservationPolicy, Result, RetentionPolicy, TargetIdentity, TopicReference,
     sample::{dynamic_record_json_value, dynamic_record_to_json_sample},
 };
 
+#[cfg(test)]
 const UPDATE_BUFFER_CAPACITY: usize = 256;
 
 /// Lifecycle state for a topic observation.
 ///
 /// Observations rebuild their underlying cached subscription when the requested
-/// topic, target identity, retention policy, explicit reconnect revision, or
+/// topic, target identity, observation policy, explicit reconnect revision, or
 /// relevant graph state changes. Status snapshots retain frozen previous cache
 /// metadata while rebuilding, retrying, or blocked so callers can keep displaying
 /// the last readable data without keeping the old subscription live.
@@ -322,7 +323,7 @@ pub struct TopicObservationBuilder<T> {
     topic: TopicReference,
     namespace: Option<String>,
     node_name: DesiredNodeName,
-    retention: RetentionPolicy,
+    policy: ObservationPolicy,
     _value: PhantomData<T>,
 }
 
@@ -333,7 +334,7 @@ impl<T> TopicObservationBuilder<T> {
             topic,
             namespace: None,
             node_name: DesiredNodeName::Inherit,
-            retention: RetentionPolicy::LatestOnly,
+            policy: ObservationPolicy::default(),
             _value: PhantomData,
         }
     }
@@ -376,8 +377,19 @@ impl<T> TopicObservationBuilder<T> {
 
     /// Set how much data the observation retains.
     pub fn retention(mut self, retention: RetentionPolicy) -> Self {
-        self.retention = retention;
+        self.policy = self.policy.with_retention(retention);
         self
+    }
+
+    /// Configure this observation with a full observation policy.
+    pub fn policy(mut self, policy: ObservationPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Return the configured observation policy.
+    pub fn observation_policy(&self) -> ObservationPolicy {
+        self.policy
     }
 
     /// Return the topic reference requested for this observation.
@@ -387,7 +399,7 @@ impl<T> TopicObservationBuilder<T> {
 
     /// Return the configured retention policy.
     pub fn retention_policy(&self) -> RetentionPolicy {
-        self.retention
+        self.policy.retention()
     }
 }
 
@@ -402,10 +414,10 @@ where
             topic: self.topic,
             namespace: self.namespace,
             node_name: self.node_name,
-            retention: self.retention,
+            policy: self.policy,
             reconnect_revision: 0,
         });
-        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+        let (updates, _) = broadcast::channel(self.policy.update_buffer_capacity().get());
         let state = Arc::new(Mutex::new(TopicObservationState {
             status: TopicObservationStatus::Building,
             display_cache: None,
@@ -430,10 +442,10 @@ impl TopicObservationBuilder<DynamicPayload> {
             topic: self.topic,
             namespace: self.namespace,
             node_name: self.node_name,
-            retention: self.retention,
+            policy: self.policy,
             reconnect_revision: 0,
         });
-        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+        let (updates, _) = broadcast::channel(self.policy.update_buffer_capacity().get());
         let state = Arc::new(Mutex::new(TopicObservationState {
             status: TopicObservationStatus::Building,
             display_cache: None,
@@ -451,7 +463,6 @@ impl TopicObservationBuilder<DynamicPayload> {
         }
     }
 }
-
 /// Builder for a dynamic topic observation.
 pub struct DynamicTopicObservationBuilder {
     inner: TopicObservationBuilder<DynamicPayload>,
@@ -470,6 +481,17 @@ impl DynamicTopicObservationBuilder {
     pub fn retention(mut self, retention: RetentionPolicy) -> Self {
         self.inner = self.inner.retention(retention);
         self
+    }
+
+    /// Configure this observation with a full observation policy.
+    pub fn policy(mut self, policy: ObservationPolicy) -> Self {
+        self.inner = self.inner.policy(policy);
+        self
+    }
+
+    /// Return the configured observation policy.
+    pub fn observation_policy(&self) -> ObservationPolicy {
+        self.inner.observation_policy()
     }
 
     /// Override the namespace used to resolve this observation's relative topic before spawning.
@@ -537,7 +559,13 @@ impl<T> TopicObservation<T> {
     #[cfg(test)]
     fn new(desired: DesiredObservation) -> Self {
         let (desired_sender, _) = watch::channel(desired);
-        let (updates, _) = broadcast::channel(UPDATE_BUFFER_CAPACITY);
+        let (updates, _) = broadcast::channel(
+            desired_sender
+                .borrow()
+                .policy
+                .update_buffer_capacity()
+                .get(),
+        );
 
         Self {
             state: Arc::new(Mutex::new(TopicObservationState {
@@ -603,7 +631,7 @@ impl<T> TopicObservation<T> {
     /// Change the retention policy used on the next rebuild.
     pub fn set_retention(&self, retention: RetentionPolicy) {
         self.controls.desired_sender.send_modify(|desired| {
-            desired.retention = retention;
+            desired.policy = desired.policy.with_retention(retention);
         });
     }
 
@@ -794,7 +822,7 @@ struct DesiredObservation {
     topic: TopicReference,
     namespace: Option<String>,
     node_name: DesiredNodeName,
-    retention: RetentionPolicy,
+    policy: ObservationPolicy,
     reconnect_revision: u64,
 }
 
@@ -812,7 +840,7 @@ impl DesiredObservation {
             topic,
             namespace: None,
             node_name: DesiredNodeName::Inherit,
-            retention,
+            policy: ObservationPolicy::default().with_retention(retention),
             reconnect_revision: 0,
         }
     }
@@ -841,7 +869,7 @@ struct DynamicGraphFingerprint {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ObservationBuildKey {
     resolved_topic: String,
-    retention: RetentionPolicy,
+    policy: ObservationPolicy,
     reconnect_revision: u64,
 }
 
@@ -1037,7 +1065,7 @@ where
     CachedSubscriptionBuilder::new(node, desired.topic.as_str())?
         .target_identity(identity)
         .schema_discovery_timeout(schema_discovery_timeout)
-        .retention(desired.retention)
+        .policy(desired.policy)
         .build_typed::<T>()
         .await
 }
@@ -1051,7 +1079,7 @@ async fn build_dynamic_cache(
     CachedSubscriptionBuilder::new(node, desired.topic.as_str())?
         .target_identity(identity)
         .schema_discovery_timeout(schema_discovery_timeout)
-        .retention(desired.retention)
+        .policy(desired.policy)
         .build_dynamic()
         .await
 }
@@ -1173,7 +1201,7 @@ fn observation_build_key(
     let resolved_topic = desired.topic.resolve(&identity).ok()?;
     Some(ObservationBuildKey {
         resolved_topic,
-        retention: desired.retention,
+        policy: desired.policy,
         reconnect_revision: desired.reconnect_revision,
     })
 }
@@ -1517,7 +1545,7 @@ fn resolve_build_target(
     let resolved_topic = desired.topic.resolve(&identity)?;
     let build_key = ObservationBuildKey {
         resolved_topic: resolved_topic.clone(),
-        retention: desired.retention,
+        policy: desired.policy,
         reconnect_revision: desired.reconnect_revision,
     };
     let graph_fingerprint = topic_graph_fingerprint(node, &resolved_topic);
@@ -1879,8 +1907,8 @@ mod tests {
     };
     use crate::{
         CachedSubscriptionStatus, CachedSubscriptionStatusSnapshot, CachedSubscriptionUpdate,
-        CachedSubscriptionUpdateReceiver, RetentionPolicy, SampleMetadata, SampleRecord,
-        TargetIdentity, TopicReference, cache::CachedSubscriptionState,
+        CachedSubscriptionUpdateReceiver, ObservationPolicy, RetentionPolicy, SampleMetadata,
+        SampleRecord, TargetIdentity, TopicReference, cache::CachedSubscriptionState,
     };
 
     fn test_type_info() -> ros_z::TypeInfo {
@@ -1960,7 +1988,7 @@ mod tests {
             topic: TopicReference::new("~trace").unwrap(),
             namespace: None,
             node_name: DesiredNodeName::Inherit,
-            retention: RetentionPolicy::LatestOnly,
+            policy: ObservationPolicy::default().with_retention(RetentionPolicy::LatestOnly),
             reconnect_revision: 0,
         };
 
@@ -1980,7 +2008,7 @@ mod tests {
             topic: TopicReference::new("~trace").unwrap(),
             namespace: Some("/99".to_string()),
             node_name: DesiredNodeName::Name("vision".to_string()),
-            retention: RetentionPolicy::LatestOnly,
+            policy: ObservationPolicy::default().with_retention(RetentionPolicy::LatestOnly),
             reconnect_revision: 0,
         };
 

--- a/crates/ros-z-debug/src/observation.rs
+++ b/crates/ros-z-debug/src/observation.rs
@@ -463,6 +463,7 @@ impl TopicObservationBuilder<DynamicPayload> {
         }
     }
 }
+
 /// Builder for a dynamic topic observation.
 pub struct DynamicTopicObservationBuilder {
     inner: TopicObservationBuilder<DynamicPayload>,

--- a/crates/ros-z-debug/src/policy.rs
+++ b/crates/ros-z-debug/src/policy.rs
@@ -6,6 +6,18 @@ use crate::{Result, RetentionPolicy};
 
 const DEFAULT_UPDATE_BUFFER_CAPACITY: usize = 256;
 
+/// Observer-side buffering and retention policy for debug subscriptions.
+///
+/// This policy configures how `ros-z-debug` observes a topic. It does not
+/// change publisher behavior or topic semantics. Subscriber QoS controls the
+/// advertised subscription QoS, subscriber queue capacity controls the local
+/// `ros-z` callback-to-receiver queue, update buffer capacity controls cached
+/// update notifications, and retention controls how many decoded samples the
+/// cache keeps.
+///
+/// Use [`ObservationPolicy::default`] to preserve the historic defaults. Use
+/// [`ObservationPolicy::latest`] for latest-only observation with quieter queue
+/// overflow logging, then apply builder-style overrides for expert tuning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ObservationPolicy {
     retention: RetentionPolicy,
@@ -28,6 +40,11 @@ impl Default for ObservationPolicy {
 }
 
 impl ObservationPolicy {
+    /// Return the latest-only observation preset.
+    ///
+    /// This keeps subscriber QoS at the default, derives local subscriber queue
+    /// capacity from that QoS, keeps the update broadcast buffer at its default,
+    /// and reports local queue overflow at debug level.
     pub fn latest() -> Self {
         Self {
             queue_overflow_reporting: QueueOverflowReporting::Debug,
@@ -35,6 +52,11 @@ impl ObservationPolicy {
         }
     }
 
+    /// Return a time-window observation policy.
+    ///
+    /// Samples newer than `duration` are retained, subject to the retention
+    /// policy's maximum sample bound. Local queue overflow is reported at warn
+    /// level so delayed consumers remain visible.
     pub fn time_window(duration: Duration) -> Result<Self> {
         Ok(Self {
             retention: RetentionPolicy::time_window(duration)?,
@@ -43,56 +65,75 @@ impl ObservationPolicy {
         })
     }
 
+    /// Configured cache retention policy.
     pub fn retention(self) -> RetentionPolicy {
         self.retention
     }
 
+    /// Optional advertised subscriber QoS override.
+    ///
+    /// `None` means the underlying `ros-z` subscriber uses its default QoS.
     pub fn subscriber_qos(self) -> Option<QosProfile> {
         self.subscriber_qos
     }
 
+    /// Optional local subscriber queue capacity override.
+    ///
+    /// `None` means the local queue capacity is derived from the effective
+    /// subscriber QoS history depth.
     pub fn subscriber_queue_capacity(self) -> Option<NonZeroUsize> {
         self.subscriber_queue_capacity
     }
 
+    /// Cached update broadcast channel capacity.
     pub fn update_buffer_capacity(self) -> NonZeroUsize {
         self.update_buffer_capacity
     }
 
+    /// Local subscriber queue overflow reporting level.
     pub fn queue_overflow_reporting(self) -> QueueOverflowReporting {
         self.queue_overflow_reporting
     }
 
+    /// Override cache retention.
     pub fn with_retention(mut self, retention: RetentionPolicy) -> Self {
         self.retention = retention;
         self
     }
 
+    /// Override the advertised subscriber QoS.
+    ///
+    /// This affects subscription matching and QoS metadata. It does not set the
+    /// local callback-to-receiver queue capacity unless that capacity is left
+    /// derived from QoS.
     pub fn with_subscriber_qos(mut self, qos: QosProfile) -> Self {
         self.subscriber_qos = Some(qos);
         self
     }
 
-    pub fn with_default_subscriber_qos(mut self) -> Self {
-        self.subscriber_qos = None;
-        self
-    }
-
+    /// Override the local subscriber callback-to-receiver queue capacity.
+    ///
+    /// This does not change advertised subscriber QoS. When unset, the local
+    /// queue capacity is derived from the effective QoS history depth.
     pub fn with_subscriber_queue_capacity(mut self, capacity: NonZeroUsize) -> Self {
         self.subscriber_queue_capacity = Some(capacity);
         self
     }
 
-    pub fn derive_subscriber_queue_capacity_from_qos(mut self) -> Self {
-        self.subscriber_queue_capacity = None;
-        self
-    }
-
+    /// Override cached update broadcast channel capacity.
+    ///
+    /// This controls how many cache update notifications can lag behind each
+    /// receiver. It does not change subscriber QoS or the local subscriber
+    /// receive queue.
     pub fn with_update_buffer_capacity(mut self, capacity: NonZeroUsize) -> Self {
         self.update_buffer_capacity = capacity;
         self
     }
 
+    /// Override local subscriber queue overflow reporting.
+    ///
+    /// This controls log output only. Overflow still drops the oldest queued
+    /// sample and does not alter subscriber QoS.
     pub fn with_queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
         self.queue_overflow_reporting = reporting;
         self

--- a/crates/ros-z-debug/src/policy.rs
+++ b/crates/ros-z-debug/src/policy.rs
@@ -1,0 +1,180 @@
+use std::{num::NonZeroUsize, time::Duration};
+
+use ros_z::{pubsub::QueueOverflowReporting, qos::QosProfile};
+
+use crate::{Result, RetentionPolicy};
+
+const DEFAULT_UPDATE_BUFFER_CAPACITY: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ObservationPolicy {
+    retention: RetentionPolicy,
+    subscriber_qos: Option<QosProfile>,
+    subscriber_queue_capacity: Option<NonZeroUsize>,
+    update_buffer_capacity: NonZeroUsize,
+    queue_overflow_reporting: QueueOverflowReporting,
+}
+
+impl Default for ObservationPolicy {
+    fn default() -> Self {
+        Self {
+            retention: RetentionPolicy::LatestOnly,
+            subscriber_qos: None,
+            subscriber_queue_capacity: None,
+            update_buffer_capacity: default_update_buffer_capacity(),
+            queue_overflow_reporting: QueueOverflowReporting::Warn,
+        }
+    }
+}
+
+impl ObservationPolicy {
+    pub fn latest() -> Self {
+        Self {
+            queue_overflow_reporting: QueueOverflowReporting::Debug,
+            ..Self::default()
+        }
+    }
+
+    pub fn time_window(duration: Duration) -> Result<Self> {
+        Ok(Self {
+            retention: RetentionPolicy::time_window(duration)?,
+            queue_overflow_reporting: QueueOverflowReporting::Warn,
+            ..Self::default()
+        })
+    }
+
+    pub fn retention(self) -> RetentionPolicy {
+        self.retention
+    }
+
+    pub fn subscriber_qos(self) -> Option<QosProfile> {
+        self.subscriber_qos
+    }
+
+    pub fn subscriber_queue_capacity(self) -> Option<NonZeroUsize> {
+        self.subscriber_queue_capacity
+    }
+
+    pub fn update_buffer_capacity(self) -> NonZeroUsize {
+        self.update_buffer_capacity
+    }
+
+    pub fn queue_overflow_reporting(self) -> QueueOverflowReporting {
+        self.queue_overflow_reporting
+    }
+
+    pub fn with_retention(mut self, retention: RetentionPolicy) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    pub fn with_subscriber_qos(mut self, qos: QosProfile) -> Self {
+        self.subscriber_qos = Some(qos);
+        self
+    }
+
+    pub fn with_default_subscriber_qos(mut self) -> Self {
+        self.subscriber_qos = None;
+        self
+    }
+
+    pub fn with_subscriber_queue_capacity(mut self, capacity: NonZeroUsize) -> Self {
+        self.subscriber_queue_capacity = Some(capacity);
+        self
+    }
+
+    pub fn derive_subscriber_queue_capacity_from_qos(mut self) -> Self {
+        self.subscriber_queue_capacity = None;
+        self
+    }
+
+    pub fn with_update_buffer_capacity(mut self, capacity: NonZeroUsize) -> Self {
+        self.update_buffer_capacity = capacity;
+        self
+    }
+
+    pub fn with_queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
+        self.queue_overflow_reporting = reporting;
+        self
+    }
+}
+
+fn default_update_buffer_capacity() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_UPDATE_BUFFER_CAPACITY)
+        .expect("default update buffer capacity must be non-zero")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{num::NonZeroUsize, time::Duration};
+
+    use ros_z::pubsub::QueueOverflowReporting;
+
+    use crate::{ObservationPolicy, RetentionPolicy};
+
+    #[test]
+    fn default_policy_preserves_current_behavior() {
+        let policy = ObservationPolicy::default();
+
+        assert_eq!(policy.retention(), RetentionPolicy::LatestOnly);
+        assert!(policy.subscriber_qos().is_none());
+        assert!(policy.subscriber_queue_capacity().is_none());
+        assert_eq!(policy.update_buffer_capacity().get(), 256);
+        assert_eq!(
+            policy.queue_overflow_reporting(),
+            QueueOverflowReporting::Warn
+        );
+    }
+
+    #[test]
+    fn latest_policy_keeps_capacity_derived_from_qos_but_reports_at_debug() {
+        let policy = ObservationPolicy::latest();
+
+        assert_eq!(policy.retention(), RetentionPolicy::LatestOnly);
+        assert!(policy.subscriber_qos().is_none());
+        assert!(policy.subscriber_queue_capacity().is_none());
+        assert_eq!(policy.update_buffer_capacity().get(), 256);
+        assert_eq!(
+            policy.queue_overflow_reporting(),
+            QueueOverflowReporting::Debug
+        );
+    }
+
+    #[test]
+    fn time_window_policy_uses_warn_reporting() {
+        let policy = ObservationPolicy::time_window(Duration::from_secs(5)).unwrap();
+
+        assert!(matches!(policy.retention(), RetentionPolicy::TimeWindow(_)));
+        assert!(policy.subscriber_qos().is_none());
+        assert!(policy.subscriber_queue_capacity().is_none());
+        assert_eq!(policy.update_buffer_capacity().get(), 256);
+        assert_eq!(
+            policy.queue_overflow_reporting(),
+            QueueOverflowReporting::Warn
+        );
+    }
+
+    #[test]
+    fn overrides_are_permissive_and_independent() {
+        let qos = ros_z::qos::QosProfile {
+            reliability: ros_z::qos::QosReliability::BestEffort,
+            ..Default::default()
+        };
+        let queue_capacity = NonZeroUsize::new(7).unwrap();
+        let update_capacity = NonZeroUsize::new(17).unwrap();
+
+        let policy = ObservationPolicy::latest()
+            .with_subscriber_qos(qos)
+            .with_subscriber_queue_capacity(queue_capacity)
+            .with_update_buffer_capacity(update_capacity)
+            .with_queue_overflow_reporting(QueueOverflowReporting::Silent);
+
+        assert_eq!(policy.subscriber_qos(), Some(qos));
+        assert_eq!(policy.subscriber_queue_capacity(), Some(queue_capacity));
+        assert_eq!(policy.update_buffer_capacity(), update_capacity);
+        assert_eq!(
+            policy.queue_overflow_reporting(),
+            QueueOverflowReporting::Silent
+        );
+    }
+}

--- a/crates/ros-z-debug/tests/topic_observer.rs
+++ b/crates/ros-z-debug/tests/topic_observer.rs
@@ -20,6 +20,38 @@ struct FloatDebugValue {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn topic_observation_builder_policy_preserves_overrides_when_retention_changes()
+-> ros_z_debug::Result<()> {
+    let context = ContextBuilder::default().build().await?;
+    let observer_node = Arc::new(context.create_node("policy_observer").build().await?);
+    let observer = TopicObserver::new(observer_node, TopicObserverOptions::with_namespace("/42")?);
+    let queue_capacity = std::num::NonZeroUsize::new(9).unwrap();
+    let policy =
+        ros_z_debug::ObservationPolicy::latest().with_subscriber_queue_capacity(queue_capacity);
+
+    let builder = observer
+        .observe_typed::<String>("state")?
+        .policy(policy)
+        .retention(RetentionPolicy::time_window(
+            std::time::Duration::from_secs(1),
+        )?);
+
+    assert!(matches!(
+        builder.observation_policy().retention(),
+        RetentionPolicy::TimeWindow(_)
+    ));
+    assert_eq!(
+        builder.observation_policy().subscriber_queue_capacity(),
+        Some(queue_capacity)
+    );
+
+    let dynamic_builder = observer.observe_dynamic("state")?.policy(policy);
+    assert_eq!(dynamic_builder.observation_policy(), policy);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn typed_observation_rebuilds_when_inherited_namespace_changes() -> ros_z_debug::Result<()> {
     let context = ContextBuilder::default().build().await?;
     let publisher_node = context.create_node("typed_retarget_pub").build().await?;

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -9,7 +9,10 @@ use crate::{
     endpoint_builder::{EndpointBuilderContext, MessageEndpointType},
     entity::{EndpointEntity, EndpointKind, SchemaHash, TypeInfo},
     graph::Graph,
-    pubsub::{RawPayload, RawPayloadCodec, RawSubscriber, SubscriberBuilder, SubscriberOptions},
+    pubsub::{
+        QueueOverflowReporting, RawPayload, RawPayloadCodec, RawSubscriber, SubscriberBuilder,
+        SubscriberOptions,
+    },
     qos::QosProfile,
     topic_name::{qualify_remote_private_service_name, qualify_topic_name},
 };
@@ -535,6 +538,16 @@ impl DynamicSubscriberDiscoveryBuilder {
         self
     }
 
+    pub fn queue_capacity(mut self, queue_capacity: std::num::NonZeroUsize) -> Self {
+        self.options = self.options.queue_capacity(queue_capacity);
+        self
+    }
+
+    pub fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
+        self.options = self.options.queue_overflow_reporting(reporting);
+        self
+    }
+
     /// Limit accepted samples by their zenoh origin locality.
     ///
     /// The locality filter is applied to the dynamic subscriber created after
@@ -593,6 +606,16 @@ impl DynamicRawSubscriberDiscoveryBuilder {
     /// Set the QoS profile used by the built raw dynamic subscriber.
     pub fn qos(mut self, qos: QosProfile) -> Self {
         self.options = self.options.qos(qos);
+        self
+    }
+
+    pub fn queue_capacity(mut self, queue_capacity: std::num::NonZeroUsize) -> Self {
+        self.options = self.options.queue_capacity(queue_capacity);
+        self
+    }
+
+    pub fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
+        self.options = self.options.queue_overflow_reporting(reporting);
         self
     }
 

--- a/crates/ros-z/src/dynamic/discovery.rs
+++ b/crates/ros-z/src/dynamic/discovery.rs
@@ -538,11 +538,19 @@ impl DynamicSubscriberDiscoveryBuilder {
         self
     }
 
+    /// Set the local dynamic subscriber receive queue capacity.
+    ///
+    /// This does not change advertised endpoint QoS. If unset, capacity is
+    /// derived from the effective QoS history depth after discovery succeeds.
     pub fn queue_capacity(mut self, queue_capacity: std::num::NonZeroUsize) -> Self {
         self.options = self.options.queue_capacity(queue_capacity);
         self
     }
 
+    /// Set how local dynamic subscriber queue overflow is reported.
+    ///
+    /// This only controls log output. Overflow still drops the oldest queued
+    /// sample and does not alter advertised endpoint QoS.
     pub fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
         self.options = self.options.queue_overflow_reporting(reporting);
         self
@@ -609,11 +617,19 @@ impl DynamicRawSubscriberDiscoveryBuilder {
         self
     }
 
+    /// Set the local raw dynamic subscriber receive queue capacity.
+    ///
+    /// This does not change advertised endpoint QoS. If unset, capacity is
+    /// derived from the effective QoS history depth after discovery succeeds.
     pub fn queue_capacity(mut self, queue_capacity: std::num::NonZeroUsize) -> Self {
         self.options = self.options.queue_capacity(queue_capacity);
         self
     }
 
+    /// Set how local raw dynamic subscriber queue overflow is reported.
+    ///
+    /// This only controls log output. Overflow still drops the oldest queued
+    /// sample and does not alter advertised endpoint QoS.
     pub fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
         self.options = self.options.queue_overflow_reporting(reporting);
         self

--- a/crates/ros-z/src/prelude.rs
+++ b/crates/ros-z/src/prelude.rs
@@ -26,7 +26,9 @@ pub use crate::node::Node;
 pub use crate::parameter::NodeParametersExt;
 
 /// Core pub/sub handles and builders.
-pub use crate::pubsub::{Publisher, PublisherBuilder, Subscriber, SubscriberBuilder};
+pub use crate::pubsub::{
+    Publisher, PublisherBuilder, QueueOverflowReporting, Subscriber, SubscriberBuilder,
+};
 
 /// Static schema construction traits and helpers.
 pub use crate::schema::{
@@ -44,3 +46,15 @@ pub use crate::{Message, SerdeCdrCodec, Service};
 
 /// Type metadata traits for custom message and service definitions.
 pub use crate::{SchemaHash, ServiceTypeInfo, TypeInfo};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prelude_exports_queue_overflow_reporting() {
+        let reporting = QueueOverflowReporting::Silent;
+
+        assert_eq!(reporting, QueueOverflowReporting::Silent);
+    }
+}

--- a/crates/ros-z/src/prelude.rs
+++ b/crates/ros-z/src/prelude.rs
@@ -46,15 +46,3 @@ pub use crate::{Message, SerdeCdrCodec, Service};
 
 /// Type metadata traits for custom message and service definitions.
 pub use crate::{SchemaHash, ServiceTypeInfo, TypeInfo};
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn prelude_exports_queue_overflow_reporting() {
-        let reporting = QueueOverflowReporting::Silent;
-
-        assert_eq!(reporting, QueueOverflowReporting::Silent);
-    }
-}

--- a/crates/ros-z/src/pubsub.rs
+++ b/crates/ros-z/src/pubsub.rs
@@ -10,14 +10,14 @@ pub use metadata::{PublicationId, Received};
 pub use publisher::{PreparedPublication, Publisher, PublisherBuilder};
 pub use raw::{RawPayload, RawPayloadCodec, RawSubscriber, RawSubscriberBuilder};
 pub(crate) use subscriber::SubscriberOptions;
-pub use subscriber::{Subscriber, SubscriberBuilder};
+pub use subscriber::{QueueOverflowReporting, Subscriber, SubscriberBuilder};
 
 pub(crate) const DEFAULT_TRANSIENT_LOCAL_REPLAY_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::{num::NonZeroUsize, sync::Arc};
 
     use crate::dynamic::{DynamicPayload, DynamicStruct};
     use crate::qos::{
@@ -31,14 +31,42 @@ mod tests {
     };
 
     #[test]
-    fn transient_local_subscriber_queue_capacity_matches_qos_depth() {
+    fn subscriber_queue_capacity_matches_qos_depth_without_override() {
         let qos = ros_z_protocol::qos::QosProfile {
             durability: QosDurability::TransientLocal,
             history: QosHistory::KeepLast(3),
             ..Default::default()
         };
 
-        assert_eq!(subscriber::subscriber_queue_capacity(&qos), 3);
+        assert_eq!(subscriber::subscriber_queue_capacity(&qos, None), 3);
+    }
+
+    #[test]
+    fn subscriber_queue_capacity_uses_explicit_override() {
+        let qos = ros_z_protocol::qos::QosProfile {
+            history: QosHistory::KeepLast(3),
+            ..Default::default()
+        };
+        let capacity = NonZeroUsize::new(64).expect("capacity is non-zero");
+
+        assert_eq!(
+            subscriber::subscriber_queue_capacity(&qos, Some(capacity)),
+            64
+        );
+    }
+
+    #[test]
+    fn subscriber_queue_capacity_override_bounds_keep_all_qos() {
+        let qos = ros_z_protocol::qos::QosProfile {
+            history: QosHistory::KeepAll,
+            ..Default::default()
+        };
+        let capacity = NonZeroUsize::new(2).expect("capacity is non-zero");
+
+        assert_eq!(
+            subscriber::subscriber_queue_capacity(&qos, Some(capacity)),
+            2
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/ros-z/src/pubsub/raw.rs
+++ b/crates/ros-z/src/pubsub/raw.rs
@@ -6,7 +6,7 @@ use zenoh::sample::Sample;
 
 use crate::Result;
 use crate::message::WireDecoder;
-use crate::pubsub::subscriber::{SubscriberBuilder, SubscriberResources};
+use crate::pubsub::subscriber::{QueueOverflowReporting, SubscriberBuilder, SubscriberResources};
 use crate::qos::QosProfile;
 use crate::queue::BoundedQueue;
 
@@ -76,6 +76,18 @@ where
     pub fn qos(self, qos: QosProfile) -> Self {
         Self {
             inner: self.inner.qos(qos),
+        }
+    }
+
+    pub fn queue_capacity(self, queue_capacity: std::num::NonZeroUsize) -> Self {
+        Self {
+            inner: self.inner.queue_capacity(queue_capacity),
+        }
+    }
+
+    pub fn queue_overflow_reporting(self, reporting: QueueOverflowReporting) -> Self {
+        Self {
+            inner: self.inner.queue_overflow_reporting(reporting),
         }
     }
 

--- a/crates/ros-z/src/pubsub/raw.rs
+++ b/crates/ros-z/src/pubsub/raw.rs
@@ -79,12 +79,20 @@ where
         }
     }
 
+    /// Set the local raw subscriber receive queue capacity.
+    ///
+    /// This does not change advertised endpoint QoS. If unset, capacity is
+    /// derived from the effective QoS history depth.
     pub fn queue_capacity(self, queue_capacity: std::num::NonZeroUsize) -> Self {
         Self {
             inner: self.inner.queue_capacity(queue_capacity),
         }
     }
 
+    /// Set how local raw subscriber queue overflow is reported.
+    ///
+    /// This only controls log output. Overflow still drops the oldest queued
+    /// sample and does not alter advertised endpoint QoS.
     pub fn queue_overflow_reporting(self, reporting: QueueOverflowReporting) -> Self {
         Self {
             inner: self.inner.queue_overflow_reporting(reporting),

--- a/crates/ros-z/src/pubsub/replay.rs
+++ b/crates/ros-z/src/pubsub/replay.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -706,7 +707,12 @@ pub(crate) fn transient_local_cache_capacity(
 
 pub(crate) fn transient_local_replay_live_capacity(
     qos: &ros_z_protocol::qos::QosProfile,
+    queue_capacity: Option<NonZeroUsize>,
 ) -> Option<usize> {
+    if let Some(queue_capacity) = queue_capacity {
+        return Some(queue_capacity.get());
+    }
+
     match qos.history {
         QosHistory::KeepLast(depth) => Some(depth),
         QosHistory::KeepAll => None,
@@ -910,6 +916,54 @@ pub(crate) fn spawn_transient_local_replay_task(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replay_live_capacity_uses_qos_history_without_override() {
+        let qos = ros_z_protocol::qos::QosProfile {
+            history: QosHistory::KeepLast(3),
+            ..Default::default()
+        };
+
+        assert_eq!(transient_local_replay_live_capacity(&qos, None), Some(3));
+    }
+
+    #[test]
+    fn replay_live_capacity_uses_explicit_override_for_keep_last() {
+        let qos = ros_z_protocol::qos::QosProfile {
+            history: QosHistory::KeepLast(3),
+            ..Default::default()
+        };
+        let capacity = std::num::NonZeroUsize::new(64).expect("capacity is non-zero");
+
+        assert_eq!(
+            transient_local_replay_live_capacity(&qos, Some(capacity)),
+            Some(64)
+        );
+    }
+
+    #[test]
+    fn replay_live_capacity_stays_disabled_for_keep_all_without_override() {
+        let qos = ros_z_protocol::qos::QosProfile {
+            history: QosHistory::KeepAll,
+            ..Default::default()
+        };
+
+        assert_eq!(transient_local_replay_live_capacity(&qos, None), None);
+    }
+
+    #[test]
+    fn replay_live_capacity_uses_explicit_override_for_keep_all() {
+        let qos = ros_z_protocol::qos::QosProfile {
+            history: QosHistory::KeepAll,
+            ..Default::default()
+        };
+        let capacity = std::num::NonZeroUsize::new(2).expect("capacity is non-zero");
+
+        assert_eq!(
+            transient_local_replay_live_capacity(&qos, Some(capacity)),
+            Some(2)
+        );
+    }
 
     #[test]
     fn replay_window_drops_duplicate_publication_ids() {

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -50,7 +50,7 @@ pub enum QueueOverflowReporting {
     Silent,
     /// Emit a debug log message for each local queue overflow.
     Debug,
-    /// Emit a warning log message for each local queue overflow.
+    /// Emit a warning log message for each local queue overflow. This is the default reporting mode.
     #[default]
     Warn,
 }

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
@@ -21,11 +22,26 @@ use crate::queue::BoundedQueue;
 use crate::topic_name::qualify_topic_name;
 use ros_z_protocol::qos::{QosDurability, QosHistory};
 
-pub(super) fn subscriber_queue_capacity(qos: &ros_z_protocol::qos::QosProfile) -> usize {
+pub(super) fn subscriber_queue_capacity(
+    qos: &ros_z_protocol::qos::QosProfile,
+    queue_capacity: Option<NonZeroUsize>,
+) -> usize {
+    if let Some(queue_capacity) = queue_capacity {
+        return queue_capacity.get();
+    }
+
     match qos.history {
         QosHistory::KeepLast(depth) => depth,
         QosHistory::KeepAll => usize::MAX,
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum QueueOverflowReporting {
+    Silent,
+    Debug,
+    #[default]
+    Warn,
 }
 
 #[derive(Debug, Clone)]
@@ -33,6 +49,8 @@ pub(crate) struct SubscriberOptions {
     pub(crate) qos: ros_z_protocol::qos::QosProfile,
     pub(crate) locality: Option<zenoh::sample::Locality>,
     pub(crate) transient_local_replay_timeout: Duration,
+    pub(crate) queue_capacity: Option<NonZeroUsize>,
+    pub(crate) queue_overflow_reporting: QueueOverflowReporting,
 }
 
 impl Default for SubscriberOptions {
@@ -41,6 +59,8 @@ impl Default for SubscriberOptions {
             qos: crate::endpoint_builder::default_protocol_qos(),
             locality: None,
             transient_local_replay_timeout: crate::pubsub::DEFAULT_TRANSIENT_LOCAL_REPLAY_TIMEOUT,
+            queue_capacity: None,
+            queue_overflow_reporting: QueueOverflowReporting::Warn,
         }
     }
 }
@@ -58,6 +78,16 @@ impl SubscriberOptions {
 
     pub(crate) fn transient_local_replay_timeout(mut self, timeout: Duration) -> Self {
         self.transient_local_replay_timeout = timeout;
+        self
+    }
+
+    pub(crate) fn queue_capacity(mut self, queue_capacity: NonZeroUsize) -> Self {
+        self.queue_capacity = Some(queue_capacity);
+        self
+    }
+
+    pub(crate) fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
+        self.queue_overflow_reporting = reporting;
         self
     }
 }
@@ -91,6 +121,7 @@ struct QueueDropContext {
     node_name: String,
     type_name: String,
     queue_capacity: usize,
+    queue_overflow_reporting: QueueOverflowReporting,
 }
 
 impl QueueDropContext {
@@ -98,6 +129,7 @@ impl QueueDropContext {
         log_prefix: &'static str,
         entity: &EndpointEntity,
         queue_capacity: usize,
+        queue_overflow_reporting: QueueOverflowReporting,
     ) -> Result<Self> {
         let topic = qualify_topic_name(&entity.topic, &entity.node.namespace, &entity.node.name)
             .map_err(|source| crate::Error::topic_name(entity.topic.clone(), source))?;
@@ -109,6 +141,7 @@ impl QueueDropContext {
             node_name: entity.node.name.clone(),
             type_name: entity.type_info.name.clone(),
             queue_capacity,
+            queue_overflow_reporting,
         })
     }
 }
@@ -119,19 +152,41 @@ fn record_queue_push<T>(
     context: &QueueDropContext,
     sample: T,
 ) {
-    if queue.push(sample) {
-        let total_dropped_samples = dropped_samples.fetch_add(1, Ordering::Relaxed) + 1;
-        warn!(
-            subscriber = context.log_prefix,
-            topic = %context.topic,
-            node_namespace = %context.node_namespace,
-            node_name = %context.node_name,
-            type_name = %context.type_name,
-            queue_capacity = context.queue_capacity,
-            drop_policy = "oldest",
-            total_dropped_samples,
-            "subscriber queue full; dropped oldest sample"
-        );
+    if !queue.push(sample) {
+        return;
+    }
+
+    let total_dropped_samples = dropped_samples.fetch_add(1, Ordering::Relaxed) + 1;
+    match context.queue_overflow_reporting {
+        QueueOverflowReporting::Silent => {}
+        QueueOverflowReporting::Debug => {
+            debug!(
+                subscriber = context.log_prefix,
+                topic = %context.topic,
+                node_namespace = %context.node_namespace,
+                node_name = %context.node_name,
+                type_name = %context.type_name,
+                queue_capacity = context.queue_capacity,
+                queue_overflow_reporting = ?context.queue_overflow_reporting,
+                drop_policy = "oldest",
+                total_dropped_samples,
+                "subscriber queue full; dropped oldest sample"
+            );
+        }
+        QueueOverflowReporting::Warn => {
+            warn!(
+                subscriber = context.log_prefix,
+                topic = %context.topic,
+                node_namespace = %context.node_namespace,
+                node_name = %context.node_name,
+                type_name = %context.type_name,
+                queue_capacity = context.queue_capacity,
+                queue_overflow_reporting = ?context.queue_overflow_reporting,
+                drop_policy = "oldest",
+                total_dropped_samples,
+                "subscriber queue full; dropped oldest sample"
+            );
+        }
     }
 }
 
@@ -166,6 +221,21 @@ impl<T, C> SubscriberBuilder<T, C> {
 
     pub fn qos(mut self, qos: QosProfile) -> Self {
         self.options = self.options.qos(qos);
+        self
+    }
+
+    /// Set the local subscriber receive queue capacity.
+    ///
+    /// This does not change advertised endpoint QoS. If unset, capacity is
+    /// derived from the effective QoS history depth.
+    pub fn queue_capacity(mut self, queue_capacity: NonZeroUsize) -> Self {
+        self.options = self.options.queue_capacity(queue_capacity);
+        self
+    }
+
+    /// Set how local subscriber queue overflow is reported.
+    pub fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
+        self.options = self.options.queue_overflow_reporting(reporting);
         self
     }
 
@@ -233,12 +303,17 @@ impl<T, C> SubscriberBuilder<T, C> {
     pub(crate) async fn build_raw_queue_async(self) -> Result<raw::RawSubscriber> {
         let prepared = self.prepare_build("RAW_SUB")?;
         let entity = &prepared.entity;
-        let queue_size = subscriber_queue_capacity(&entity.qos);
+        let queue_size = subscriber_queue_capacity(&entity.qos, prepared.options.queue_capacity);
         let queue = Arc::new(BoundedQueue::new(queue_size));
         let raw_queue = queue.clone();
         let dropped_samples = Arc::new(AtomicU64::new(0));
         let raw_dropped_samples = dropped_samples.clone();
-        let drop_context = QueueDropContext::from_entity("RAW_SUB", entity, queue_size)?;
+        let drop_context = QueueDropContext::from_entity(
+            "RAW_SUB",
+            entity,
+            queue_size,
+            prepared.options.queue_overflow_reporting,
+        )?;
         let resources = prepared
             .build_subscriber_resources(
                 entity,
@@ -413,12 +488,17 @@ where
     {
         let prepared = self.prepare_build("SUB")?;
         let entity = &prepared.entity;
-        let queue_size = subscriber_queue_capacity(&entity.qos);
+        let queue_size = subscriber_queue_capacity(&entity.qos, prepared.options.queue_capacity);
         let queue = Arc::new(BoundedQueue::new(queue_size));
         let subscriber_queue = queue.clone();
         let dropped_samples = Arc::new(AtomicU64::new(0));
         let subscriber_dropped_samples = dropped_samples.clone();
-        let drop_context = QueueDropContext::from_entity("SUB", entity, queue_size)?;
+        let drop_context = QueueDropContext::from_entity(
+            "SUB",
+            entity,
+            queue_size,
+            prepared.options.queue_overflow_reporting,
+        )?;
         let resources = prepared
             .build_subscriber_resources(
                 entity,

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -36,10 +36,21 @@ pub(super) fn subscriber_queue_capacity(
     }
 }
 
+/// Controls how local subscriber queue overflow is reported.
+///
+/// This setting only affects reporting. It does not change advertised QoS,
+/// queue capacity, or the queue drop policy. When the local receive queue is
+/// full, the oldest queued sample is still dropped to make room for the newest
+/// sample.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum QueueOverflowReporting {
+    /// Do not emit a log message when the local queue overflows.
+    ///
+    /// Dropped samples are still accounted internally.
     Silent,
+    /// Emit a debug log message for each local queue overflow.
     Debug,
+    /// Emit a warning log message for each local queue overflow.
     #[default]
     Warn,
 }
@@ -234,6 +245,9 @@ impl<T, C> SubscriberBuilder<T, C> {
     }
 
     /// Set how local subscriber queue overflow is reported.
+    ///
+    /// This only controls log output. Overflow still drops the oldest queued
+    /// sample and does not alter advertised endpoint QoS.
     pub fn queue_overflow_reporting(mut self, reporting: QueueOverflowReporting) -> Self {
         self.options = self.options.queue_overflow_reporting(reporting);
         self

--- a/crates/ros-z/src/pubsub/subscriber.rs
+++ b/crates/ros-z/src/pubsub/subscriber.rs
@@ -201,6 +201,53 @@ fn record_queue_push<T>(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn queue_drop_context(reporting: QueueOverflowReporting) -> QueueDropContext {
+        QueueDropContext {
+            log_prefix: "TEST_SUB",
+            topic: "/test_topic".to_owned(),
+            node_namespace: "/".to_owned(),
+            node_name: "test_node".to_owned(),
+            type_name: "test_msgs/msg/Test".to_owned(),
+            queue_capacity: 2,
+            queue_overflow_reporting: reporting,
+        }
+    }
+
+    fn assert_record_queue_push_drops_oldest_and_counts(reporting: QueueOverflowReporting) {
+        let queue = BoundedQueue::new(2);
+        let dropped_samples = AtomicU64::new(0);
+        let context = queue_drop_context(reporting);
+
+        record_queue_push(&queue, &dropped_samples, &context, 1);
+        record_queue_push(&queue, &dropped_samples, &context, 2);
+        record_queue_push(&queue, &dropped_samples, &context, 3);
+
+        assert_eq!(queue.try_recv(), Some(2));
+        assert_eq!(queue.try_recv(), Some(3));
+        assert_eq!(queue.try_recv(), None);
+        assert_eq!(dropped_samples.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn record_queue_push_drops_oldest_and_counts_for_silent_reporting() {
+        assert_record_queue_push_drops_oldest_and_counts(QueueOverflowReporting::Silent);
+    }
+
+    #[test]
+    fn record_queue_push_drops_oldest_and_counts_for_debug_reporting() {
+        assert_record_queue_push_drops_oldest_and_counts(QueueOverflowReporting::Debug);
+    }
+
+    #[test]
+    fn record_queue_push_drops_oldest_and_counts_for_warn_reporting() {
+        assert_record_queue_push_drops_oldest_and_counts(QueueOverflowReporting::Warn);
+    }
+}
+
 async fn declare_liveliness(session: &Session, entity: &EndpointEntity) -> Result<LivelinessToken> {
     let liveliness_key_expr = entity.liveliness_key_expr()?.0;
     session
@@ -405,8 +452,10 @@ impl PreparedSubscriberBuild {
                 _replay_guard: None,
             })
         } else {
-            let Some(live_capacity) = replay::transient_local_replay_live_capacity(&entity.qos)
-            else {
+            let Some(live_capacity) = replay::transient_local_replay_live_capacity(
+                &entity.qos,
+                self.options.queue_capacity,
+            ) else {
                 warn!(
                     "[{}] TransientLocal + KeepAll requested; replay coordination is disabled because history is unbounded",
                     log_prefix


### PR DESCRIPTION
## Summary

Adds observer-side policy configuration for ROS-Z debugging.

## Motivation

Local subscriber queue capacity was previously coupled to QoS history depth, which caused observation workloads using default `KeepLast(10)` QoS to emit queue overflow warnings under load. Observation code now has explicit knobs for local queue capacity and overflow reporting without changing advertised QoS by default.

## Implementation

- Adds `ros_z::pubsub::QueueOverflowReporting`.
- Adds local subscriber `queue_capacity(...)` and `queue_overflow_reporting(...)` builder knobs across typed, raw, and dynamic subscriber builders.
- Adds `ros_z_debug::ObservationPolicy` for retention, optional subscriber QoS, optional local queue capacity, overflow reporting, and update buffer capacity.
- Threads `ObservationPolicy` through cached subscriptions and topic observations while preserving existing defaults.

## Verification

- `cargo fmt --check`
- `cargo nextest run -p ros-z --test pubsub`
- `cargo nextest run -p ros-z-debug`
- `cargo check -p twix`
- `git diff --check`