### PR TITLE
Localize game branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7661,7 +7661,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.29.0"
+version = "7.30.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.29.0"
+version = "7.30.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/deploy_config.rs
+++ b/tools/pepsi/src/deploy_config.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use chrono::Utc;
+use chrono::Local;
 use color_eyre::{Result, eyre::WrapErr};
 use serde::{Deserialize, Deserializer, de::Error as DeserializeError};
 use tokio::fs::read_to_string;
@@ -44,7 +44,7 @@ impl DeployConfig {
     }
 
     pub fn log_directory_name(&self) -> String {
-        let date = Utc::now().date_naive();
+        let date = Local::now().date_naive();
 
         if let Some(opponent) = &self.opponent {
             format!("{date}-HULKs-vs-{opponent}")


### PR DESCRIPTION
## Why? What?

Currently game branches use the current date in UTC.
This isn't very intuitive when in timezones far from UTC since we usually think in Spieltagen.
This PR changes it to use the local timezone.

## How to Test

Run
 ```
cp deploy.toml.example deploy.toml
./pepsi gamebranch
```
when local date is different from date at UTC+0

Then look at branch name to confirm matches local date.