### PR TITLE
Use X5 timestamp as source of truth

### DIFF
--- a/crates/nodes/ball_filter/src/lib.rs
+++ b/crates/nodes/ball_filter/src/lib.rs
@@ -61,7 +61,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?
         .create_future_subscriber::<Vec<Object<RobocupObjectLabel>>>(
             "detected_objects",
-            Duration::from_millis(1),
+            Duration::from_millis(25),
         )
         .await?
         .build();

--- a/crates/nodes/detection/src/lib.rs
+++ b/crates/nodes/detection/src/lib.rs
@@ -18,7 +18,6 @@ use types::{
     object_detection::{NUMBER_OF_VALUES_PER_OBJECT, Object, RobocupObjectLabel, YOLOObjectLabel},
     parameters::DetectionParameters,
     pose_detection::{NUMBER_OF_VALUES_PER_POSE, Pose},
-    time_wrapper::TimeWrapper,
 };
 
 pub const NUMBER_OF_DETECTIONS: usize = 300;
@@ -61,7 +60,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
     let node_parameters = node.bind_parameter_as::<DetectionParameters>("detection")?;
 
     let image_sub = node
-        .subscriber::<TimeWrapper<Image>>("inputs/left_image")
+        .subscriber::<Image>("inputs/left_image")
         .build()
         .await?;
     let inference_duration_pub = node
@@ -111,13 +110,15 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             continue;
         }
 
-        let timed_image = image_sub.recv().await?;
-        let image_time = timed_image.time;
+        let image = image_sub.recv().await?;
 
-        let detected_objects_pending = detected_objects_pub.announce(image_time).await?;
-        let detected_poses_pending = detected_poses_pub.announce(image_time).await?;
+        let detected_objects_pending = detected_objects_pub
+            .announce(image.header.stamp.into())
+            .await?;
+        let detected_poses_pending = detected_poses_pub
+            .announce(image.header.stamp.into())
+            .await?;
 
-        let image = timed_image.inner;
         check_image(&image)?;
 
         let inference_start = Instant::now();

--- a/crates/nodes/image_receiver/src/lib.rs
+++ b/crates/nodes/image_receiver/src/lib.rs
@@ -14,7 +14,6 @@ use ros2::sensor_msgs::{camera_info::CameraInfo, image::Image};
 use types::ycbcr422_image::YCbCr422Image;
 use types::{stereo_image_pair::StereoImagePair, time_wrapper::TimeWrapper};
 use x5_receiver::receiver::{Side, X5Receiver};
-use x5_receiver::types::X5CameraFrame;
 
 const X5_ADDRESS: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 127, 10)), 7654);
 
@@ -25,12 +24,9 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("image_receiver").build().await?;
 
-    let left_image_pub = node
-        .publisher::<TimeWrapper<Image>>("inputs/left_image")
-        .build()
-        .await?;
+    let left_image_pub = node.publisher::<Image>("inputs/left_image").build().await?;
     let right_image_pub = node
-        .publisher::<TimeWrapper<Image>>("inputs/right_image")
+        .publisher::<Image>("inputs/right_image")
         .build()
         .await?;
     let camera_info_pub = node
@@ -46,7 +42,7 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let stereo_image_pair_pub = node
-        .publisher::<TimeWrapper<StereoImagePair>>("inputs/stereo_image_pair")
+        .publisher::<StereoImagePair>("inputs/stereo_image_pair")
         .build()
         .await?;
 
@@ -59,138 +55,53 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
     let mut right_frame_receiver = x5_receiver.subscribe_image(Side::Right);
 
     loop {
-        tokio::select! {
+        let stereo_image_pair = tokio::select! {
             left_image = left_frame_receiver.recv() => {
-                let now = node.clock().now();
-                let received = ReceivedImage::new(now, left_image);
-                handle_left_image(
-                    &left_image_pub,
-                    &ycbcr422_image_pub,
-                    &stereo_image_pair_pub,
-                    &mut stereo_image_pairer,
-                    received,
-                )
-                .await?;
+                let frame_identifier = left_image.header.frame_identifier;
+                let image: Image = left_image.clone().into();
+                left_image_pub.publish(&image).await?;
+                publish_ycbcr422_image(&ycbcr422_image_pub, image.header.stamp.into(), image.clone()).await?;
+                stereo_image_pairer.insert(CameraSide::Left, frame_identifier, image)
             }
             right_image = right_frame_receiver.recv() => {
-                let now = node.clock().now();
-                let received = ReceivedImage::new(now, right_image);
-                handle_right_image(
-                    &right_image_pub,
-                    &stereo_image_pair_pub,
-                    &mut stereo_image_pairer,
-                    received,
-                )
-                .await?;
+                let frame_identifier = right_image.header.frame_identifier;
+                let image: Image = right_image.clone().into();
+                right_image_pub.publish(&image).await?;
+                stereo_image_pairer.insert(CameraSide::Right, frame_identifier, image)
             }
             _ = camera_info_timer.tick() => {
                 camera_info_pub
                     .publish(&camera_info.left_camera_info())
                     .await?;
+                continue
             }
+        };
+
+        if !stereo_image_pair_pub.has_subscribers() {
+            stereo_image_pairer.clear();
+            continue;
         }
+
+        let Some(stereo_image_pair) = stereo_image_pair else {
+            continue;
+        };
+        stereo_image_pair_pub.publish(&stereo_image_pair).await?;
     }
-}
-
-#[derive(Debug, Clone)]
-struct ReceivedImage {
-    frame_identifier: u32,
-    image_time: Time,
-    image: Image,
-}
-
-impl ReceivedImage {
-    fn new(image_time: Time, frame: X5CameraFrame) -> Self {
-        Self {
-            frame_identifier: frame.header.frame_identifier,
-            image_time,
-            image: frame.into(),
-        }
-    }
-}
-
-async fn handle_left_image(
-    left_image_pub: &Publisher<TimeWrapper<Image>>,
-    ycbcr422_image_pub: &Publisher<TimeWrapper<YCbCr422Image>>,
-    stereo_image_pair_pub: &Publisher<TimeWrapper<StereoImagePair>>,
-    stereo_image_pairer: &mut StereoImagePairer,
-    received_image: ReceivedImage,
-) -> Result<()> {
-    left_image_pub
-        .publish(&TimeWrapper {
-            time: received_image.image_time,
-            inner: received_image.image.clone(),
-        })
-        .await?;
-
-    publish_ycbcr422_image(ycbcr422_image_pub, received_image.clone()).await?;
-
-    maybe_publish_stereo_image_pair(
-        stereo_image_pair_pub,
-        stereo_image_pairer,
-        CameraSide::Left,
-        received_image,
-    )
-    .await
-}
-
-async fn handle_right_image(
-    right_image_pub: &Publisher<TimeWrapper<Image>>,
-    stereo_image_pair_pub: &Publisher<TimeWrapper<StereoImagePair>>,
-    stereo_image_pairer: &mut StereoImagePairer,
-    received_image: ReceivedImage,
-) -> Result<()> {
-    right_image_pub
-        .publish(&TimeWrapper {
-            time: received_image.image_time,
-            inner: received_image.image.clone(),
-        })
-        .await?;
-
-    maybe_publish_stereo_image_pair(
-        stereo_image_pair_pub,
-        stereo_image_pairer,
-        CameraSide::Right,
-        received_image,
-    )
-    .await
 }
 
 async fn publish_ycbcr422_image(
-    ycbcr422_image_pub: &Publisher<TimeWrapper<YCbCr422Image>>,
-    image: ReceivedImage,
+    publisher: &Publisher<TimeWrapper<YCbCr422Image>>,
+    time: Time,
+    image: Image,
 ) -> Result<()> {
-    let rgb_image: RgbImage = image.image.try_into()?;
-    ycbcr422_image_pub
+    let rgb_image: RgbImage = image.try_into()?;
+    let ycbcr422_image = (&rgb_image).into();
+    publisher
         .publish(&TimeWrapper {
-            time: image.image_time,
-            inner: (&rgb_image).into(),
+            time,
+            inner: ycbcr422_image,
         })
         .await?;
-    Ok(())
-}
-
-async fn maybe_publish_stereo_image_pair(
-    stereo_image_pair_pub: &Publisher<TimeWrapper<StereoImagePair>>,
-    stereo_image_pairer: &mut StereoImagePairer,
-    side: CameraSide,
-    image: ReceivedImage,
-) -> Result<()> {
-    if !stereo_image_pair_pub.has_subscribers() {
-        stereo_image_pairer.clear();
-        return Ok(());
-    }
-
-    let time = image.image_time;
-    if let Some(stereo_image_pair) = stereo_image_pairer.insert(side, image) {
-        stereo_image_pair_pub
-            .publish(&TimeWrapper {
-                time,
-                inner: stereo_image_pair,
-            })
-            .await?;
-    }
-
     Ok(())
 }
 
@@ -210,16 +121,21 @@ struct StereoImagePairer {
 impl StereoImagePairer {
     const MAX_UNMATCHED_FRAME_AGE: u32 = 8;
 
-    fn insert(&mut self, side: CameraSide, image: ReceivedImage) -> Option<StereoImagePair> {
-        self.update_latest_frame_identifier(image.frame_identifier);
+    fn insert(
+        &mut self,
+        side: CameraSide,
+        frame_identifier: u32,
+        image: Image,
+    ) -> Option<StereoImagePair> {
+        self.update_latest_frame_identifier(frame_identifier);
 
         let (remove_from, insert_in) = match side {
             CameraSide::Left => (&mut self.pending_right, &mut self.pending_left),
             CameraSide::Right => (&mut self.pending_left, &mut self.pending_right),
         };
 
-        let Some(other) = remove_from.remove(&image.frame_identifier) else {
-            insert_in.insert(image.frame_identifier, image.image);
+        let Some(other) = remove_from.remove(&frame_identifier) else {
+            insert_in.insert(frame_identifier, image);
             self.expire_old_frames();
             return None;
         };
@@ -227,12 +143,12 @@ impl StereoImagePairer {
         self.expire_old_frames();
 
         let (left, right) = match side {
-            CameraSide::Left => (image.image, other),
-            CameraSide::Right => (other, image.image),
+            CameraSide::Left => (image, other),
+            CameraSide::Right => (other, image),
         };
 
         Some(StereoImagePair {
-            frame_identifier: image.frame_identifier,
+            frame_identifier,
             left,
             right,
         })

--- a/crates/ros2/src/builtin_interfaces/time.rs
+++ b/crates/ros2/src/builtin_interfaces/time.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[repr(C)]
 #[derive(
     Clone,
+    Copy,
     Debug,
     Default,
     Serialize,
@@ -28,6 +29,13 @@ pub struct Time {
     /// The time -1.7 seconds is represented as {sec: -2, nanosec: 3e8}
     /// The time 1.7 seconds is represented as {sec: 1, nanosec: 7e8}
     pub nanosec: u32,
+}
+
+impl From<Time> for ros_z::time::Time {
+    fn from(value: Time) -> Self {
+        let nanos = value.sec as i64 * 1_000_000_000 + value.nanosec as i64;
+        ros_z::time::Time::from_nanos(nanos)
+    }
 }
 
 impl From<Time> for SystemTime {

--- a/crates/x5_receiver/src/receiver.rs
+++ b/crates/x5_receiver/src/receiver.rs
@@ -10,6 +10,7 @@ use crate::types::{
 };
 
 pub const MAX_ALLOCATION_SIZE: usize = 4 * 1024 * 1024;
+pub const EXPOSURE_TIME: Duration = Duration::from_millis(12);
 
 pub struct X5Receiver {
     _task: AbortOnDropHandle<()>,
@@ -168,13 +169,14 @@ impl X5ReceiverTask {
         let mut header_bytes = [0u8; size_of::<X5CameraFrameHeader>()];
         self.connection.read_exact(&mut header_bytes).await?;
 
-        let header: X5CameraFrameHeader = unsafe { std::mem::transmute(header_bytes) };
+        let mut header: X5CameraFrameHeader = unsafe { std::mem::transmute(header_bytes) };
         if header.payload_size as usize > MAX_ALLOCATION_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "payload size exceeds maximum allocation size",
             ));
         }
+        header.timestamp_nanoseconds += EXPOSURE_TIME.as_nanos() as u64 / 2;
 
         let nv12_data = Arc::<[u8]>::new_zeroed_slice(header.payload_size as usize);
         let mut nv12_data = unsafe { nv12_data.assume_init() };

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -9,7 +9,6 @@ use ros_z_debug::{SampleRecord, TopicObservation, TopicObservationStatus};
 use ros2::sensor_msgs::image::Image as RosImage;
 use serde_json::{Value, json};
 use thiserror::Error;
-use types::time_wrapper::TimeWrapper;
 use uuid::Uuid;
 
 use crate::{
@@ -63,7 +62,7 @@ enum ObservationState {
 }
 
 struct ObservedImage {
-    observation: TopicObservation<TimeWrapper<RosImage>>,
+    observation: TopicObservation<RosImage>,
     _repaint: ObservationRepaint,
     render_cache: RenderedImageCache,
 }
@@ -253,7 +252,7 @@ impl ImagePanel {
 }
 
 struct RenderedImageCache {
-    sample: Option<Arc<SampleRecord<TimeWrapper<RosImage>>>>,
+    sample: Option<Arc<SampleRecord<RosImage>>>,
     metadata: Option<RenderedMetadata>,
     texture: Option<TextureHandle>,
     dimensions: Option<[usize; 2]>,
@@ -277,18 +276,14 @@ impl RenderedImageCache {
         }
     }
 
-    fn refresh(
-        &mut self,
-        egui_context: &Context,
-        observation: &TopicObservation<TimeWrapper<RosImage>>,
-    ) {
+    fn refresh(&mut self, egui_context: &Context, observation: &TopicObservation<RosImage>) {
         self.refresh_sample(egui_context, observation.latest());
     }
 
     fn refresh_sample(
         &mut self,
         egui_context: &Context,
-        sample: Option<Arc<SampleRecord<TimeWrapper<RosImage>>>>,
+        sample: Option<Arc<SampleRecord<RosImage>>>,
     ) {
         if same_sample(self.sample.as_ref(), sample.as_ref()) {
             return;
@@ -305,7 +300,7 @@ impl RenderedImageCache {
         };
 
         self.metadata = Some(RenderedMetadata::from(record.as_ref()));
-        match decode_color_image(&record.value.inner) {
+        match decode_color_image(&record.value) {
             Ok(image) => {
                 self.dimensions = Some(image.size);
                 self.texture = Some(egui_context.load_texture(
@@ -338,8 +333,8 @@ impl RenderedImageCache {
 }
 
 fn same_sample(
-    current: Option<&Arc<SampleRecord<TimeWrapper<RosImage>>>>,
-    next: Option<&Arc<SampleRecord<TimeWrapper<RosImage>>>>,
+    current: Option<&Arc<SampleRecord<RosImage>>>,
+    next: Option<&Arc<SampleRecord<RosImage>>>,
 ) -> bool {
     match (current, next) {
         (Some(current), Some(next)) => Arc::ptr_eq(current, next),
@@ -348,8 +343,8 @@ fn same_sample(
     }
 }
 
-impl From<&SampleRecord<TimeWrapper<RosImage>>> for RenderedMetadata {
-    fn from(record: &SampleRecord<TimeWrapper<RosImage>>) -> Self {
+impl From<&SampleRecord<RosImage>> for RenderedMetadata {
+    fn from(record: &SampleRecord<RosImage>) -> Self {
         Self {
             resolved_topic: record.metadata.resolved_topic.clone(),
             type_name: record.metadata.type_info.name.to_string(),
@@ -359,7 +354,7 @@ impl From<&SampleRecord<TimeWrapper<RosImage>>> for RenderedMetadata {
                 .map(format_time)
                 .unwrap_or_else(|| "none".to_string()),
             publication_id: format_publication_id(record.publication_id),
-            image_time: format_time(record.value.time),
+            image_time: format_time(record.value.header.stamp.into()),
         }
     }
 }
@@ -367,14 +362,14 @@ impl From<&SampleRecord<TimeWrapper<RosImage>>> for RenderedMetadata {
 fn create_observation(
     context: &impl ObservationContext,
     topic: &str,
-) -> Result<(TopicObservation<TimeWrapper<RosImage>>, ObservationRepaint), Report> {
+) -> Result<(TopicObservation<RosImage>, ObservationRepaint), Report> {
     let runtime_handle = context.backend().runtime_handle().clone();
     // ros_z_debug spawns observation tasks internally and needs a current runtime.
     let _runtime_context = runtime_handle.enter();
     let observation = context
         .backend()
         .observer()
-        .observe_typed::<TimeWrapper<RosImage>>(topic)
+        .observe_typed::<RosImage>(topic)
         .wrap_err("failed to create image topic observation")?
         .spawn();
     let repaint = observation.repaint_on_updates(context);
@@ -399,7 +394,6 @@ mod tests {
     use ros_z_debug::{TopicObserver, TopicObserverOptions};
     use ros2::{sensor_msgs::image::Image as RosImage, std_msgs::header::Header};
     use serde_json::json;
-    use types::time_wrapper::TimeWrapper;
 
     use crate::{backend::RobotBackend, panel::PanelCreationContext};
 
@@ -431,13 +425,6 @@ mod tests {
             is_bigendian: 0,
             step: width * 3,
             data: data.into(),
-        }
-    }
-
-    fn wrapped_image(image: RosImage) -> TimeWrapper<RosImage> {
-        TimeWrapper {
-            time: Time::from_nanos(123),
-            inner: image,
         }
     }
 
@@ -490,16 +477,16 @@ mod tests {
             TopicObserverOptions::with_namespace("/").unwrap(),
         );
         let publisher = node
-            .publisher::<TimeWrapper<RosImage>>("/inputs/left_image")
+            .publisher::<RosImage>("/inputs/left_image")
             .build()
             .await
             .unwrap();
         let observation = observer
-            .observe_typed::<TimeWrapper<RosImage>>("inputs/left_image")
+            .observe_typed::<RosImage>("inputs/left_image")
             .unwrap()
             .spawn();
         let mut cache = RenderedImageCache::new("test-image-cache");
-        let image = wrapped_image(rgb8_image(2, 1, vec![255, 0, 0, 0, 255, 0]));
+        let image = rgb8_image(2, 1, vec![255, 0, 0, 0, 255, 0]);
 
         tokio::time::timeout(Duration::from_secs(3), async {
             while observation.latest().is_none() {


### PR DESCRIPTION
## Why? What?

@alexschmander discovered the time sync is indeed working between camera and orin board.
However I learned from HTWK, that the time stamp describes the exposure start and the exposure (currently) takes about 12ms. So an offset of 6ms is best to hit the mid of image exposure. This PR removes `TimeWrapper<...>` around `Image` and updates all call sites.
The time from image exposure start to receival seems to be about 26ms, removing the 6ms to get to half exposure time, the time is about 20ms. I therefore updated safety lags to 25ms.

- Fixes #

## ToDo / Known Issues

*If this is a WIP describe which problems are to be fixed.*

## Ideas for Next Iterations (Not This PR)

*If there are some improvements that could be done in a next iteration, describe them here.*

## How to Test

- Check ball projection on ground is barely moving when moving the head
