### PR TITLE
direct remote control on robot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "controller_handler"
+version = "0.1.0"
+dependencies = [
+ "color-eyre",
+ "gilrs",
+ "ros-z",
+ "tokio",
+ "tracing",
+ "types",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,6 +4770,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.31.3",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5415,6 +5461,7 @@ dependencies = [
  "camera_matrix_calculator",
  "clap",
  "color-eyre",
+ "controller_handler",
  "detection",
  "fake_odometry",
  "fall_down_state_receiver",
@@ -5851,6 +5898,26 @@ name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "inout"
@@ -6420,6 +6487,16 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.9.0",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -7611,6 +7688,17 @@ dependencies = [
  "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
  "objc2-core-foundation",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8248,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "pepsi"
-version = "7.36.0"
+version = "7.37.0"
 dependencies = [
  "aliveness",
  "argument_parsers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "crates/nodes/button_event_bridge",
   "crates/nodes/button_event_handler",
   "crates/nodes/camera_matrix_calculator",
+  "crates/nodes/controller_handler",
   "crates/nodes/detection",
   "crates/nodes/fake_odometry",
   "crates/nodes/fall_down_state_receiver",
@@ -147,6 +148,7 @@ chrono = "0.4.39"
 clap = { version = "4.5.29", features = ["derive", "env"] }
 clap_complete = "4.5.44"
 color-eyre = "0.6.3"
+controller_handler = { path = "crates/nodes/controller_handler" }
 convert_case = "0.7.1"
 coordinate_systems = { path = "crates/coordinate_systems" }
 detection = { path = "crates/nodes/detection" }
@@ -170,6 +172,7 @@ futures-util = "0.3.31"
 game_controller_filter = { path = "crates/nodes/game_controller_filter" }
 game_controller_state_filter = { path = "crates/nodes/game_controller_state_filter" }
 geometry = { path = "crates/geometry" }
+gilrs = "0.11.2"
 glob = "0.3.2"
 global_parameter_provider = { path = "crates/nodes/global_parameter_provider" }
 ground_provider = { path = "crates/nodes/ground_provider" }

--- a/crates/bevyhavior_simulator/src/behavior_runtime.rs
+++ b/crates/bevyhavior_simulator/src/behavior_runtime.rs
@@ -162,6 +162,7 @@ fn create_behavior_blackboard(parameters: BehaviorParameters) -> BehaviorBlackbo
         field_dimensions: FieldDimensions::default(),
         parameters,
         world_state: WorldState::default(),
+        controller_input: None,
         path_obstacles_output: Vec::new(),
         time_since_last_switch: Duration::ZERO,
         direction_difference: 0.0,

--- a/crates/bevyhavior_simulator/src/kinematics.rs
+++ b/crates/bevyhavior_simulator/src/kinematics.rs
@@ -257,7 +257,7 @@ fn apply_head_motion(
     tick_duration: Duration,
     config: &SimulationConfig,
 ) -> Orientation2<Ground> {
-    let desired_yaw = desired_head_yaw(head_motion, now, config)
+    let desired_yaw = desired_head_yaw(current_yaw, head_motion, now, tick_duration, config)
         .clamp(config.head_yaw_minimum, config.head_yaw_maximum);
     let maximum_movement = config.head_yaw_velocity * tick_duration.as_secs_f32();
     let movement =
@@ -268,11 +268,16 @@ fn apply_head_motion(
 }
 
 fn desired_head_yaw(
+    current_yaw: Orientation2<Ground>,
     head_motion: Option<HeadMotion>,
     now: SystemTime,
+    tick_duration: Duration,
     config: &SimulationConfig,
 ) -> f32 {
     match head_motion {
+        Some(HeadMotion::MoveWithVelocity { yaw, .. }) => {
+            current_yaw.angle() + yaw * tick_duration.as_secs_f32()
+        }
         Some(HeadMotion::LookAt { target, .. }) => {
             Orientation2::from_vector(target.coords()).angle()
         }

--- a/crates/hulk_ros_z/Cargo.toml
+++ b/crates/hulk_ros_z/Cargo.toml
@@ -20,6 +20,7 @@ button_event_handler = { workspace = true }
 camera_matrix_calculator = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 color-eyre = { workspace = true }
+controller_handler = { workspace = true }
 detection = { workspace = true, features = ["ort-dynamic"] }
 fake_odometry = { workspace = true }
 fall_down_state_receiver = { workspace = true }

--- a/crates/hulk_ros_z/src/main.rs
+++ b/crates/hulk_ros_z/src/main.rs
@@ -142,6 +142,7 @@ async fn spawn_all(ctx: Arc<Context>, log_path: Option<PathBuf>) -> Result<Runni
     join_set.spawn(button_event_bridge::run_boxed(ctx.clone()));
     join_set.spawn(button_event_handler::run_boxed(ctx.clone()));
     join_set.spawn(camera_matrix_calculator::run_boxed(ctx.clone()));
+    join_set.spawn(controller_handler::run_boxed(ctx.clone()));
     join_set.spawn(detection::run_boxed(ctx.clone()));
     join_set.spawn(fake_odometry::run_boxed(ctx.clone()));
     join_set.spawn(fall_down_state_receiver::run_boxed(ctx.clone()));

--- a/crates/nodes/behavior_node/src/actions.rs
+++ b/crates/nodes/behavior_node/src/actions.rs
@@ -28,12 +28,17 @@ pub fn prepare(blackboard: &mut Blackboard) -> Status {
 }
 
 pub fn remote_control(blackboard: &mut Blackboard) -> Status {
-    let parameters = &blackboard.parameters.control.remote_control;
-    let remote_control_motion_command = BodyMotion::WalkWithVelocity {
-        velocity: vector![parameters.walk.forward, parameters.walk.left,],
-        angular_velocity: parameters.walk.turn,
+    let Some(input) = &blackboard.controller_input else {
+        return Status::Failure;
     };
-    blackboard.body_motion = Some(remote_control_motion_command);
+
+    blackboard.body_motion = Some(BodyMotion::WalkWithVelocity {
+        velocity: vector![
+            input.axis_value("LeftStickY"),
+            -input.axis_value("LeftStickX")
+        ],
+        angular_velocity: -input.axis_value("RightStickX"),
+    });
     Status::Success
 }
 

--- a/crates/nodes/behavior_node/src/actions.rs
+++ b/crates/nodes/behavior_node/src/actions.rs
@@ -1,5 +1,8 @@
 use linear_algebra::vector;
-use types::{behavior_tree::Status, motion_command::BodyMotion};
+use types::{
+    behavior_tree::Status,
+    motion_command::{BodyMotion, HeadMotion},
+};
 
 use crate::node::Blackboard;
 
@@ -38,6 +41,10 @@ pub fn remote_control(blackboard: &mut Blackboard) -> Status {
             -input.axis_value("LeftStickX")
         ],
         angular_velocity: -input.axis_value("RightStickX"),
+    });
+    blackboard.head_motion = Some(HeadMotion::MoveWithVelocity {
+        yaw: input.button_value("DPadLeft") - input.button_value("DPadRight"),
+        pitch: input.button_value("DPadDown") - input.button_value("DPadUp"),
     });
     Status::Success
 }

--- a/crates/nodes/behavior_node/src/conditions.rs
+++ b/crates/nodes/behavior_node/src/conditions.rs
@@ -153,14 +153,17 @@ pub fn is_primary_state(blackboard: &mut Blackboard, primary_state: PrimaryState
 }
 
 pub fn is_remote_controlled(blackboard: &mut Blackboard) -> bool {
-    blackboard.controller_input.as_ref().is_some_and(|controller| controller.connected)
-}
-
-pub fn is_remote_kick_mode(blackboard: &mut Blackboard) -> bool {
     blackboard
         .controller_input
         .as_ref()
-        .is_some_and(|controller| controller.is_pressed("RightTrigger"))
+        .is_some_and(|controller| controller.connected)
+}
+
+pub fn is_remote_kick_mode(blackboard: &mut Blackboard, button: &str) -> bool {
+    blackboard
+        .controller_input
+        .as_ref()
+        .is_some_and(|controller| controller.is_pressed(button))
 }
 
 pub fn has_ball_position(blackboard: &mut Blackboard) -> bool {

--- a/crates/nodes/behavior_node/src/conditions.rs
+++ b/crates/nodes/behavior_node/src/conditions.rs
@@ -153,15 +153,14 @@ pub fn is_primary_state(blackboard: &mut Blackboard, primary_state: PrimaryState
 }
 
 pub fn is_remote_controlled(blackboard: &mut Blackboard) -> bool {
-    blackboard.parameters.control.remote_control.enable
+    blackboard.controller_input.as_ref().is_some_and(|controller| controller.connected)
 }
 
 pub fn is_remote_kick_mode(blackboard: &mut Blackboard) -> bool {
     blackboard
-        .parameters
-        .control
-        .remote_control
-        .kick_mode_toggle
+        .controller_input
+        .as_ref()
+        .is_some_and(|controller| controller.is_pressed("RightTrigger"))
 }
 
 pub fn has_ball_position(blackboard: &mut Blackboard) -> bool {

--- a/crates/nodes/behavior_node/src/kick.rs
+++ b/crates/nodes/behavior_node/src/kick.rs
@@ -214,7 +214,7 @@ pub fn intercept(blackboard: &mut Blackboard) -> Status {
     }
     Status::Failure
 }
-pub fn set_kick_target_in_front(blackboard: &mut Blackboard) -> Status {
+pub fn set_kick_target_beyond_ball(blackboard: &mut Blackboard) -> Status {
     if let (Some(ground_to_field), Some(ball)) = (
         blackboard.world_state.robot.ground_to_field,
         &blackboard.visual_kick_ball_position,
@@ -225,7 +225,10 @@ pub fn set_kick_target_in_front(blackboard: &mut Blackboard) -> Status {
     }) = blackboard.body_motion.as_mut()
     {
         if blackboard.last_motion_type != Some(MotionType::Kick) {
-            let kick_target = ground_to_field * point!(3.0, 0.0);
+            let Some(direction) = ball.position.coords().try_normalize(f32::EPSILON) else {
+                return Status::Failure;
+            };
+            let kick_target = ground_to_field * (ball.position + direction * 10.0);
             blackboard.last_kick_target = Some(kick_target);
         }
 

--- a/crates/nodes/behavior_node/src/node.rs
+++ b/crates/nodes/behavior_node/src/node.rs
@@ -1,4 +1,9 @@
-use std::{net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use booster::FallDownState;
 use color_eyre::Result;
@@ -13,6 +18,7 @@ use tracing::info;
 use types::{
     ball_position::{BallPosition, HypotheticalBallPosition},
     behavior_tree::NodeTrace,
+    controller_input::ControllerInput,
     field_dimensions::{FieldDimensions, Side},
     filtered_game_controller_state::FilteredGameControllerState,
     messages::OutgoingMessage,
@@ -44,6 +50,7 @@ pub struct Blackboard {
     pub field_dimensions: FieldDimensions,
     pub parameters: BehaviorParameters,
     pub world_state: WorldState,
+    pub controller_input: Option<ControllerInput>,
 
     pub path_obstacles_output: Vec<PathObstacle>,
     pub time_since_last_switch: Duration,
@@ -158,6 +165,11 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
         .cache(1)
         .build()
         .await?;
+    let controller_input_cache = node
+        .subscriber::<ControllerInput>("inputs/controller_input")
+        .cache(1)
+        .build()
+        .await?;
     let ball_state_cache = node
         .subscriber::<Option<BallState>>("ball_state")
         .cache(1)
@@ -261,6 +273,7 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             .unwrap_or_default(),
         parameters: parameters.snapshot().typed().clone(),
         world_state: WorldState::default(),
+        controller_input: None,
 
         path_obstacles_output: Vec::new(),
         time_since_last_switch: Duration::ZERO,
@@ -312,6 +325,10 @@ pub async fn run(ctx: Arc<Context>) -> Result<()> {
             .map(|n| *n)
             .unwrap_or_default();
         blackboard.parameters = parameters.snapshot().typed().clone();
+        blackboard.controller_input = controller_input_cache
+            .get_after(Time::from_wallclock(SystemTime::now()) - Duration::from_millis(250))
+            .filter(|input| input.connected)
+            .map(|input| input.as_ref().clone());
 
         let player_states = player_states_cache
             .get_latest()

--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -1,4 +1,4 @@
-use types::{motion_type::MotionType, primary_state::PrimaryState};
+use types::{motion_command::KickPower, motion_type::MotionType, primary_state::PrimaryState};
 
 use crate::{
     action,
@@ -12,7 +12,7 @@ use crate::{
     },
     goalkeeper::goalkeeper_subtree,
     head::{look_around, look_at_ball_subtree, look_straight_ahead, search_for_lost_ball_subtree},
-    kick::{intercept, kick, kick_power_subtree, kick_subtree, set_kick_target_in_front},
+    kick::{intercept, kick, kick_subtree, set_kick_target_in_front, use_kick_power},
     negation,
     node::Blackboard,
     penalty_shootout::{is_penalty_shootout, penalty_shootout_subtree},
@@ -161,16 +161,23 @@ fn remote_control_subtree() -> Node<Blackboard> {
     sequence!(
         condition!(is_remote_controlled),
         selection!(
-            sequence!(
-                condition!(is_remote_kick_mode),
-                subtree!(look_at_ball_subtree),
-                sequence!(
-                    action!(kick),
-                    action!(set_kick_target_in_front),
-                    subtree!(kick_power_subtree),
-                )
+            subtree!(
+                remote_kick_subtree,
+                "LeftTrigger",
+                KickPower::Rumpelstilzchen
             ),
-            sequence!(action!(look_straight_ahead), action!(remote_control))
+            subtree!(remote_kick_subtree, "RightTrigger", KickPower::Schlong),
+            action!(remote_control)
         )
+    )
+}
+
+fn remote_kick_subtree(button: &'static str, kick_power: KickPower) -> Node<Blackboard> {
+    sequence!(
+        condition!(is_remote_kick_mode, button),
+        subtree!(look_at_ball_subtree),
+        action!(kick),
+        action!(set_kick_target_in_front),
+        action!(use_kick_power, kick_power),
     )
 }

--- a/crates/nodes/behavior_node/src/tree.rs
+++ b/crates/nodes/behavior_node/src/tree.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     goalkeeper::goalkeeper_subtree,
     head::{look_around, look_at_ball_subtree, look_straight_ahead, search_for_lost_ball_subtree},
-    kick::{intercept, kick, kick_subtree, set_kick_target_in_front, use_kick_power},
+    kick::{intercept, kick, kick_subtree, set_kick_target_beyond_ball, use_kick_power},
     negation,
     node::Blackboard,
     penalty_shootout::{is_penalty_shootout, penalty_shootout_subtree},
@@ -177,7 +177,7 @@ fn remote_kick_subtree(button: &'static str, kick_power: KickPower) -> Node<Blac
         condition!(is_remote_kick_mode, button),
         subtree!(look_at_ball_subtree),
         action!(kick),
-        action!(set_kick_target_in_front),
+        action!(set_kick_target_beyond_ball),
         action!(use_kick_power, kick_power),
     )
 }

--- a/crates/nodes/controller_handler/Cargo.toml
+++ b/crates/nodes/controller_handler/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "controller_handler"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+color-eyre = { workspace = true }
+gilrs = { workspace = true }
+ros-z = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+types = { workspace = true }

--- a/crates/nodes/controller_handler/src/lib.rs
+++ b/crates/nodes/controller_handler/src/lib.rs
@@ -1,0 +1,73 @@
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
+
+use color_eyre::Result;
+use gilrs::{Gilrs, ev::AxisOrBtn};
+use ros_z::prelude::*;
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::warn;
+use types::controller_input::{ControllerAxis, ControllerButton, ControllerInput};
+
+pub fn run_boxed(ctx: Arc<Context>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+    Box::pin(run(ctx))
+}
+
+async fn run(ctx: Arc<Context>) -> Result<()> {
+    let node = ctx.create_node("controller_handler").build().await?;
+
+    let controller_input_pub = node
+        .publisher::<ControllerInput>("inputs/controller_input")
+        .build()
+        .await?;
+
+    let mut gilrs = match Gilrs::new() {
+        Ok(gilrs) => gilrs,
+        Err(error) => {
+            warn!(%error, "failed to initialize controller handler");
+            return Ok(());
+        }
+    };
+    let mut ticker = interval(Duration::from_millis(20));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        let controller_input = read_controller_input(&mut gilrs);
+        controller_input_pub.publish(&controller_input).await?;
+    }
+}
+
+fn read_controller_input(gilrs: &mut Gilrs) -> ControllerInput {
+    while gilrs.next_event().is_some() {}
+
+    let Some((_, gamepad)) = gilrs.gamepads().next() else {
+        return ControllerInput::default();
+    };
+
+    let mut input = ControllerInput {
+        connected: true,
+        device_name: gamepad.name().to_owned(),
+        axes: Vec::new(),
+        buttons: Vec::new(),
+    };
+
+    for (code, data) in gamepad.state().axes() {
+        if let Some(AxisOrBtn::Axis(axis)) = gamepad.axis_or_btn_name(code) {
+            input.axes.push(ControllerAxis {
+                name: format!("{axis:?}"),
+                value: data.value(),
+            });
+        }
+    }
+
+    for (code, data) in gamepad.state().buttons() {
+        if let Some(AxisOrBtn::Btn(button)) = gamepad.axis_or_btn_name(code) {
+            input.buttons.push(ControllerButton {
+                name: format!("{button:?}"),
+                pressed: data.is_pressed(),
+                value: data.value(),
+            });
+        }
+    }
+
+    input
+}

--- a/crates/nodes/head_motion/src/lib.rs
+++ b/crates/nodes/head_motion/src/lib.rs
@@ -132,12 +132,17 @@ impl HeadMotionState {
             return filtered_head_joints;
         }
 
-        let raw_positions = joints_from_motion(
-            look_around_target_joints,
-            look_at,
-            motor_states,
-            motion_command,
-        );
+        let raw_positions = match motion_command.head_motion() {
+            Some(HeadMotion::MoveWithVelocity { yaw, pitch }) => {
+                self.last_positions + HeadJoints { yaw, pitch } * last_cycle_duration.as_secs_f32()
+            }
+            _ => joints_from_motion(
+                look_around_target_joints,
+                look_at,
+                motor_states,
+                motion_command,
+            ),
+        };
         let maximum_movement = parameters.maximum_velocity * last_cycle_duration.as_secs_f32();
 
         let controlled_positions = HeadJoints {

--- a/crates/types/src/controller_input.rs
+++ b/crates/types/src/controller_input.rs
@@ -16,6 +16,13 @@ impl ControllerInput {
             .map_or(0.0, |axis| axis.value)
     }
 
+    pub fn button_value(&self, name: &str) -> f32 {
+        self.buttons
+            .iter()
+            .find(|button| button.name == name)
+            .map_or(0.0, |button| button.value)
+    }
+
     pub fn is_pressed(&self, name: &str) -> bool {
         self.buttons
             .iter()

--- a/crates/types/src/controller_input.rs
+++ b/crates/types/src/controller_input.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ros_z::Message)]
+pub struct ControllerInput {
+    pub connected: bool,
+    pub device_name: String,
+    pub axes: Vec<ControllerAxis>,
+    pub buttons: Vec<ControllerButton>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ros_z::Message)]
+pub struct ControllerAxis {
+    pub name: String,
+    pub value: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ros_z::Message)]
+pub struct ControllerButton {
+    pub name: String,
+    pub pressed: bool,
+    pub value: f32,
+}

--- a/crates/types/src/controller_input.rs
+++ b/crates/types/src/controller_input.rs
@@ -8,6 +8,21 @@ pub struct ControllerInput {
     pub buttons: Vec<ControllerButton>,
 }
 
+impl ControllerInput {
+    pub fn axis_value(&self, name: &str) -> f32 {
+        self.axes
+            .iter()
+            .find(|axis| axis.name == name)
+            .map_or(0.0, |axis| axis.value)
+    }
+
+    pub fn is_pressed(&self, name: &str) -> bool {
+        self.buttons
+            .iter()
+            .any(|button| button.name == name && button.pressed)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ros_z::Message)]
 pub struct ControllerAxis {
     pub name: String,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod buttons;
 pub mod calibration;
 pub mod color;
 pub mod condition_input;
+pub mod controller_input;
 pub mod cycle_time;
 pub mod detected_feet;
 pub mod fall_down_state;

--- a/crates/types/src/motion_command.rs
+++ b/crates/types/src/motion_command.rs
@@ -155,6 +155,10 @@ pub enum HeadMotion {
         target: Point2<Ground>,
     },
     Unstiff,
+    MoveWithVelocity {
+        yaw: f32,
+        pitch: f32,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize, Message)]

--- a/crates/types/src/parameters.rs
+++ b/crates/types/src/parameters.rs
@@ -8,16 +8,7 @@ use serde::{Deserialize, Serialize};
 use coordinate_systems::{Camera, Field, Ground, NormalizedPixel, Pixel, Robot};
 use linear_algebra::{Framed, Point2, Vector2, Vector3};
 
-use crate::{
-    field_color::FieldColorParameters, motion_command::MotionCommand, players::Players, step::Step,
-};
-
-#[derive(Clone, Debug, Default, Deserialize, Serialize, ros_z::Message)]
-pub struct RemoteControlParameters {
-    pub walk: Step,
-    pub kick_mode_toggle: bool,
-    pub enable: bool,
-}
+use crate::{field_color::FieldColorParameters, motion_command::MotionCommand, players::Players};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, ros_z::Message)]
 pub struct WhistleDetectionParameters {
@@ -60,7 +51,6 @@ pub struct BehaviorParameters {
 pub struct BehaviorControlParameters {
     pub allow_switch: AllowSwitchParameters,
     pub injected_motion_command: Option<MotionCommand>,
-    pub remote_control: RemoteControlParameters,
     pub is_simple: bool,
 }
 

--- a/docs/tooling/pepsi.md
+++ b/docs/tooling/pepsi.md
@@ -48,7 +48,8 @@ Many subcommands can act on multiple robots concurrently.
 
 `logs` or and `postgame` can be used after a (test-)game to download logs, the latter also shuts down the HULKs binary and disables wifi.
 
-`gammaray` is used for flashing a HULKs-OS image to one or more robots.
+On K1 robots, `gammaray` configures HULK and disables manufacturer controller programs; `boosterize` restores manufacturer control.
+See [Remote Control](remote_control.md) for setup, gamepad bindings, and restoration instructions.
 
 ## Build Options
 

--- a/docs/tooling/remote_control.md
+++ b/docs/tooling/remote_control.md
@@ -1,0 +1,22 @@
+# Remote Control
+
+`./pepsi gammaray <robot>` disables the manufacturer controller services for HULK remote control.
+`./pepsi boosterize <robot>` restores the `RemoteController` section in `/opt/booster/Daemon/bin/child.ini` and enables and starts `joystick_ros2`.
+
+## Controls
+
+| Control | Action |
+| --- | --- |
+| Left stick up/down | Walk forward/backward |
+| Left stick left/right | Walk sideways |
+| Right stick left/right | Turn the robot |
+| D-pad left/right | Move the head left/right |
+| D-pad up/down | Move the head up/down |
+| Hold left shoulder, L1/LB | Rumpelstilzchen kick |
+| Hold right shoulder, R1/RB | Schlong kick |
+| Analog triggers, L2/LT and R2/RT | Unbound |
+| Right stick up/down | Unbound |
+
+## Restore Manufacturer Controls
+
+Boosterize restores the `RemoteController` section in `/opt/booster/Daemon/bin/child.ini` and enables and starts `joystick_ros2`.

--- a/etc/parameters/base/behavior_node.json5
+++ b/etc/parameters/base/behavior_node.json5
@@ -9,15 +9,6 @@
       damping: { secs: 0, nanos: 0 },
     },
     injected_motion_command: null,
-    remote_control: {
-      walk: {
-        forward: 0.0,
-        left: 0.0,
-        turn: 0.0,
-      },
-      kick_mode_toggle: false,
-      enable: false,
-    },
     is_simple: false,
   },
   ball: {

--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,8 @@
 
       devShells.${system}.default = craneLibrary.devShell {
         inputsFrom = [ pepsi twix rosz ];
-        packages = with pkgs; [ rust-analyzer rsync openssh ];
-        env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath guiLibraries;
+        packages = with pkgs; [ rust-analyzer rsync openssh systemd.dev ];
+        env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (guiLibraries ++ [ pkgs.systemd ]);
       };
     };
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Machine Learning: tooling/machine-learning.md
       - Behavior Simulator: tooling/behavior_simulator.md
       - Behavior Tree Simulator Design: tooling/behavior_tree_simulator_design.md
+      - Remote Control: tooling/remote_control.md
       - Debugging with GDB/LLDB: tooling/debugging.md
       - Profiling with perf: tooling/profiling.md
   - Operating System:

--- a/tools/k1-setup/hulk-runtime.container
+++ b/tools/k1-setup/hulk-runtime.container
@@ -7,6 +7,9 @@ Image=hulk-runtime:latest
 Network=host
 AddDevice=nvidia.com/gpu=all
 AddDevice=/dev/snd
+Volume=/dev/input:/dev/input:rw
+PodmanArgs=--device-cgroup-rule="c 13:* rw"
+GroupAdd=101
 RunInit=true
 
 Volume=/usr/lib/aarch64-linux-gnu/tegra:/usr/lib/aarch64-linux-gnu/tegra
@@ -15,11 +18,13 @@ WorkingDir=/home/booster/hulk
 
 Environment=LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra
 Environment=ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so
+Environment=GILRS_DISABLE_UDEV=1
 EnvironmentFile=/run/hulk-runtime.env
 
 Exec=sleep infinity
 
 [Service]
+ExecStartPre=/usr/bin/mkdir -p /dev/input
 ExecStartPre=/usr/bin/bash -c "echo HARDWARE_ID=$(/usr/local/bin/jetson_release -s | /usr/bin/grep 'Serial Number:' | /usr/bin/grep '[0-9]*$' -o) > /run/hulk-runtime.env"
 ExecStartPre=/usr/bin/jetson_clocks
 

--- a/tools/k1-setup/inference-runtime/Containerfile
+++ b/tools/k1-setup/inference-runtime/Containerfile
@@ -2,5 +2,5 @@ FROM docker.io/dustynv/onnxruntime:1.22-r36.4.0-cu128-24.04
 
 
 RUN apt-get update && \
-    apt-get install -y curl clang libssl-dev pkg-config libasound2-dev && \
+    apt-get install -y curl clang libssl-dev pkg-config libasound2-dev libudev1 && \
     rm -rf /var/lib/apt/lists/*

--- a/tools/pepsi/Cargo.toml
+++ b/tools/pepsi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pepsi"
-version = "7.36.0"
+version = "7.37.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tools/pepsi/src/boosterize.rs
+++ b/tools/pepsi/src/boosterize.rs
@@ -4,7 +4,10 @@ use color_eyre::Result;
 use argument_parsers::RobotAddress;
 use robot::Robot;
 
-use crate::{gammaray::CommandExt, progress_indicator::ProgressIndicator};
+use crate::{
+    gammaray::{CommandExt, MANUFACTURER_CONTROLLER_SCRIPT},
+    progress_indicator::ProgressIndicator,
+};
 
 #[derive(Args, Debug)]
 pub struct Arguments {
@@ -33,6 +36,14 @@ pub async fn boosterize(arguments: Arguments) -> Result<()> {
                     .arg("sudo systemctl disable --now")
                     .arg("hulk")
                     .ssh_with_log("disabling hulk", &progress_bar)
+                    .await?;
+                robot
+                    .ssh_to_robot()?
+                    .arg(format!(
+                        "sudo bash -s -- enable /opt/booster/Daemon/bin/child.ini <<'EOF'\n{}\nEOF",
+                        MANUFACTURER_CONTROLLER_SCRIPT
+                    ))
+                    .ssh_with_log("restoring manufacturer controller", &progress_bar)
                     .await?;
                 robot
                     .ssh_to_robot()?

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -285,18 +285,18 @@ async fn gammaray_robot(
         .await?;
 
     robot
-        .ssh_to_robot()?
-        .arg("sudo systemctl daemon-reload")
-        .ssh_with_log("reloading service daemon", &progress_bar)
-        .await?;
-
-    robot
         .rsync_with_robot()?
         .arg("--rsync-path=sudo rsync")
         .arg("--info=progress2")
         .arg(setup.join("hulk-runtime.container"))
         .arg(format!("{}:/etc/containers/systemd/", robot.address))
         .rsync_with_log("uploading service file", &progress_bar)
+        .await?;
+
+    robot
+        .ssh_to_robot()?
+        .arg("sudo systemctl daemon-reload")
+        .ssh_with_log("reloading service daemon", &progress_bar)
         .await?;
 
     robot
@@ -322,8 +322,8 @@ async fn gammaray_robot(
 
     robot
         .ssh_to_robot()?
-        .arg("sudo systemctl enable hulk && sudo systemctl restart hulk")
-        .ssh_with_log("enabling and restarting hulk", &progress_bar)
+        .arg("sudo systemctl enable hulk && sudo systemctl stop hulk && sudo systemctl restart hulk-runtime && sudo systemctl start hulk")
+        .ssh_with_log("enabling and restarting hulk and its runtime", &progress_bar)
         .await?;
 
     robot

--- a/tools/pepsi/src/gammaray.rs
+++ b/tools/pepsi/src/gammaray.rs
@@ -50,6 +50,36 @@ const WIFI_PASSWORD: &str = "HSL?!HSL?!";
 
 const PODMAN_INSTALLATION_SCRIPT: &str = include_str!("install-podman.sh");
 
+pub(super) const MANUFACTURER_CONTROLLER_SCRIPT: &str = r#"set -euo pipefail
+
+mode="$1"
+case "$mode" in
+    enable|disable) ;;
+    *) echo "Expected enable or disable" >&2; exit 1 ;;
+esac
+
+config="$(readlink -f "$2")"
+updated="$(mktemp "${config}.XXXXXX")"
+trap 'rm -f "$updated"' EXIT
+cp --preserve=mode,ownership "$config" "$updated"
+
+awk -v mode="$mode" -v marker='; HULK disabled RemoteController: ' '
+    { sub("^" marker, "") }
+    /^[[:space:]]*\[/ {
+        in_controller = ($0 ~ /^[[:space:]]*\[RemoteController\]/)
+    }
+    { print (mode == "disable" && in_controller ? marker : "") $0 }
+' "$config" > "$updated"
+
+if ! cmp -s "$config" "$updated"; then
+    systemctl stop hulk
+    mv "$updated" "$config"
+    systemctl restart booster-daemon
+fi
+
+systemctl "$mode" --now joystick_ros2
+"#;
+
 static ADD_ZENOH_APT_SOURCES: &str = "
 curl -L https://download.eclipse.org/zenoh/debian-repo/zenoh-public-key | sudo gpg --dearmor --yes --output /etc/apt/keyrings/zenoh-public-key.gpg
 grep \"https://download.eclipse.org/zenoh/debian-repo/\" /etc/apt/sources.list || echo \"deb [signed-by=/etc/apt/keyrings/zenoh-public-key.gpg] https://download.eclipse.org/zenoh/debian-repo/ /\" | sudo tee -a /etc/apt/sources.list > /dev/null
@@ -318,6 +348,15 @@ async fn gammaray_robot(
         .ssh_to_robot()?
         .arg("sudo systemctl enable --now jetson-clocks-refresh.timer")
         .ssh_with_log("enabling jetson clocks refresh timer", &progress_bar)
+        .await?;
+
+    robot
+        .ssh_to_robot()?
+        .arg(format!(
+            "sudo bash -s -- disable /opt/booster/Daemon/bin/child.ini <<'EOF'\n{}\nEOF",
+            MANUFACTURER_CONTROLLER_SCRIPT
+        ))
+        .ssh_with_log("disabling manufacturer controller", &progress_bar)
         .await?;
 
     robot

--- a/tools/sdk_container/Containerfile
+++ b/tools/sdk_container/Containerfile
@@ -32,6 +32,7 @@ RUN dpkg --add-architecture arm64 && \
         libssl-dev \
         libssl-dev:arm64 \
         libstdc++-11-dev-arm64-cross \
+        libudev-dev:arm64 \
         pkg-config && \
     rm -rf \
         /usr/lib/llvm-14/include \


### PR DESCRIPTION
## Why? What?
Adds a controller handler, that takes the direct controller input, also updates gammaray for that. Also disables the booster controller service with boosterize and reenables it with boosterize. Then it rebinds the behavior remote control tree to the right controls. The remote controll is always active if a controller is connected, so all controllers need to be turned off during the game, else it will not do anything.

## Ideas for Next Iterations (Not This PR)
loca for the kick for real torwandschießen without the field

## How to Test
Gammaray and upload the robot connect a controller and look in the docs for controls, afterwards boosterize the robot and look if it can wave and kickbox again.