### PR TITLE
Watch pings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7661,7 +7661,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.30.0"
+version = "7.31.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.30.0"
+version = "7.31.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -3,15 +3,20 @@ use std::time::Duration;
 use clap::Args;
 
 use argument_parsers::RobotAddress;
+use color_eyre::owo_colors::OwoColorize;
 use robot::Robot;
+use tokio::time::Instant;
 
 use crate::progress_indicator::ProgressIndicator;
 
 #[derive(Args)]
 pub struct Arguments {
     /// Timeout in seconds after which ping is aborted
-    #[arg(long, default_value = "2")]
+    #[arg(long, short, default_value = "2")]
     pub timeout: u64,
+    /// Repeat ping indefinitely
+    #[arg(long, short)]
+    pub watch: bool,
     /// The Robots to ping to e.g. 20w or 10.1.24.22
     #[arg(required = true)]
     pub robots: Vec<RobotAddress>,
@@ -22,13 +27,42 @@ pub async fn ping(arguments: Arguments) {
         .map_tasks(
             arguments.robots,
             "Pinging Robot...",
-            |robot_address, _progress_bar| async move {
-                Robot::try_new_with_ping_and_arguments(
-                    robot_address.ip,
-                    Duration::from_secs(arguments.timeout),
-                )
-                .await
-                .map(|_| ())
+            |robot_address, progress_bar| async move {
+                let mut last_change = Instant::now();
+                let mut last_success = false;
+                loop {
+                    let result = Robot::try_new_with_ping_and_arguments(
+                        robot_address.ip,
+                        Duration::from_secs(arguments.timeout),
+                    )
+                    .await
+                    .map(|_| ());
+
+                    if !arguments.watch {
+                        return result;
+                    }
+
+                    let message = match &result {
+                        Ok(_) => {
+                            if !last_success {
+                                last_change = Instant::now();
+                            }
+                            format!("{} since {}s", "✔".green(), last_change.elapsed().as_secs())
+                        }
+                        Err(report) => {
+                            if last_success {
+                                last_change = Instant::now();
+                            }
+                            format!(
+                                "{} {report} since {}s",
+                                "✗".red(),
+                                last_change.elapsed().as_secs()
+                            )
+                        }
+                    };
+                    last_success = result.is_ok();
+                    progress_bar.set_message(message);
+                }
             },
         )
         .await;

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -12,11 +12,14 @@ use crate::progress_indicator::ProgressIndicator;
 #[derive(Args)]
 pub struct Arguments {
     /// Timeout in seconds after which ping is aborted
-    #[arg(long, short, default_value = "2")]
+    #[arg(long, short, default_value = "1")]
     pub timeout: f64,
     /// Repeat ping indefinitely
     #[arg(long, short)]
     pub watch: bool,
+    /// Interval in seconds between ping attempts when watching
+    #[arg(long, short, default_value = "1")]
+    pub interval: f64,
     /// The Robots to ping to e.g. 20w or 10.1.24.22
     #[arg(required = true)]
     pub robots: Vec<RobotAddress>,
@@ -24,6 +27,7 @@ pub struct Arguments {
 
 pub async fn ping(arguments: Arguments) {
     let timeout = Duration::from_secs_f64(arguments.timeout);
+    let interval = Duration::from_secs_f64(arguments.interval);
     ProgressIndicator::new()
         .map_tasks(
             arguments.robots,
@@ -32,9 +36,11 @@ pub async fn ping(arguments: Arguments) {
                 let mut last_change = Instant::now();
                 let mut last_success = false;
                 loop {
+                    let ping_start = Instant::now();
                     let result = Robot::try_new_with_ping_and_arguments(robot_address.ip, timeout)
                         .await
                         .map(|_| ());
+                    let ping_duration = ping_start.elapsed();
 
                     if !arguments.watch {
                         return result;
@@ -51,7 +57,6 @@ pub async fn ping(arguments: Arguments) {
                                 last_change.elapsed().as_secs()
                             );
                             progress_bar.set_message(message);
-                            sleep(timeout).await;
                         }
                         Err(report) => {
                             if last_success {
@@ -66,6 +71,7 @@ pub async fn ping(arguments: Arguments) {
                         }
                     };
                     last_success = result.is_ok();
+                    sleep(interval.saturating_sub(ping_duration)).await;
                 }
             },
         )

--- a/tools/pepsi/src/ping.rs
+++ b/tools/pepsi/src/ping.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use argument_parsers::RobotAddress;
 use color_eyre::owo_colors::OwoColorize;
 use robot::Robot;
-use tokio::time::Instant;
+use tokio::time::{Instant, sleep};
 
 use crate::progress_indicator::ProgressIndicator;
 
@@ -13,7 +13,7 @@ use crate::progress_indicator::ProgressIndicator;
 pub struct Arguments {
     /// Timeout in seconds after which ping is aborted
     #[arg(long, short, default_value = "2")]
-    pub timeout: u64,
+    pub timeout: f64,
     /// Repeat ping indefinitely
     #[arg(long, short)]
     pub watch: bool,
@@ -23,6 +23,7 @@ pub struct Arguments {
 }
 
 pub async fn ping(arguments: Arguments) {
+    let timeout = Duration::from_secs_f64(arguments.timeout);
     ProgressIndicator::new()
         .map_tasks(
             arguments.robots,
@@ -31,37 +32,40 @@ pub async fn ping(arguments: Arguments) {
                 let mut last_change = Instant::now();
                 let mut last_success = false;
                 loop {
-                    let result = Robot::try_new_with_ping_and_arguments(
-                        robot_address.ip,
-                        Duration::from_secs(arguments.timeout),
-                    )
-                    .await
-                    .map(|_| ());
+                    let result = Robot::try_new_with_ping_and_arguments(robot_address.ip, timeout)
+                        .await
+                        .map(|_| ());
 
                     if !arguments.watch {
                         return result;
                     }
 
-                    let message = match &result {
+                    match &result {
                         Ok(_) => {
                             if !last_success {
                                 last_change = Instant::now();
                             }
-                            format!("{} since {}s", "✔".green(), last_change.elapsed().as_secs())
+                            let message = format!(
+                                "{} since {}s",
+                                "✔".green(),
+                                last_change.elapsed().as_secs()
+                            );
+                            progress_bar.set_message(message);
+                            sleep(timeout).await;
                         }
                         Err(report) => {
                             if last_success {
                                 last_change = Instant::now();
                             }
-                            format!(
+                            let message = format!(
                                 "{} {report} since {}s",
                                 "✗".red(),
                                 last_change.elapsed().as_secs()
-                            )
+                            );
+                            progress_bar.set_message(message);
                         }
                     };
                     last_success = result.is_ok();
-                    progress_bar.set_message(message);
                 }
             },
         )


### PR DESCRIPTION
## Why? What?

Allows `pepsi ping --watch / -w` which repeatedly pings each robot independently.
This is better than `watch pepsi ping` because each robot has its own independent timeout instead of barrier-syncing on pepsi exiting.

## How to Test

`./pepsi stups -w 42 43`