### PR TITLE
Load robot number from team.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5545,6 +5545,7 @@ dependencies = [
  "odometer_bridge",
  "player_state_receiver",
  "primary_state_filter",
+ "repository",
  "ros-z",
  "rule_obstacle_composer",
  "safe_pose_checker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8172,7 +8172,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.32.0"
+version = "7.33.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/hulk_ros_z/Cargo.toml
+++ b/crates/hulk_ros_z/Cargo.toml
@@ -47,6 +47,7 @@ obstacle_filter = { workspace = true }
 odometer_bridge = { workspace = true }
 player_state_receiver = { workspace = true }
 primary_state_filter = { workspace = true }
+repository = { workspace = true }
 ros-z = { workspace = true }
 rule_obstacle_composer = { workspace = true }
 safe_pose_checker = { workspace = true }

--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -3,8 +3,9 @@ use std::{env, future::Future, path::PathBuf, sync::Arc, time::Duration};
 use clap::Parser;
 use color_eyre::{
     Result,
-    eyre::{Context as _, ContextCompat, bail},
+    eyre::{Context as _, ContextCompat, bail, eyre},
 };
+use repository::{Repository, team::Team};
 use ros_z::prelude::*;
 use tokio::task::JoinSet;
 use tracing_subscriber::EnvFilter;
@@ -13,11 +14,6 @@ const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Parser)]
 struct Args {
-    #[arg(
-        long,
-        help = "Robot graph namespace. Bare values like '42' become '/42'; invalid ros-z names are rejected."
-    )]
-    robot: String,
     #[arg(long)]
     location: String,
     #[arg(long, default_value = "parameters/ros_z")]
@@ -54,7 +50,6 @@ where
 
 async fn run() -> Result<()> {
     let args = Args::parse();
-    let namespace = derive_namespace(&args.robot);
 
     let Some(hardware_id) = env::var_os("HARDWARE_ID") else {
         bail!("environment variable HARDWARE_ID not set");
@@ -63,6 +58,8 @@ async fn run() -> Result<()> {
         .into_string()
         .ok()
         .wrap_err("id was not valid UTF-8")?;
+    let robot_number = load_robot_number(&hardware_id).await?;
+    let namespace = derive_namespace(&robot_number.to_string());
 
     let parameter_layers =
         derive_parameter_layers(&args.parameter_root, &args.location, &hardware_id);
@@ -107,6 +104,21 @@ fn derive_parameter_layers(
         parameter_root.join("location").join(location),
         parameter_root.join("robot").join(robot),
     ]
+}
+
+async fn load_robot_number(hardware_id: &str) -> Result<u8> {
+    let repository =
+        Repository::new(env::current_dir().wrap_err("failed to get current directory")?);
+    let team = repository.read_team_configuration().await?;
+    robot_number_for_hardware_id(&team, hardware_id)
+}
+
+fn robot_number_for_hardware_id(team: &Team, hardware_id: &str) -> Result<u8> {
+    team.robots
+        .iter()
+        .find(|robot| robot.id == hardware_id)
+        .map(|robot| robot.number)
+        .ok_or_else(|| eyre!(r#"ID "{hardware_id}" not found in team.toml"#))
 }
 
 fn derive_namespace(robot: &str) -> String {

--- a/crates/ros-z/README.md
+++ b/crates/ros-z/README.md
@@ -64,9 +64,9 @@ is reserved by the current ros-z liveliness identity encoding, and `*` is a
 selector wildcard rather than a concrete endpoint character.
 
 Applications should pass graph names through unchanged except for adding a
-leading slash where they accept a bare namespace. For example,
-`hulk_ros_z --robot 42` uses namespace `/42`; invalid names such as `robot%01`
-are rejected instead of rewritten.
+leading slash where they accept a bare namespace. For example, a bare robot
+number `42` becomes namespace `/42`; invalid names such as `robot%01` are
+rejected instead of rewritten.
 
 ## Examples
 

--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -14,7 +14,6 @@ chown -R booster:booster /home/booster/hulk/logs
   --user "$(id -u booster)" \
   hulk \
   /home/booster/hulk/bin/hulk_ros_z \
-  --robot ROBOT_NUMBER \
   --location default-location \
   --parameter-root etc/parameters/ros_z \
   --router tcp/127.0.0.1:7447 \

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.32.0"
+version = "7.33.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -284,18 +284,6 @@ async fn gammaray_robot(
 
     robot
         .ssh_to_robot()?
-        .arg("sudo sed")
-        .arg("--in-place")
-        .arg(format!(
-            "'s#--robot ROBOT_NUMBER#--robot {}#'",
-            team_robot.number
-        ))
-        .arg("/usr/bin/launch-hulk")
-        .ssh_with_log("hacking launch-hulk", &progress_bar)
-        .await?;
-
-    robot
-        .ssh_to_robot()?
         .arg("sudo systemctl daemon-reload")
         .ssh_with_log("reloading service daemon", &progress_bar)
         .await?;


### PR DESCRIPTION
## Why? What?

removes patching launch-hulk with the robot number during gammaray and instead uses the temu.toml to look up the robot number using the hardware id.

## How to Test

- gammaray
- upload
- everything should work as before.