### PR TITLE
Always clock the jetsons

### DIFF
--- a/tools/k1-setup/jetson-clocks-refresh.service
+++ b/tools/k1-setup/jetson-clocks-refresh.service
@@ -4,4 +4,7 @@ After=nvpmodel.service
 
 [Service]
 Type=oneshot
+StandardOutput=journal
+StandardError=journal
+ExecStartPre=/usr/bin/jetson_clocks --show
 ExecStart=/usr/bin/jetson_clocks

--- a/tools/k1-setup/jetson-clocks-refresh.service
+++ b/tools/k1-setup/jetson-clocks-refresh.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Re-apply Jetson clocks
+After=nvpmodel.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/jetson_clocks

--- a/tools/k1-setup/jetson-clocks-refresh.timer
+++ b/tools/k1-setup/jetson-clocks-refresh.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically re-apply Jetson clocks
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Unit=jetson-clocks-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -231,6 +231,8 @@ async fn gammaray_robot(
         .arg("--rsync-path=sudo rsync")
         .arg("--info=progress2")
         .arg(setup.join("hulk.service"))
+        .arg(setup.join("jetson-clocks-refresh.service"))
+        .arg(setup.join("jetson-clocks-refresh.timer"))
         .arg(format!("{}:/etc/systemd/system/", robot.address))
         .rsync_with_log("uploading service files", &progress_bar)
         .await?;
@@ -322,6 +324,12 @@ async fn gammaray_robot(
             "enabling and restarting zenoh-bridge-dds services",
             &progress_bar,
         )
+        .await?;
+
+    robot
+        .ssh_to_robot()?
+        .arg("sudo systemctl enable --now jetson-clocks-refresh.timer")
+        .ssh_with_log("enabling jetson clocks refresh timer", &progress_bar)
         .await?;
 
     robot


### PR DESCRIPTION
## Why? What?

Adds a systemd unit which repeatedly runs `jetson_clocks`.
Also includes a `jetson_clocks --show` ExecPre to allow us to determine where/when the clock speeds break again.

- Fixes #2710

## How to Test

`pepsi gammastrahl`