### PR TITLE
add temperature logging

### DIFF
--- a/tools/k1-setup/jetson-clocks-refresh.service
+++ b/tools/k1-setup/jetson-clocks-refresh.service
@@ -7,4 +7,5 @@ Type=oneshot
 StandardOutput=journal
 StandardError=journal
 ExecStartPre=/usr/bin/jetson_clocks --show
+ExecStartPre=bash -c 'for z in /sys/class/thermal/thermal_zone*; do printf "%%s: %%s C\n" "$(cat "$z/type")" "$(( $(<"$z/temp") / 1000 ))"; done'
 ExecStart=/usr/bin/jetson_clocks


### PR DESCRIPTION
## Why? What?


```
Jul 04 13:01:52 Ernst-Guenther bash[70137]: cpu-thermal: 90 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: gpu-thermal: 92 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: cv0-thermal: 84 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: cv1-thermal: 84 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: cv2-thermal: 81 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: soc0-thermal: 83 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: soc1-thermal: 84 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: soc2-thermal: 84 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: tj-thermal: 92 C
Jul 04 13:01:52 Ernst-Guenther bash[70137]: iwlwifi_1: 68 C
```

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

dedicated script file instead of cryptic ExecStartPre=

## How to Test

gammaray with recent pepsi
`pepsi muschel 42 "journalctl -fu jetson-clocks-refresh.service"`