### PR TITLE
Remove old playerstates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8429,6 +8429,7 @@ dependencies = [
  "hsl_network_messages",
  "linear_algebra",
  "ros-z",
+ "serde",
  "tokio",
  "types",
 ]

--- a/crates/nodes/player_state_receiver/Cargo.toml
+++ b/crates/nodes/player_state_receiver/Cargo.toml
@@ -10,5 +10,6 @@ color-eyre = { workspace = true }
 hsl_network_messages = { workspace = true }
 linear_algebra = { workspace = true }
 ros-z = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 types = { workspace = true }

--- a/crates/nodes/player_state_receiver/src/lib.rs
+++ b/crates/nodes/player_state_receiver/src/lib.rs
@@ -1,13 +1,20 @@
-use std::{pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 use color_eyre::Result;
-use hsl_network_messages::HulkMessage;
-use ros_z::{prelude::*, qos::QosDurability};
+use hsl_network_messages::{HulkMessage, PlayerNumber};
+use ros_z::{prelude::*, qos::QosDurability, time::Time};
+use serde::{Deserialize, Serialize};
 use types::{
     ball_position::BallPosition, filtered_game_controller_state::FilteredGameControllerState,
     messages::IncomingMessage, players::Players, time_wrapper::TimeWrapper,
     world_state::PlayerState,
 };
+
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[serde(deny_unknown_fields)]
+pub struct Parameters {
+    pub maximum_age: Duration,
+}
 
 pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
     Box::pin(run(ctx))
@@ -15,6 +22,8 @@ pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> +
 
 pub async fn run(ctx: Arc<Context>) -> Result<()> {
     let node = ctx.create_node("player_state_receiver").build().await?;
+
+    let parameters = node.bind_parameter_as::<Parameters>("player_state_receiver")?;
     let filtered_game_controller_state_sub = node
         .subscriber::<FilteredGameControllerState>("filtered_game_controller_state")
         .build()
@@ -33,15 +42,26 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .await?;
 
     let mut player_states = Players::new(None);
+    let mut expiry_tick = node.create_timer(Duration::from_millis(100));
     loop {
         tokio::select! {
+            _ = expiry_tick.tick() => {
+                let maximum_age = parameters.snapshot().typed().maximum_age;
+                if clear_old_player_states(&mut player_states, node.clock().now(), maximum_age) {
+                    player_states_pub.publish(&player_states).await?;
+                }
+            }
             received_game_controller_state = filtered_game_controller_state_sub.recv() => {
                 let game_controller_state = received_game_controller_state?;
                 clear_penalized_players(&mut player_states, &game_controller_state);
+                let maximum_age = parameters.snapshot().typed().maximum_age;
+                clear_old_player_states(&mut player_states, node.clock().now(), maximum_age);
                 player_states_pub.publish(&player_states).await?;
             }
             received_message = filtered_message_sub.recv() => {
                 apply_message(&mut player_states, received_message?);
+                let maximum_age = parameters.snapshot().typed().maximum_age;
+                clear_old_player_states(&mut player_states, node.clock().now(), maximum_age);
                 player_states_pub.publish(&player_states).await?;
             }
         }
@@ -80,6 +100,31 @@ fn clear_penalized_players(
             player_states[player_number] = None;
         }
     }
+}
+
+fn clear_old_player_states(
+    player_states: &mut Players<Option<TimeWrapper<PlayerState>>>,
+    now: Time,
+    maximum_age: Duration,
+) -> bool {
+    let mut removed_any = false;
+    for player_number in [
+        PlayerNumber::One,
+        PlayerNumber::Two,
+        PlayerNumber::Three,
+        PlayerNumber::Four,
+        PlayerNumber::Five,
+    ] {
+        let player_state = &mut player_states[player_number];
+        if player_state
+            .as_ref()
+            .is_some_and(|player_state| now.duration_since(player_state.time) >= maximum_age)
+        {
+            *player_state = None;
+            removed_any = true;
+        }
+    }
+    removed_any
 }
 
 #[cfg(test)]
@@ -141,5 +186,46 @@ mod tests {
 
         assert!(states[PlayerNumber::Two].is_none());
         assert!(states[PlayerNumber::Three].is_some());
+    }
+
+    #[test]
+    fn old_player_states_are_cleared() {
+        let mut states = Players::new(None);
+        states[PlayerNumber::Two] = Some(TimeWrapper {
+            time: Time::from_nanos(1_000_000_000),
+            inner: PlayerState::default(),
+        });
+        states[PlayerNumber::Three] = Some(TimeWrapper {
+            time: Time::from_nanos(1_500_000_000),
+            inner: PlayerState::default(),
+        });
+
+        let removed_any = clear_old_player_states(
+            &mut states,
+            Time::from_nanos(2_000_000_000),
+            Duration::from_secs(1),
+        );
+
+        assert!(removed_any);
+        assert!(states[PlayerNumber::Two].is_none());
+        assert!(states[PlayerNumber::Three].is_some());
+    }
+
+    #[test]
+    fn fresh_player_states_are_kept() {
+        let mut states = Players::new(None);
+        states[PlayerNumber::Two] = Some(TimeWrapper {
+            time: Time::from_nanos(1_000_000_001),
+            inner: PlayerState::default(),
+        });
+
+        let removed_any = clear_old_player_states(
+            &mut states,
+            Time::from_nanos(2_000_000_000),
+            Duration::from_secs(1),
+        );
+
+        assert!(!removed_any);
+        assert!(states[PlayerNumber::Two].is_some());
     }
 }

--- a/etc/parameters/ros_z/base/player_states_receiver.json5
+++ b/etc/parameters/ros_z/base/player_states_receiver.json5
@@ -1,0 +1,6 @@
+{
+  maximum_age: {
+    nanos: 0,
+    secs: 1,
+  },
+}


### PR DESCRIPTION
## Why? What?

remove old player_state after
- Fixes #2737 

## How to Test

take two robots and both in playing in the same wifi.
when one robot turns off or dosnt send any message anymore we should forget the state from them