### PR TITLE
Temporally aligned image overlays

### DIFF
--- a/crates/bevyhavior_simulator/src/auto_referee.rs
+++ b/crates/bevyhavior_simulator/src/auto_referee.rs
@@ -804,6 +804,7 @@ mod tests {
         assert!(ball.state.is_none());
     }
 
+    #[test]
     fn auto_referee_config_defaults_match_hsl_timings() {
         let config = AutoRefereeConfig::default();
 

--- a/crates/nodes/ball_filter/src/lib.rs
+++ b/crates/nodes/ball_filter/src/lib.rs
@@ -69,7 +69,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .create_future_map_builder()
         .create_future_subscriber::<Odometer>("inputs/odometer", Duration::from_millis(1))
         .await?
-        .create_future_subscriber::<Vec<Object<RobocupObjectLabel>>>(
+        .create_future_subscriber::<TimeWrapper<Vec<Object<RobocupObjectLabel>>>>(
             "detected_objects",
             Duration::from_millis(25),
         )
@@ -147,7 +147,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
                         .as_ref()
                         .map(|camera_matrix| &camera_matrix.inner);
                     let Some(projected_balls) = project_detected_balls(
-                        Some(&detected_objects),
+                        Some(&detected_objects.inner),
                         camera_matrix,
                         parameters,
                         field_dimensions.ball_radius,

--- a/crates/nodes/detection/src/lib.rs
+++ b/crates/nodes/detection/src/lib.rs
@@ -18,6 +18,7 @@ use types::{
     object_detection::{NUMBER_OF_VALUES_PER_OBJECT, Object, RobocupObjectLabel, YOLOObjectLabel},
     parameters::DetectionParameters,
     pose_detection::{NUMBER_OF_VALUES_PER_POSE, Pose},
+    time_wrapper::TimeWrapper,
 };
 
 pub const NUMBER_OF_DETECTIONS: usize = 300;
@@ -85,10 +86,10 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
         .build()
         .await?;
     let detected_objects_pub = node
-        .announcing_publisher::<Vec<Object<RobocupObjectLabel>>>("detected_objects")
+        .announcing_publisher::<TimeWrapper<Vec<Object<RobocupObjectLabel>>>>("detected_objects")
         .await?;
     let detected_poses_pub = node
-        .announcing_publisher::<Vec<Pose<YOLOObjectLabel>>>("detected_poses")
+        .announcing_publisher::<TimeWrapper<Vec<Pose<YOLOObjectLabel>>>>("detected_poses")
         .await?;
 
     let initial_parameters_snapshot = node_parameters.snapshot();
@@ -126,12 +127,9 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             continue;
         }
 
-        let detected_objects_pending = detected_objects_pub
-            .announce(image.header.stamp.into())
-            .await?;
-        let detected_poses_pending = detected_poses_pub
-            .announce(image.header.stamp.into())
-            .await?;
+        let image_time = image.header.stamp.into();
+        let detected_objects_pending = detected_objects_pub.announce(image_time).await?;
+        let detected_poses_pending = detected_poses_pub.announce(image_time).await?;
 
         check_image(&image)?;
 
@@ -198,10 +196,16 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
             .await?;
 
         detected_objects_pending
-            .publish(&output.detected_objects)
+            .publish(&TimeWrapper {
+                time: image_time,
+                inner: output.detected_objects,
+            })
             .await?;
         detected_poses_pending
-            .publish(&output.detected_poses)
+            .publish(&TimeWrapper {
+                time: image_time,
+                inner: output.detected_poses,
+            })
             .await?;
     }
 }

--- a/crates/nodes/localization-3d/tests/association_recording_fixtures.rs
+++ b/crates/nodes/localization-3d/tests/association_recording_fixtures.rs
@@ -197,7 +197,7 @@ fn extract_fixtures(path: &Path) -> Result<Vec<AssociationFixture>, Box<dyn Erro
         }
 
         let expected =
-            expected_associations_from_debug(&detection.value, &camera.value, &debug_value);
+            expected_associations_from_debug(&detection.value, &camera.value, debug_value);
         if expected.len() != debug_value.inliers {
             stats.expected_count_mismatch += 1;
             continue;

--- a/crates/nodes/obstacle_filter/src/lib.rs
+++ b/crates/nodes/obstacle_filter/src/lib.rs
@@ -124,12 +124,12 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
 
     let mut detections = node
         .create_future_map_builder()
-        .create_future_subscriber::<Vec<Object<RobocupObjectLabel>>>(
+        .create_future_subscriber::<TimeWrapper<Vec<Object<RobocupObjectLabel>>>>(
             "detected_objects",
             Duration::from_millis(50),
         )
         .await?
-        .create_future_subscriber::<Vec<Pose<YOLOObjectLabel>>>(
+        .create_future_subscriber::<TimeWrapper<Vec<Pose<YOLOObjectLabel>>>>(
             "detected_poses",
             Duration::from_millis(50),
         )
@@ -157,8 +157,12 @@ async fn run(ctx: Arc<Context>) -> Result<()> {
                     };
                     let mut outputs = Vec::new();
                     for (detection_time, (detected_objects, detected_poses)) in item.persistent {
-                        let detected_objects = detected_objects.unwrap_or_default();
-                        let detected_poses = detected_poses.unwrap_or_default();
+                        let detected_objects = detected_objects
+                            .map(|detected_objects| detected_objects.inner)
+                            .unwrap_or_default();
+                        let detected_poses = detected_poses
+                            .map(|detected_poses| detected_poses.inner)
+                            .unwrap_or_default();
                         let camera_matrix = camera_matrix_cache.get_nearest(detection_time);
                         let current_odometry_to_last_odometry =
                             current_odometry_to_last_odometry_cache.get_nearest(detection_time);

--- a/tools/twix/src/panels/image/image_overlay.rs
+++ b/tools/twix/src/panels/image/image_overlay.rs
@@ -1,12 +1,13 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use color_eyre::{Report, eyre::Context as _};
 use coordinate_systems::Pixel;
 use eframe::egui::{Align2, Color32, FontId, Painter, Pos2, Rect, Stroke, Ui, pos2};
 use linear_algebra::{Point2, point};
-use ros_z::Message;
-use ros_z_debug::{SampleRecord, TopicObservation};
+use ros_z::{Message, time::Time};
+use ros_z_debug::{RetentionPolicy, SampleRecord, TopicObservation};
 use serde_json::{Value, json};
+use types::time_wrapper::TimeWrapper;
 
 use crate::repaint::{ObservationContext, ObservationRepaint, RepaintOnUpdates};
 
@@ -14,6 +15,8 @@ use super::overlays::{
     BallDetectionOverlay, FieldBorderOverlay, HorizonOverlay, LineDetectionOverlay,
     ObjectDetectionOverlay, PoseDetectionOverlay,
 };
+
+const OVERLAY_RETENTION_WINDOW: Duration = Duration::from_secs(2);
 
 pub(super) struct ImageOverlays {
     line_detection: OverlaySlot<LineDetectionOverlay>,
@@ -53,13 +56,13 @@ impl ImageOverlays {
         });
     }
 
-    pub(super) fn paint(&self, painter: &ImageOverlayPainter) {
-        self.line_detection.paint(painter);
-        self.ball_detection.paint(painter);
-        self.horizon.paint(painter);
-        self.field_border.paint(painter);
-        self.object_detection.paint(painter);
-        self.pose_detection.paint(painter);
+    pub(super) fn paint(&self, painter: &ImageOverlayPainter, image_time: Time) {
+        self.line_detection.paint(painter, image_time);
+        self.ball_detection.paint(painter, image_time);
+        self.horizon.paint(painter, image_time);
+        self.field_border.paint(painter, image_time);
+        self.object_detection.paint(painter, image_time);
+        self.pose_detection.paint(painter, image_time);
     }
 
     pub(super) fn save(&self) -> Value {
@@ -155,9 +158,9 @@ where
         }
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
+    fn paint(&self, painter: &ImageOverlayPainter, image_time: Time) {
         if let Some(overlay) = &self.overlay {
-            overlay.paint(painter);
+            overlay.paint(painter, image_time);
         }
     }
 
@@ -174,7 +177,7 @@ pub(super) trait ImageOverlay: Sized {
     where
         C: ObservationContext;
 
-    fn paint(&self, painter: &ImageOverlayPainter);
+    fn paint(&self, painter: &ImageOverlayPainter, image_time: Time);
 }
 
 pub(super) struct OverlayObservation<T> {
@@ -201,6 +204,29 @@ where
     pub(super) fn latest(&self) -> Option<Arc<SampleRecord<T>>> {
         self.observation.latest()
     }
+
+    fn recent(&self) -> Vec<Arc<SampleRecord<T>>> {
+        let Some(latest) = self.observation.latest() else {
+            return Vec::new();
+        };
+        self.observation.window(
+            latest.source_time - OVERLAY_RETENTION_WINDOW,
+            latest.source_time,
+        )
+    }
+}
+
+impl<T> OverlayObservation<TimeWrapper<T>>
+where
+    TimeWrapper<T>: Message + Send + Sync + 'static,
+    <TimeWrapper<T> as Message>::Codec: Send + Sync,
+{
+    pub(super) fn at_time(&self, time: Time) -> Option<Arc<SampleRecord<TimeWrapper<T>>>> {
+        self.recent()
+            .into_iter()
+            .rev()
+            .find(|record| record.value.time == time)
+    }
 }
 
 fn create_typed_observation<T>(
@@ -218,6 +244,9 @@ where
         .backend()
         .observer()
         .observe_typed::<T>(topic)
+        .and_then(|builder| {
+            Ok(builder.retention(RetentionPolicy::time_window(OVERLAY_RETENTION_WINDOW)?))
+        })
         .wrap_err_with(|| format!("failed to create typed topic observation for {topic}"))?
         .spawn();
     let repaint = observation.repaint_on_updates(context);

--- a/tools/twix/src/panels/image/image_overlay.rs
+++ b/tools/twix/src/panels/image/image_overlay.rs
@@ -65,6 +65,16 @@ impl ImageOverlays {
         self.pose_detection.paint(painter, image_time);
     }
 
+    pub(super) fn preferred_image_time(&self) -> Option<Time> {
+        [
+            self.object_detection.latest_time(),
+            self.pose_detection.latest_time(),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+    }
+
     pub(super) fn save(&self) -> Value {
         json!({
             LineDetectionOverlay::STORAGE_KEY: self.line_detection.save(),
@@ -164,6 +174,10 @@ where
         }
     }
 
+    fn latest_time(&self) -> Option<Time> {
+        self.overlay.as_ref().and_then(ImageOverlay::latest_time)
+    }
+
     fn save(&self) -> Value {
         json!({"active": self.active})
     }
@@ -178,6 +192,10 @@ pub(super) trait ImageOverlay: Sized {
         C: ObservationContext;
 
     fn paint(&self, painter: &ImageOverlayPainter, image_time: Time);
+
+    fn latest_time(&self) -> Option<Time> {
+        None
+    }
 }
 
 pub(super) struct OverlayObservation<T> {
@@ -227,6 +245,28 @@ where
             .rev()
             .find(|record| record.value.time == time)
     }
+
+    pub(super) fn latest_time(&self) -> Option<Time> {
+        self.latest().map(|record| record.value.time)
+    }
+
+    pub(super) fn nearest_to_time(
+        &self,
+        time: Time,
+        tolerance: Duration,
+    ) -> Option<Arc<SampleRecord<TimeWrapper<T>>>> {
+        let nearest = self
+            .recent()
+            .into_iter()
+            .min_by_key(|record| time_distance(record.value.time, time))?;
+        (time_distance(nearest.value.time, time) <= tolerance).then_some(nearest)
+    }
+}
+
+fn time_distance(first: Time, second: Time) -> Duration {
+    first
+        .duration_since(second)
+        .max(second.duration_since(first))
 }
 
 fn create_typed_observation<T>(

--- a/tools/twix/src/panels/image/image_overlay.rs
+++ b/tools/twix/src/panels/image/image_overlay.rs
@@ -223,14 +223,8 @@ where
         self.observation.latest()
     }
 
-    fn recent(&self) -> Vec<Arc<SampleRecord<T>>> {
-        let Some(latest) = self.observation.latest() else {
-            return Vec::new();
-        };
-        self.observation.window(
-            latest.source_time - OVERLAY_RETENTION_WINDOW,
-            latest.source_time,
-        )
+    fn get_all(&self) -> Vec<Arc<SampleRecord<T>>> {
+        self.observation.get_all()
     }
 }
 
@@ -239,13 +233,6 @@ where
     TimeWrapper<T>: Message + Send + Sync + 'static,
     <TimeWrapper<T> as Message>::Codec: Send + Sync,
 {
-    pub(super) fn at_time(&self, time: Time) -> Option<Arc<SampleRecord<TimeWrapper<T>>>> {
-        self.recent()
-            .into_iter()
-            .rev()
-            .find(|record| record.value.time == time)
-    }
-
     pub(super) fn latest_time(&self) -> Option<Time> {
         self.latest().map(|record| record.value.time)
     }
@@ -256,10 +243,17 @@ where
         tolerance: Duration,
     ) -> Option<Arc<SampleRecord<TimeWrapper<T>>>> {
         let nearest = self
-            .recent()
+            .get_all()
             .into_iter()
             .min_by_key(|record| time_distance(record.value.time, time))?;
         (time_distance(nearest.value.time, time) <= tolerance).then_some(nearest)
+    }
+
+    pub(super) fn at_time(&self, time: Time) -> Option<Arc<SampleRecord<TimeWrapper<T>>>> {
+        self.get_all()
+            .into_iter()
+            .rev()
+            .find(|record| record.value.time == time)
     }
 }
 
@@ -284,10 +278,8 @@ where
         .backend()
         .observer()
         .observe_typed::<T>(topic)
-        .and_then(|builder| {
-            Ok(builder.retention(RetentionPolicy::time_window(OVERLAY_RETENTION_WINDOW)?))
-        })
         .wrap_err_with(|| format!("failed to create typed topic observation for {topic}"))?
+        .retention(RetentionPolicy::time_window(OVERLAY_RETENTION_WINDOW)?)
         .spawn();
     let repaint = observation.repaint_on_updates(context);
     Ok((observation, repaint))

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use color_eyre::{Report, eyre::Context as _};
 use eframe::egui::{ColorImage, Context, TextureHandle, TextureOptions, Ui, load::SizedTexture};
 use hulk_widgets::CompletionEdit;
 use image::RgbImage;
 use ros_z::{Message, entity::EndpointKind, pubsub::PublicationId, time::Time};
-use ros_z_debug::{SampleRecord, TopicObservation, TopicObservationStatus};
+use ros_z_debug::{RetentionPolicy, SampleRecord, TopicObservation, TopicObservationStatus};
 use ros2::sensor_msgs::image::Image as RosImage;
 use serde_json::{Value, json};
 use thiserror::Error;
@@ -24,6 +24,7 @@ mod image_overlay;
 mod overlays;
 
 pub const DEFAULT_IMAGE_TOPIC: &str = "inputs/left_image";
+const IMAGE_RETENTION_WINDOW: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Error)]
 enum ImageDecodeError {
@@ -138,9 +139,12 @@ impl Panel for ImagePanel {
                 }
                 ObservationState::Observing(observed) => {
                     Self::render_status(ui, observed.observation.status());
-                    observed
-                        .render_cache
-                        .refresh(&context.egui_context, &observed.observation);
+                    let preferred_image_time = self.overlays.preferred_image_time();
+                    observed.render_cache.refresh(
+                        &context.egui_context,
+                        &observed.observation,
+                        preferred_image_time,
+                    );
 
                     let Some(metadata) = observed.render_cache.metadata() else {
                         ui.label("Waiting for first sample.");
@@ -282,8 +286,16 @@ impl RenderedImageCache {
         }
     }
 
-    fn refresh(&mut self, egui_context: &Context, observation: &TopicObservation<RosImage>) {
-        self.refresh_sample(egui_context, observation.latest());
+    fn refresh(
+        &mut self,
+        egui_context: &Context,
+        observation: &TopicObservation<RosImage>,
+        preferred_image_time: Option<Time>,
+    ) {
+        let sample = preferred_image_time
+            .and_then(|time| image_sample_at_time(observation, time))
+            .or_else(|| observation.latest());
+        self.refresh_sample(egui_context, sample);
     }
 
     fn refresh_sample(
@@ -334,7 +346,7 @@ impl RenderedImageCache {
     }
 
     fn image_time(&self) -> Option<Time> {
-        self.sample.as_ref().map(|record| record.value.time)
+        self.sample.as_ref().map(|record| image_time(&record.value))
     }
 
     fn error(&self) -> Option<&str> {
@@ -364,9 +376,28 @@ impl From<&SampleRecord<RosImage>> for RenderedMetadata {
                 .map(format_time)
                 .unwrap_or_else(|| "none".to_string()),
             publication_id: format_publication_id(record.publication_id),
-            image_time: format_time(record.value.header.stamp.into()),
+            image_time: format_time(image_time(&record.value)),
         }
     }
+}
+
+fn image_time(image: &RosImage) -> Time {
+    image.header.stamp.into()
+}
+
+fn image_sample_at_time(
+    observation: &TopicObservation<RosImage>,
+    time: Time,
+) -> Option<Arc<SampleRecord<RosImage>>> {
+    let latest = observation.latest()?;
+    observation
+        .window(
+            latest.source_time - IMAGE_RETENTION_WINDOW,
+            latest.source_time,
+        )
+        .into_iter()
+        .rev()
+        .find(|record| image_time(&record.value) == time)
 }
 
 fn create_observation(
@@ -380,6 +411,9 @@ fn create_observation(
         .backend()
         .observer()
         .observe_typed::<RosImage>(topic)
+        .and_then(|builder| {
+            Ok(builder.retention(RetentionPolicy::time_window(IMAGE_RETENTION_WINDOW)?))
+        })
         .wrap_err("failed to create image topic observation")?
         .spawn();
     let repaint = observation.repaint_on_updates(context);
@@ -507,7 +541,7 @@ mod tests {
         .await
         .expect("observation should receive published image");
 
-        cache.refresh(&context, &observation);
+        cache.refresh(&context, &observation, None);
 
         assert_eq!(cache.dimensions(), Some([2, 1]));
         assert!(cache.texture().is_some());

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -389,15 +389,12 @@ fn image_sample_at_time(
     observation: &TopicObservation<RosImage>,
     time: Time,
 ) -> Option<Arc<SampleRecord<RosImage>>> {
-    let latest = observation.latest()?;
     observation
-        .window(
-            latest.source_time - IMAGE_RETENTION_WINDOW,
-            latest.source_time,
-        )
-        .into_iter()
+        .get_all()
+        .iter()
         .rev()
         .find(|record| image_time(&record.value) == time)
+        .cloned()
 }
 
 fn create_observation(
@@ -411,10 +408,8 @@ fn create_observation(
         .backend()
         .observer()
         .observe_typed::<RosImage>(topic)
-        .and_then(|builder| {
-            Ok(builder.retention(RetentionPolicy::time_window(IMAGE_RETENTION_WINDOW)?))
-        })
         .wrap_err("failed to create image topic observation")?
+        .retention(RetentionPolicy::time_window(IMAGE_RETENTION_WINDOW)?)
         .spawn();
     let repaint = observation.repaint_on_updates(context);
     Ok((observation, repaint))

--- a/tools/twix/src/panels/image/mod.rs
+++ b/tools/twix/src/panels/image/mod.rs
@@ -165,13 +165,16 @@ impl Panel for ImagePanel {
                             size,
                         };
                         let response = ui.add(eframe::egui::Image::new(texture).shrink_to_fit());
-                        if let Some(dimensions) = observed.render_cache.dimensions() {
+                        if let (Some(dimensions), Some(image_time)) = (
+                            observed.render_cache.dimensions(),
+                            observed.render_cache.image_time(),
+                        ) {
                             let painter = ImageOverlayPainter::new(
                                 ui.painter_at(response.rect),
                                 response.rect,
                                 dimensions,
                             );
-                            self.overlays.paint(&painter);
+                            self.overlays.paint(&painter, image_time);
                         }
                     }
                 }
@@ -328,6 +331,10 @@ impl RenderedImageCache {
 
     fn dimensions(&self) -> Option<[usize; 2]> {
         self.dimensions
+    }
+
+    fn image_time(&self) -> Option<Time> {
+        self.sample.as_ref().map(|record| record.value.time)
     }
 
     fn error(&self) -> Option<&str> {

--- a/tools/twix/src/panels/image/overlays/ball_detection.rs
+++ b/tools/twix/src/panels/image/overlays/ball_detection.rs
@@ -2,6 +2,7 @@ use color_eyre::Report;
 use coordinate_systems::Pixel;
 use eframe::egui::{Color32, Stroke};
 use geometry::circle::Circle;
+use ros_z::time::Time;
 
 use crate::repaint::ObservationContext;
 
@@ -27,7 +28,7 @@ impl ImageOverlay for BallDetectionOverlay {
         })
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
+    fn paint(&self, painter: &ImageOverlayPainter, _image_time: Time) {
         let Some(filtered_balls) = self.filtered_balls.latest() else {
             return;
         };

--- a/tools/twix/src/panels/image/overlays/field_border.rs
+++ b/tools/twix/src/panels/image/overlays/field_border.rs
@@ -2,6 +2,7 @@ use color_eyre::Report;
 use coordinate_systems::Pixel;
 use eframe::egui::{Color32, Stroke};
 use linear_algebra::Point2;
+use ros_z::time::Time;
 use types::{field_border::FieldBorder as FieldBorderData, time_wrapper::TimeWrapper};
 
 use crate::repaint::ObservationContext;
@@ -27,7 +28,7 @@ impl ImageOverlay for FieldBorderOverlay {
         })
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
+    fn paint(&self, painter: &ImageOverlayPainter, _image_time: Time) {
         let Some(candidates) = self.candidates.latest() else {
             return;
         };

--- a/tools/twix/src/panels/image/overlays/horizon.rs
+++ b/tools/twix/src/panels/image/overlays/horizon.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use color_eyre::Report;
 use eframe::egui::{Color32, Stroke};
 use linear_algebra::point;
@@ -8,6 +10,8 @@ use types::time_wrapper::TimeWrapper;
 use crate::repaint::ObservationContext;
 
 use super::super::image_overlay::{ImageOverlay, ImageOverlayPainter, OverlayObservation};
+
+const CAMERA_MATRIX_ALIGNMENT_TOLERANCE: Duration = Duration::from_millis(100);
 
 pub(in crate::panels::image) struct HorizonOverlay {
     camera_matrix: OverlayObservation<TimeWrapper<CameraMatrix>>,
@@ -27,7 +31,10 @@ impl ImageOverlay for HorizonOverlay {
     }
 
     fn paint(&self, painter: &ImageOverlayPainter, image_time: Time) {
-        let Some(camera_matrix) = self.camera_matrix.at_time(image_time) else {
+        let Some(camera_matrix) = self
+            .camera_matrix
+            .nearest_to_time(image_time, CAMERA_MATRIX_ALIGNMENT_TOLERANCE)
+        else {
             return;
         };
         let Some(horizon) = camera_matrix.value.inner.horizon else {
@@ -48,5 +55,9 @@ impl ImageOverlay for HorizonOverlay {
             5.0,
             Stroke::new(3.0, Color32::GREEN),
         );
+    }
+
+    fn latest_time(&self) -> Option<Time> {
+        self.camera_matrix.latest_time()
     }
 }

--- a/tools/twix/src/panels/image/overlays/horizon.rs
+++ b/tools/twix/src/panels/image/overlays/horizon.rs
@@ -2,6 +2,7 @@ use color_eyre::Report;
 use eframe::egui::{Color32, Stroke};
 use linear_algebra::point;
 use projection::camera_matrix::CameraMatrix;
+use ros_z::time::Time;
 use types::time_wrapper::TimeWrapper;
 
 use crate::repaint::ObservationContext;
@@ -25,8 +26,8 @@ impl ImageOverlay for HorizonOverlay {
         })
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
-        let Some(camera_matrix) = self.camera_matrix.latest() else {
+    fn paint(&self, painter: &ImageOverlayPainter, image_time: Time) {
+        let Some(camera_matrix) = self.camera_matrix.at_time(image_time) else {
             return;
         };
         let Some(horizon) = camera_matrix.value.inner.horizon else {

--- a/tools/twix/src/panels/image/overlays/line_detection.rs
+++ b/tools/twix/src/panels/image/overlays/line_detection.rs
@@ -2,6 +2,7 @@ use color_eyre::Report;
 use coordinate_systems::Pixel;
 use eframe::egui::{Color32, Stroke};
 use geometry::line_segment::LineSegment;
+use ros_z::time::Time;
 use types::{
     image_segments::{EdgeType, GenericSegment},
     line_data::{DiscardedLine, LineDiscardReason},
@@ -35,7 +36,7 @@ impl ImageOverlay for LineDetectionOverlay {
         })
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
+    fn paint(&self, painter: &ImageOverlayPainter, _image_time: Time) {
         let (Some(lines), Some(discarded_lines), Some(filtered_segments)) = (
             self.lines_in_image.latest(),
             self.discarded_lines.latest(),

--- a/tools/twix/src/panels/image/overlays/object_detection.rs
+++ b/tools/twix/src/panels/image/overlays/object_detection.rs
@@ -33,6 +33,10 @@ impl ImageOverlay for ObjectDetectionOverlay {
         };
         paint_bounding_boxes(painter, &object_detections.value.inner, Color32::LIGHT_RED);
     }
+
+    fn latest_time(&self) -> Option<Time> {
+        self.object_detections.latest_time()
+    }
 }
 
 fn paint_bounding_boxes(

--- a/tools/twix/src/panels/image/overlays/object_detection.rs
+++ b/tools/twix/src/panels/image/overlays/object_detection.rs
@@ -1,13 +1,17 @@
 use color_eyre::Report;
 use eframe::egui::{Align2, Color32, Stroke};
-use types::object_detection::{Object, RobocupObjectLabel};
+use ros_z::time::Time;
+use types::{
+    object_detection::{Object, RobocupObjectLabel},
+    time_wrapper::TimeWrapper,
+};
 
 use crate::repaint::ObservationContext;
 
 use super::super::image_overlay::{ImageOverlay, ImageOverlayPainter, OverlayObservation};
 
 pub(in crate::panels::image) struct ObjectDetectionOverlay {
-    object_detections: OverlayObservation<Vec<Object<RobocupObjectLabel>>>,
+    object_detections: OverlayObservation<TimeWrapper<Vec<Object<RobocupObjectLabel>>>>,
 }
 
 impl ImageOverlay for ObjectDetectionOverlay {
@@ -23,11 +27,11 @@ impl ImageOverlay for ObjectDetectionOverlay {
         })
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
-        let Some(object_detections) = self.object_detections.latest() else {
+    fn paint(&self, painter: &ImageOverlayPainter, image_time: Time) {
+        let Some(object_detections) = self.object_detections.at_time(image_time) else {
             return;
         };
-        paint_bounding_boxes(painter, &object_detections.value, Color32::LIGHT_RED);
+        paint_bounding_boxes(painter, &object_detections.value.inner, Color32::LIGHT_RED);
     }
 }
 

--- a/tools/twix/src/panels/image/overlays/pose_detection.rs
+++ b/tools/twix/src/panels/image/overlays/pose_detection.rs
@@ -55,6 +55,10 @@ impl ImageOverlay for PoseDetectionOverlay {
         };
         paint_poses(painter, &poses.value.inner);
     }
+
+    fn latest_time(&self) -> Option<Time> {
+        self.poses.latest_time()
+    }
 }
 
 fn paint_poses(painter: &ImageOverlayPainter, poses: &[Pose<YOLOObjectLabel>]) {

--- a/tools/twix/src/panels/image/overlays/pose_detection.rs
+++ b/tools/twix/src/panels/image/overlays/pose_detection.rs
@@ -1,9 +1,11 @@
 use color_eyre::Report;
 use eframe::egui::{Align2, Color32, Stroke};
 use linear_algebra::point;
+use ros_z::time::Time;
 use types::{
     object_detection::YOLOObjectLabel,
     pose_detection::{Keypoint, Pose},
+    time_wrapper::TimeWrapper,
 };
 
 use crate::repaint::ObservationContext;
@@ -31,7 +33,7 @@ const POSE_SKELETON_KEYPOINT_LINE_MAPPING: [(usize, usize); 16] = [
 const KEYPOINT_CONFIDENCE_THRESHOLD: f32 = 0.8;
 
 pub(in crate::panels::image) struct PoseDetectionOverlay {
-    poses: OverlayObservation<Vec<Pose<YOLOObjectLabel>>>,
+    poses: OverlayObservation<TimeWrapper<Vec<Pose<YOLOObjectLabel>>>>,
 }
 
 impl ImageOverlay for PoseDetectionOverlay {
@@ -47,11 +49,11 @@ impl ImageOverlay for PoseDetectionOverlay {
         })
     }
 
-    fn paint(&self, painter: &ImageOverlayPainter) {
-        let Some(poses) = self.poses.latest() else {
+    fn paint(&self, painter: &ImageOverlayPainter, image_time: Time) {
+        let Some(poses) = self.poses.at_time(image_time) else {
             return;
         };
-        paint_poses(painter, &poses.value);
+        paint_poses(painter, &poses.value.inner);
     }
 }
 


### PR DESCRIPTION
## Why? What?

Adds temporal syncing between the image displayed in the twix image panel and the overlays display on top of it. Buffers the image and then draws the matched image for the later arriving overlay data. 

- Fixes #

## How to Test

- Open twix. Put the ball in Initial at the side of the field and let it rotate its head. The overlays should be perfectly aligned to the image while the head is rotating.
