### PR TITLE
add pepsi upload --prepare flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.34.0"
+version = "7.35.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.34.0"
+version = "7.35.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -42,7 +42,7 @@ pub struct UploadArguments {
     /// Skip the OS version check
     #[arg(long)]
     pub skip_os_check: bool,
-    /// Do not build before uploading
+    /// Build, don't upload
     #[arg(long)]
     pub prepare: bool,
     /// The Robots to upload to e.g. 20w or 10.1.24.22

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use argument_parsers::RobotAddress;
-use clap::{Args, CommandFactory};
+use clap::Args;
 use color_eyre::{
     Result,
     eyre::{WrapErr, bail},
@@ -46,6 +46,7 @@ pub struct UploadArguments {
     #[arg(long)]
     pub prepare: bool,
     /// The Robots to upload to e.g. 20w or 10.1.24.22
+    #[arg(required_unless_present("prepare"))]
     pub robots: Vec<RobotAddress>,
 }
 
@@ -119,15 +120,6 @@ async fn upload_with_progress(
 }
 
 pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()> {
-    if !arguments.upload.prepare && arguments.upload.robots.is_empty() {
-        crate::Arguments::command()
-            .error(
-                clap::error::ErrorKind::ArgumentConflict,
-                "Specify at least one robot to upload to, or use --prepare to build without uploading",
-            )
-            .exit();
-    }
-
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
     const BINARY_NAME: &str = "hulk_ros_z";
     let hulk_binary = get_binary(arguments.build.profile(), BINARY_NAME);

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use argument_parsers::RobotAddress;
-use clap::Args;
+use clap::{Args, CommandFactory};
 use color_eyre::{
     Result,
     eyre::{WrapErr, bail},
@@ -42,8 +42,10 @@ pub struct UploadArguments {
     /// Skip the OS version check
     #[arg(long)]
     pub skip_os_check: bool,
+    /// Do not build before uploading
+    #[arg(long)]
+    pub prepare: bool,
     /// The Robots to upload to e.g. 20w or 10.1.24.22
-    #[arg(required = true)]
     pub robots: Vec<RobotAddress>,
 }
 
@@ -117,6 +119,15 @@ async fn upload_with_progress(
 }
 
 pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()> {
+    if !arguments.upload.prepare && arguments.upload.robots.is_empty() {
+        crate::Arguments::command()
+            .error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "Specify at least one robot to upload to, or use --prepare to build without uploading",
+            )
+            .exit();
+    }
+
     let upload_directory = tempdir().wrap_err("failed to get temporary directory")?;
     const BINARY_NAME: &str = "hulk_ros_z";
     let hulk_binary = get_binary(arguments.build.profile(), BINARY_NAME);
@@ -136,6 +147,10 @@ pub async fn upload(arguments: Arguments, repository: &Repository) -> Result<()>
         cargo(cargo_arguments, repository, &[&hulk_binary])
             .await
             .wrap_err("failed to build")?;
+    }
+
+    if arguments.upload.prepare {
+        return Ok(());
     }
 
     repository


### PR DESCRIPTION
## Why? What?

Adds a `--prepare` flag to pepsi upload, similar to pepsi pregame.
With `--prepare`, the robots parameter become optional and upload is skipped.

## ToDo / Known Issues

none

## Ideas for Next Iterations (Not This PR)

none

## How to Test

`pepsi hochlad --prepare`
`pepsi hochlad 42 --prepare`
`pepsi hochlad` (fails with a helpful message)