### PR TITLE
Download journal with logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8172,7 +8172,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.33.0"
+version = "7.34.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/crates/robot/src/lib.rs
+++ b/crates/robot/src/lib.rs
@@ -227,9 +227,18 @@ impl Robot {
             .status()
             .await
             .wrap_err("failed to write dmesg to kernel.log")?;
-
         if !status.success() {
             bail!("dmesg pipe ssh command exited with {status}");
+        }
+
+        let status = self
+            .ssh_to_robot()?
+            .arg("sudo journalctl --no-pager > hulk/logs/system.log")
+            .status()
+            .await
+            .wrap_err("failed to write journalctl to system.log")?;
+        if !status.success() {
+            bail!("journalctl pipe ssh command exited with {status}");
         }
 
         let rsync = self

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.33.0"
+version = "7.34.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Why? What?

Downloads the whole systemd journal during `pspsps postgame` and `pspsps logs download`

## How to Test

- `./pepsi postgame`
- or `./pepsi logs download`
- then inspect log folder, should contain `system.log` with journal content.