### PR TITLE
Remove kickoff obstacles

### DIFF
--- a/crates/nodes/rule_obstacle_composer/src/lib.rs
+++ b/crates/nodes/rule_obstacle_composer/src/lib.rs
@@ -158,45 +158,6 @@ fn compose_rule_obstacles(
                 ));
             }
         },
-        (
-            FilteredGameControllerState {
-                game_state: FilteredGameState::Ready,
-                sub_state: None,
-                kicking_team: Some(Team::Hulks),
-                ..
-            },
-            _,
-        ) => {
-            let center_circle_ballspace_free_obstacle = RuleObstacle::Circle(Circle {
-                center: Point::origin(),
-                radius: parameters.center_circle_ballspace_free_obstacle_radius,
-            });
-
-            rule_obstacles.push(center_circle_ballspace_free_obstacle);
-        }
-        (
-            FilteredGameControllerState {
-                game_state: FilteredGameState::Ready,
-                sub_state: None,
-                kicking_team: None,
-                ..
-            }
-            | FilteredGameControllerState {
-                game_state: FilteredGameState::Ready,
-                sub_state: None,
-                kicking_team: Some(Team::Opponent),
-                ..
-            },
-            _,
-        ) => {
-            let center_circle_obstacle = RuleObstacle::Circle(Circle {
-                center: Point::origin(),
-                radius: field_dimensions.center_circle_diameter / 2.0
-                    + parameters.center_circle_obstacle_radius_increase,
-            });
-
-            rule_obstacles.push(center_circle_obstacle);
-        }
         _ => (),
     };
 


### PR DESCRIPTION
## Why? What?

Remove kickoff obstacles to get faster into our field and dont bound against the obstacle
- Fixes #2796

## How to Test

let the robot walk to the opponents half infront of the center circle and then let the robot walk back in ready