### PR TITLE
Out with the old; In with the new!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7594,7 +7594,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.30.0"
+version = "7.31.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -14,7 +14,7 @@ chown -R booster:booster /home/booster/hulk/logs
   --user $(id -u booster) \
   hulk \
   /home/booster/hulk/bin/hulk_ros_z \
-  --robot {} \
+  --robot ROBOT_NUMBER \
   --location default-location \
   --parameter-root etc/parameters/ros_z \
   --router tcp/127.0.0.1:7447 \

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -13,6 +13,11 @@ chown -R booster:booster /home/booster/hulk/logs
   --env RUST_BACKTRACE=1 \
   --user $(id -u booster) \
   hulk \
-  /home/booster/hulk/bin/hulk_booster --log-path "${INTERNAL_LOG_PATH}" \
+  /home/booster/hulk/bin/hulk_ros_z \
+  --robot {} \
+  --location default-location \
+  --parameter-root etc/parameters/ros_z \
+  --router tcp/127.0.0.1:7447 \
+  --log-path "${INTERNAL_LOG_PATH}" \
   > >(tee "${INTERNAL_LOG_PATH}/hulk.out") \
   2> >(tee "${INTERNAL_LOG_PATH}/hulk.err")

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.30.0"
+version = "7.31.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -42,10 +42,6 @@ pub struct Arguments {
     /// e.g. `../update_x5`
     #[arg(short, long)]
     update_x5_file: Option<PathBuf>,
-
-    /// Use old booster binary
-    #[arg(long)]
-    old: bool,
 }
 
 static PACKAGES: [&str; 2] = ["zenohd", "zenoh-bridge-dds"];
@@ -79,7 +75,6 @@ pub async fn gammaray(arguments: Arguments, repository: &Repository) -> Result<(
                     arguments.update_x5_file.as_deref(),
                     &team,
                     setup_path,
-                    arguments.old,
                 )
             },
         )
@@ -97,7 +92,6 @@ async fn gammaray_robot(
     update_x5_file: Option<&Path>,
     team: &Team,
     setup: &Path,
-    old: bool,
 ) -> Result<()> {
     let robot = Robot::try_new_with_ping(robot.ip).await?;
 
@@ -280,15 +274,17 @@ async fn gammaray_robot(
         .rsync_with_log("uploading binaries", &progress_bar)
         .await?;
 
-    if !old {
-        robot
-            .ssh_to_robot()?
-            .arg("sudo sed")
-            .arg("--in-place")
-            .arg(format!("'s#hulk_booster .*#hulk_ros_z --robot {} --location default-location --parameter-root etc/parameters/ros_z --router tcp/127.0.0.1:7447 \\\\#'", team_robot.number))
-            .arg("/usr/bin/launch-hulk")
-            .ssh_with_log("hacking launch-hulk", &progress_bar).await?;
-    }
+    robot
+        .ssh_to_robot()?
+        .arg("sudo sed")
+        .arg("--in-place")
+        .arg(format!(
+            "'s#--robot ROBOT_NUMBER#--robot {}#'",
+            team_robot.number
+        ))
+        .arg("/usr/bin/launch-hulk")
+        .ssh_with_log("hacking launch-hulk", &progress_bar)
+        .await?;
 
     robot
         .ssh_to_robot()?

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -26,9 +26,6 @@ pub struct Arguments {
     pub environment: EnvironmentArguments,
     #[command(flatten, next_help_heading = "Cargo Options")]
     pub build: build::Arguments,
-    /// Use old booster binary
-    #[arg(long)]
-    pub old: bool,
 }
 
 #[derive(Args)]
@@ -121,17 +118,14 @@ async fn upload_with_progress(
 
 pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()> {
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
-    let binary_name = match arguments.old {
-        true => "hulk_booster",
-        false => "hulk_ros_z",
-    };
-    let hulk_binary = get_binary(arguments.build.profile(), binary_name);
+    const BINARY_NAME: &str = "hulk_ros_z";
+    let hulk_binary = get_binary(arguments.build.profile(), BINARY_NAME);
 
     let cargo_arguments = cargo::Arguments {
         manifest: Some(
             repository
                 .root
-                .join(format!("crates/{binary_name}/Cargo.toml"))
+                .join(format!("crates/{BINARY_NAME}/Cargo.toml"))
                 .into_os_string(),
         ),
         environment: arguments.environment,
@@ -168,7 +162,7 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
                         upload_arguments,
                         &progress,
                         repository,
-                        binary_name,
+                        BINARY_NAME,
                     )
                     .await
                     .as_ref(),


### PR DESCRIPTION
## Why? What?

Removes the `old` flag from gammaray and upload which allowed uploading and running the now removed old framework hulk binary.

## How to Test

Everything for the new framework should continue working as expected but gammaray and upload no longer accept `--old`.