### PR TITLE
Remove trailing semicolons in macro in expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,15 +2461,16 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+version = "0.1.2"
+dependencies = [
+ "cfg_aliases 0.2.2",
+]
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cgl"
@@ -4951,7 +4952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
  "bitflags 2.13.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "cgl",
  "dispatch2",
  "glutin_egl_sys",
@@ -4975,7 +4976,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -6722,7 +6723,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "codespan-reporting",
  "half",
  "hashbrown 0.16.1",
@@ -7006,7 +7007,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -7018,7 +7019,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -8643,7 +8644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -8685,7 +8686,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2 0.6.4",
@@ -10342,7 +10343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bae1df58c5fea7502e8e352ec26b5579f6178e1fdb311e088580c980dee25ed"
 dependencies = [
  "bitflags 1.3.2",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "parking_lot",
  "parking_lot_core",
@@ -10356,7 +10357,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1389c88ddd739ec6d3f8f83343764a0e944cd23cfbf126a9796a714b0b6edd6f"
 dependencies = [
- "cfg_aliases 0.1.1",
+ "cfg_aliases 0.1.2",
  "memchr",
  "proc-macro2",
  "quote",
@@ -12024,7 +12025,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "document-features",
  "hashbrown 0.16.1",
  "js-sys",
@@ -12055,7 +12056,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.13.0",
  "bytemuck",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "document-features",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12117,7 +12118,7 @@ dependencies = [
  "block",
  "bytemuck",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
@@ -12833,7 +12834,7 @@ dependencies = [
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -13646,7 +13647,7 @@ dependencies = [
  "advisory-lock",
  "async-trait",
  "buddy_system_allocator",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "crossbeam-channel",
  "crossbeam-queue",
  "nix 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/bevyhavior_simulator",
   "crates/booster",
   "crates/calibration",
+  "crates/cfg_aliases_0_1",
   "crates/coordinate_systems",
   "crates/egui_bevy",
   "crates/energy_optimization",
@@ -350,6 +351,7 @@ zip = { version = "2.4.2", default-features = false, features = [
 ] }
 
 [patch.crates-io]
+cfg_aliases_0_1 = { package = "cfg_aliases", path = "crates/cfg_aliases_0_1" }
 # Pinned to forked serde version since https://github.com/serde-rs/serde/pull/2513 is not merged
 serde = { git = "https://github.com/HULKs/serde.git", rev = "ef30eb8fdd0ee12e4e6f3f5615c6bb022e02d1b2" }
 # Pinned to forked serde version since https://github.com/serde-rs/serde/pull/2513 is not merged

--- a/crates/argument_parsers/src/lib.rs
+++ b/crates/argument_parsers/src/lib.rs
@@ -24,7 +24,9 @@ pub fn parse_systemctl_action(systemctl_action: &str) -> Result<SystemctlAction>
         "start" => Ok(SystemctlAction::Start),
         "status" => Ok(SystemctlAction::Status),
         "stop" => Ok(SystemctlAction::Stop),
-        _ => bail!("unexpected systemctl action"),
+        _ => {
+            bail!("unexpected systemctl action");
+        }
     }
 }
 
@@ -57,7 +59,9 @@ pub fn parse_network(network: &str) -> Result<Network> {
         "HSL_I" => Ok(Network::HslI),
         "HSL_J" => Ok(Network::HslJ),
         "HSL_HULKs" => Ok(Network::HslHulks),
-        _ => bail!("unexpected network"),
+        _ => {
+            bail!("unexpected network");
+        }
     }
 }
 
@@ -209,7 +213,9 @@ fn parse_assignment(input: &str) -> Result<(&str, PlayerNumber)> {
         "3" => PlayerNumber::Three,
         "4" => PlayerNumber::Four,
         "5" => PlayerNumber::Five,
-        _ => bail!("unexpected player number {player_number}"),
+        _ => {
+            bail!("unexpected player number {player_number}");
+        }
     };
     Ok((prefix, player_number))
 }

--- a/crates/booster/src/lib.rs
+++ b/crates/booster/src/lib.rs
@@ -111,7 +111,7 @@ impl LowState {
                 .copied()
                 .collect::<Joints<MotorState>>())
         } else {
-            bail!("failed to construct motor states")
+            bail!("failed to construct motor states");
         }
     }
 
@@ -123,7 +123,7 @@ impl LowState {
                 .copied()
                 .collect::<Joints<MotorState>>())
         } else {
-            bail!("failed to construct motor states")
+            bail!("failed to construct motor states");
         }
     }
 }

--- a/crates/cfg_aliases_0_1/Cargo.toml
+++ b/crates/cfg_aliases_0_1/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cfg_aliases"
+version = "0.1.2"
+edition = "2018"
+publish = false
+
+[dependencies]
+cfg_aliases_0_2 = { package = "cfg_aliases", version = "0.2.2" }

--- a/crates/cfg_aliases_0_1/src/lib.rs
+++ b/crates/cfg_aliases_0_1/src/lib.rs
@@ -1,0 +1,1 @@
+pub use cfg_aliases_0_2::cfg_aliases;

--- a/crates/hsl_network_messages/src/game_controller_return_message.rs
+++ b/crates/hsl_network_messages/src/game_controller_return_message.rs
@@ -58,12 +58,16 @@ impl TryFrom<RoboCupGameControlReturnData> for GameControllerReturnMessage {
                 3 => PlayerNumber::Three,
                 4 => PlayerNumber::Four,
                 5 => PlayerNumber::Five,
-                _ => bail!("unexpected player number {}", message.playerNum),
+                _ => {
+                    bail!("unexpected player number {}", message.playerNum);
+                }
             },
             fallen: match message.fallen {
                 1 => true,
                 0 => false,
-                _ => bail!("unexpected fallen state"),
+                _ => {
+                    bail!("unexpected fallen state");
+                }
             },
             pose: Pose2::new(
                 point![message.pose[0] / 1000.0, message.pose[1] / 1000.0],

--- a/crates/hsl_network_messages/src/game_controller_state_message.rs
+++ b/crates/hsl_network_messages/src/game_controller_state_message.rs
@@ -74,11 +74,13 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
             match (message.teams[0].teamNumber, message.teams[1].teamNumber) {
                 (HULKS_TEAM_NUMBER, _) => (0, 1),
                 (_, HULKS_TEAM_NUMBER) => (1, 0),
-                _ => bail!(
-                    "failed to find HULKs team, teams were {:?} and {:?}",
-                    message.teams[0],
-                    message.teams[1]
-                ),
+                _ => {
+                    bail!(
+                        "failed to find HULKs team, teams were {:?} and {:?}",
+                        message.teams[0],
+                        message.teams[1]
+                    );
+                }
             };
         const MAXIMUM_NUMBER_OF_PENALTY_SHOOTS: u8 = 16;
         if message.teams[hulks_team_index].penaltyShot >= MAXIMUM_NUMBER_OF_PENALTY_SHOOTS {
@@ -133,7 +135,9 @@ impl TryFrom<RoboCupGameControlData> for GameControllerStateMessage {
             stopped: match message.stopped {
                 0 => false,
                 1 => true,
-                _ => bail!("unexpected stopped value: {}", message.stopped),
+                _ => {
+                    bail!("unexpected stopped value: {}", message.stopped);
+                }
             },
             game_phase: GamePhase::try_from(message.gamePhase, message.kickingTeam)?,
             game_state: GameState::try_from(message.state)?,
@@ -218,7 +222,9 @@ impl CompetitionType {
             COMPETITION_TYPE_SMALL => Ok(CompetitionType::Small),
             COMPETITION_TYPE_MIDDLE => Ok(CompetitionType::Middle),
             COMPETITION_TYPE_LARGE => Ok(CompetitionType::Large),
-            _ => bail!("unexpected competition type"),
+            _ => {
+                bail!("unexpected competition type");
+            }
         }
     }
 }
@@ -246,7 +252,9 @@ impl GamePhase {
             GAME_PHASE_PENALTY_SHOOT_OUT => Ok(GamePhase::PenaltyShootout { kicking_team: team }),
             GAME_PHASE_EXTRA_TIME => Ok(GamePhase::Extratime),
             GAME_PHASE_TIMEOUT => Ok(GamePhase::Timeout),
-            _ => bail!("unexpected game phase"),
+            _ => {
+                bail!("unexpected game phase");
+            }
         }
     }
 }
@@ -268,7 +276,9 @@ impl GameState {
             STATE_SET => Ok(GameState::Set),
             STATE_PLAYING => Ok(GameState::Playing),
             STATE_FINISHED => Ok(GameState::Finished),
-            _ => bail!("unexpected game state"),
+            _ => {
+                bail!("unexpected game state");
+            }
         }
     }
 }
@@ -315,7 +325,9 @@ impl SubState {
             SET_PLAY_THROW_IN => Ok(Some(SubState::ThrowIn)),
             SET_PLAY_GOAL_KICK => Ok(Some(SubState::GoalKick)),
             SET_PLAY_CORNER_KICK => Ok(Some(SubState::CornerKick)),
-            _ => bail!("unexpected sub state"),
+            _ => {
+                bail!("unexpected sub state");
+            }
         }
     }
 }
@@ -333,7 +345,9 @@ impl TryFrom<u8> for Half {
         match half {
             1 => Ok(Half::First),
             0 => Ok(Half::Second),
-            _ => bail!("unexpected half"),
+            _ => {
+                bail!("unexpected half");
+            }
         }
     }
 }
@@ -380,7 +394,9 @@ impl TryFrom<u8> for TeamColor {
             TEAM_PURPLE => Ok(TeamColor::Purple),
             TEAM_BROWN => Ok(TeamColor::Brown),
             TEAM_GRAY => Ok(TeamColor::Gray),
-            _ => bail!("unexpected team color"),
+            _ => {
+                bail!("unexpected team color");
+            }
         }
     }
 }
@@ -445,7 +461,9 @@ impl Penalty {
             PENALTY_CAUTIONED => Ok(Some(Penalty::Cautioned { remaining })),
             PENALTY_SENT_OFF => Ok(Some(Penalty::SentOff { remaining })),
             PENALTY_SUBSTITUTE => Ok(Some(Penalty::Substitute { remaining })),
-            _ => bail!("unexpected penalty type"),
+            _ => {
+                bail!("unexpected penalty type");
+            }
         }
     }
 }

--- a/crates/nodes/booster_sdk_interface/src/lib.rs
+++ b/crates/nodes/booster_sdk_interface/src/lib.rs
@@ -655,7 +655,7 @@ async fn retryable_rpc_call<T>(
     if await_rpc_call(future, operation, attempt).await.is_some() {
         Ok(())
     } else {
-        color_eyre::eyre::bail!("retryable rpc call failed")
+        color_eyre::eyre::bail!("retryable rpc call failed");
     }
 }
 

--- a/crates/nodes/detection/src/lib.rs
+++ b/crates/nodes/detection/src/lib.rs
@@ -234,7 +234,7 @@ fn extract_outputs<'a>(outputs: &'a SessionOutputs<'a>) -> Result<ModelOutputs<'
             "object detection output not of expected shape. Expected: {:?}, got: {:?}",
             TaskHead::ObjectDetection.expected_shape(),
             objects_output.shape()
-        )
+        );
     }
     let reshaped_objects_output = objects_output.squeeze().into_dimensionality()?;
 
@@ -244,7 +244,7 @@ fn extract_outputs<'a>(outputs: &'a SessionOutputs<'a>) -> Result<ModelOutputs<'
             "pose detection output not of expected shape. Expected: {:?}, got: {:?}",
             TaskHead::PoseDetection.expected_shape(),
             poses_output.shape()
-        )
+        );
     }
     let reshaped_pose_output = poses_output.squeeze().into_dimensionality()?;
 

--- a/crates/nodes/localization-3d/src/node.rs
+++ b/crates/nodes/localization-3d/src/node.rs
@@ -240,7 +240,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             }
             result = &mut backend_handle => {
                 result.wrap_err("failed to join")?.wrap_err("solver failed")?;
-                bail!("solver stopped unexpectedly")
+                bail!("solver stopped unexpectedly");
             }
             result = frontend.wait_for_optimization_result() => {
                 result?;

--- a/crates/nodes/stereo_visual_odometry/benches/kitti_odometry.rs
+++ b/crates/nodes/stereo_visual_odometry/benches/kitti_odometry.rs
@@ -241,7 +241,9 @@ fn decode_gray_png(
             .chunks_exact(4)
             .map(|pixel| rgb_to_luma(pixel[0], pixel[1], pixel[2]))
             .collect(),
-        unsupported => bail!("unsupported PNG format for {path}: {unsupported:?}"),
+        unsupported => {
+            bail!("unsupported PNG format for {path}: {unsupported:?}");
+        }
     };
 
     Ok(GrayImage {

--- a/crates/robot/src/lib.rs
+++ b/crates/robot/src/lib.rs
@@ -86,7 +86,9 @@ impl Robot {
             .await
         {
             Ok(output) if output.status.success() => Ok(Self::new(host)),
-            _ => bail!("No route to {host}"),
+            _ => {
+                bail!("No route to {host}");
+            }
         }
     }
 
@@ -507,7 +509,7 @@ async fn monitor_rsync_progress_with(
             result = process.wait() => {
                 if let Ok(status) = result
                     && !status.success() {
-                        bail!("rsync failed")
+                        bail!("rsync failed");
                     }
             }
         }

--- a/crates/ros-z-cli/src/commands/echo.rs
+++ b/crates/ros-z-cli/src/commands/echo.rs
@@ -82,7 +82,9 @@ async fn receive_message(
     match deadline {
         Some(deadline) => match tokio::time::timeout_at(deadline, receive).await {
             Ok(result) => result.wrap_err_with(|| format!("subscriber receive failed for {topic}")),
-            Err(_) => bail!("timed out waiting for messages on {topic}"),
+            Err(_) => {
+                bail!("timed out waiting for messages on {topic}");
+            }
         },
         None => receive
             .await

--- a/crates/ros-z-cli/src/commands/parameter.rs
+++ b/crates/ros-z-cli/src/commands/parameter.rs
@@ -234,7 +234,7 @@ where
         return Ok(());
     }
 
-    bail!("{action} failed for {node_fqn}: {}", response.message())
+    bail!("{action} failed for {node_fqn}: {}", response.message());
 }
 
 trait ParameterServiceResponse {

--- a/crates/ros-z-cli/src/commands/schema.rs
+++ b/crates/ros-z-cli/src/commands/schema.rs
@@ -81,7 +81,7 @@ fn verify_schema_capability_from_services(
         return Ok(());
     }
 
-    bail!("node exists but does not expose schema inspection service: {node_fqn}")
+    bail!("node exists but does not expose schema inspection service: {node_fqn}");
 }
 
 fn schema_service_name(node_fqn: &str) -> String {

--- a/crates/ros-z-cli/src/support/nodes.rs
+++ b/crates/ros-z-cli/src/support/nodes.rs
@@ -54,16 +54,20 @@ pub fn resolve_node_target(graph: &ros_z::graph::GraphData, selector: &str) -> R
         .collect();
 
     match matches.as_slice() {
-        [] => bail!("node not found: {selector}"),
+        [] => {
+            bail!("node not found: {selector}");
+        }
         [target] => Ok(target.clone()),
-        _ => bail!(
-            "node name '{selector}' is ambiguous: {}",
-            matches
-                .iter()
-                .map(NodeTarget::fully_qualified_name)
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
+        _ => {
+            bail!(
+                "node name '{selector}' is ambiguous: {}",
+                matches
+                    .iter()
+                    .map(NodeTarget::fully_qualified_name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
     }
 }
 

--- a/crates/ros-z-cli/src/support/parameter.rs
+++ b/crates/ros-z-cli/src/support/parameter.rs
@@ -53,12 +53,16 @@ fn resolve_parameter_node_fqn_from_candidates(
         .collect();
 
     match matches.as_slice() {
-        [] => bail!("node not found: {selector}"),
+        [] => {
+            bail!("node not found: {selector}");
+        }
         [node_fqn] => Ok(node_fqn.clone()),
-        _ => bail!(
-            "node name '{selector}' is ambiguous: {}",
-            matches.join(", ")
-        ),
+        _ => {
+            bail!(
+                "node name '{selector}' is ambiguous: {}",
+                matches.join(", ")
+            );
+        }
     }
 }
 
@@ -71,7 +75,7 @@ fn verify_parameter_capability_from_services(
         return Ok(());
     }
 
-    bail!("node exists but does not expose remote parameter services: {node_fqn}")
+    bail!("node exists but does not expose remote parameter services: {node_fqn}");
 }
 
 fn sorted_node_fqns(graph: &GraphData) -> Vec<String> {

--- a/tools/annotato/src/main.rs
+++ b/tools/annotato/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
             let annotation_json = PathBuf::from_iter(["current", &dataset_name, "data.json"]);
             if !image_folder.exists() {
                 if offline {
-                    bail!("dataset {dataset_name} not present, but offline flag was set")
+                    bail!("dataset {dataset_name} not present, but offline flag was set");
                 }
                 println!("dataset {dataset_name} not present, downloading...");
                 rsync::rsync_to_local("current", &dataset_name)?;

--- a/tools/annotato/src/rsync.rs
+++ b/tools/annotato/src/rsync.rs
@@ -23,7 +23,7 @@ pub fn rsync_dataset_list() -> Result<Vec<String>> {
         .arg("--list-only")
         .output()?;
     if !output.status.success() {
-        bail!(String::from_utf8(output.stderr)?)
+        bail!(String::from_utf8(output.stderr)?);
     }
     let output = String::from_utf8(output.stdout)?;
     Ok(output.lines().map(|line| line.to_owned()).collect())
@@ -44,7 +44,7 @@ pub fn rsync_to_local(local_folder: impl AsRef<Path>, dataset_name: &str) -> Res
         .output()?;
 
     if !output.status.success() {
-        bail!(String::from_utf8(output.stderr)?)
+        bail!(String::from_utf8(output.stderr)?);
     }
 
     Ok(())
@@ -65,7 +65,7 @@ pub fn rsync_to_host(local_folder: impl AsRef<Path>, dataset_name: &str) -> Resu
         .output()?;
 
     if !output.status.success() {
-        bail!(String::from_utf8(output.stderr)?)
+        bail!(String::from_utf8(output.stderr)?);
     }
 
     Ok(())

--- a/tools/mujoco-simulator/mujoco-rust-server/src/websocket.rs
+++ b/tools/mujoco-simulator/mujoco-rust-server/src/websocket.rs
@@ -30,7 +30,9 @@ async fn receive_connection_info(
                 return bincode::deserialize(&data).wrap_err("failed to deserialize");
             }
             Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
-            Message::Close(_) => bail!("close requested"),
+            Message::Close(_) => {
+                bail!("close requested");
+            }
         }
     }
 }

--- a/tools/pepsi/src/cargo/environment.rs
+++ b/tools/pepsi/src/cargo/environment.rs
@@ -37,7 +37,9 @@ impl FromStr for Environment {
             "docker" => Self::Docker {
                 image: right.map(str::to_owned),
             },
-            _ => bail!("unknown option {left}"),
+            _ => {
+                bail!("unknown option {left}");
+            }
         })
     }
 }

--- a/tools/pepsi/src/format.rs
+++ b/tools/pepsi/src/format.rs
@@ -35,7 +35,7 @@ async fn rustfmt(root: impl AsRef<Path>, check: bool) -> Result<()> {
         return Ok(());
     }
 
-    bail!(String::from_utf8(output.stderr).expect("stderr was not utf8"))
+    bail!(String::from_utf8(output.stderr).expect("stderr was not utf8"));
 }
 
 async fn taplo_fmt(root: impl AsRef<Path>, check: bool) -> Result<()> {
@@ -55,7 +55,7 @@ async fn taplo_fmt(root: impl AsRef<Path>, check: bool) -> Result<()> {
         return Ok(());
     }
 
-    bail!(String::from_utf8(output.stderr).expect("stderr was not utf8"))
+    bail!(String::from_utf8(output.stderr).expect("stderr was not utf8"));
 }
 
 async fn ruff_fmt(root: impl AsRef<Path>, check: bool) -> Result<()> {
@@ -75,7 +75,7 @@ async fn ruff_fmt(root: impl AsRef<Path>, check: bool) -> Result<()> {
         return Ok(());
     }
 
-    bail!(String::from_utf8(output.stderr).expect("stderr was not utf8"))
+    bail!(String::from_utf8(output.stderr).expect("stderr was not utf8"));
 }
 
 pub async fn format(arguments: Arguments, repository: &Repository) -> Result<()> {

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -492,10 +492,14 @@ impl CommandExt for Command {
 
         match process.wait().await?.code() {
             Some(0) => Ok(()),
-            Some(code) => bail!(
-                "{name}: process exited with error code {code}\nstdout:\n{stdout}\nstderr:\n{stderr}"
-            ),
-            None => bail!("process was killed"),
+            Some(code) => {
+                bail!(
+                    "{name}: process exited with error code {code}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                );
+            }
+            None => {
+                bail!("process was killed");
+            }
         }
     }
 }
@@ -506,7 +510,9 @@ async fn fail_on_non_zero_exit_code(
     let maybe_code = process.wait().await?.code();
     match maybe_code {
         Some(0) => Ok(()),
-        None => bail!("process was killed"),
+        None => {
+            bail!("process was killed");
+        }
         Some(code) => {
             let mut stderr = String::new();
             process

--- a/tools/pepsi/src/player_number.rs
+++ b/tools/pepsi/src/player_number.rs
@@ -65,7 +65,7 @@ pub fn check_for_duplication(assignments: &[RobotNumberPlayerAssignment]) -> Res
                 || !existing_player_numbers.insert(player_number)
         },
     ) {
-        bail!("duplication in Robot to player number assignments")
+        bail!("duplication in Robot to player number assignments");
     }
     Ok(())
 }

--- a/tools/pepsi/src/pre_game.rs
+++ b/tools/pepsi/src/pre_game.rs
@@ -193,7 +193,7 @@ async fn setup_robot(
                 .retrieve_logs()
                 .await
                 .wrap_err("failed to retrieve logs")?;
-            bail!("failed to restart hulk: {error:#?}\nLogs:\n{logs}")
+            bail!("failed to restart hulk: {error:#?}\nLogs:\n{logs}");
         };
     }
 

--- a/tools/pepsi/src/upload.rs
+++ b/tools/pepsi/src/upload.rs
@@ -113,7 +113,7 @@ async fn upload_with_progress(
                 .retrieve_logs()
                 .await
                 .wrap_err("failed to retrieve logs")?;
-            bail!("failed to restart hulk: {error:#?}\nLogs:\n{logs}")
+            bail!("failed to restart hulk: {error:#?}\nLogs:\n{logs}");
         };
     }
     Ok(())

--- a/tools/tensorrt-compile/src/main.rs
+++ b/tools/tensorrt-compile/src/main.rs
@@ -138,12 +138,14 @@ fn resolve_input_shapes(
         let dynamic = model_shape.iter().any(|dimension| *dimension < 0);
         let shape = match overrides.get(&input.name) {
             Some(shape) => validate_shape(&input.name, model_shape, shape)?,
-            None if dynamic => bail!(
-                "input '{}' has dynamic shape {}; pass --{} dim1,dim2,...",
-                input.name,
-                format_shape(model_shape),
-                input.name
-            ),
+            None if dynamic => {
+                bail!(
+                    "input '{}' has dynamic shape {}; pass --{} dim1,dim2,...",
+                    input.name,
+                    format_shape(model_shape),
+                    input.name
+                );
+            }
             None => model_shape.to_vec(),
         };
         resolved.push(InputShape {

--- a/tools/twix-legacy/src/selectable_panel_macro.rs
+++ b/tools/twix-legacy/src/selectable_panel_macro.rs
@@ -24,7 +24,9 @@ macro_rules! impl_selectable_panel {
                     $(
                         $name::NAME => Ok(SelectablePanel::$name($name::new(context))),
                     )*
-                    _ => bail!("\"{panel_name}\": no such panel"),
+                    _ => {
+                        bail!("\"{panel_name}\": no such panel");
+                    }
                 }
             }
 

--- a/tools/twix/src/selectable_panel_macro.rs
+++ b/tools/twix/src/selectable_panel_macro.rs
@@ -31,7 +31,9 @@ macro_rules! impl_selectable_panel {
                     $(
                         <$name as $crate::panel::Panel>::STORAGE_ID => Ok(Self::$name($name::new(context))),
                     )*
-                    _ => color_eyre::eyre::bail!("unknown panel storage id: {storage_id}"),
+                    _ => {
+                        color_eyre::eyre::bail!("unknown panel storage id: {storage_id}");
+                    }
                 }
             }
 
@@ -51,7 +53,9 @@ macro_rules! impl_selectable_panel {
                     $(
                         <$name as $crate::panel::Panel>::DISPLAY_NAME => Ok(Self::$name($name::new(context))),
                     )*
-                    _ => color_eyre::eyre::bail!("unknown panel display name: {display_name}"),
+                    _ => {
+                        color_eyre::eyre::bail!("unknown panel display name: {display_name}");
+                    }
                 }
             }
 


### PR DESCRIPTION
## Why? What?

The bail macro cannot be used in an expression context in latest rust nightly, causing compilation to fail. This PR changes all our `bail!` invocations to be in a statement context, making everything compile again.

[Rust tracking issue #79813](https://github.com/rust-lang/rust/issues/79813)
Based on #2863

## ToDo / Known Issues

## Ideas for Next Iterations (Not This PR)

## How to Test

```sh
rustup run nightly ./pepsi clippy
```