### PR TITLE
Dont go from Prepare to Penalized

### DIFF
--- a/crates/nodes/primary_state_filter/src/lib.rs
+++ b/crates/nodes/primary_state_filter/src/lib.rs
@@ -174,7 +174,10 @@ impl PrimaryStateFilter {
             (state, FilteredGameState::Stop) if !matches!(state, PrimaryState::Damping) => {
                 PrimaryState::Stop
             }
-            (state, _) if is_penalized && !matches!(state, PrimaryState::Damping) => {
+            (state, _)
+                if is_penalized
+                    && !matches!(state, PrimaryState::Damping | PrimaryState::Prepare) =>
+            {
                 PrimaryState::Penalized
             }
             (PrimaryState::Stop, game_state) => {


### PR DESCRIPTION
## Why? What?

We currently directly transition from Prepare to Penalized during a game, when the robot is penalized. Since we are in Soccer mode, when in Penalized, the robot cannot be picked up. We want to be able to but the robot into Prepare, then carry the robot to the side of the field, and then transition back into Initial and then penalized.  Forbids transition from `PrimaryState::Prepare` directly to `PrimaryState::Penalized` 

- Depends on #2722 
- Fixes #2700 

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

*Describe how to test your changes. (For the reviewer)*
