### PR TITLE
Chown correct directory

### DIFF
--- a/tools/k1-setup/launch-hulk
+++ b/tools/k1-setup/launch-hulk
@@ -7,7 +7,7 @@ INTERNAL_LOG_PATH="/home/booster/hulk/logs/${CURRENT_DATE}"
 mkdir -p "${INTERNAL_LOG_PATH}"
 ln -sfn "${INTERNAL_LOG_PATH}" "/home/booster/hulk/logs/latest"
 touch "${INTERNAL_LOG_PATH}/hulk.out" "${INTERNAL_LOG_PATH}/hulk.err"
-chown -R booster:booster /home/booster/hulk/logs
+chown -R booster:booster /home/booster/hulk
 
 /usr/local/bin/podman exec \
   --env RUST_BACKTRACE=1 \


### PR DESCRIPTION
## Why? What?

- Gammaray starts `hulk` service at the end
- `hulk` service runs `launch-hulk`
- `launch-hulk` creates ~/hulk/logs` directory
- then chowns `~/hulk/logs` but not `~/hulk`

Previously an upload directly after a gammaray on a fresh robot would fail because of missing write perms in `~/hulk`

## How to Test

Gammaray fresh robot, then upload