### PR TITLE
Add gamepad manual control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +3988,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4445,6 +4469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4569,6 +4599,21 @@ dependencies = [
  "ros-z-streams",
  "serde",
  "tokio",
+ "types",
+]
+
+[[package]]
+name = "gamepad"
+version = "0.1.0"
+dependencies = [
+ "color-eyre",
+ "evdev",
+ "kinematics",
+ "linear_algebra",
+ "ros-z",
+ "serde",
+ "tokio",
+ "tracing",
  "types",
 ]
 
@@ -5524,6 +5569,7 @@ dependencies = [
  "field_mark_association",
  "game_controller_filter",
  "game_controller_state_filter",
+ "gamepad",
  "global_parameter_provider",
  "ground_provider",
  "head_motion",
@@ -9038,6 +9084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "radsort"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10939,6 +10991,12 @@ name = "talc"
 version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -13461,6 +13519,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x11-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
   "crates/nodes/field_mark_association",
   "crates/nodes/game_controller_filter",
   "crates/nodes/game_controller_state_filter",
+  "crates/nodes/gamepad",
   "crates/nodes/global_parameter_provider",
   "crates/nodes/ground_provider",
   "crates/nodes/head_motion",
@@ -193,6 +194,7 @@ egui_extras = { version = "0.33.3", features = ["image"] }
 egui_plot = "0.34.0"
 energy_optimization = { path = "crates/energy_optimization" }
 enum-iterator = "2.1.0"
+evdev = "0.13.2"
 enum_dispatch = "0.3.13"
 enumset = "1.1.10"
 env_logger = "0.11.8"
@@ -208,6 +210,7 @@ framework = { path = "crates/framework" }
 futures-util = "0.3.31"
 game_controller_filter = { path = "crates/nodes/game_controller_filter" }
 game_controller_state_filter = { path = "crates/nodes/game_controller_state_filter" }
+gamepad = { path = "crates/nodes/gamepad" }
 geometry = { path = "crates/geometry" }
 gilrs = "0.11.0"
 glob = "0.3.2"

--- a/crates/bevyhavior_simulator/src/kinematics.rs
+++ b/crates/bevyhavior_simulator/src/kinematics.rs
@@ -300,6 +300,7 @@ fn desired_head_yaw(
                 (elapsed * std::f32::consts::TAU / period).sin() * amplitude
             }
         }
+        Some(HeadMotion::JointAngles { joints }) => joints.yaw,
         Some(HeadMotion::ZeroAngles)
         | Some(HeadMotion::Center { .. })
         | Some(HeadMotion::Unstiff)

--- a/crates/hulk_ros_z/Cargo.toml
+++ b/crates/hulk_ros_z/Cargo.toml
@@ -25,6 +25,7 @@ fall_down_state_receiver = { workspace = true }
 field_mark_association = { workspace = true }
 game_controller_filter = { workspace = true }
 game_controller_state_filter = { workspace = true }
+gamepad = { workspace = true }
 global_parameter_provider = { workspace = true }
 ground_provider = { workspace = true }
 head_motion = { workspace = true }

--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -148,6 +148,7 @@ async fn spawn_all(ctx: Arc<Context>, log_path: Option<PathBuf>) -> Result<Runni
     join_set.spawn(field_mark_association::run_boxed(ctx.clone()));
     join_set.spawn(game_controller_filter::run_boxed(ctx.clone()));
     join_set.spawn(game_controller_state_filter::run_boxed(ctx.clone()));
+    join_set.spawn(gamepad::run_boxed(ctx.clone()));
     join_set.spawn(global_parameter_provider::run_boxed(ctx.clone()));
     join_set.spawn(ground_provider::run_boxed(ctx.clone()));
     join_set.spawn(head_motion::run_boxed(ctx.clone()));

--- a/crates/nodes/behavior_node/src/node.rs
+++ b/crates/nodes/behavior_node/src/node.rs
@@ -15,6 +15,7 @@ use types::{
     behavior_tree::NodeTrace,
     field_dimensions::{FieldDimensions, Side},
     filtered_game_controller_state::FilteredGameControllerState,
+    gamepad::GamepadManualMotion,
     messages::OutgoingMessage,
     motion_command::{BodyMotion, HeadMotion, MotionCommand},
     motion_type::MotionType,
@@ -73,6 +74,24 @@ pub struct Blackboard {
 
 pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
     Box::pin(run(ctx))
+}
+
+fn select_motion_command(
+    primary_state: PrimaryState,
+    autonomous_motion_command: MotionCommand,
+    gamepad_manual_motion: Option<&GamepadManualMotion>,
+) -> MotionCommand {
+    if primary_state == PrimaryState::Damping {
+        return autonomous_motion_command;
+    }
+
+    match gamepad_manual_motion {
+        Some(GamepadManualMotion {
+            active: true,
+            motion_command,
+        }) => motion_command.clone(),
+        _ => autonomous_motion_command,
+    }
 }
 
 fn validate_behavior_parameters(
@@ -204,6 +223,11 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             durability: QosDurability::TransientLocal,
             ..Default::default()
         })
+        .cache(1)
+        .build()
+        .await?;
+    let gamepad_manual_motion_cache = node
+        .subscriber::<GamepadManualMotion>("gamepad/manual_motion")
         .cache(1)
         .build()
         .await?;
@@ -384,7 +408,14 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         }
 
         let (status, trace) = block_in_place(|| tree.tick_with_trace(&mut blackboard));
-        let motion_command: MotionCommand = assemble_motion_command(&blackboard, status)?;
+        let autonomous_motion_command: MotionCommand =
+            assemble_motion_command(&blackboard, status)?;
+        let gamepad_manual_motion = gamepad_manual_motion_cache.get_latest();
+        let motion_command = select_motion_command(
+            blackboard.world_state.robot.primary_state,
+            autonomous_motion_command,
+            gamepad_manual_motion.as_deref(),
+        );
 
         let previous_motion_command = blackboard.last_motion_command.clone();
         blackboard.last_motion_command = motion_command.clone();
@@ -435,5 +466,85 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             .publish_if_subscribed(|| async { blackboard.clone() })
             .await?;
         motion_command_pub.publish(&motion_command).await?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linear_algebra::vector;
+    use types::{
+        gamepad::GamepadManualMotion,
+        motion_command::{HeadMotion, ImageRegion, MotionCommand},
+        primary_state::PrimaryState,
+    };
+
+    use super::select_motion_command;
+
+    fn stand_command() -> MotionCommand {
+        MotionCommand::Stand {
+            head: HeadMotion::Center {
+                image_region_target: ImageRegion::Center,
+            },
+        }
+    }
+
+    fn manual_walk_command() -> MotionCommand {
+        MotionCommand::WalkWithVelocity {
+            head: HeadMotion::Center {
+                image_region_target: ImageRegion::Center,
+            },
+            velocity: vector![0.2, -0.1],
+            angular_velocity: 0.3,
+        }
+    }
+
+    #[test]
+    fn damping_ignores_active_gamepad_manual_motion() {
+        let autonomous = MotionCommand::Damping;
+        let manual = GamepadManualMotion {
+            active: true,
+            motion_command: manual_walk_command(),
+        };
+
+        let selected = select_motion_command(PrimaryState::Damping, autonomous, Some(&manual));
+
+        assert_eq!(selected, MotionCommand::Damping);
+    }
+
+    #[test]
+    fn non_damping_uses_active_gamepad_manual_motion() {
+        let autonomous = stand_command();
+        let manual_motion_command = manual_walk_command();
+        let manual = GamepadManualMotion {
+            active: true,
+            motion_command: manual_motion_command.clone(),
+        };
+
+        let selected = select_motion_command(PrimaryState::Playing, autonomous, Some(&manual));
+
+        assert_eq!(selected, manual_motion_command);
+    }
+
+    #[test]
+    fn non_damping_uses_autonomous_motion_when_gamepad_inactive() {
+        let autonomous = stand_command();
+        let manual = GamepadManualMotion {
+            active: false,
+            motion_command: manual_walk_command(),
+        };
+
+        let selected =
+            select_motion_command(PrimaryState::Playing, autonomous.clone(), Some(&manual));
+
+        assert_eq!(selected, autonomous);
+    }
+
+    #[test]
+    fn non_damping_uses_autonomous_motion_without_gamepad_sample() {
+        let autonomous = stand_command();
+
+        let selected = select_motion_command(PrimaryState::Playing, autonomous.clone(), None);
+
+        assert_eq!(selected, autonomous);
     }
 }

--- a/crates/nodes/gamepad/Cargo.toml
+++ b/crates/nodes/gamepad/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gamepad"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+color-eyre = { workspace = true }
+evdev = { workspace = true }
+kinematics = { workspace = true }
+linear_algebra = { workspace = true }
+ros-z = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+types = { workspace = true }

--- a/crates/nodes/gamepad/src/evdev_input.rs
+++ b/crates/nodes/gamepad/src/evdev_input.rs
@@ -1,0 +1,239 @@
+use std::{io, path::Path};
+
+use evdev::{AbsoluteAxisCode, Device, EventSummary, KeyCode};
+
+use crate::state::{GamepadState, normalize_axis};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
+    LeftX,
+    LeftY,
+    RightX,
+    HatX,
+    HatY,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AxisRange {
+    minimum: i32,
+    maximum: i32,
+}
+
+impl AxisRange {
+    const SONY_STICK: Self = Self {
+        minimum: 0,
+        maximum: 255,
+    };
+
+    fn normalize(self, value: i32, deadzone: f32) -> f32 {
+        normalize_axis(value, self.minimum, self.maximum, deadzone)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AxisRanges {
+    left_x: AxisRange,
+    left_y: AxisRange,
+    right_x: AxisRange,
+}
+
+impl Default for AxisRanges {
+    fn default() -> Self {
+        Self {
+            left_x: AxisRange::SONY_STICK,
+            left_y: AxisRange::SONY_STICK,
+            right_x: AxisRange::SONY_STICK,
+        }
+    }
+}
+
+pub struct GamepadReader {
+    device: Device,
+    axis_ranges: AxisRanges,
+}
+
+pub fn axis_for(axis: AbsoluteAxisCode) -> Option<Axis> {
+    match axis {
+        AbsoluteAxisCode::ABS_X => Some(Axis::LeftX),
+        AbsoluteAxisCode::ABS_Y => Some(Axis::LeftY),
+        AbsoluteAxisCode::ABS_RX => Some(Axis::RightX),
+        AbsoluteAxisCode::ABS_HAT0X => Some(Axis::HatX),
+        AbsoluteAxisCode::ABS_HAT0Y => Some(Axis::HatY),
+        _ => None,
+    }
+}
+
+pub fn is_start_button(key: KeyCode) -> bool {
+    key == KeyCode::BTN_START || key == KeyCode::BTN_MODE
+}
+
+impl GamepadReader {
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let device = Device::open(path)?;
+        device.set_nonblocking(true)?;
+        let axis_ranges = read_axis_ranges(&device)?;
+
+        let supported_keys = device.supported_keys();
+        let supported_axes = device.supported_absolute_axes();
+        tracing::info!(
+            target: "gamepad::evdev",
+            path = %path.display(),
+            name = ?device.name(),
+            physical_path = ?device.physical_path(),
+            unique_name = ?device.unique_name(),
+            supports_start = supported_keys.is_some_and(|keys| keys.contains(KeyCode::BTN_START)),
+            supports_mode = supported_keys.is_some_and(|keys| keys.contains(KeyCode::BTN_MODE)),
+            supports_left_x = supported_axes.is_some_and(|axes| axes.contains(AbsoluteAxisCode::ABS_X)),
+            supports_left_y = supported_axes.is_some_and(|axes| axes.contains(AbsoluteAxisCode::ABS_Y)),
+            supports_right_x = supported_axes.is_some_and(|axes| axes.contains(AbsoluteAxisCode::ABS_RX)),
+            supports_hat_x = supported_axes.is_some_and(|axes| axes.contains(AbsoluteAxisCode::ABS_HAT0X)),
+            supports_hat_y = supported_axes.is_some_and(|axes| axes.contains(AbsoluteAxisCode::ABS_HAT0Y)),
+            ?axis_ranges,
+            "opened gamepad device"
+        );
+
+        Ok(Self {
+            device,
+            axis_ranges,
+        })
+    }
+
+    pub fn drain_events(
+        &mut self,
+        state: &mut GamepadState,
+        parameters: &crate::Parameters,
+    ) -> io::Result<()> {
+        loop {
+            let events = match self.device.fetch_events() {
+                Ok(events) => events,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) => return Err(error),
+            };
+
+            let mut saw_event = false;
+            for event in events {
+                saw_event = true;
+                match event.destructure() {
+                    EventSummary::Key(_, key, value) if is_start_button(key) => {
+                        tracing::debug!(
+                            target: "gamepad::evdev",
+                            ?key,
+                            value,
+                            mapped = "start",
+                            "received gamepad key event"
+                        );
+                        state.update_start_button(value != 0, parameters)
+                    }
+                    EventSummary::Key(_, key, value) => {
+                        tracing::debug!(
+                            target: "gamepad::evdev",
+                            ?key,
+                            value,
+                            "received unmapped gamepad key event"
+                        );
+                    }
+                    EventSummary::AbsoluteAxis(_, axis, value) => {
+                        let mapped_axis = axis_for(axis);
+                        let normalized_value = match mapped_axis {
+                            Some(Axis::LeftX) => Some(
+                                self.axis_ranges
+                                    .left_x
+                                    .normalize(value, parameters.deadzone),
+                            ),
+                            Some(Axis::LeftY) => Some(
+                                self.axis_ranges
+                                    .left_y
+                                    .normalize(value, parameters.deadzone),
+                            ),
+                            Some(Axis::RightX) => Some(
+                                self.axis_ranges
+                                    .right_x
+                                    .normalize(value, parameters.deadzone),
+                            ),
+                            Some(Axis::HatX) | Some(Axis::HatY) => {
+                                Some(value.signum().clamp(-1, 1) as f32)
+                            }
+                            None => None,
+                        };
+                        tracing::debug!(
+                            target: "gamepad::evdev",
+                            ?axis,
+                            value,
+                            ?mapped_axis,
+                            ?normalized_value,
+                            "received gamepad axis event"
+                        );
+                        apply_axis_event(state, self.axis_ranges, axis, value, parameters.deadzone);
+                    }
+                    other => {
+                        tracing::debug!(
+                            target: "gamepad::evdev",
+                            ?other,
+                            "received unmapped gamepad event"
+                        );
+                    }
+                }
+            }
+
+            if !saw_event {
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn read_axis_ranges(device: &Device) -> io::Result<AxisRanges> {
+    let mut axis_ranges = AxisRanges::default();
+    for (axis, info) in device.get_absinfo()? {
+        let range = AxisRange {
+            minimum: info.minimum(),
+            maximum: info.maximum(),
+        };
+        match axis_for(axis) {
+            Some(Axis::LeftX) => axis_ranges.left_x = range,
+            Some(Axis::LeftY) => axis_ranges.left_y = range,
+            Some(Axis::RightX) => axis_ranges.right_x = range,
+            Some(Axis::HatX) | Some(Axis::HatY) | None => {}
+        }
+    }
+    Ok(axis_ranges)
+}
+
+fn apply_axis_event(
+    state: &mut GamepadState,
+    axis_ranges: AxisRanges,
+    axis: AbsoluteAxisCode,
+    value: i32,
+    deadzone: f32,
+) {
+    match axis_for(axis) {
+        Some(Axis::LeftX) => state.set_left_x(axis_ranges.left_x.normalize(value, deadzone)),
+        Some(Axis::LeftY) => state.set_left_y(axis_ranges.left_y.normalize(value, deadzone)),
+        Some(Axis::RightX) => state.set_right_x(axis_ranges.right_x.normalize(value, deadzone)),
+        Some(Axis::HatX) => state.set_dpad_x(value.signum().clamp(-1, 1)),
+        Some(Axis::HatY) => state.set_dpad_y(value.signum().clamp(-1, 1)),
+        None => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_sony_controller_axes() {
+        assert_eq!(axis_for(AbsoluteAxisCode::ABS_X), Some(Axis::LeftX));
+        assert_eq!(axis_for(AbsoluteAxisCode::ABS_Y), Some(Axis::LeftY));
+        assert_eq!(axis_for(AbsoluteAxisCode::ABS_RX), Some(Axis::RightX));
+        assert_eq!(axis_for(AbsoluteAxisCode::ABS_HAT0X), Some(Axis::HatX));
+        assert_eq!(axis_for(AbsoluteAxisCode::ABS_HAT0Y), Some(Axis::HatY));
+        assert_eq!(axis_for(AbsoluteAxisCode::ABS_Z), None);
+    }
+
+    #[test]
+    fn maps_start_button_only() {
+        assert!(is_start_button(KeyCode::BTN_START));
+        assert!(is_start_button(KeyCode::BTN_MODE));
+        assert!(!is_start_button(KeyCode::BTN_SELECT));
+    }
+}

--- a/crates/nodes/gamepad/src/lib.rs
+++ b/crates/nodes/gamepad/src/lib.rs
@@ -1,0 +1,68 @@
+use std::{boxed::Box, future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use color_eyre::Result;
+use ros_z::prelude::*;
+
+mod evdev_input;
+pub mod state;
+
+use evdev_input::GamepadReader;
+use state::GamepadState;
+use types::gamepad::GamepadManualMotion;
+
+pub use state::Parameters;
+
+pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+    Box::pin(run(ctx))
+}
+
+async fn run(ctx: Arc<Context>) -> Result<()> {
+    let node = ctx.create_node("gamepad").build().await?;
+
+    let parameters = node.bind_parameter_as::<Parameters>("gamepad")?;
+    let manual_motion_pub = node
+        .publisher::<GamepadManualMotion>("gamepad/manual_motion")
+        .build()
+        .await?;
+
+    let initial_parameters_snapshot = parameters.snapshot();
+    let mut state = GamepadState::new(initial_parameters_snapshot.typed());
+    let mut reader = None;
+    let mut next_reconnect = node.clock().now();
+    let mut last_tick = node.clock().now();
+    let mut timer = node.create_timer(Duration::from_millis(20));
+
+    loop {
+        timer.tick().await;
+
+        let now = node.clock().now();
+        let cycle_duration = now.duration_since(last_tick);
+        last_tick = now;
+        let parameters_snapshot = parameters.snapshot();
+        let parameters = parameters_snapshot.typed();
+
+        if reader.is_none() && now >= next_reconnect {
+            match GamepadReader::open(&parameters.device_path) {
+                Ok(opened_reader) => reader = Some(opened_reader),
+                Err(_) => next_reconnect = now + parameters.reconnect_interval,
+            }
+        }
+
+        if let Some(open_reader) = &mut reader
+            && let Err(error) = open_reader.drain_events(&mut state, parameters)
+        {
+            tracing::info!(
+                target: "gamepad::evdev",
+                error = %error,
+                reconnect_interval = ?parameters.reconnect_interval,
+                "lost gamepad device while reading events"
+            );
+            reader = None;
+            next_reconnect = now + parameters.reconnect_interval;
+        }
+
+        let input_is_unavailable = reader.is_none();
+        let manual_motion = state.manual_motion(parameters, cycle_duration, input_is_unavailable);
+        manual_motion_pub.publish(&manual_motion).await?;
+    }
+}

--- a/crates/nodes/gamepad/src/state.rs
+++ b/crates/nodes/gamepad/src/state.rs
@@ -1,0 +1,370 @@
+use std::{path::PathBuf, time::Duration};
+
+use kinematics::joints::head::HeadJoints;
+use ros_z::Message;
+use serde::{Deserialize, Serialize};
+use types::{
+    gamepad::GamepadManualMotion,
+    motion_command::{HeadMotion, MotionCommand},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[serde(deny_unknown_fields)]
+pub struct Parameters {
+    pub device_path: PathBuf,
+    pub reconnect_interval: Duration,
+    pub deadzone: f32,
+    pub maximum_forward_velocity: f32,
+    pub maximum_left_velocity: f32,
+    pub maximum_angular_velocity: f32,
+    pub head_center: HeadJoints<f32>,
+    pub head_minimum: HeadJoints<f32>,
+    pub head_maximum: HeadJoints<f32>,
+    pub head_velocity: HeadJoints<f32>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Axes {
+    left_x: f32,
+    left_y: f32,
+    right_x: f32,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Dpad {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct GamepadState {
+    active: bool,
+    last_start_pressed: bool,
+    axes: Axes,
+    dpad: Dpad,
+    manual_head: HeadJoints<f32>,
+}
+
+pub fn normalize_axis(value: i32, minimum: i32, maximum: i32, deadzone: f32) -> f32 {
+    let half_range = (maximum - minimum) as f32 / 2.0;
+    if half_range <= 0.0 {
+        return 0.0;
+    }
+
+    let center = (minimum + maximum) as f32 / 2.0;
+    let normalized = ((value as f32 - center) / half_range).clamp(-1.0, 1.0);
+    if normalized.abs() < deadzone {
+        0.0
+    } else {
+        normalized
+    }
+}
+
+impl GamepadState {
+    pub fn new(parameters: &Parameters) -> Self {
+        Self {
+            active: false,
+            last_start_pressed: false,
+            axes: Axes::default(),
+            dpad: Dpad::default(),
+            manual_head: parameters.head_center,
+        }
+    }
+
+    pub fn update_start_button(&mut self, pressed: bool, parameters: &Parameters) {
+        if pressed && !self.last_start_pressed {
+            self.active = !self.active;
+            tracing::info!(
+                target: "gamepad::input",
+                active = self.active,
+                "gamepad manual control toggled"
+            );
+            if !self.active {
+                self.manual_head = parameters.head_center;
+            }
+        }
+        self.last_start_pressed = pressed;
+    }
+
+    pub fn set_left_x(&mut self, value: f32) {
+        self.axes.left_x = value.clamp(-1.0, 1.0);
+    }
+
+    pub fn set_left_y(&mut self, value: f32) {
+        self.axes.left_y = value.clamp(-1.0, 1.0);
+    }
+
+    pub fn set_right_x(&mut self, value: f32) {
+        self.axes.right_x = value.clamp(-1.0, 1.0);
+    }
+
+    pub fn set_dpad_x(&mut self, value: i32) {
+        self.dpad.x = value.clamp(-1, 1);
+    }
+
+    pub fn set_dpad_y(&mut self, value: i32) {
+        self.dpad.y = value.clamp(-1, 1);
+    }
+
+    pub fn manual_motion(
+        &mut self,
+        parameters: &Parameters,
+        cycle_duration: Duration,
+        input_is_unavailable: bool,
+    ) -> GamepadManualMotion {
+        if input_is_unavailable {
+            self.axes = Axes::default();
+        }
+
+        if self.active && !input_is_unavailable {
+            let seconds = cycle_duration.as_secs_f32();
+            self.manual_head.yaw += self.dpad.x as f32 * parameters.head_velocity.yaw * seconds;
+            self.manual_head.pitch += self.dpad.y as f32 * parameters.head_velocity.pitch * seconds;
+        }
+
+        self.manual_head.yaw = self
+            .manual_head
+            .yaw
+            .clamp(parameters.head_minimum.yaw, parameters.head_maximum.yaw);
+        self.manual_head.pitch = self
+            .manual_head
+            .pitch
+            .clamp(parameters.head_minimum.pitch, parameters.head_maximum.pitch);
+
+        let (forward, left, angular_velocity) = if self.active && !input_is_unavailable {
+            (
+                -self.axes.left_y * parameters.maximum_forward_velocity,
+                -self.axes.left_x * parameters.maximum_left_velocity,
+                -self.axes.right_x * parameters.maximum_angular_velocity,
+            )
+        } else {
+            (0.0, 0.0, 0.0)
+        };
+
+        GamepadManualMotion {
+            active: self.active,
+            motion_command: MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: self.manual_head,
+                },
+                velocity: linear_algebra::vector![forward, left],
+                angular_velocity,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use types::motion_command::{HeadMotion, MotionCommand};
+
+    use super::*;
+
+    fn parameters() -> Parameters {
+        Parameters {
+            device_path: PathBuf::from("/dev/input/by-id/test-event-joystick"),
+            reconnect_interval: Duration::from_secs(1),
+            deadzone: 0.15,
+            maximum_forward_velocity: 0.3,
+            maximum_left_velocity: 0.2,
+            maximum_angular_velocity: 0.5,
+            head_center: HeadJoints {
+                yaw: 0.0,
+                pitch: 0.4,
+            },
+            head_minimum: HeadJoints {
+                yaw: -0.785,
+                pitch: -0.3,
+            },
+            head_maximum: HeadJoints {
+                yaw: 0.785,
+                pitch: 1.0,
+            },
+            head_velocity: HeadJoints {
+                yaw: 1.0,
+                pitch: 1.0,
+            },
+        }
+    }
+
+    fn walk_motion(message: GamepadManualMotion) -> MotionCommand {
+        message.motion_command
+    }
+
+    #[test]
+    fn normalizes_center_deadzone_and_extremes() {
+        assert_eq!(normalize_axis(128, 0, 255, 0.15), 0.0);
+        assert_eq!(normalize_axis(140, 0, 255, 0.15), 0.0);
+        assert!(normalize_axis(255, 0, 255, 0.15) > 0.99);
+        assert!(normalize_axis(0, 0, 255, 0.15) < -0.99);
+        assert_eq!(normalize_axis(10, 10, 10, 0.15), 0.0);
+    }
+
+    #[test]
+    fn start_button_rising_edge_toggles_once() {
+        let parameters = parameters();
+        let mut state = GamepadState::new(&parameters);
+
+        state.update_start_button(true, &parameters);
+        assert!(
+            state
+                .manual_motion(&parameters, Duration::ZERO, false)
+                .active
+        );
+
+        state.update_start_button(true, &parameters);
+        assert!(
+            state
+                .manual_motion(&parameters, Duration::ZERO, false)
+                .active
+        );
+
+        state.update_start_button(false, &parameters);
+        state.update_start_button(true, &parameters);
+        assert!(
+            !state
+                .manual_motion(&parameters, Duration::ZERO, false)
+                .active
+        );
+    }
+
+    #[test]
+    fn unavailable_input_keeps_active_but_zeroes_velocity() {
+        let parameters = parameters();
+        let mut state = GamepadState::new(&parameters);
+
+        state.update_start_button(true, &parameters);
+        state.set_left_y(-1.0);
+        state.set_left_x(-1.0);
+        state.set_right_x(-1.0);
+
+        let message = state.manual_motion(&parameters, Duration::from_millis(20), true);
+
+        assert!(message.active);
+        assert_eq!(
+            walk_motion(message),
+            MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: parameters.head_center,
+                },
+                velocity: linear_algebra::vector![0.0, 0.0],
+                angular_velocity: 0.0,
+            }
+        );
+    }
+
+    #[test]
+    fn reconnect_without_axis_event_does_not_resume_old_velocity() {
+        let parameters = parameters();
+        let mut state = GamepadState::new(&parameters);
+
+        state.update_start_button(true, &parameters);
+        state.set_left_y(-1.0);
+
+        state.manual_motion(&parameters, Duration::from_millis(20), true);
+
+        let message = state.manual_motion(&parameters, Duration::from_millis(20), false);
+        assert_eq!(
+            walk_motion(message),
+            MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: parameters.head_center,
+                },
+                velocity: linear_algebra::vector![0.0, 0.0],
+                angular_velocity: 0.0,
+            }
+        );
+
+        state.set_left_y(-1.0);
+
+        let message = state.manual_motion(&parameters, Duration::from_millis(20), false);
+        assert_eq!(
+            walk_motion(message),
+            MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: parameters.head_center,
+                },
+                velocity: linear_algebra::vector![0.3, 0.0],
+                angular_velocity: 0.0,
+            }
+        );
+    }
+
+    #[test]
+    fn axes_map_to_forward_left_and_turn() {
+        let parameters = parameters();
+        let mut state = GamepadState::new(&parameters);
+
+        state.update_start_button(true, &parameters);
+        state.set_left_y(-1.0);
+        state.set_left_x(-1.0);
+        state.set_right_x(-1.0);
+
+        let message = state.manual_motion(&parameters, Duration::from_millis(20), false);
+
+        assert_eq!(
+            walk_motion(message),
+            MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: parameters.head_center,
+                },
+                velocity: linear_algebra::vector![0.3, 0.2],
+                angular_velocity: 0.5,
+            }
+        );
+    }
+
+    #[test]
+    fn dpad_integrates_head_target_and_clamps_without_wrapping() {
+        let parameters = parameters();
+        let mut state = GamepadState::new(&parameters);
+
+        state.update_start_button(true, &parameters);
+        state.set_dpad_x(-1);
+        state.set_dpad_y(-1);
+
+        let message = state.manual_motion(&parameters, Duration::from_secs(10), false);
+
+        assert_eq!(
+            walk_motion(message),
+            MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: HeadJoints {
+                        yaw: parameters.head_minimum.yaw,
+                        pitch: parameters.head_minimum.pitch,
+                    },
+                },
+                velocity: linear_algebra::vector![0.0, 0.0],
+                angular_velocity: 0.0,
+            }
+        );
+    }
+
+    #[test]
+    fn toggle_off_resets_manual_head_target_to_center() {
+        let parameters = parameters();
+        let mut state = GamepadState::new(&parameters);
+
+        state.update_start_button(true, &parameters);
+        state.set_dpad_x(1);
+        state.manual_motion(&parameters, Duration::from_secs(1), false);
+        state.update_start_button(false, &parameters);
+        state.update_start_button(true, &parameters);
+
+        let message = state.manual_motion(&parameters, Duration::ZERO, false);
+
+        assert!(!message.active);
+        assert_eq!(
+            walk_motion(message),
+            MotionCommand::WalkWithVelocity {
+                head: HeadMotion::JointAngles {
+                    joints: parameters.head_center,
+                },
+                velocity: linear_algebra::vector![0.0, 0.0],
+                angular_velocity: 0.0,
+            }
+        );
+    }
+}

--- a/crates/nodes/head_motion/src/lib.rs
+++ b/crates/nodes/head_motion/src/lib.rs
@@ -170,6 +170,7 @@ fn joints_from_motion(
     motion_command: &MotionCommand,
 ) -> HeadJoints<f32> {
     match motion_command.head_motion() {
+        Some(HeadMotion::JointAngles { joints }) => joints,
         Some(HeadMotion::Center {
             image_region_target: ImageRegion::Top,
         }) => HeadJoints {
@@ -249,6 +250,28 @@ mod tests {
         );
 
         assert_eq!(head_joints, measured_head);
+    }
+
+    #[test]
+    fn joint_angles_use_requested_target() {
+        let requested = HeadJoints {
+            yaw: 0.2,
+            pitch: -0.1,
+        };
+        let mut state = HeadMotionState::new();
+
+        let head_joints = state.update(
+            &test_parameters(),
+            HeadJoints::default(),
+            HeadJoints::default(),
+            &Joints::default(),
+            Duration::from_secs(1),
+            &MotionCommand::Stand {
+                head: HeadMotion::JointAngles { joints: requested },
+            },
+        );
+
+        assert_eq!(head_joints, requested);
     }
 
     #[test]

--- a/crates/types/src/gamepad.rs
+++ b/crates/types/src/gamepad.rs
@@ -1,0 +1,22 @@
+use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
+use ros_z::Message;
+use serde::{Deserialize, Serialize};
+
+use crate::motion_command::MotionCommand;
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    PartialEq,
+    Serialize,
+    PathSerialize,
+    PathDeserialize,
+    PathIntrospect,
+    Message,
+)]
+pub struct GamepadManualMotion {
+    pub active: bool,
+    pub motion_command: MotionCommand,
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -21,6 +21,7 @@ pub mod filtered_game_state;
 pub mod filtered_segments;
 pub mod filtered_whistle;
 pub mod game_controller_state;
+pub mod gamepad;
 pub mod grayscale_image;
 pub mod heatmap;
 pub mod image_segments;

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -2,6 +2,7 @@ use ros_z::Message;
 use serde::{Deserialize, Serialize};
 
 use coordinate_systems::{Field, Ground};
+use kinematics::joints::head::HeadJoints;
 use linear_algebra::{Orientation2, Point2, Vector2};
 use path_serde::{PathDeserialize, PathIntrospect, PathSerialize};
 
@@ -187,6 +188,9 @@ pub enum BodyMotion {
 )]
 pub enum HeadMotion {
     ZeroAngles,
+    JointAngles {
+        joints: HeadJoints<f32>,
+    },
     Center {
         image_region_target: ImageRegion,
     },
@@ -265,6 +269,8 @@ pub enum KickPower {
 mod tests {
     use super::*;
 
+    use kinematics::joints::head::HeadJoints;
+
     #[test]
     fn damping_has_no_head_motion() {
         assert_eq!(MotionCommand::Damping.head_motion(), None);
@@ -280,5 +286,21 @@ mod tests {
         );
 
         assert_eq!(motion, MotionCommand::Damping);
+    }
+
+    #[test]
+    fn joint_angles_are_head_motion() {
+        let joints = HeadJoints {
+            yaw: 0.25,
+            pitch: -0.1,
+        };
+        let motion = MotionCommand::Stand {
+            head: HeadMotion::JointAngles { joints },
+        };
+
+        assert_eq!(
+            motion.head_motion(),
+            Some(HeadMotion::JointAngles { joints })
+        );
     }
 }

--- a/etc/parameters/ros_z/base/gamepad.json5
+++ b/etc/parameters/ros_z/base/gamepad.json5
@@ -1,0 +1,12 @@
+{
+  device_path: "/dev/input/by-id/usb-Sony_Interactive_Entertainment_Wireless_Controller-event-joystick",
+  reconnect_interval: { secs: 1, nanos: 0 },
+  deadzone: 0.15,
+  maximum_forward_velocity: 0.3,
+  maximum_left_velocity: 0.2,
+  maximum_angular_velocity: 0.5,
+  head_center: { yaw: 0.0, pitch: 0.4 },
+  head_minimum: { yaw: -0.785, pitch: -0.3 },
+  head_maximum: { yaw: 0.785, pitch: 1.0 },
+  head_velocity: { yaw: 1.0, pitch: 1.0 },
+}


### PR DESCRIPTION
## Summary
- add a framework-native gamepad node that reads the Sony controller via evdev
- publish manual walking/head commands and select them in behavior outside Damping
- add D-pad head joint control with clamping and stale-input zeroing

## Verification
- cargo test -p types joint_angles_are_head_motion
- cargo test -p head_motion joint_angles_use_requested_target
- cargo test -p gamepad
- cargo nextest run -p behavior_node
- cargo check -p gamepad -p behavior_node -p head_motion -p hulk_ros_z -p types
- cargo fmt --check