### PR TITLE
Move head in ready

### DIFF
--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -81,7 +81,7 @@ pub fn create_tree() -> Node<Blackboard> {
 }
 
 fn ready_subtree() -> Node<Blackboard> {
-    sequence!(action!(walk_to_kickoff_pose))
+    sequence!(action!(walk_to_kickoff_pose), action!(look_around),)
 }
 
 fn playing_subtree() -> Node<Blackboard> {

--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -19,7 +19,7 @@ use crate::{
     selection, sequence,
     substates::{is_in_sub_state, sub_state_subtree},
     subtree,
-    switch_motion_type::switch_motion_type,
+    switch_motion_type::{is_last_motion_type, switch_motion_type},
     voronoi::calculate_voronoi_grid,
     walk::{
         walk_alternatives_subtree, walk_to_ball_subtree, walk_to_kickoff_pose,
@@ -81,7 +81,13 @@ pub fn create_tree() -> Node<Blackboard> {
 }
 
 fn ready_subtree() -> Node<Blackboard> {
-    sequence!(action!(walk_to_kickoff_pose))
+    sequence!(
+        action!(walk_to_kickoff_pose),
+        sequence!(
+            condition!(is_last_motion_type, MotionType::Stand),
+            action!(look_around),
+        ),
+    )
 }
 
 fn playing_subtree() -> Node<Blackboard> {

--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -19,7 +19,7 @@ use crate::{
     selection, sequence,
     substates::{is_in_sub_state, sub_state_subtree},
     subtree,
-    switch_motion_type::{is_last_motion_type, switch_motion_type},
+    switch_motion_type::switch_motion_type,
     voronoi::calculate_voronoi_grid,
     walk::{
         walk_alternatives_subtree, walk_to_ball_subtree, walk_to_kickoff_pose,
@@ -81,13 +81,7 @@ pub fn create_tree() -> Node<Blackboard> {
 }
 
 fn ready_subtree() -> Node<Blackboard> {
-    sequence!(
-        action!(walk_to_kickoff_pose),
-        sequence!(
-            condition!(is_last_motion_type, MotionType::Stand),
-            action!(look_around),
-        ),
-    )
+    sequence!(action!(walk_to_kickoff_pose))
 }
 
 fn playing_subtree() -> Node<Blackboard> {

--- a/crates/nodes/behavior_node/src/walk.rs
+++ b/crates/nodes/behavior_node/src/walk.rs
@@ -5,7 +5,7 @@ use linear_algebra::{Isometry2, Orientation2, Point, Point2, Pose2, point};
 use path_planner::path_planner::PathPlanner;
 use types::{
     behavior_tree::Status,
-    motion_command::{BodyMotion, HeadMotion, MotionCommand, OrientationMode},
+    motion_command::{BodyMotion, MotionCommand, OrientationMode},
     motion_type::MotionType,
     path::{Path, direct_path},
 };
@@ -234,7 +234,7 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
         );
 
         let kickoff_pose_in_ground = field_to_ground * kickoff_pose_in_field;
-        blackboard.head_motion = Some(HeadMotion::LookAround);
+        // blackboard.head_motion = Some(HeadMotion::LookAround);
         walk_to(
             blackboard,
             kickoff_pose_in_ground,

--- a/crates/nodes/behavior_node/src/walk.rs
+++ b/crates/nodes/behavior_node/src/walk.rs
@@ -5,7 +5,7 @@ use linear_algebra::{Isometry2, Orientation2, Point, Point2, Pose2, point};
 use path_planner::path_planner::PathPlanner;
 use types::{
     behavior_tree::Status,
-    motion_command::{BodyMotion, MotionCommand, OrientationMode},
+    motion_command::{BodyMotion, HeadMotion, MotionCommand, OrientationMode},
     motion_type::MotionType,
     path::{Path, direct_path},
 };
@@ -234,7 +234,7 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
         );
 
         let kickoff_pose_in_ground = field_to_ground * kickoff_pose_in_field;
-
+        blackboard.head_motion = Some(HeadMotion::LookAround);
         walk_to(
             blackboard,
             kickoff_pose_in_ground,

--- a/crates/nodes/behavior_node/src/walk.rs
+++ b/crates/nodes/behavior_node/src/walk.rs
@@ -234,7 +234,7 @@ pub fn walk_to_kickoff_pose(blackboard: &mut Blackboard) -> Status {
         );
 
         let kickoff_pose_in_ground = field_to_ground * kickoff_pose_in_field;
-        // blackboard.head_motion = Some(HeadMotion::LookAround);
+
         walk_to(
             blackboard,
             kickoff_pose_in_ground,


### PR DESCRIPTION
## Why? What?

When the robot is in Ready, we now use HeadMotion::LookAround in walk_to_kickoff_pose.

- Fixes #2761 

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

Run behavior simulator with a scenario that starts with Initial and then goes to Ready after a few seconds.
Or, upload on a robot and test with game controller.
